### PR TITLE
Use server default value for autocomplete limit

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
@@ -95,10 +95,7 @@ public class ApiUtils {
       @Nullable String searchQuery) {
     RetrofitBucket retrofitBucket = getRetrofitBucketForContactsSearch(baseUrl, searchQuery);
     retrofitBucket.setUrl(baseUrl + ocsApiVersion + "/core/autocomplete/get");
-
     retrofitBucket.getQueryMap().put("itemId", "new");
-    retrofitBucket.getQueryMap().put("limit", "50");
-
     return retrofitBucket;
   }
 


### PR DESCRIPTION
There is no real need to use a custom limit, when the server has a sane default as well as a setting to overwrite this.