### PR TITLE
gradle: replace use of obsolete 'compile' configuration.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -146,7 +146,7 @@ dependencies {
     implementation ('com.gitlab.bitfireAT:dav4jvm:f2078bc846', {
         exclude group: 'org.ogce', module: 'xpp3'	// Android comes with its own XmlPullParser
     })
-    compile 'org.conscrypt:conscrypt-android:2.0.0'
+    implementation 'org.conscrypt:conscrypt-android:2.0.0'
 
 
     implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'


### PR DESCRIPTION
'compile' is obsolete and has been replaced with 'implementation' and 'api'.