### PR TITLE
Fix call notification layout for landscape

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/CallNotificationController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/CallNotificationController.java
@@ -266,7 +266,7 @@ public class CallNotificationController extends BaseController {
 
     private void loadAvatar() {
         int avatarSize = Math.round(NextcloudTalkApplication
-                .getSharedApplication().getResources().getDimension(R.dimen.avatar_size_very_big));
+                .getSharedApplication().getResources().getDimension(R.dimen.avatar_fetching_size_very_big));
 
         switch (currentRoom.getType()) {
             case ROOM_TYPE_ONE_TO_ONE_CALL:

--- a/app/src/main/res/layout/controller_call_notification.xml
+++ b/app/src/main/res/layout/controller_call_notification.xml
@@ -29,7 +29,7 @@
         android:id="@+id/incomingCallTextView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="32dp"
+        android:layout_marginTop="16dp"
         android:text="@string/nc_incoming_call"
         android:textAlignment="center"
         android:textColor="@color/white30"
@@ -57,51 +57,45 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.498"
+        app:layout_constraintVertical_bias="0.45"
         tools:src="@color/white" />
 
-    <com.nextcloud.talk.utils.MagicFlipView
-        android:id="@+id/callAnswerVoiceOnlyView"
-        android:layout_width="60dp"
-        android:layout_height="60dp"
-        android:layout_marginBottom="48dp"
-        app:checked="false"
-        app:enableInitialAnimation="false"
-        app:frontBackgroundColor="@color/colorPrimary"
-        app:frontImage="@drawable/ic_mic_white_24px"
-        app:layout_anchorGravity="top|center"
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.129"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent">
+        <com.nextcloud.talk.utils.MagicFlipView
+            android:id="@+id/callAnswerVoiceOnlyView"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:layout_margin="24dp"
+            app:checked="false"
+            app:enableInitialAnimation="false"
+            app:frontBackgroundColor="@color/colorPrimary"
+            app:frontImage="@drawable/ic_mic_white_24px" />
 
-    <com.nextcloud.talk.utils.MagicFlipView
-        android:id="@+id/callAnswerCameraView"
-        android:layout_width="60dp"
-        android:layout_height="60dp"
-        android:layout_marginBottom="48dp"
-        app:checked="false"
-        app:enableInitialAnimation="false"
-        app:frontBackgroundColor="@color/colorPrimary"
-        app:frontImage="@drawable/ic_videocam_white_24px"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toStartOf="parent" />
+        <com.nextcloud.talk.utils.MagicFlipView
+            android:id="@+id/callAnswerCameraView"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:layout_margin="24dp"
+            app:checked="false"
+            app:enableInitialAnimation="false"
+            app:frontBackgroundColor="@color/colorPrimary"
+            app:frontImage="@drawable/ic_videocam_white_24px" />
 
 
-    <com.nextcloud.talk.utils.MagicFlipView
-        android:id="@+id/callControlHangupView"
-        android:layout_width="60dp"
-        android:layout_height="60dp"
-        android:layout_marginBottom="48dp"
-        app:checked="false"
-        app:enableInitialAnimation="false"
-        app:frontBackgroundColor="@color/nc_darkRed"
-        app:frontImage="@drawable/ic_call_end_white_24px"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.87"
-        app:layout_constraintStart_toStartOf="parent" />
+        <com.nextcloud.talk.utils.MagicFlipView
+            android:id="@+id/callControlHangupView"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:layout_margin="24dp"
+            app:checked="false"
+            app:enableInitialAnimation="false"
+            app:frontBackgroundColor="@color/nc_darkRed"
+            app:frontImage="@drawable/ic_call_end_white_24px" />
+    </LinearLayout>
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values-land/dimens.xml
+++ b/app/src/main/res/values-land/dimens.xml
@@ -5,4 +5,6 @@
 
     <dimen name="display_target_image_size">120dp</dimen>
     <dimen name="display_target_image_margin">16dp</dimen>
+
+    <dimen name="avatar_size_very_big">120dp</dimen>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -16,7 +16,8 @@
     <dimen name="margin_between_elements">8dp</dimen>
     <dimen name="avatar_size">40dp</dimen>
     <dimen name="avatar_size_big">80dp</dimen>
-    <dimen name="avatar_size_very_big">120dp</dimen>
+    <dimen name="avatar_size_very_big">@dimen/avatar_fetching_size_very_big</dimen>
+    <dimen name="avatar_fetching_size_very_big">140dp</dimen>
     <dimen name="avatar_corner_radius">20dp</dimen>
 
     <dimen name="chat_text_size">14sp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -16,7 +16,7 @@
     <dimen name="margin_between_elements">8dp</dimen>
     <dimen name="avatar_size">40dp</dimen>
     <dimen name="avatar_size_big">80dp</dimen>
-    <dimen name="avatar_size_very_big">180dp</dimen>
+    <dimen name="avatar_size_very_big">120dp</dimen>
     <dimen name="avatar_corner_radius">20dp</dimen>
 
     <dimen name="chat_text_size">14sp</dimen>


### PR DESCRIPTION
* slightly lower the call notification avatar size, 
* optimize for layout to work for portrait and landscape

The avatar is still quite large in landscape, so the `dimens` value could be lowered to `140dp` or `120dp` and should still look okay fort portrait.

![portrait](https://user-images.githubusercontent.com/1315170/41533205-4785ab44-72fa-11e8-97da-d63ea80fb341.png)
![landscape](https://user-images.githubusercontent.com/1315170/41533204-4761d610-72fa-11e8-9265-7f61134c39b0.png)
