### PR TITLE
remove % since this is a special character in Android Strings

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -161,7 +161,7 @@ Nextcloud Talk supports:
 * Mobile apps for Android and iOS
 * Mobile call &amp; chat push notifications
 * Integration in Nextcloud Files and Nextcloud Groupware
-* Fully on-premise, 100% open source
+* Fully on-premise, completely open source
 * End-to-end Encrypted calls
 * Scaling to millions of users
 * SIP gate: dial in by phone


### PR DESCRIPTION
see $subject. I removed the "%" in the store description since lint will throw warnings since it is a special character (lint warnings in the translations)