### PR TITLE
Status bar and navigation bar theming

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/components/filebrowser/controllers/BrowserController.kt
+++ b/app/src/main/java/com/nextcloud/talk/components/filebrowser/controllers/BrowserController.kt
@@ -41,7 +41,6 @@ import com.nextcloud.talk.controllers.base.BaseController
 import com.nextcloud.talk.interfaces.SelectionInterface
 import com.nextcloud.talk.jobs.ShareOperationWorker
 import com.nextcloud.talk.newarch.local.models.User
-import com.nextcloud.talk.newarch.local.models.UserNgEntity
 import com.nextcloud.talk.utils.bundle.BundleKeys
 import eu.davidea.fastscroller.FastScroller
 import eu.davidea.flexibleadapter.FlexibleAdapter

--- a/app/src/main/java/com/nextcloud/talk/controllers/base/BaseController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/base/BaseController.kt
@@ -46,9 +46,11 @@ import com.nextcloud.talk.R
 import com.nextcloud.talk.activities.MainActivity
 import com.nextcloud.talk.controllers.base.providers.ActionBarProvider
 import com.nextcloud.talk.newarch.utils.dp
+import com.nextcloud.talk.utils.DisplayUtils
 import com.nextcloud.talk.utils.preferences.AppPreferences
 import com.uber.autodispose.lifecycle.LifecycleScopeProvider
 import kotlinx.android.synthetic.main.activity_main.*
+import kotlinx.android.synthetic.main.activity_main.view.*
 import kotlinx.android.synthetic.main.search_layout.*
 import kotlinx.android.synthetic.main.search_layout.view.*
 import org.greenrobot.eventbus.EventBus
@@ -190,13 +192,14 @@ abstract class BaseController : ButterKnifeController(), ComponentCallbacks {
                 val layoutParams = it.searchCardView?.layoutParams as AppBarLayout.LayoutParams
 
                 if (value) {
-                    it.appBar?.setBackgroundResource(R.color.transparent)
                     layoutParams.scrollFlags = AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL or AppBarLayout.LayoutParams.SCROLL_FLAG_SNAP or AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER_ALWAYS
                 } else {
-                    it.appBar?.setBackgroundResource(R.color.colorPrimary)
+                    it.appBar.setStatusBarForegroundColor(resources!!.getColor(R.color.fg_default))
+                    it.appBar?.toolbar?.setTitleTextColor(resources!!.getColor(R.color.fg_default))
                     layoutParams.scrollFlags = 0
                 }
-
+                DisplayUtils.applyColorToStatusBar(activity!!, resources!!.getColor(R.color.bg_default))
+                DisplayUtils.applyColorToNavgiationBar(activity!!.window, resources!!.getColor(R.color.bg_default))
                 it.searchCardView?.layoutParams = layoutParams
                 it.clearButton?.setOnClickListener {
                     activity?.inputEditText?.text = null

--- a/app/src/main/java/com/nextcloud/talk/newarch/features/account/serverentry/ServerEntryView.kt
+++ b/app/src/main/java/com/nextcloud/talk/newarch/features/account/serverentry/ServerEntryView.kt
@@ -23,10 +23,7 @@
 package com.nextcloud.talk.newarch.features.account.serverentry
 
 import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.MotionEvent
-import android.view.View
-import android.view.ViewGroup
+import android.view.*
 import androidx.core.view.isVisible
 import androidx.core.widget.doOnTextChanged
 import androidx.lifecycle.Observer
@@ -37,6 +34,7 @@ import com.bluelinelabs.conductor.changehandler.HorizontalChangeHandler
 import com.nextcloud.talk.R
 import com.nextcloud.talk.newarch.features.account.loginentry.LoginEntryView
 import com.nextcloud.talk.newarch.mvvm.BaseView
+import com.nextcloud.talk.utils.DisplayUtils
 import com.nextcloud.talk.utils.bundle.BundleKeys
 import com.uber.autodispose.lifecycle.LifecycleScopeProvider
 import kotlinx.android.synthetic.main.server_entry_view.view.*
@@ -128,5 +126,12 @@ class ServerEntryView : BaseView() {
 
     override fun getAppBarLayoutType(): AppBarLayoutType {
         return AppBarLayoutType.EMPTY
+    }
+
+    override fun onAttach(view: View) {
+        super.onAttach(view)
+
+        DisplayUtils.applyColorToStatusBar(activity!!, resources!!.getColor(R.color.colorPrimary))
+        DisplayUtils.applyColorToNavgiationBar(activity!!.window, resources!!.getColor(R.color.colorPrimary))
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/newarch/features/chat/ChatPresenter.kt
+++ b/app/src/main/java/com/nextcloud/talk/newarch/features/chat/ChatPresenter.kt
@@ -120,7 +120,7 @@ open class ChatPresenter<T : Any>(context: Context, private val onElementClickPa
                                         .endConfig()
                                         .buildRect(
                                                 ">_",
-                                                context.resources.getColor(R.color.black)
+                                                context.resources.getColor(R.color.fg_default)
                                         )
                                 holder.itemView.authorAvatar.loadAny(drawable, imageLoader.getImageLoader())
                             } else {

--- a/app/src/main/java/com/nextcloud/talk/newarch/features/chat/ChatView.kt
+++ b/app/src/main/java/com/nextcloud/talk/newarch/features/chat/ChatView.kt
@@ -36,9 +36,11 @@ import android.text.Editable
 import android.text.InputFilter
 import android.text.TextUtils
 import android.text.TextWatcher
+import android.util.Log
 import android.view.*
 import android.widget.ImageView
 import android.widget.PopupMenu
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.view.isVisible
 import androidx.lifecycle.observe
 import androidx.recyclerview.widget.ItemTouchHelper
@@ -496,6 +498,14 @@ class ChatView(private val bundle: Bundle) : BaseView(), ImageLoaderInterface {
             conversationVideoMenuItem?.isVisible = false
         } else {
             conversationVoiceCallMenuItem?.isVisible = true
+
+            if (!DisplayUtils.isDarkThemeEnabled(resources!!)) {
+                conversationVoiceCallMenuItem?.icon = DisplayUtils.getTintedDrawable(resources!!, R.drawable.ic_call_black_24dp, R.color.fg_default)
+                conversationVideoMenuItem?.icon = DisplayUtils.getTintedDrawable(resources!!, R.drawable.ic_videocam_white_24px, R.color.fg_default)
+            } else {
+                conversationVoiceCallMenuItem?.icon = resources!!.getDrawable(R.drawable.ic_call_white_24dp)
+            }
+
             conversationVideoMenuItem?.isVisible = true
         }
     }

--- a/app/src/main/java/com/nextcloud/talk/utils/DisplayUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/DisplayUtils.kt
@@ -21,9 +21,11 @@
 package com.nextcloud.talk.utils
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.res.ColorStateList
+import android.content.res.Configuration
 import android.content.res.Resources
 import android.graphics.Bitmap
 import android.graphics.Canvas
@@ -41,12 +43,15 @@ import android.text.style.StyleSpan
 import android.util.Log
 import android.util.TypedValue
 import android.view.View
+import android.view.Window
+import android.view.WindowManager
 import android.widget.EditText
 import android.widget.TextView
 import androidx.annotation.ColorInt
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.XmlRes
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.AppCompatDrawableManager
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.DrawableCompat
@@ -375,5 +380,54 @@ object DisplayUtils {
                 )
         )
         return drawable
+    }
+
+    fun applyColorToNavgiationBar(window: Window, @ColorInt color: Int) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                var decor = window.decorView
+                if (AppCompatDelegate.getDefaultNightMode() == AppCompatDelegate.MODE_NIGHT_NO) {
+                    var systemUiFlags = View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        systemUiFlags = View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR or View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR or
+                                WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS
+                    }
+                    decor.systemUiVisibility = systemUiFlags
+                } else {
+                    decor.systemUiVisibility = 0
+                }
+                window.navigationBarColor = color
+            }
+        }
+    }
+
+    fun applyColorToStatusBar(activity: Activity, @ColorInt color: Int) {
+        val window = activity.window
+        if (window != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+            window.statusBarColor = color
+        }
+    }
+
+    fun isDarkThemeEnabled(resources: Resources): Boolean {
+        if (AppCompatDelegate.getDefaultNightMode() == AppCompatDelegate.MODE_NIGHT_NO) {
+            return false
+        }
+
+        if (AppCompatDelegate.getDefaultNightMode() == AppCompatDelegate.MODE_NIGHT_YES) {
+            return true
+        }
+
+        val currentNightMode = (resources!!.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK)
+        when (currentNightMode) {
+            Configuration.UI_MODE_NIGHT_YES -> {
+                return true
+            }
+            Configuration.UI_MODE_NIGHT_NO,
+            Configuration.UI_MODE_NIGHT_UNDEFINED -> {
+            }
+        }
+        return false
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -31,7 +31,7 @@
         android:id="@+id/appBar"
         android:layout_width="match_parent"
         android:layout_height="56dp"
-        android:background="@color/transparent"
+        android:background="@color/bg_default"
         android:elevation="0dp"
         android:clipChildren="true"
         android:clipToPadding="false"
@@ -46,8 +46,6 @@
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:background="@color/transparent"
-            android:theme="@style/ThemeOverlay.MaterialComponents.Dark.ActionBar"
             app:contentInsetStartWithNavigation="0dp"
             app:layout_scrollFlags="enterAlwaysCollapsed|noScroll"
             app:popupTheme="@style/appActionBarPopupMenu">

--- a/app/src/main/res/layout/call_item.xml
+++ b/app/src/main/res/layout/call_item.xml
@@ -67,6 +67,6 @@
         android:layout_marginStart="8dp"
         android:layout_marginEnd="8dp"
         android:layout_marginBottom="8dp"
-        android:textColor="@android:color/white" />
+        android:textColor="@color/fg_inverse" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/call_states.xml
+++ b/app/src/main/res/layout/call_states.xml
@@ -56,6 +56,6 @@
         android:gravity="center"
         android:text="@string/nc_connecting_call"
         android:textAlignment="center"
-        android:textColor="@color/white" />
+        android:textColor="@color/fg_inverse" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/contacts_list_view.xml
+++ b/app/src/main/res/layout/contacts_list_view.xml
@@ -3,7 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:animateLayoutChanges="true">
+    android:animateLayoutChanges="true"
+    android:background="@color/bg_default">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/selectedParticipantsRecyclerView"

--- a/app/src/main/res/layout/controller_account_verification.xml
+++ b/app/src/main/res/layout/controller_account_verification.xml
@@ -22,7 +22,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/nc_white_color"
+    android:background="@color/bg_default"
     android:keepScreenOn="true">
 
     <ProgressBar
@@ -53,6 +53,7 @@
         android:layout_marginRight="@dimen/activity_horizontal_margin"
         android:textAlignment="center"
         android:textSize="18sp"
+        android:textColor="@color/fg_default"
         tools:text="Verifying..." />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/controller_browser.xml
+++ b/app/src/main/res/layout/controller_browser.xml
@@ -39,6 +39,8 @@
         android:layout_width="match_parent"
         android:layout_height="64dp"
         android:background="@color/bg_default"
+        app:itemTextColor="@color/fg_default"
+        app:itemIconTint="@color/fg_default"
         app:menu="@menu/file_browser_path" />
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
@@ -47,6 +49,8 @@
         android:layout_height="64dp"
         android:layout_alignParentBottom="true"
         android:background="@color/bg_default"
+        app:itemTextColor="@color/fg_default"
+        app:itemIconTint="@color/fg_default"
         app:menu="@menu/file_browser_bottom" />
 
     <include

--- a/app/src/main/res/layout/controller_call_menu.xml
+++ b/app/src/main/res/layout/controller_call_menu.xml
@@ -22,7 +22,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@color/nc_white_color">
+    android:background="@color/bg_default">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerView"

--- a/app/src/main/res/layout/controller_chat.xml
+++ b/app/src/main/res/layout/controller_chat.xml
@@ -23,7 +23,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:keepScreenOn="true"
-    android:animateLayoutChanges="true">
+    android:animateLayoutChanges="true"
+    android:background="@color/bg_default">
 
     <include layout="@layout/lobby_view"
         android:visibility="gone"/>

--- a/app/src/main/res/layout/controller_entry_menu.xml
+++ b/app/src/main/res/layout/controller_entry_menu.xml
@@ -35,7 +35,7 @@
         android:layout_marginEnd="8dp"
         android:layout_marginBottom="12dp"
         android:alpha="0.7"
-        android:background="#0000"
+        android:background="@color/bg_default"
         android:enabled="false"
         android:text="@string/nc_proceed"
         android:textColor="@color/colorPrimary" />

--- a/app/src/main/res/layout/controller_locked.xml
+++ b/app/src/main/res/layout/controller_locked.xml
@@ -49,5 +49,5 @@
         android:padding="16dp"
         android:text="@string/nc_locked"
         android:textAlignment="center"
-        android:textColor="@color/white" />
+        android:textColor="@color/fg_inverse" />
 </RelativeLayout>

--- a/app/src/main/res/layout/controller_operations_menu.xml
+++ b/app/src/main/res/layout/controller_operations_menu.xml
@@ -21,7 +21,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@color/nc_white_color">
+    android:background="@color/bg_default">
 
     <ImageView
         android:id="@+id/result_image_view"
@@ -70,7 +70,7 @@
         android:layout_alignParentEnd="true"
         android:layout_marginEnd="8dp"
         android:layout_marginBottom="12dp"
-        android:background="#0000"
+        android:background="@color/bg_inverse"
         android:text="@string/nc_ok"
         android:textColor="@color/colorPrimary"
         android:visibility="gone" />
@@ -84,7 +84,7 @@
         android:layout_marginEnd="8dp"
         android:layout_marginBottom="12dp"
         android:layout_toStartOf="@id/ok_button"
-        android:background="#0000"
+        android:background="@color/bg_inverse"
         android:text="@string/nc_join_via_web"
         android:textColor="@color/nc_darkGreen"
         android:visibility="gone" />

--- a/app/src/main/res/layout/conversations_list_view.xml
+++ b/app/src/main/res/layout/conversations_list_view.xml
@@ -25,7 +25,8 @@
     android:id="@+id/generic_rv_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:animateLayoutChanges="true">
+    android:animateLayoutChanges="true"
+    android:background="@color/bg_default">
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipeRefreshLayoutView"

--- a/app/src/main/res/layout/message_state.xml
+++ b/app/src/main/res/layout/message_state.xml
@@ -43,6 +43,7 @@
         android:textAlignment="center"
         android:text="@string/nc_conversations_empty"
         android:textSize="16sp"
+        android:textColor="@color/fg_default"
         />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/new_group_conversation_view.xml
+++ b/app/src/main/res/layout/new_group_conversation_view.xml
@@ -24,7 +24,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:animateLayoutChanges="true">
+    android:animateLayoutChanges="true"
+    android:background="@color/bg_default">
 
     <RelativeLayout
         android:layout_width="match_parent"
@@ -35,7 +36,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:endIconMode="clear_text"
-            android:hint="@string/nc_call_name">
+            android:hint="@string/nc_call_name"
+            android:theme="@style/TextInputLayout">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/conversationNameInputEditText"
@@ -52,7 +54,7 @@
             android:layout_below="@id/conversationNameTextInputLayout"
             android:layout_marginHorizontal="8dp"
             android:layout_marginBottom="8dp"
-            android:text="@string/nc_allow_guests"></com.google.android.material.switchmaterial.SwitchMaterial>
+            android:text="@string/nc_allow_guests" />
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/passwordTextInputLayout"
@@ -61,7 +63,8 @@
             android:layout_below="@id/allowGuestsSwitchMaterial"
             android:visibility="gone"
             app:endIconMode="password_toggle"
-            android:hint="@string/nc_password_optional">
+            android:hint="@string/nc_password_optional"
+            android:theme="@style/TextInputLayout">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/passwordInputEditText"

--- a/app/src/main/res/layout/rv_item_app.xml
+++ b/app/src/main/res/layout/rv_item_app.xml
@@ -22,7 +22,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@color/white"
+    android:background="@color/bg_default"
     android:paddingTop="16dp"
     android:paddingBottom="16dp">
 
@@ -46,7 +46,7 @@
         android:layout_toEndOf="@id/icon_image_view"
         android:focusable="false"
         android:focusableInTouchMode="false"
-        android:textColor="@color/black"
+        android:textColor="@color/fg_default"
         android:textSize="16sp"
         tools:text="Start a new conversation" />
 

--- a/app/src/main/res/layout/rv_item_browser_file.xml
+++ b/app/src/main/res/layout/rv_item_browser_file.xml
@@ -21,8 +21,8 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="@dimen/double_margin_between_elements"
-    android:background="@color/bg_default">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_margin="@dimen/double_margin_between_elements">
 
     <CheckBox
         android:id="@+id/selectFileCheckbox"
@@ -42,7 +42,7 @@
         android:layout_below="@id/file_icon"
         android:layout_alignEnd="@id/file_icon"
         android:src="@drawable/ic_star_black_24dp"
-        android:tint="@color/grey_600" />
+        app:tint="@color/grey_600" />
 
     <ImageView
         android:id="@+id/fileEncryptedImageView"

--- a/app/src/main/res/menu/menu_conversation.xml
+++ b/app/src/main/res/menu/menu_conversation.xml
@@ -23,7 +23,7 @@
 
     <item
         android:id="@+id/conversation_voice_call"
-        android:icon="@drawable/ic_call_white_24dp"
+        android:icon="@drawable/ic_call_black_24dp"
         android:orderInCategory="0"
         android:title="@string/nc_conversation_menu_voice_call"
         app:showAsAction="ifRoom" />

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -30,6 +30,10 @@
 
     <color name="bg_default">#222222</color>
     <color name="bg_alt">#222222</color>
+    <color name="bg_inverse">@color/grey950</color>
+
+    <color name="fg_default">#FFFFFF</color>
+    <color name="fg_inverse">#222222</color>
 
     <!-- Chat window incoming message text & informational -->
     <color name="nc_incoming_text_default">#D8D8D8</color>
@@ -41,7 +45,6 @@
     <color name="bg_selected_participant_clear_icon">#EFEFEF</color>
     <color name="bg_message_list_incoming_bubble">#484848</color>
     <color name="bg_message_list_outcoming_bubble">#003F62</color>
-    <color name="fg_inverse">#222222</color>
 
     <color name="emoji_background">#313031</color>
     <color name="emoji_divider">#15FFFFFF</color>

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar.Bridge">
-        <item name="android:windowLightStatusBar">?attr/isLightTheme</item>
-        <item name="textInputStyle">@style/TextInputLayout</item>
+        <item name="android:navigationBarColor">@color/bg_default</item>
     </style>
-
-
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -57,11 +57,12 @@
     <color name="emoji_icons">#61000000</color>
     <color name="emoji_divider">#15000000</color>
 
-    <color name="fg_default">#000000</color>
+    <color name="fg_default">#666666</color>
     <color name="fg_inverse">#FFFFFF</color>
 
     <color name="bg_default">#FFFFFF</color>
     <color name="bg_alt">@color/white60</color>
+    <color name="bg_inverse">@color/grey950</color>
     <color name="nc_chip_mention_you_background">#0083C9</color>
     <color name="nc_chip_mention_others_background">@color/white</color>
     <color name="bg_dark_mention_chips">#333333</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -31,6 +31,7 @@
         <item name="android:textColor">@color/nc_incoming_text_default</item>
         <item name="android:popupMenuStyle">@style/appActionBarPopupMenu</item>
         <item name="actionOverflowMenuStyle">@style/appActionBarPopupMenu</item>
+        <item name="textInputStyle">@style/TextInputLayout</item>
     </style>
 
     <style name="ErrorAppearance" parent="@android:style/TextAppearance">
@@ -56,8 +57,9 @@
     </style>
 
     <style name="Toolbar_TextAppearance" parent="TextAppearance.AppCompat.Widget.ActionBar.Title">
-        <item name="android:colorPrimary">@color/fg_inverse</item>
-        <item name="android:textColor">@color/fg_inverse</item>
+        <item name="android:colorPrimary">@color/fg_default</item>
+        <item name="android:textColor">@color/fg_default</item>
+        <item name="android:textColorPrimary">@color/fg_default</item>
     </style>
 
     <style name="appActionBarPopupMenu" parent="@style/Widget.AppCompat.PopupMenu.Overflow">
@@ -69,5 +71,14 @@
     <style name="circleImageView" parent="">
         <item name="cornerFamily">rounded</item>
         <item name="cornerSize">50%</item>
+    </style>
+
+    <style name="TextInputLayout" parent="Widget.MaterialComponents.TextInputLayout.FilledBox">
+        <item name="colorControlActivated">@color/fg_default</item>
+        <item name="colorControlHighlight">@color/fg_default</item>
+        <item name="boxBackgroundColor">@color/bg_default</item>
+        <item name="hintTextColor">@color/fg_default</item>
+        <item name="helperTextTextColor">@color/fg_default</item>
+        <item name="boxStrokeColor">@color/fg_default</item>
     </style>
 </resources>


### PR DESCRIPTION
Status bar and navigation bar theming

Misc fixes for UI elements to bring them inline with the status bar and
nav bar colours.

Addresses issue #860. 

Ready for review. Screenshots:

![screenshot-2020-09-21_19 02 46 717](https://user-images.githubusercontent.com/1926270/93813097-7d687a80-fc4a-11ea-992a-c730ee3f5826.png)

![screenshot-2020-09-21_19 02 25 678](https://user-images.githubusercontent.com/1926270/93813109-81949800-fc4a-11ea-9eca-7bceccead004.png)

![screenshot-2020-09-08_20 01 29 079](https://user-images.githubusercontent.com/1926270/93813123-86f1e280-fc4a-11ea-97f6-50a7b0b5c4a8.png)


![screenshot-2020-09-08_20 01 46 813](https://user-images.githubusercontent.com/1926270/93813131-8b1e0000-fc4a-11ea-9878-28b24ac98be0.png)

Signed-off-by: Daniel Bailey <daniel.bailey@grappleIT.co.uk>