### PR TITLE
trying to manually tint bottom sheet navigation items

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/MagicBottomNavigationController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/MagicBottomNavigationController.java
@@ -24,16 +24,57 @@
 
 package com.nextcloud.talk.controllers;
 
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.PorterDuff;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.support.annotation.ColorRes;
 import android.support.annotation.IdRes;
+import android.support.annotation.NonNull;
+import android.support.annotation.RequiresApi;
+import android.support.design.widget.BottomNavigationView;
+import android.support.design.widget.CoordinatorLayout;
+import android.support.v4.graphics.drawable.DrawableCompat;
+import android.text.TextUtils;
+import android.util.Log;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
 
 import com.bluelinelabs.conductor.Controller;
+import com.bluelinelabs.conductor.Router;
+import com.bumptech.glide.load.model.GlideUrl;
+import com.bumptech.glide.load.model.LazyHeaders;
+import com.bumptech.glide.load.resource.bitmap.CircleCrop;
+import com.bumptech.glide.request.RequestOptions;
+import com.bumptech.glide.request.target.SimpleTarget;
+import com.bumptech.glide.request.target.Target;
+import com.bumptech.glide.request.transition.Transition;
 import com.nextcloud.talk.R;
+import com.nextcloud.talk.application.NextcloudTalkApplication;
 import com.nextcloud.talk.controllers.base.bottomnavigation.BottomNavigationController;
 import com.nextcloud.talk.controllers.base.bottomnavigation.BottomNavigationMenuItem;
+import com.nextcloud.talk.models.database.UserEntity;
+import com.nextcloud.talk.utils.ApiUtils;
+import com.nextcloud.talk.utils.animations.ViewHidingBehaviourAnimation;
+import com.nextcloud.talk.utils.database.user.UserUtils;
+import com.nextcloud.talk.utils.glide.GlideApp;
 
 import java.lang.reflect.Constructor;
 
+import javax.inject.Inject;
+
+import autodagger.AutoInjector;
+
+@AutoInjector(NextcloudTalkApplication.class)
 public class MagicBottomNavigationController extends BottomNavigationController {
+    @Inject
+    UserUtils userUtils;
+
+    private int settingsMenuItemIndex = 0;
 
     public MagicBottomNavigationController() {
         super(R.menu.menu_navigation);
@@ -71,6 +112,101 @@ public class MagicBottomNavigationController extends BottomNavigationController 
                     "Controller must have a public empty constructor. "
                             + itemId);
         }
+
         return controller;
+    }
+
+    @Override
+    protected void onAttach(@NonNull View view) {
+        super.onAttach(view);
+        //getBottomNavigationView().setItemIconTintList(null);
+
+        Menu menu = getMenu();
+        int menuSize = menu.size();
+        if (menuSize > 0) {
+            settingsMenuItemIndex = menuSize - 1;
+            MenuItem menuItem = menu.getItem(settingsMenuItemIndex);
+            menuItem.getIcon().setTintList(null);
+            // tint grey
+            //menuItem.getIcon().clearColorFilter();
+            //menuItem.getIcon().setColorFilter(context.getResources().getColor(R.color.grey600), PorterDuff.Mode.SRC_ATOP);
+            //menuItem.setIcon(tintDrawable(menuItem.getIcon(), R.color.grey600));
+            loadAvatarImage(menu.getItem(menuSize - 1));
+        }
+    }
+
+    @Override
+    protected void onViewBound(@NonNull View view) {
+        super.onViewBound(view);
+        NextcloudTalkApplication.getSharedApplication().getComponentApplication().inject(this);
+    }
+
+    private void loadAvatarImage(MenuItem item) {
+        UserEntity userEntity = userUtils.getCurrentUser();
+        String avatarId;
+
+        if (userEntity != null) {
+            if (!TextUtils.isEmpty(userEntity.getUserId())) {
+                avatarId = userEntity.getUserId();
+            } else {
+                avatarId = userEntity.getUsername();
+            }
+
+            GlideUrl glideUrl = new GlideUrl(ApiUtils.getUrlForAvatarWithName(userEntity.getBaseUrl(),
+                    avatarId, true), new LazyHeaders.Builder()
+                    .setHeader("Accept", "image/*")
+                    .setHeader("User-Agent", ApiUtils.getUserAgent())
+                    .build());
+
+            Target target = new SimpleTarget<BitmapDrawable>(100, 100) {
+                @Override
+                public void onResourceReady(BitmapDrawable resource, Transition<? super BitmapDrawable> transition) {
+                    item.setIcon(resource);
+                }
+            };
+
+            GlideApp.with(NextcloudTalkApplication.getSharedApplication().getApplicationContext())
+                    .load(glideUrl)
+                    .centerInside()
+                    .apply(RequestOptions.bitmapTransform(new CircleCrop()))
+                    .circleCrop()
+                    .into(target);
+        }
+    }
+
+    private void tintBottomNavigation(int itemId) {
+        int currentSelection = getCurrentlySelectedItemId();
+        if (currentSelection != itemId) {
+
+            /* Ensure correct tinting based on new selection */
+            Menu menu = getMenu();
+            Context context = NextcloudTalkApplication.getSharedApplication().getApplicationContext();
+            for (int i = 0; i < menu.size(); i++) {
+                if (i > settingsMenuItemIndex || i < settingsMenuItemIndex) {
+                    MenuItem menuItem = menu.getItem(i);
+                    if (menuItem.getItemId() != itemId) {
+                        // tint grey
+                        menuItem.getIcon().clearColorFilter();
+                        menuItem.getIcon().setColorFilter(context.getResources().getColor(R.color.grey600), PorterDuff.Mode.SRC_ATOP);
+                        //menuItem.setIcon(tintDrawable(menuItem.getIcon(), R.color.grey600));
+                    } else if (menuItem.getItemId() == itemId) {
+                        // tint primary
+                        menuItem.getIcon().clearColorFilter();
+                        menuItem.setIcon(tintDrawable(menuItem.getIcon(), R.color.colorPrimary));
+                    }
+                }
+            }
+        }
+    }
+
+    private static Drawable tintDrawable(Drawable drawable, @ColorRes int color) {
+        if (drawable != null) {
+            Drawable wrap = DrawableCompat.wrap(drawable);
+            Context context = NextcloudTalkApplication.getSharedApplication().getApplicationContext();
+            wrap.setColorFilter(context.getResources().getColor(color), PorterDuff.Mode.SRC_ATOP);
+            return wrap;
+        }
+
+        return null;
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/controllers/MagicBottomNavigationController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/MagicBottomNavigationController.java
@@ -119,18 +119,11 @@ public class MagicBottomNavigationController extends BottomNavigationController 
     @Override
     protected void onAttach(@NonNull View view) {
         super.onAttach(view);
-        //getBottomNavigationView().setItemIconTintList(null);
+        getBottomNavigationView().setItemIconTintList(null);
 
         Menu menu = getMenu();
         int menuSize = menu.size();
         if (menuSize > 0) {
-            settingsMenuItemIndex = menuSize - 1;
-            MenuItem menuItem = menu.getItem(settingsMenuItemIndex);
-            menuItem.getIcon().setTintList(null);
-            // tint grey
-            //menuItem.getIcon().clearColorFilter();
-            //menuItem.getIcon().setColorFilter(context.getResources().getColor(R.color.grey600), PorterDuff.Mode.SRC_ATOP);
-            //menuItem.setIcon(tintDrawable(menuItem.getIcon(), R.color.grey600));
             loadAvatarImage(menu.getItem(menuSize - 1));
         }
     }
@@ -172,41 +165,5 @@ public class MagicBottomNavigationController extends BottomNavigationController 
                     .circleCrop()
                     .into(target);
         }
-    }
-
-    private void tintBottomNavigation(int itemId) {
-        int currentSelection = getCurrentlySelectedItemId();
-        if (currentSelection != itemId) {
-
-            /* Ensure correct tinting based on new selection */
-            Menu menu = getMenu();
-            Context context = NextcloudTalkApplication.getSharedApplication().getApplicationContext();
-            for (int i = 0; i < menu.size(); i++) {
-                if (i > settingsMenuItemIndex || i < settingsMenuItemIndex) {
-                    MenuItem menuItem = menu.getItem(i);
-                    if (menuItem.getItemId() != itemId) {
-                        // tint grey
-                        menuItem.getIcon().clearColorFilter();
-                        menuItem.getIcon().setColorFilter(context.getResources().getColor(R.color.grey600), PorterDuff.Mode.SRC_ATOP);
-                        //menuItem.setIcon(tintDrawable(menuItem.getIcon(), R.color.grey600));
-                    } else if (menuItem.getItemId() == itemId) {
-                        // tint primary
-                        menuItem.getIcon().clearColorFilter();
-                        menuItem.setIcon(tintDrawable(menuItem.getIcon(), R.color.colorPrimary));
-                    }
-                }
-            }
-        }
-    }
-
-    private static Drawable tintDrawable(Drawable drawable, @ColorRes int color) {
-        if (drawable != null) {
-            Drawable wrap = DrawableCompat.wrap(drawable);
-            Context context = NextcloudTalkApplication.getSharedApplication().getApplicationContext();
-            wrap.setColorFilter(context.getResources().getColor(color), PorterDuff.Mode.SRC_ATOP);
-            return wrap;
-        }
-
-        return null;
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/controllers/base/bottomnavigation/BottomNavigationController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/base/bottomnavigation/BottomNavigationController.java
@@ -310,10 +310,6 @@ public abstract class BottomNavigationController extends BaseController {
         return bottomNavigationView;
     }
 
-    public int getCurrentlySelectedItemId() {
-        return currentlySelectedItemId;
-    }
-
     /**
      * Get the {@link Menu} Resource ID from {@link Controller#getArgs()}
      *

--- a/app/src/main/java/com/nextcloud/talk/controllers/base/bottomnavigation/BottomNavigationController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/base/bottomnavigation/BottomNavigationController.java
@@ -24,6 +24,8 @@
 
 package com.nextcloud.talk.controllers.base.bottomnavigation;
 
+import android.content.Context;
+import android.graphics.PorterDuff;
 import android.os.Bundle;
 import android.support.annotation.MenuRes;
 import android.support.annotation.NonNull;
@@ -43,6 +45,7 @@ import com.bluelinelabs.conductor.Router;
 import com.bluelinelabs.conductor.RouterTransaction;
 import com.bluelinelabs.conductor.changehandler.FadeChangeHandler;
 import com.nextcloud.talk.R;
+import com.nextcloud.talk.application.NextcloudTalkApplication;
 import com.nextcloud.talk.controllers.base.BaseController;
 import com.nextcloud.talk.utils.animations.ViewHidingBehaviourAnimation;
 import com.nextcloud.talk.utils.bundle.BundleBuilder;
@@ -55,10 +58,11 @@ import butterknife.BindView;
  * The backstack of each {@link MenuItem} is switched out, in order to maintain a separate backstack
  * for each {@link MenuItem} - even though that is against the Google Design Guidelines:
  *
+ * @author chris6647@gmail.com
  * @see <a
- *     href="https://material.io/guidelines/components/bottom-navigation.html#bottom-navigation-behavior">Material
- *     Design Guidelines</a>
- *
+ * href="https://material.io/guidelines/components/bottom-navigation.html#bottom-navigation-behavior">Material
+ * Design Guidelines</a>
+ * <p>
  * Internally works similarly to {@link com.bluelinelabs.conductor.support.RouterPagerAdapter},
  * in the sense that it keeps track of the currently active {@link MenuItem} and the paired
  * Child {@link Router}. Everytime we navigate from one to another,
@@ -66,8 +70,6 @@ import butterknife.BindView;
  * of the Child {@link Router}, and cache it, so we have it available when we navigate to
  * another {@link MenuItem} and can then restore the correct Child {@link Router}
  * (and thus the entire backstack)
- *
- * @author chris6647@gmail.com
  */
 public abstract class BottomNavigationController extends BaseController {
 
@@ -135,7 +137,7 @@ public abstract class BottomNavigationController extends BaseController {
          * and in case of resuming the app (i.e. when the view is not created again)
          */
         if (routerSavedStateBundles == null) {
-            Menu menu = bottomNavigationView.getMenu();
+            Menu menu = getMenu();
             int menuSize = menu.size();
             routerSavedStateBundles = new SparseArray<>(menuSize);
             for (int i = 0; i < menuSize; i++) {
@@ -162,6 +164,11 @@ public abstract class BottomNavigationController extends BaseController {
              */
             getChildRouter(currentlySelectedItemId).rebindIfNeeded();
         }
+    }
+
+    @NonNull
+    protected Menu getMenu() {
+        return bottomNavigationView.getMenu();
     }
 
     /**
@@ -233,13 +240,15 @@ public abstract class BottomNavigationController extends BaseController {
             routerSavedStateBundles.remove(currentlySelectedItemId);
 
             /* Ensure correct Checked state based on new selection */
-            Menu menu = bottomNavigationView.getMenu();
+            Menu menu = getMenu();
             for (int i = 0; i < menu.size(); i++) {
                 MenuItem menuItem = menu.getItem(i);
                 if (menuItem.isChecked() && menuItem.getItemId() != itemId) {
                     menuItem.setChecked(false);
                 } else if (menuItem.getItemId() == itemId) {
                     menuItem.setChecked(true);
+                    menuItem.getIcon().clearColorFilter();
+                    menuItem.getIcon().setColorFilter(getResources().getColor(R.color.grey600), PorterDuff.Mode.SRC_ATOP);
                 }
             }
 
@@ -295,6 +304,14 @@ public abstract class BottomNavigationController extends BaseController {
             Log.d(TAG, "handleBack called with getChildRouter(currentlySelectedItemId) == null.");
             return false;
         }
+    }
+
+    public BottomNavigationView getBottomNavigationView() {
+        return bottomNavigationView;
+    }
+
+    public int getCurrentlySelectedItemId() {
+        return currentlySelectedItemId;
     }
 
     /**

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,6 +3,7 @@
     <color name="colorPrimary">#0082C9</color>
     <color name="colorPrimaryDark">#006AA3</color>
     <color name="colorAccent">#007CC2</color>
+    <color name="grey600">#757575</color>
 
     <color name="nc_darkRed">#D32F2F</color>
     <color name="nc_darkGreen">#006400</color>


### PR DESCRIPTION
unsuccessful....

Hi @mario here are my tries to get this done but, no way found to get it working... I can deactivate the auto-tintings, then I see the avatar (else it'll be just a grey/blue circle since it gets auto tinted...). but then no icon in the bottom bar gets tinted.

We had the same issue in the drawer for the files app which is why I implemented manual state/tinting handling but for whatever reason this doesn't work for the bottom navigation view, I tint the icons but it doesn't show up on the view ?!...

Atm I have no clue how to implement this design request :/