### PR TITLE
[v8.0.x] Fix some issues related to guest participants

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/CallController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/CallController.java
@@ -2031,16 +2031,11 @@ public class CallController extends BaseController {
         }
     }
 
-    private void gotNick(String sessionOrUserId, String nick, boolean isFromAnEvent, String type) {
-        if (isFromAnEvent && hasExternalSignalingServer) {
-            // get session based on userId
-            sessionOrUserId = webSocketClient.getSessionForUserId(sessionOrUserId);
-        }
-
-        sessionOrUserId += "+" + type;
+    private void gotNick(String sessionId, String nick, boolean isFromAnEvent, String type) {
+        sessionId += "+" + type;
 
         if (relativeLayout != null) {
-            RelativeLayout relativeLayout = remoteRenderersLayout.findViewWithTag(sessionOrUserId);
+            RelativeLayout relativeLayout = remoteRenderersLayout.findViewWithTag(sessionId);
             TextView textView = relativeLayout.findViewById(R.id.peer_nick_text_view);
             if (!textView.getText().equals(nick)) {
                 textView.setText(nick);

--- a/app/src/main/java/com/nextcloud/talk/controllers/CallController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/CallController.java
@@ -1746,7 +1746,7 @@ public class CallController extends BaseController {
             }
         } else if (peerConnectionEvent.getPeerConnectionEventType().equals(PeerConnectionEvent
                 .PeerConnectionEventType.NICK_CHANGE)) {
-            gotNick(peerConnectionEvent.getSessionId(), peerConnectionEvent.getNick(), true, peerConnectionEvent.getVideoStreamType());
+            gotNick(peerConnectionEvent.getSessionId(), peerConnectionEvent.getNick(), peerConnectionEvent.getVideoStreamType());
         } else if (peerConnectionEvent.getPeerConnectionEventType().equals(PeerConnectionEvent
                 .PeerConnectionEventType.VIDEO_CHANGE) && !isVoiceOnlyCall) {
             gotAudioOrVideoChange(true, peerConnectionEvent.getSessionId() + "+" + peerConnectionEvent.getVideoStreamType(),
@@ -2017,9 +2017,9 @@ public class CallController extends BaseController {
                 surfaceViewRenderer.setOnClickListener(videoOnClickListener);
                 remoteRenderersLayout.addView(relativeLayout);
                 if (hasExternalSignalingServer) {
-                    gotNick(session, webSocketClient.getDisplayNameForSession(session), false, type);
+                    gotNick(session, webSocketClient.getDisplayNameForSession(session), type);
                 } else {
-                    gotNick(session, getPeerConnectionWrapperForSessionIdAndType(session, type, false).getNick(), false, type);
+                    gotNick(session, getPeerConnectionWrapperForSessionIdAndType(session, type, false).getNick(), type);
                 }
 
                 if ("video".equals(type)) {
@@ -2031,7 +2031,7 @@ public class CallController extends BaseController {
         }
     }
 
-    private void gotNick(String sessionId, String nick, boolean isFromAnEvent, String type) {
+    private void gotNick(String sessionId, String nick, String type) {
         sessionId += "+" + type;
 
         if (relativeLayout != null) {

--- a/app/src/main/java/com/nextcloud/talk/webrtc/MagicPeerConnectionWrapper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/MagicPeerConnectionWrapper.java
@@ -271,7 +271,7 @@ public class MagicPeerConnectionWrapper {
                     if (dataChannelMessage.getPayload() instanceof String) {
                         internalNick = (String) dataChannelMessage.getPayload();
                         if (!internalNick.equals(nick)) {
-                            setNick(nick);
+                            setNick(internalNick);
                             EventBus.getDefault().post(new PeerConnectionEvent(PeerConnectionEvent.PeerConnectionEventType
                                     .NICK_CHANGE, sessionId, getNick(), null, videoStreamType));
                         }

--- a/app/src/main/java/com/nextcloud/talk/webrtc/MagicPeerConnectionWrapper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/MagicPeerConnectionWrapper.java
@@ -279,7 +279,7 @@ public class MagicPeerConnectionWrapper {
                         if (dataChannelMessage.getPayload() != null) {
                             HashMap<String, String> payloadHashMap = (HashMap<String, String>) dataChannelMessage.getPayload();
                             EventBus.getDefault().post(new PeerConnectionEvent(PeerConnectionEvent.PeerConnectionEventType
-                                    .NICK_CHANGE, payloadHashMap.get("userid"), payloadHashMap.get("name"), null, videoStreamType));
+                                    .NICK_CHANGE, sessionId, payloadHashMap.get("name"), null, videoStreamType));
                         }
                     }
 

--- a/app/src/main/java/com/nextcloud/talk/webrtc/MagicWebSocketInstance.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/MagicWebSocketInstance.java
@@ -247,7 +247,10 @@ public class MagicWebSocketInstance extends WebSocketListener {
                                             HashMap<String, Object> userMap = (HashMap<String, Object>) internalHashMap.get("user");
                                             participant = new Participant();
                                             participant.setUserId((String) internalHashMap.get("userid"));
-                                            participant.setDisplayName((String) userMap.get("displayname"));
+                                            if (userMap != null) {
+                                                // There is no "user" attribute for guest participants.
+                                                participant.setDisplayName((String) userMap.get("displayname"));
+                                            }
                                             usersHashMap.put((String) internalHashMap.get("sessionid"), participant);
                                         }
                                     }

--- a/app/src/main/java/com/nextcloud/talk/webrtc/MagicWebSocketInstance.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/MagicWebSocketInstance.java
@@ -406,16 +406,6 @@ public class MagicWebSocketInstance extends WebSocketListener {
         return NextcloudTalkApplication.Companion.getSharedApplication().getString(R.string.nc_nick_guest);
     }
 
-    public String getSessionForUserId(String userId) {
-        for (String session : usersHashMap.keySet()) {
-            if (userId.equals(usersHashMap.get(session).getUserId())) {
-                return session;
-            }
-        }
-
-        return "";
-    }
-
     public String getUserIdForSession(String session) {
         if (usersHashMap.containsKey(session)) {
             return usersHashMap.get(session).getUserId();


### PR DESCRIPTION
This pull request adds avatars for guests in the call view, as well as fixing other related issues. For details please refer to the individual commit messages :-)

It will probably need to be forwardported, although I have not checked.

Also note that the avatar is currently shown only for guests for which there is a peer connection (as the guest avatar depends on the nick, and the nick for guests when the HPB is used is currently sent through data channels, which require a peer connection). None of the changes from https://github.com/nextcloud/spreed/pull/4182 are applied here.

## How to test (scenario 1)

- Setup the HPB
- Create a public conversation
- With the Android app, join the public conversation
- With a browser, join the public conversation as a guest

### Result with this pull request

Nothing strange happens.

### Result without this pull request

The web socket of the Android app gets reconnected.



## How to test (scenario 2)

- Setup the HPB
- Create a public conversation
- With a browser, join the public conversation as a guest and start a call
- With the Android app, join the public conversation and join the call
- In the browser, change the guest name

### Result with this pull request

The guest name is updated.

### Result without this pull request

The guest name is not updated. Also, checking the errors in Android's logcat it can be seen that NullPointerExceptions are thrown when the guest sends a `nickChanged` event (which happens every second).



## How to test (scenario 3)

- This change applies both when the HPB is used and when it is not used. *Important:* I have tested it only with the HPB; it should work without HPB too, but testing is very much welcome :-)
- Create a public conversation
- With a browser, join the public conversation as a guest and start a call
- With the Android app, join the public conversation and join the call
- In the browser, change the guest name

### Result with this pull request

The guest avatar is initially shown and then updated when the guest name is changed.

### Result without this pull request

The guest avatar is not shown.
