### PR TITLE
Fixed spelling mistake in German translation

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -197,7 +197,7 @@
     <string name="nc_date_header_today">Heute</string>
     <string name="nc_conversation_menu_voice_call">Sprachanruf</string>
     <string name="nc_conversation_menu_video_call">Videoanruf</string>
-    <string name="nc_conversation_menu_conversation_info">Unterhaltungs-Informartion</string>
+    <string name="nc_conversation_menu_conversation_info">Unterhaltungs-Information</string>
     <string name="nc_new_messages">Neue Nachrichten</string>
     <string name="nc_no_messages_yet">Noch keine Nachrichten</string>
     <string name="nc_sent_a_link" formatted="true">%1$s hat einen Link gesendet.</string>


### PR DESCRIPTION
Hi there,
i found a spelling mistake in the German translation. Here is the fix. 
Thanks for making Nextcloud Talk on Android possible!

Benjamin