### PR TITLE
Height of conversations in list should all be the same

### DIFF
--- a/app/src/main/res/layout/rv_item_conversation_with_last_message.xml
+++ b/app/src/main/res/layout/rv_item_conversation_with_last_message.xml
@@ -24,6 +24,7 @@
   -->
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:tools="http://schemas.android.com/tools"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
 
@@ -42,7 +43,8 @@
             <ImageView
                 android:id="@id/dialogAvatar"
                 android:layout_width="@dimen/avatar_size"
-                android:layout_height="@dimen/avatar_size"/>
+                android:layout_height="@dimen/avatar_size"
+                tools:src="@drawable/ic_call_black_24dp"/>
 
             <ImageView
                 android:id="@+id/passwordProtectedRoomImageView"
@@ -71,7 +73,8 @@
             android:includeFontPadding="false"
             android:maxLines="1"
             android:textColor="@color/nc_incoming_text_default"
-            android:textSize="16sp"/>
+            android:textSize="16sp"
+            tools:text="Best conversation"/>
 
         <TextView
             android:id="@id/dialogDate"
@@ -95,8 +98,8 @@
                 android:id="@id/dialogLastMessageUserAvatar"
                 android:layout_width="@dimen/small_item_height"
                 android:layout_height="@dimen/small_item_height"
-                android:layout_centerVertical="true"
-                android:layout_marginEnd="8dp"/>
+                android:layout_marginEnd="8dp"
+                tools:src="@drawable/ic_call_black_24dp"/>
 
             <TextView
                 android:id="@id/dialogLastMessage"
@@ -107,22 +110,23 @@
                 android:layout_toStartOf="@id/dialogUnreadBubble"
                 android:ellipsize="end"
                 android:gravity="top"
-                android:maxLines="2"
+                android:lines="2"
                 android:singleLine="false"
-                android:textColor="@color/warm_grey_four"/>
+                android:textColor="@color/warm_grey_four"
+                tools:text="This is the last message\nof an incredibly long two line  conversation text"/>
 
             <TextView
                 android:id="@id/dialogUnreadBubble"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentEnd="true"
-                android:layout_centerVertical="true"
                 android:layout_marginStart="8dp"
                 android:background="@drawable/bubble_circle_unread"
                 android:gravity="center"
                 android:lines="1"
                 android:textAlignment="center"
-                android:textColor="@color/white"/>
+                android:textColor="@color/white"
+                tools:text="1"/>
 
         </RelativeLayout>
 


### PR DESCRIPTION
Resolves #320 - setting a fixed line number of 2

+ aligning avatar and unread count at the top
+ adding IDE preview rendering infos

Not 100% sure this is what has been described in #320 and if it covers all areas referred to in the issue so please have a look :)

_______

![2018-10-22 12_19_30-talk-conversationheight c__dev_src_android_nextcloud_talk-conversationheight -](https://user-images.githubusercontent.com/1315170/47288083-cd6cdb80-d5f4-11e8-9490-ebb2cdeda105.png)
