### PR TITLE
Dark theme

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,6 +63,14 @@ android {
             disable "ValidController"
             disable "ValidControllerChangeHandler"
         }
+
+        javaCompileOptions {
+            annotationProcessorOptions {
+                arguments = [
+                        parcelerStacktrace: "true"
+                ]
+            }
+        }
     }
 
     dexOptions {
@@ -134,9 +142,9 @@ configurations.all {
 
 dependencies {
     implementation fileTree(include: ['*'], dir: 'libs')
-    implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation 'com.google.android.material:material:1.1.0-alpha07'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta1'
+    implementation 'androidx.appcompat:appcompat:1.1.0-rc01'
+    implementation 'com.google.android.material:material:1.1.0-alpha08'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta2'
     implementation 'com.github.vanniktech:Emoji:0.6.0'
     implementation group: 'androidx.emoji', name: 'emoji-bundled', version: '1.0.0'
     implementation 'org.michaelevans.colorart:library:0.0.3'
@@ -235,12 +243,4 @@ dependencies {
     })
     findbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.9.0'
     findbugsPlugins 'com.mebigfatguy.fb-contrib:fb-contrib:7.4.6'
-}
-
-gradle.projectsEvaluated {
-    tasks.withType(JavaCompile) {
-        options.compilerArgs +=
-                ['-Adagger.floatingBindsMethods=enabled',
-                 '-AparcelerStacktrace',]
-    }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -135,7 +135,7 @@ configurations.all {
 dependencies {
     implementation fileTree(include: ['*'], dir: 'libs')
     implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation 'com.google.android.material:material:1.0.0'
+    implementation 'com.google.android.material:material:1.1.0-alpha07'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta1'
     implementation 'com.github.vanniktech:Emoji:0.6.0'
     implementation group: 'androidx.emoji', name: 'emoji-bundled', version: '1.0.0'

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/MagicIncomingTextMessageViewHolder.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/MagicIncomingTextMessageViewHolder.java
@@ -124,7 +124,7 @@ public class MagicIncomingTextMessageViewHolder
         } else {
             Resources resources = context.getResources();
 
-            int bg_bubble_color = appPreferences.isDarkThemeEnabled() ?
+            int bg_bubble_color = DisplayUtils.isDarkModeActive(context) ?
                                 resources.getColor(R.color.bg_message_list_incoming_bubble_dark2) :
                                 resources.getColor(R.color.bg_message_list_incoming_bubble);
 

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/MagicIncomingTextMessageViewHolder.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/MagicIncomingTextMessageViewHolder.java
@@ -122,19 +122,20 @@ public class MagicIncomingTextMessageViewHolder
                 messageUserAvatarView.getHierarchy().setPlaceholderImage(drawable);
             }
         } else {
-            Resources resources = context.getResources();
-
-            int bg_bubble_color = DisplayUtils.isDarkModeActive(context) ?
-                                resources.getColor(R.color.bg_message_list_incoming_bubble_dark2) :
-                                resources.getColor(R.color.bg_message_list_incoming_bubble);
 
             messageUserAvatarView.setVisibility(View.INVISIBLE);
-            Drawable bubbleDrawable = DisplayUtils.getMessageSelector(bg_bubble_color,
-                    resources.getColor(R.color.transparent),
-                    bg_bubble_color, R.drawable.shape_grouped_incoming_message);
-            ViewCompat.setBackground(bubble, bubbleDrawable);
             messageAuthor.setVisibility(View.GONE);
         }
+
+        Resources resources = context.getResources();
+        int bg_bubble_color = DisplayUtils.isDarkModeActive(context) ?
+                resources.getColor(R.color.bg_message_list_incoming_bubble_dark2) :
+                resources.getColor(R.color.bg_message_list_incoming_bubble);
+
+        Drawable bubbleDrawable = DisplayUtils.getMessageSelector(bg_bubble_color,
+                resources.getColor(R.color.transparent),
+                bg_bubble_color, R.drawable.shape_grouped_incoming_message);
+        ViewCompat.setBackground(bubble, bubbleDrawable);
 
         HashMap<String, HashMap<String, String>> messageParameters = message.getMessageParameters();
 

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/MagicIncomingTextMessageViewHolder.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/MagicIncomingTextMessageViewHolder.java
@@ -45,6 +45,7 @@ import com.nextcloud.talk.models.json.chat.ChatMessage;
 import com.nextcloud.talk.utils.DisplayUtils;
 import com.nextcloud.talk.utils.TextMatchers;
 import com.nextcloud.talk.utils.database.user.UserUtils;
+import com.nextcloud.talk.utils.preferences.AppPreferences;
 import com.stfalcon.chatkit.messages.MessageHolders;
 
 import javax.inject.Inject;
@@ -72,6 +73,9 @@ public class MagicIncomingTextMessageViewHolder
 
     @Inject
     Context context;
+
+    @Inject
+    AppPreferences appPreferences;
 
     private View itemView;
 
@@ -120,10 +124,14 @@ public class MagicIncomingTextMessageViewHolder
         } else {
             Resources resources = context.getResources();
 
+            int bg_bubble_color = appPreferences.isDarkThemeEnabled() ?
+                                resources.getColor(R.color.bg_message_list_incoming_bubble_dark2) :
+                                resources.getColor(R.color.bg_message_list_incoming_bubble);
+
             messageUserAvatarView.setVisibility(View.INVISIBLE);
-            Drawable bubbleDrawable = DisplayUtils.getMessageSelector(resources.getColor(R.color.white_two),
+            Drawable bubbleDrawable = DisplayUtils.getMessageSelector(bg_bubble_color,
                     resources.getColor(R.color.transparent),
-                    resources.getColor(R.color.white_two), R.drawable.shape_grouped_incoming_message);
+                    bg_bubble_color, R.drawable.shape_grouped_incoming_message);
             ViewCompat.setBackground(bubble, bubbleDrawable);
             messageAuthor.setVisibility(View.GONE);
         }

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/MagicPreviewMessageViewHolder.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/MagicPreviewMessageViewHolder.java
@@ -135,7 +135,6 @@ public class MagicPreviewMessageViewHolder extends MessageHolders.IncomingImageM
                 image.setOnClickListener(v -> {
                     Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(message.getImageUrl()));
                     browserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    browserIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT);
                     context.startActivity(browserIntent);
                 });
             } else {

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/MagicSystemMessageViewHolder.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/MagicSystemMessageViewHolder.java
@@ -54,7 +54,10 @@ public class MagicSystemMessageViewHolder extends MessageHolders.IncomingTextMes
         super.onBind(message);
 
         Resources resources = NextcloudTalkApplication.getSharedApplication().getResources();
-        int normalColor, pressedColor, mentionYouColor, mentionOthersColor;
+        int normalColor;
+        int pressedColor;
+        int mentionYouColor;
+        int mentionOthersColor;
 
         if(appPreferences.isDarkThemeEnabled()) {
             normalColor = resources.getColor(R.color.bg_system_bubble_dark);

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/MagicSystemMessageViewHolder.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/MagicSystemMessageViewHolder.java
@@ -54,19 +54,26 @@ public class MagicSystemMessageViewHolder extends MessageHolders.IncomingTextMes
         super.onBind(message);
 
         Resources resources = NextcloudTalkApplication.getSharedApplication().getResources();
+        int normalColor, pressedColor, mentionYouColor, mentionOthersColor;
 
-        int normalColor = appPreferences.isDarkThemeEnabled() ? resources.getColor(R.color.bg_system_bubble_dark) :
-                                                                resources.getColor(R.color.white_two);
-        int pressedColor = normalColor;
+        if(appPreferences.isDarkThemeEnabled()) {
+            normalColor = resources.getColor(R.color.bg_system_bubble_dark);
+            mentionYouColor = resources.getColor(R.color.fg_mention_you_dark);
+            mentionOthersColor = resources.getColor(R.color.fg_mention_others_dark);
+        } else {
+            normalColor = resources.getColor(R.color.white_two);
+            mentionYouColor = resources.getColor(R.color.fg_mention_you);
+            mentionOthersColor = resources.getColor(R.color.fg_mention_others);
+        }
+        pressedColor = normalColor;
 
         Drawable bubbleDrawable = DisplayUtils.getMessageSelector(normalColor,
-                resources.getColor(R.color.transparent), pressedColor,
-                R.drawable.shape_grouped_incoming_message);
+                                resources.getColor(R.color.transparent), pressedColor,
+                                R.drawable.shape_grouped_incoming_message);
         ViewCompat.setBackground(bubble, bubbleDrawable);
 
         Spannable messageString = new SpannableString(message.getText());
 
-        Context context = NextcloudTalkApplication.getSharedApplication().getApplicationContext();
         if (message.getMessageParameters() != null && message.getMessageParameters().size() > 0) {
             for (String key : message.getMessageParameters().keySet()) {
                 Map<String, String> individualHashMap = message.getMessageParameters().get(key);
@@ -74,9 +81,9 @@ public class MagicSystemMessageViewHolder extends MessageHolders.IncomingTextMes
                 if (individualHashMap != null && (individualHashMap.get("type").equals("user") || individualHashMap.get("type").equals("guest") || individualHashMap.get("type").equals("call"))) {
 
                     if (individualHashMap.get("id").equals(message.getActiveUser().getUserId())) {
-                        color = context.getResources().getColor(R.color.nc_incoming_text_mention_you);
+                        color = mentionYouColor;
                     } else {
-                        color = context.getResources().getColor(R.color.nc_incoming_text_mention_others);
+                        color = mentionOthersColor;
                     }
 
                     messageString =

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/MagicSystemMessageViewHolder.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/MagicSystemMessageViewHolder.java
@@ -31,14 +31,22 @@ import com.nextcloud.talk.R;
 import com.nextcloud.talk.application.NextcloudTalkApplication;
 import com.nextcloud.talk.models.json.chat.ChatMessage;
 import com.nextcloud.talk.utils.DisplayUtils;
+import com.nextcloud.talk.utils.preferences.AppPreferences;
 import com.stfalcon.chatkit.messages.MessageHolders;
 
 import java.util.Map;
+import javax.inject.Inject;
+import autodagger.AutoInjector;
 
+@AutoInjector(NextcloudTalkApplication.class)
 public class MagicSystemMessageViewHolder extends MessageHolders.IncomingTextMessageViewHolder<ChatMessage> {
+
+    @Inject
+    AppPreferences appPreferences;
 
     public MagicSystemMessageViewHolder(View itemView) {
         super(itemView);
+        NextcloudTalkApplication.getSharedApplication().getComponentApplication().inject(this);
     }
 
     @Override
@@ -47,9 +55,13 @@ public class MagicSystemMessageViewHolder extends MessageHolders.IncomingTextMes
 
         Resources resources = NextcloudTalkApplication.getSharedApplication().getResources();
 
-        Drawable bubbleDrawable = DisplayUtils.getMessageSelector(resources.getColor(R.color.white_two),
-                resources.getColor(R.color.transparent),
-                resources.getColor(R.color.white_two), R.drawable.shape_grouped_incoming_message);
+        int normalColor = appPreferences.isDarkThemeEnabled() ? resources.getColor(R.color.bg_system_bubble_dark) :
+                                                                resources.getColor(R.color.white_two);
+        int pressedColor = normalColor;
+
+        Drawable bubbleDrawable = DisplayUtils.getMessageSelector(normalColor,
+                resources.getColor(R.color.transparent), pressedColor,
+                R.drawable.shape_grouped_incoming_message);
         ViewCompat.setBackground(bubble, bubbleDrawable);
 
         Spannable messageString = new SpannableString(message.getText());
@@ -73,7 +85,6 @@ public class MagicSystemMessageViewHolder extends MessageHolders.IncomingTextMes
                 }
             }
         }
-
         text.setText(messageString);
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/MagicSystemMessageViewHolder.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/MagicSystemMessageViewHolder.java
@@ -44,6 +44,9 @@ public class MagicSystemMessageViewHolder extends MessageHolders.IncomingTextMes
     @Inject
     AppPreferences appPreferences;
 
+    @Inject
+    Context context;
+
     public MagicSystemMessageViewHolder(View itemView) {
         super(itemView);
         NextcloudTalkApplication.getSharedApplication().getComponentApplication().inject(this);
@@ -59,7 +62,7 @@ public class MagicSystemMessageViewHolder extends MessageHolders.IncomingTextMes
         int mentionYouColor;
         int mentionOthersColor;
 
-        if(appPreferences.isDarkThemeEnabled()) {
+        if(DisplayUtils.isDarkModeActive(context)) {
             normalColor = resources.getColor(R.color.bg_system_bubble_dark);
             mentionYouColor = resources.getColor(R.color.fg_mention_you_dark);
             mentionOthersColor = resources.getColor(R.color.fg_mention_others_dark);

--- a/app/src/main/java/com/nextcloud/talk/application/NextcloudTalkApplication.java
+++ b/app/src/main/java/com/nextcloud/talk/application/NextcloudTalkApplication.java
@@ -145,7 +145,7 @@ public class NextcloudTalkApplication extends MultiDexApplication implements Lif
 
         componentApplication.inject(this);
 
-        setAppTheme(appPreferences.isDarkThemeEnabled());
+        setAppTheme(appPreferences.getTheme());
         super.onCreate();
 
         ImagePipelineConfig imagePipelineConfig = ImagePipelineConfig.newBuilder(this)
@@ -200,11 +200,21 @@ public class NextcloudTalkApplication extends MultiDexApplication implements Lif
     //endregion
 
     //region Setters
-    public static void setAppTheme(Boolean darkTheme) {
-        if (darkTheme) {
-            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
-        } else {
-            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
+    public static void setAppTheme(String theme) {
+        switch (theme) {
+            case "night_no":
+                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
+                break;
+            case "night_yes":
+                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
+                break;
+            case "battery_saver":
+                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY);
+                break;
+            default:
+                // will be "follow_system" only for now
+                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM);
+
         }
     }
     //endregion

--- a/app/src/main/java/com/nextcloud/talk/application/NextcloudTalkApplication.java
+++ b/app/src/main/java/com/nextcloud/talk/application/NextcloudTalkApplication.java
@@ -25,6 +25,8 @@ import android.os.Build;
 import android.util.Log;
 import androidx.emoji.bundled.BundledEmojiCompatConfig;
 import androidx.emoji.text.EmojiCompat;
+
+import androidx.appcompat.app.AppCompatDelegate;
 import androidx.lifecycle.LifecycleObserver;
 import androidx.multidex.MultiDex;
 import androidx.multidex.MultiDexApplication;
@@ -54,6 +56,7 @@ import com.nextcloud.talk.utils.OkHttpNetworkFetcherWithCache;
 import com.nextcloud.talk.utils.database.arbitrarystorage.ArbitraryStorageModule;
 import com.nextcloud.talk.utils.database.user.UserModule;
 import com.nextcloud.talk.utils.singletons.MerlinTheWizard;
+import com.nextcloud.talk.utils.preferences.AppPreferences;
 import com.nextcloud.talk.webrtc.MagicWebRTCUtils;
 import com.vanniktech.emoji.EmojiManager;
 import com.vanniktech.emoji.googlecompat.GoogleCompatEmojiProvider;
@@ -90,6 +93,9 @@ public class NextcloudTalkApplication extends MultiDexApplication implements Lif
     protected static NextcloudTalkApplication sharedApplication;
     //region Fields (components)
     protected NextcloudTalkApplicationComponent componentApplication;
+
+    @Inject
+    AppPreferences appPreferences;
     @Inject
     OkHttpClient okHttpClient;
     //endregion
@@ -124,8 +130,6 @@ public class NextcloudTalkApplication extends MultiDexApplication implements Lif
     //region Overridden methods
     @Override
     public void onCreate() {
-        super.onCreate();
-
         sharedApplication = this;
 
         SecurityKeyManager securityKeyManager = SecurityKeyManager.getInstance();
@@ -140,6 +144,9 @@ public class NextcloudTalkApplication extends MultiDexApplication implements Lif
         DavUtils.registerCustomFactories();
 
         componentApplication.inject(this);
+
+        setAppTheme(appPreferences.isDarkThemeEnabled());
+        super.onCreate();
 
         ImagePipelineConfig imagePipelineConfig = ImagePipelineConfig.newBuilder(this)
                 .setNetworkFetcher(new OkHttpNetworkFetcherWithCache(okHttpClient))
@@ -191,6 +198,18 @@ public class NextcloudTalkApplication extends MultiDexApplication implements Lif
         return componentApplication;
     }
     //endregion
+
+    //region Setters
+    public static void setAppTheme(Boolean darkTheme) {
+        if (darkTheme) {
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
+        } else {
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
+        }
+    }
+    //endregion
+
+
 
     //region Protected methods
     protected void buildComponent() {

--- a/app/src/main/java/com/nextcloud/talk/controllers/CallController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/CallController.java
@@ -622,7 +622,7 @@ public class CallController extends BaseController {
                         .headingTvColor(getResources().getColor(R.color.colorPrimary))
                         .headingTvSize(20)
                         .headingTvText(getResources().getString(R.string.nc_push_to_talk))
-                        .subHeadingTvColor(getResources().getColor(R.color.white))
+                        .subHeadingTvColor(getResources().getColor(R.color.bg_default))
                         .subHeadingTvSize(16)
                         .subHeadingTvText(getResources().getString(R.string.nc_push_to_talk_desc))
                         .maskColor(Color.parseColor("#dc000000"))

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.java
@@ -511,7 +511,7 @@ public class ChatController extends BaseController implements MessagesListAdapte
 
     private void setupMentionAutocomplete() {
         float elevation = 6f;
-        Drawable backgroundDrawable = new ColorDrawable(Color.WHITE);
+        Drawable backgroundDrawable = new ColorDrawable(getResources().getColor(R.color.bg_default));
         AutocompletePresenter<Mention> presenter = new MentionAutocompletePresenter(getApplicationContext(), roomToken);
         AutocompleteCallback<Mention> callback = new MentionAutocompleteCallback(getActivity(),
                 conversationUser, messageInput);

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.java
@@ -189,7 +189,7 @@ public class ConversationInfoController extends BaseController {
             new LovelyStandardDialog(getActivity(), LovelyStandardDialog.ButtonLayout.HORIZONTAL)
                     .setTopColorRes(R.color.nc_darkRed)
                     .setIcon(DisplayUtils.getTintedDrawable(context.getResources(),
-                            R.drawable.ic_delete_black_24dp, R.color.white))
+                            R.drawable.ic_delete_black_24dp, R.color.bg_default))
                     .setPositiveButtonColor(context.getResources().getColor(R.color.nc_darkRed))
                     .setTitle(R.string.nc_delete_call)
                     .setMessage(conversation.getDeleteWarningMessage())

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.java
@@ -61,7 +61,7 @@ import com.nextcloud.talk.models.json.rooms.RoomOverall;
 import com.nextcloud.talk.utils.ApiUtils;
 import com.nextcloud.talk.utils.DisplayUtils;
 import com.nextcloud.talk.utils.bundle.BundleKeys;
-import com.nextcloud.talk.utils.preferencestorage.DatabaseStorageModule;
+import com.nextcloud.talk.utils.preferences.preferencestorage.DatabaseStorageModule;
 import com.yarolegovich.lovelydialog.LovelySaveStateHandler;
 import com.yarolegovich.lovelydialog.LovelyStandardDialog;
 import com.yarolegovich.mp.*;

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
@@ -683,7 +683,7 @@ public class ConversationsListController extends BaseController implements Searc
                 new LovelyStandardDialog(getActivity(), LovelyStandardDialog.ButtonLayout.HORIZONTAL)
                         .setTopColorRes(R.color.nc_darkRed)
                         .setIcon(DisplayUtils.getTintedDrawable(context.getResources(),
-                                R.drawable.ic_delete_black_24dp, R.color.white))
+                                R.drawable.ic_delete_black_24dp, R.color.bg_default))
                         .setPositiveButtonColor(context.getResources().getColor(R.color.nc_darkRed))
                         .setTitle(R.string.nc_delete_call)
                         .setMessage(conversation.getDeleteWarningMessage())

--- a/app/src/main/java/com/nextcloud/talk/controllers/SettingsController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/SettingsController.java
@@ -136,9 +136,6 @@ public class SettingsController extends BaseController {
     @BindView(R.id.settings_screen_lock_timeout)
     MaterialChoicePreference screenLockTimeoutChoicePreference;
 
-    @BindView(R.id.settings_theme)
-    MaterialSwitchPreference themeSwitchPreference;
-
     @BindView(R.id.message_text)
     TextView messageText;
     @Inject
@@ -159,7 +156,7 @@ public class SettingsController extends BaseController {
     private OnPreferenceValueChangedListener<Boolean> screenSecurityChangeListener;
     private OnPreferenceValueChangedListener<Boolean> screenLockChangeListener;
     private OnPreferenceValueChangedListener<String> screenLockTimeoutChangeListener;
-    private OnPreferenceValueChangedListener<Boolean> themeChangeListener;
+    private OnPreferenceValueChangedListener<String> themeChangeListener;
 
     private Disposable profileQueryDisposable;
     private Disposable dbQueryDisposable;
@@ -607,7 +604,6 @@ public class SettingsController extends BaseController {
                 messageView.setVisibility(View.GONE);
             }
         }
-        ((Checkable) themeSwitchPreference.findViewById(R.id.mp_checkable)).setChecked(appPreferences.isDarkThemeEnabled());
     }
 
     private void loadAvatarImage() {
@@ -782,11 +778,10 @@ public class SettingsController extends BaseController {
         }
     }
 
-    private class ThemeChangeListener implements OnPreferenceValueChangedListener<Boolean> {
+    private class ThemeChangeListener implements OnPreferenceValueChangedListener<String> {
         @Override
-        public void onChanged(Boolean newValue) {
+        public void onChanged(String newValue) {
             NextcloudTalkApplication.setAppTheme(newValue);
-            getActivity().recreate();
         }
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/controllers/SettingsController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/SettingsController.java
@@ -135,6 +135,10 @@ public class SettingsController extends BaseController {
     MaterialSwitchPreference screenLockSwitchPreference;
     @BindView(R.id.settings_screen_lock_timeout)
     MaterialChoicePreference screenLockTimeoutChoicePreference;
+
+    @BindView(R.id.settings_theme)
+    MaterialSwitchPreference themeSwitchPreference;
+
     @BindView(R.id.message_text)
     TextView messageText;
     @Inject
@@ -155,6 +159,8 @@ public class SettingsController extends BaseController {
     private OnPreferenceValueChangedListener<Boolean> screenSecurityChangeListener;
     private OnPreferenceValueChangedListener<Boolean> screenLockChangeListener;
     private OnPreferenceValueChangedListener<String> screenLockTimeoutChangeListener;
+    private OnPreferenceValueChangedListener<Boolean> themeChangeListener;
+
     private Disposable profileQueryDisposable;
     private Disposable dbQueryDisposable;
 
@@ -187,6 +193,7 @@ public class SettingsController extends BaseController {
         appPreferences.registerScreenSecurityListener(screenSecurityChangeListener = new ScreenSecurityChangeListener());
         appPreferences.registerScreenLockListener(screenLockChangeListener = new ScreenLockListener());
         appPreferences.registerScreenLockTimeoutListener(screenLockTimeoutChangeListener = new ScreenLockTimeoutListener());
+        appPreferences.registerThemeChangeListener(themeChangeListener = new ThemeChangeListener());
 
         List<String> listWithIntFields = new ArrayList<>();
         listWithIntFields.add("proxy_port");
@@ -347,7 +354,7 @@ public class SettingsController extends BaseController {
             new LovelyStandardDialog(getActivity(), LovelyStandardDialog.ButtonLayout.HORIZONTAL)
                     .setTopColorRes(R.color.nc_darkRed)
                     .setIcon(DisplayUtils.getTintedDrawable(getResources(),
-                            R.drawable.ic_delete_black_24dp, R.color.white))
+                            R.drawable.ic_delete_black_24dp, R.color.bg_default))
                     .setPositiveButtonColor(context.getResources().getColor(R.color.nc_darkRed))
                     .setTitle(R.string.nc_settings_remove_account)
                     .setMessage(R.string.nc_settings_remove_confirmation)
@@ -600,6 +607,7 @@ public class SettingsController extends BaseController {
                 messageView.setVisibility(View.GONE);
             }
         }
+        ((Checkable) themeSwitchPreference.findViewById(R.id.mp_checkable)).setChecked(appPreferences.isDarkThemeEnabled());
     }
 
     private void loadAvatarImage() {
@@ -627,6 +635,7 @@ public class SettingsController extends BaseController {
             appPreferences.unregisterScreenSecurityListener(screenSecurityChangeListener);
             appPreferences.unregisterScreenLockListener(screenLockChangeListener);
             appPreferences.unregisterScreenLockTimeoutListener(screenLockTimeoutChangeListener);
+            appPreferences.unregisterThemeChangeListener(themeChangeListener);
         }
         super.onDestroy();
     }
@@ -770,6 +779,14 @@ public class SettingsController extends BaseController {
 
                 showProxySettings();
             }
+        }
+    }
+
+    private class ThemeChangeListener implements OnPreferenceValueChangedListener<Boolean> {
+        @Override
+        public void onChanged(Boolean newValue) {
+            NextcloudTalkApplication.setAppTheme(newValue);
+            getActivity().recreate();
         }
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/utils/DisplayUtils.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/DisplayUtils.java
@@ -28,7 +28,6 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
-import android.graphics.Paint;
 import android.graphics.Typeface;
 import android.graphics.drawable.Animatable;
 import android.graphics.drawable.BitmapDrawable;
@@ -250,7 +249,7 @@ public class DisplayUtils {
 
         if (!isCall) {
             if (chipResource == R.xml.chip_outgoing_others || chipResource == R.xml.chip_accent_background) {
-                drawable = R.drawable.white_circle;
+                drawable = R.drawable.mention_chip;
             } else {
                 drawable = R.drawable.accent_circle;
             }

--- a/app/src/main/java/com/nextcloud/talk/utils/DisplayUtils.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/DisplayUtils.java
@@ -382,4 +382,16 @@ public class DisplayUtils {
         return drawable;
     }
 
+    public static boolean isDarkModeActive(Context context) {
+        int currentNightMode =
+                context.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
+        switch (currentNightMode) {
+            case Configuration.UI_MODE_NIGHT_NO:
+                return false;
+            case Configuration.UI_MODE_NIGHT_YES:
+                return true;
+            default:
+                return false;
+        }
+    }
 }

--- a/app/src/main/java/com/nextcloud/talk/utils/preferences/AppPreferences.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/preferences/AppPreferences.java
@@ -266,16 +266,20 @@ public interface AppPreferences {
     void unregisterScreenLockTimeoutListener(OnPreferenceValueChangedListener<String> listener);
 
     @KeyByResource(R.string.nc_settings_theme_key)
-    @DefaultValue(R.bool.value_false)
-    boolean isDarkThemeEnabled();
+    @DefaultValue(R.string.nc_default_theme)
+    String getTheme();
+
+    @KeyByResource(R.string.nc_settings_theme_key)
+    @RemoveMethod
+    void removeTheme();
 
     @KeyByResource(R.string.nc_settings_theme_key)
     @RegisterChangeListenerMethod
-    void registerThemeChangeListener(OnPreferenceValueChangedListener<Boolean> listener);
+    void registerThemeChangeListener(OnPreferenceValueChangedListener<String> listener);
 
     @KeyByResource(R.string.nc_settings_theme_key)
     @UnregisterChangeListenerMethod
-    void unregisterThemeChangeListener(OnPreferenceValueChangedListener<Boolean> listener);
+    void unregisterThemeChangeListener(OnPreferenceValueChangedListener<String> listener);
 
     @ClearMethod
     void clear();

--- a/app/src/main/java/com/nextcloud/talk/utils/preferences/AppPreferences.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/preferences/AppPreferences.java
@@ -265,6 +265,17 @@ public interface AppPreferences {
     @UnregisterChangeListenerMethod
     void unregisterScreenLockTimeoutListener(OnPreferenceValueChangedListener<String> listener);
 
+    @KeyByResource(R.string.nc_settings_theme_key)
+    @DefaultValue(R.bool.value_false)
+    boolean isDarkThemeEnabled();
+
+    @KeyByResource(R.string.nc_settings_theme_key)
+    @RegisterChangeListenerMethod
+    void registerThemeChangeListener(OnPreferenceValueChangedListener<Boolean> listener);
+
+    @KeyByResource(R.string.nc_settings_theme_key)
+    @UnregisterChangeListenerMethod
+    void unregisterThemeChangeListener(OnPreferenceValueChangedListener<Boolean> listener);
 
     @ClearMethod
     void clear();

--- a/app/src/main/java/com/nextcloud/talk/utils/preferences/preferencestorage/DatabaseStorageFactory.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/preferences/preferencestorage/DatabaseStorageFactory.java
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.nextcloud.talk.utils.preferencestorage;
+package com.nextcloud.talk.utils.preferences.preferencestorage;
 
 import android.content.Context;
 import com.nextcloud.talk.models.database.UserEntity;

--- a/app/src/main/java/com/nextcloud/talk/utils/preferences/preferencestorage/DatabaseStorageModule.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/preferences/preferencestorage/DatabaseStorageModule.java
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.nextcloud.talk.utils.preferencestorage;
+package com.nextcloud.talk.utils.preferences.preferencestorage;
 
 import android.os.Bundle;
 import android.text.TextUtils;

--- a/app/src/main/res/drawable/mention_chip.xml
+++ b/app/src/main/res/drawable/mention_chip.xml
@@ -22,5 +22,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="oval">
     <solid
-        android:color="@color/bg_default"/>
+        android:color="@color/bg_dark_mention_chips"/>
 </shape>

--- a/app/src/main/res/drawable/shape_grouped_incoming_message.xml
+++ b/app/src/main/res/drawable/shape_grouped_incoming_message.xml
@@ -28,6 +28,6 @@
         android:bottomLeftRadius="@dimen/message_bubble_corners_radius"
         android:topRightRadius="@dimen/message_bubble_corners_radius" />
 
-    <solid android:color="@color/white" />
+    <solid android:color="@color/bg_default" />
 
 </shape>

--- a/app/src/main/res/drawable/shape_grouped_outcoming_message.xml
+++ b/app/src/main/res/drawable/shape_grouped_outcoming_message.xml
@@ -28,6 +28,6 @@
         android:topLeftRadius="@dimen/message_bubble_corners_radius"
         android:bottomRightRadius="@dimen/message_bubble_corners_radius" />
 
-    <solid android:color="@color/white" />
+    <solid android:color="@color/bg_default" />
 
 </shape>

--- a/app/src/main/res/drawable/shape_incoming_message.xml
+++ b/app/src/main/res/drawable/shape_incoming_message.xml
@@ -28,6 +28,6 @@
         android:bottomLeftRadius="@dimen/message_bubble_corners_radius"
         android:topRightRadius="@dimen/message_bubble_corners_radius" />
 
-    <solid android:color="@color/white" />
+    <solid android:color="@color/bg_default" />
 
 </shape>

--- a/app/src/main/res/drawable/shape_outcoming_message.xml
+++ b/app/src/main/res/drawable/shape_outcoming_message.xml
@@ -28,6 +28,6 @@
         android:topLeftRadius="@dimen/message_bubble_corners_radius"
         android:bottomRightRadius="@dimen/message_bubble_corners_radius" />
 
-    <solid android:color="@color/white" />
+    <solid android:color="@color/bg_default" />
 
 </shape>

--- a/app/src/main/res/drawable/shape_video_bubble.xml
+++ b/app/src/main/res/drawable/shape_video_bubble.xml
@@ -23,7 +23,7 @@
     <item>
         <shape
             android:shape="oval">
-            <solid android:color="@color/white"/>
+            <solid android:color="@color/bg_default"/>
         </shape>
     </item>
     <item android:drawable="@drawable/ic_videocam_grey_600_24dp"/>

--- a/app/src/main/res/drawable/shape_voice_bubble.xml
+++ b/app/src/main/res/drawable/shape_voice_bubble.xml
@@ -23,7 +23,7 @@
     <item>
         <shape
             android:shape="oval">
-            <solid android:color="@color/white"/>
+            <solid android:color="@color/bg_default"/>
         </shape>
     </item>
     <item android:drawable="@drawable/ic_mic_grey_600_24dp"/>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -36,7 +36,8 @@
             android:theme="@style/ThemeOverlay.MaterialComponents.Dark.ActionBar"
             app:contentInsetStart="24dp"
             app:contentInsetStartWithNavigation="0dp"
-            app:titleMarginStart="0dp" />
+            app:titleMarginStart="0dp"
+            app:popupTheme="@style/appActionBarPopupMenu" />
     </com.google.android.material.appbar.AppBarLayout>
 
     <com.bluelinelabs.conductor.ChangeHandlerFrameLayout

--- a/app/src/main/res/layout/bottom_sheet.xml
+++ b/app/src/main/res/layout/bottom_sheet.xml
@@ -22,7 +22,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@color/white"
+    android:background="@color/bg_bottom_sheet"
     app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
 

--- a/app/src/main/res/layout/controller_browser.xml
+++ b/app/src/main/res/layout/controller_browser.xml
@@ -23,13 +23,14 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/background_color"
+    android:background="@color/bg_default"
     android:orientation="vertical">
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/path_navigation"
         android:layout_width="match_parent"
         android:layout_height="64dp"
+        android:background="@color/bg_default"
         app:menu="@menu/file_browser_path" />
 
     <androidx.recyclerview.widget.RecyclerView
@@ -45,6 +46,7 @@
         android:layout_width="match_parent"
         android:layout_height="64dp"
         android:layout_alignParentBottom="true"
+        android:background="@color/bg_default"
         app:menu="@menu/file_browser_bottom" />
 
     <include

--- a/app/src/main/res/layout/controller_call_notification.xml
+++ b/app/src/main/res/layout/controller_call_notification.xml
@@ -43,7 +43,7 @@
             android:layout_marginTop="16dp"
             android:text="@string/nc_incoming_call"
             android:textAlignment="center"
-            android:textColor="@color/white30"
+            android:textColor="@color/controller_call_incomingCallTextView"
             android:textSize="16sp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/controller_chat.xml
+++ b/app/src/main/res/layout/controller_chat.xml
@@ -48,8 +48,8 @@
         app:incomingBubblePaddingLeft="@dimen/message_bubble_corners_padding"
         app:incomingBubblePaddingRight="@dimen/message_bubble_corners_padding"
         app:incomingBubblePaddingTop="@dimen/message_bubble_corners_padding"
-        app:incomingDefaultBubbleColor="@color/white_two"
-        app:incomingDefaultBubblePressedColor="@color/white_two"
+        app:incomingDefaultBubbleColor="@color/bg_message_list_incoming_bubble"
+        app:incomingDefaultBubblePressedColor="@color/bg_message_list_incoming_bubble"
         app:incomingDefaultBubbleSelectedColor="@color/transparent"
         app:incomingImageTimeTextSize="12sp"
         app:incomingTextColor="@color/nc_incoming_text_default"
@@ -81,7 +81,7 @@
         app:pb_backgroundColor="@color/colorPrimary"
         app:pb_icon="@drawable/ic_baseline_arrow_downward_24px"
         app:pb_text="@string/nc_new_messages"
-        app:pb_textColor="@color/white" />
+        app:pb_textColor="@color/bg_default" />
 
     <View
         android:id="@+id/separator"
@@ -90,7 +90,7 @@
         android:layout_above="@+id/messageInputView"
         android:layout_marginLeft="16dp"
         android:layout_marginRight="16dp"
-        android:background="@color/nc_light_grey" />
+        android:background="@color/controller_chat_separator" />
 
     <com.stfalcon.chatkit.messages.MessageInput
         android:id="@+id/messageInputView"
@@ -108,7 +108,7 @@
         app:inputButtonMargin="8dp"
         app:inputButtonWidth="36dp"
         app:inputHint="@string/nc_hint_enter_a_message"
-        app:inputTextColor="@color/black"
+        app:inputTextColor="@color/fg_default"
         app:inputTextSize="16sp"
         app:showAttachmentButton="true" />
 

--- a/app/src/main/res/layout/controller_chat.xml
+++ b/app/src/main/res/layout/controller_chat.xml
@@ -81,7 +81,7 @@
         app:pb_backgroundColor="@color/colorPrimary"
         app:pb_icon="@drawable/ic_baseline_arrow_downward_24px"
         app:pb_text="@string/nc_new_messages"
-        app:pb_textColor="@color/bg_default" />
+        app:pb_textColor="@color/fg_inverse" />
 
     <View
         android:id="@+id/separator"

--- a/app/src/main/res/layout/controller_conversation_info.xml
+++ b/app/src/main/res/layout/controller_conversation_info.xml
@@ -23,7 +23,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/nc_white_color"
+    android:background="@color/bg_controller_conv_info"
     android:orientation="vertical">
 
     <ProgressBar
@@ -71,7 +71,8 @@
                         android:layout_height="wrap_content"
                         android:layout_below="@id/avatar_image"
                         android:layout_centerHorizontal="true"
-                        android:layout_marginTop="@dimen/margin_between_elements" />
+                        android:layout_marginTop="@dimen/margin_between_elements"
+                        android:textColor="@color/fg_default" />
 
                 </RelativeLayout>
             </com.yarolegovich.mp.MaterialPreferenceCategory>
@@ -116,7 +117,7 @@
                     android:id="@+id/recycler_view"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    tools:listitem="@layout/rv_item_contact"></androidx.recyclerview.widget.RecyclerView>
+                    tools:listitem="@layout/rv_item_contact" />
 
             </com.yarolegovich.mp.MaterialPreferenceCategory>
 

--- a/app/src/main/res/layout/controller_conversations_rv.xml
+++ b/app/src/main/res/layout/controller_conversations_rv.xml
@@ -23,8 +23,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/generic_rv_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/nc_white_color">
+    android:layout_height="match_parent">
 
     <ProgressBar
         android:id="@+id/progressBar"

--- a/app/src/main/res/layout/controller_entry_menu.xml
+++ b/app/src/main/res/layout/controller_entry_menu.xml
@@ -22,7 +22,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@color/nc_white_color">
+    android:background="@color/bg_bottom_sheet">
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/text_input_layout"

--- a/app/src/main/res/layout/controller_generic_rv.xml
+++ b/app/src/main/res/layout/controller_generic_rv.xml
@@ -22,8 +22,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/generic_rv_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/nc_white_color">
+    android:layout_height="match_parent">
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipe_refresh_layout"

--- a/app/src/main/res/layout/controller_server_selection.xml
+++ b/app/src/main/res/layout/controller_server_selection.xml
@@ -35,6 +35,8 @@
         android:scaleType="fitXY"
         app:srcCompat="@drawable/ic_logo" />
 
+    <!-- Server selection window should be ignorant of theme colour
+        thus colors are set statically -->
     <studio.carbonylgroup.textfieldboxes.TextFieldBoxes
         android:id="@+id/text_field_boxes"
         android:layout_width="match_parent"
@@ -46,7 +48,8 @@
         app:helperText=" "
         app:labelText="@string/nc_server_url"
         app:panelBackgroundColor="@color/colorPrimary"
-        app:primaryColor="@android:color/white">
+        app:primaryColor="@android:color/white"
+        app:secondaryColor="@android:color/white">
 
         <studio.carbonylgroup.textfieldboxes.ExtendedEditText
             android:id="@+id/extended_edit_text"
@@ -55,7 +58,7 @@
             android:imeOptions="actionDone"
             android:inputType="textUri"
             android:singleLine="true"
-            android:textColor="@android:color/white" />
+            android:textColor="@color/fg_inverse" />
 
     </studio.carbonylgroup.textfieldboxes.TextFieldBoxes>
 

--- a/app/src/main/res/layout/controller_settings.xml
+++ b/app/src/main/res/layout/controller_settings.xml
@@ -60,7 +60,8 @@
                 android:layout_height="wrap_content"
                 android:layout_below="@id/avatar_image"
                 android:layout_centerHorizontal="true"
-                android:layout_marginTop="@dimen/margin_between_elements" />
+                android:layout_marginTop="@dimen/margin_between_elements"
+                android:textColor="@color/fg_default" />
 
             <TextView
                 android:id="@+id/base_url_text"
@@ -68,7 +69,8 @@
                 android:layout_height="wrap_content"
                 android:layout_below="@id/display_name_text"
                 android:layout_centerHorizontal="true"
-                android:layout_margin="4dp" />
+                android:layout_margin="4dp"
+                android:textColor="@color/fg_default" />
 
 
             <com.yarolegovich.mp.MaterialStandardPreference
@@ -108,6 +110,22 @@
                 apc:mp_title="@string/nc_settings_add_account" />
 
         </RelativeLayout>
+
+    </com.yarolegovich.mp.MaterialPreferenceCategory>
+
+    <com.yarolegovich.mp.MaterialPreferenceCategory
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:animateLayoutChanges="true"
+        apc:mpc_title="@string/nc_settings_appearance"
+        apc:mpc_title_color="@color/colorPrimary">
+
+        <com.yarolegovich.mp.MaterialSwitchPreference
+            android:id="@+id/settings_theme"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            apc:mp_key="@string/nc_settings_theme_key"
+            apc:mp_title="@string/nc_settings_theme_title" />
 
     </com.yarolegovich.mp.MaterialPreferenceCategory>
 

--- a/app/src/main/res/layout/controller_settings.xml
+++ b/app/src/main/res/layout/controller_settings.xml
@@ -120,12 +120,17 @@
         apc:mpc_title="@string/nc_settings_appearance"
         apc:mpc_title_color="@color/colorPrimary">
 
-        <com.yarolegovich.mp.MaterialSwitchPreference
+        <com.yarolegovich.mp.MaterialChoicePreference
             android:id="@+id/settings_theme"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             apc:mp_key="@string/nc_settings_theme_key"
-            apc:mp_title="@string/nc_settings_theme_title" />
+            apc:mp_title="@string/nc_settings_theme_title"
+            apc:mp_default_value="@string/nc_default_theme"
+            apc:mp_entry_values="@array/theme_entry_values"
+            apc:mp_entry_descriptions="@array/theme_descriptions"
+            apc:mp_show_value="onBottom"
+            />
 
     </com.yarolegovich.mp.MaterialPreferenceCategory>
 
@@ -184,7 +189,7 @@
             apc:mp_entry_values="@array/screen_lock_timeout_entry_values"
             apc:mp_entry_descriptions="@array/screen_lock_timeout_descriptions"
             apc:mp_key="@string/nc_settings_screen_lock_timeout_key"
-            apc:mp_show_value="onRight"
+            apc:mp_show_value="onBottom"
             apc:mp_title="@string/nc_settings_screen_lock_timeout_title" />
 
         <com.yarolegovich.mp.MaterialSwitchPreference

--- a/app/src/main/res/layout/rv_item_browser_file.xml
+++ b/app/src/main/res/layout/rv_item_browser_file.xml
@@ -23,7 +23,7 @@
     android:layout_width="match_parent"
     android:layout_height="@dimen/rv_item_view_height"
     android:layout_margin="@dimen/double_margin_between_elements"
-    android:background="@color/background_color">
+    android:background="@color/bg_default">
 
     <com.facebook.drawee.view.SimpleDraweeView
         android:id="@+id/file_icon"

--- a/app/src/main/res/layout/rv_item_conversation_with_last_message.xml
+++ b/app/src/main/res/layout/rv_item_conversation_with_last_message.xml
@@ -75,7 +75,7 @@
             android:ellipsize="end"
             android:includeFontPadding="false"
             android:maxLines="1"
-            android:textColor="@color/nc_incoming_text_default"
+            android:textColor="@color/conversation_item_header"
             android:textSize="16sp"
             tools:text="Best conversation" />
 
@@ -86,7 +86,7 @@
             android:layout_alignParentEnd="true"
             android:ellipsize="end"
             android:maxLines="1"
-            android:textColor="@color/warm_grey_two" />
+            android:textColor="@color/conversation_date" />
 
         <RelativeLayout
             android:layout_width="match_parent"
@@ -115,7 +115,7 @@
                 android:gravity="top"
                 android:lines="1"
                 android:singleLine="true"
-                android:textColor="@color/warm_grey_four"
+                android:textColor="@color/conversation_last_message"
                 tools:text="This is the last message\nof an incredibly long two line  conversation text" />
 
             <TextView
@@ -128,7 +128,7 @@
                 android:gravity="center"
                 android:lines="1"
                 android:textAlignment="center"
-                android:textColor="@color/white"
+                android:textColor="@color/conversation_unread_bubble"
                 tools:text="1" />
 
         </RelativeLayout>

--- a/app/src/main/res/layout/rv_item_menu.xml
+++ b/app/src/main/res/layout/rv_item_menu.xml
@@ -24,7 +24,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@color/white">
+    android:background="@color/bg_default">
 
     <TextView
         android:id="@+id/menu_text"
@@ -34,7 +34,7 @@
         android:focusable="false"
         android:focusableInTouchMode="false"
         android:gravity="center_vertical"
-        android:textColor="@color/black"
+        android:textColor="@color/fg_default"
         android:textSize="16sp"
         tools:drawableLeft="@drawable/ic_add_grey600_24px"
         tools:drawablePadding="16dp"

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -3,7 +3,9 @@
   ~ Nextcloud Talk application
   ~
   ~ @author Mario Danic
-  ~ Copyright (C) 2017-2018 Mario Danic <mario@lovelyhq.com>
+  ~ Copyright (C) 2017-2019 Mario Danic <mario@lovelyhq.com>
+  ~ @author Daniel Bailey
+  ~ Copyright (C) 2019 Daniel Bailey <db@grappleIT.co.uk>
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
@@ -19,8 +21,20 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="oval">
-    <solid
-        android:color="@color/bg_default"/>
-</shape>
+<resources>
+    <color name="conversation_item_header">#6c94a8</color>
+
+    <color name="fg_default">#eeeeee</color>
+
+    <color name="bg_default">#333333</color>
+    <color name="bg_alt">#333333</color>
+
+    <!-- Chat window incoming message text & informational -->
+    <color name="nc_incoming_text_default">#8FADBD</color>
+    <color name="bg_message_list_incoming_bubble">#444444</color>
+    <color name="nc_grey">@android:color/holo_purple</color>
+    <color name="bg_bottom_sheet">#222222</color>
+
+    <color name="emoji_background">#313031</color>
+    <color name="emoji_divider">#15FFFFFF</color>
+</resources>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -31,6 +31,11 @@
 
     <!-- Chat window incoming message text & informational -->
     <color name="nc_incoming_text_default">#8FADBD</color>
+
+    <color name="nc_incoming_text_mention_you">#C98879</color>
+    <!--<color name="nc_incoming_text_mention_others">#3a718f</color>-->
+    <color name="nc_incoming_text_mention_others">@color/nc_darkRed</color>
+
     <color name="bg_message_list_incoming_bubble">#444444</color>
     <color name="nc_grey">@android:color/holo_purple</color>
     <color name="bg_bottom_sheet">#222222</color>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -22,7 +22,8 @@
   -->
 
 <resources>
-    <color name="conversation_item_header">#6c94a8</color>
+    <color name="conversation_item_header">#9FBDCC</color>
+    <!--<color name="conversation_item_header">#CFCFCF</color>-->
 
     <color name="fg_default">#eeeeee</color>
 
@@ -30,15 +31,16 @@
     <color name="bg_alt">#333333</color>
 
     <!-- Chat window incoming message text & informational -->
-    <color name="nc_incoming_text_default">#8FADBD</color>
+    <color name="nc_incoming_text_default">#9FBDCC</color>
+    <!--<color name="nc_incoming_text_default">#CFCFCF</color>-->
 
     <color name="nc_incoming_text_mention_you">#C98879</color>
     <!--<color name="nc_incoming_text_mention_others">#3a718f</color>-->
     <color name="nc_incoming_text_mention_others">@color/nc_darkRed</color>
 
-    <color name="bg_message_list_incoming_bubble">#444444</color>
     <color name="nc_grey">@android:color/holo_purple</color>
     <color name="bg_bottom_sheet">#222222</color>
+    <color name="bg_message_list_incoming_bubble">#444444</color>
 
     <color name="emoji_background">#313031</color>
     <color name="emoji_divider">#15FFFFFF</color>

--- a/app/src/main/res/values-v28/arrays.xml
+++ b/app/src/main/res/values-v28/arrays.xml
@@ -61,13 +61,13 @@
     </array>
 
     <array name="theme_descriptions">
-        <item>@string/nc_settings_theme_battery_saver</item>
+        <item>@string/nc_settings_theme_follow_system</item>
         <item>@string/nc_settings_theme_light</item>
         <item>@string/nc_settings_theme_dark</item>
     </array>
 
     <array name="theme_entry_values">
-        <item>@string/nc_settings_theme_battery_saver_key</item>
+        <item>@string/nc_settings_theme_follow_system_key</item>
         <item>@string/nc_settings_theme_light_key</item>
         <item>night_yes</item>
     </array>

--- a/app/src/main/res/values-v28/defaults.xml
+++ b/app/src/main/res/values-v28/defaults.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Nextcloud Talk application
+  ~
+  ~ @author Mario Danic
+  ~ Copyright (C) 2017-2019 Mario Danic <mario@lovelyhq.com>
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<resources>
+    <string name="nc_default_theme">@string/nc_settings_theme_follow_system_key</string>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -64,6 +64,7 @@
     <color name="bg_default">#FFFFFF</color>
     <color name="bg_alt">@color/white60</color>
     <color name="bg_system_bubble_dark">#444444</color>
+    <color name="bg_dark_mention_chips">#333333</color>
     <color name="bg_message_list_incoming_bubble">#EFEFEF</color>
     <color name="bg_message_list_incoming_bubble_dark2">#444444</color>
     <color name="bg_bottom_sheet">#46ffffff</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -23,27 +23,44 @@
     <color name="colorPrimary">#0082C9</color>
     <color name="colorPrimaryDark">#006AA3</color>
     <color name="colorAccent">#007CC2</color>
-    <color name="nc_outcoming_text_default">@color/white</color>
+
+    <!-- Text color of sent messages -->
+    <color name="nc_outcoming_text_default">#FFFFFF</color>
+    <!-- Text color of received messages -->
     <color name="nc_incoming_text_default">#37505D</color>
+
+    <!-- Name of person or group for the chat conversation -->
+    <color name="conversation_item_header">#37505D</color>
+    <color name="conversation_date">@color/warm_grey_two</color>
+    <color name="conversation_last_message">@color/warm_grey_four</color>
+    <color name="conversation_unread_bubble">#FFFFFF</color>
+
     <color name="nc_incoming_text_mention_you">#C98879</color>
     <color name="nc_incoming_text_mention_others">#37505D</color>
-    <color name="nc_text_color">@color/black</color>
 
     <color name="nc_darkRed">#D32F2F</color>
     <color name="nc_darkGreen">#006400</color>
     <color name="nc_white_color">@color/per70white</color>
     <color name="nc_light_blue_color">#7FC0E3</color>
-    <color name="nc_light_grey">#E8E8E8</color>
+    <color name="controller_chat_separator">#E8E8E8</color>
     <color name="grey_600">#757575</color>
     <color name="nc_grey">#D5D5D5</color>
-    <color name="material_white_smoke">#F5F5F5</color>
-    <color name="white30">#E9FFFFFF</color>
+    <color name="controller_call_incomingCallTextView">#E9FFFFFF</color>
     <color name="grey950">#111111</color>
 
-    <color name="emoji_background">#ECEFF1</color>
+    <!-- Emoji list in chat window -->
+    <color name="emoji_background">#eceff1</color>
     <color name="emoji_icons">#61000000</color>
     <color name="emoji_divider">#15000000</color>
 
-    <color name="background_color">#FAFAFA</color>
-</resources>
+    <color name="fg_default">#000000</color>
+    <color name="fg_inverse">#FFFFFF</color>
+    <color name="bg_default">#FFFFFF</color>
+    <color name="bg_alt">@color/white60</color>
+    <color name="bg_system_bubble_dark">#444444</color>
+    <color name="bg_bottom_sheet">#46ffffff</color>
 
+    <!-- "Conversation Info" window -->
+    <color name="bg_controller_conv_info">@color/bg_default</color>
+    <color name="bg_message_list_incoming_bubble">#979797</color>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -64,9 +64,10 @@
     <color name="bg_default">#FFFFFF</color>
     <color name="bg_alt">@color/white60</color>
     <color name="bg_system_bubble_dark">#444444</color>
+    <color name="bg_message_list_incoming_bubble">#EFEFEF</color>
+    <color name="bg_message_list_incoming_bubble_dark2">#444444</color>
     <color name="bg_bottom_sheet">#46ffffff</color>
 
     <!-- "Conversation Info" window -->
     <color name="bg_controller_conv_info">@color/bg_default</color>
-    <color name="bg_message_list_incoming_bubble">#979797</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -55,6 +55,12 @@
 
     <color name="fg_default">#000000</color>
     <color name="fg_inverse">#FFFFFF</color>
+    <color name="fg_mention_you">#C98879</color>
+    <color name="fg_mention_others">#37505D</color>
+
+    <color name="fg_mention_you_dark">#C98879</color>
+    <color name="fg_mention_others_dark">#4c96bd</color>
+
     <color name="bg_default">#FFFFFF</color>
     <color name="bg_alt">@color/white60</color>
     <color name="bg_system_bubble_dark">#444444</color>

--- a/app/src/main/res/values/defaults.xml
+++ b/app/src/main/res/values/defaults.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Nextcloud Talk application
+  ~
+  ~ @author Mario Danic
+  ~ Copyright (C) 2017-2019 Mario Danic <mario@lovelyhq.com>
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<resources>
+    <string name="nc_default_theme">@string/nc_settings_theme_battery_saver_key</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,6 +88,11 @@
     <string name="nc_settings_vibrate_desc">Phone will vibrate unless it\'s silenced</string>
     <string name="nc_settings_vibrate_key" translatable="false">notifications_vibrate</string>
 
+    <string name="nc_settings_appearance">Appearance</string>
+    <string name="nc_settings_theme_title">Theme</string>
+    <string name="nc_settings_theme_key">theme</string>
+    <string name="nc_settings_theme_light">Light</string>
+    <string name="nc_settings_theme_dark">Dark</string>
     <string name="nc_settings_privacy">Privacy</string>
     <string name="nc_settings_screen_lock_title">Screen lock</string>
     <string name="nc_settings_screen_lock_desc">Lock %1$s with Android screen lock or supported biometric method</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,6 +91,11 @@
     <string name="nc_settings_appearance">Appearance</string>
     <string name="nc_settings_theme_title">Theme</string>
     <string name="nc_settings_theme_key">theme</string>
+    <string name="nc_settings_theme_battery_saver_key" translatable="false">battery_saver</string>
+    <string name="nc_settings_theme_follow_system_key" translatable="false">follow_system</string>
+    <string name="nc_settings_theme_light_key" translatable="false">night_no</string>
+    <string name="nc_settings_theme_follow_system">Use system default</string>
+    <string name="nc_settings_theme_battery_saver">Set by Battery Saver</string>
     <string name="nc_settings_theme_light">Light</string>
     <string name="nc_settings_theme_dark">Dark</string>
     <string name="nc_settings_privacy">Privacy</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -44,7 +44,7 @@
     </style>
 
     <style name="ChipOutgoingTextAppearance" parent="TextAppearance.MaterialComponents.Chip">
-        <item name="android:textColor">@color/nc_outcoming_text_default</item>
+        <item name="android:textColor">@color/nc_incoming_text_default</item>
     </style>
 
     <style name="ChipMentionTextAppearance" parent="TextAppearance.MaterialComponents.Chip">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -21,14 +21,17 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.MaterialComponents.Light.NoActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar.Bridge">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorPrimary</item>
         <item name="android:panelFullBackground">@color/colorPrimary</item>
         <item name="android:itemBackground">@color/nc_outcoming_text_default</item>
-        <item name="android:textColor">@color/nc_text_color</item>
+        <item name="android:textColor">@color/fg_default</item>
+        <item name="android:popupMenuStyle">@style/appActionBarPopupMenu</item>
+        <item name="actionOverflowMenuStyle">@style/appActionBarPopupMenu</item>
+        <item name="actionBarStyle">@style/appActionBarStyle</item>
     </style>
 
     <style name="ErrorAppearance" parent="@android:style/TextAppearance">
@@ -46,6 +49,22 @@
 
     <style name="ChipMentionTextAppearance" parent="TextAppearance.MaterialComponents.Chip">
         <item name="android:textColor">@color/colorAccent</item>
+    </style>
+
+    <style name="appActionBarStyle" parent="@style/Widget.MaterialComponents.ActionBar.Solid">
+        <item name="android:colorPrimary">@color/fg_inverse</item>
+        <item name="android:textColor">@color/fg_inverse</item>
+    </style>
+
+    <style name="Toolbar_TextAppearance" parent="TextAppearance.AppCompat.Widget.ActionBar.Title">
+        <item name="android:colorPrimary">@color/fg_inverse</item>
+        <item name="android:textColor">@color/fg_inverse</item>
+    </style>
+
+    <style name="appActionBarPopupMenu" parent="@style/Widget.AppCompat.PopupMenu.Overflow">
+        <item name="android:colorPrimary">@color/fg_inverse</item>
+        <item name="android:background">@color/bg_alt</item>
+        <item name="android:textColor">@color/fg_default</item>
     </style>
 
 </resources>

--- a/app/src/main/res/xml/chip_outgoing_others.xml
+++ b/app/src/main/res/xml/chip_outgoing_others.xml
@@ -22,7 +22,7 @@
 <chip xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:textAppearance="@style/ChipOutgoingTextAppearance"
-    app:chipStrokeColor="@color/white"
+    app:chipStrokeColor="@color/bg_default"
     app:chipBackgroundColor="@color/transparent"
     app:chipStrokeWidth="1dp"
     app:closeIconEnabled="false" />

--- a/app/src/main/res/xml/chip_outgoing_own_mention.xml
+++ b/app/src/main/res/xml/chip_outgoing_own_mention.xml
@@ -22,5 +22,5 @@
 <chip xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:textAppearance="@style/ChipMentionTextAppearance"
-    app:chipBackgroundColor="@color/white"
+    app:chipBackgroundColor="@color/bg_default"
     app:closeIconEnabled="false" />


### PR DESCRIPTION
Initial work on a dark theme. There's still quite a bit of styling to do.
Closes #207.

- [x] Conversation & information bubbles in the chat window need to be styled in dark mode.
- [x] Emoji screen background is black, should match the chat window background colour.
- [x] Conversation info screen has a black background when it should be dark grey to match the settings window.
- [x] Long press on a conversation and the dialog at the bottom of the screen is not styled.

A couple of notes:
* The material library version 1.1.0-alpha02 and newer has a name conflict with TextFieldBoxes, see: https://github.com/HITGIF/TextFieldBoxes/issues/97
* Do I need to commit the .idea files? They're in my gitignore.