### PR TITLE
Handle client certificate alias if currentUser is null (relates to #195)

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/utils/ssl/MagicKeyManager.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/ssl/MagicKeyManager.kt
@@ -44,10 +44,11 @@ class MagicKeyManager(private val keyManager: X509KeyManager, private val usersR
         user?.let {
             it.clientCertificate?.let {
                 alias = it
-            } ?: run {
-                appPreferences.temporaryClientCertAlias?.let {
-                    alias = it
-                }
+            }
+        }
+        if (alias == null) {
+            appPreferences.temporaryClientCertAlias?.let {
+                alias = it
             }
         }
 


### PR DESCRIPTION
Unfortunately I couldn't verify the problem or test the fix on this branch. The login GUI seems to be somewhat broken currently due to refactoring process (no option for client certificates showing).
But looking at the code, the master branch has a similar problem in the logic as v.8.0.x which I addressed in PR #746.

Signed-off-by: Stephan Ritscher <no3pam@gmail.com>