### PR TITLE
Fix wording details

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,11 +85,11 @@
     <!-- Room menu -->
     <string name="nc_start_conversation">Start a conversation</string>
     <string name="nc_configure_room">Configure conversation</string>
-    <string name="nc_configure_named_room">Configure conversation %1$s</string>
+    <string name="nc_configure_named_room">%1$s</string>
     <string name="nc_leave">Leave conversation</string>
     <string name="nc_rename">Rename conversation</string>
     <string name="nc_set_password">Set a password</string>
-    <string name="nc_change_password">Change a password</string>
+    <string name="nc_change_password">Change password</string>
     <string name="nc_clear_password">Clear password</string>
     <string name="nc_share_link">Share link</string>
     <string name="nc_share_link_via">Share link via</string>


### PR DESCRIPTION
When using the 3-dot-menu for a conversation, it only needs to show the conversation name in the title. "Configure conversation" before that is not necessary.

(Also detail fix »Change a password« → »Change password«)