### PR TITLE
Odd newlines cleaned up

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,8 +53,7 @@
     <string name="nc_settings_remove_account">Remove account</string>
     <string name="nc_settings_add_account">Add a new account</string>
     <string name="nc_settings_wrong_account">Only current account can be reauthorized</string>
-    <string name="nc_settings_no_talk_installed">Talk app is not installed on the server you tried to authorize
-        against</string>
+    <string name="nc_settings_no_talk_installed">Talk app is not installed on the server you tried to authorize against</string>
     <string name="nc_settings_account_updated">Your already existing account was updated, instead of adding a new one</string>
     <string name="nc_account_scheduled_for_deletion">The account is scheduled for deletion, and cannot be changed</string>
 
@@ -85,16 +84,11 @@
     <string name="nc_more_contacts_selected">contacts selected</string>
 
     <!-- Permissions -->
-    <string name="nc_permissions">Permissions need to be granted to establish a video and/or audio call. Please
-        click \"ALLOW\" in the upcoming system dialog.</string>
-    <string name="nc_permissions_audio">Microphone permission needs to be granted to enable audio calls. Please
-        click \"ALLOW\" in the upcoming system dialog.</string>
-    <string name="nc_permissions_video">Camera permission needs to be granted to enable video calls. Please
-        click \"ALLOW\" in the upcoming system dialog.</string>
-    <string name="nc_camera_permission_permanently_denied">To enable video communication please grant \"Camera\"
-        permission in the system settings.</string>
-    <string name="nc_microphone_permission_permanently_denied">To enable voice communication please grant
-        \"Microphone\" permission in the system settings.</string>
+    <string name="nc_permissions">Permissions need to be granted to establish a video and/or audio call. Please click \"ALLOW\" in the upcoming system dialog.</string>
+    <string name="nc_permissions_audio">Microphone permission needs to be granted to enable audio calls. Please click \"ALLOW\" in the upcoming system dialog.</string>
+    <string name="nc_permissions_video">Camera permission needs to be granted to enable video calls. Please click \"ALLOW\" in the upcoming system dialog.</string>
+    <string name="nc_camera_permission_permanently_denied">To enable video communication please grant \"Camera\" permission in the system settings.</string>
+    <string name="nc_microphone_permission_permanently_denied">To enable voice communication please grant \"Microphone\" permission in the system settings.</string>
     <string name="nc_permissions_settings">Open settings</string>
 
     <!-- Call -->


### PR DESCRIPTION
Previously looked like this on TX:
"Permissions need to be granted to establish a video and/or audio call. Please
       click \"ALLOW\" in the upcoming system dialog."