### PR TITLE
[v8.0.x] Fix frozen video when screen is shared

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/webrtc/MagicPeerConnectionWrapper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/MagicPeerConnectionWrapper.java
@@ -109,11 +109,13 @@ public class MagicPeerConnectionWrapper {
                 magicDataChannel.registerObserver(new MagicDataChannelObserver());
                 if (isMCUPublisher) {
                     peerConnection.createOffer(magicSdpObserver, sdpConstraints);
-                } else if (hasMCU) {
+                } else if (hasMCU && this.videoStreamType.equals("video")) {
+                    // If the connection type is "screen" the client sharing the screen will send an
+                    // offer; offers should be requested only for videos.
                     HashMap<String, String> hashMap = new HashMap<>();
                     hashMap.put("sessionId", sessionId);
                     EventBus.getDefault().post(new WebSocketCommunicationEvent("peerReadyForRequestingOffer", hashMap));
-                } else if (hasInitiated) {
+                } else if (!hasMCU && hasInitiated) {
                     peerConnection.createOffer(magicSdpObserver, sdpConstraints);
 
                 }


### PR DESCRIPTION
When another participant shared the screen a new offer was requested. However, the offer was requested for the video instead of for the screen, which caused the HPB to stop the previous video connection and replace it with a new one. As receiving new offers for an existing connection is not properly handled the offer was applied to the existing peer connection, which caused the new offer to be ignored and the old peer connection to be kept (but frozen due to the HPB not sending more data for that connection).

Requesting offers are not needed when the peer connection is a screen, as the HPB will automatically send the offers itself. Therefore, now offers are requested only when the connection is of `video` type.

It will probably need to be forwardported, although I have not checked.

Note that the video was frozen only if the screen is shared once the Android app is already in the call. If the other participant shares the screen and then the Android app joins the call the video will not be frozen (although sometimes only the screen is shown; there is some issue in that case too, but it seems to be a different one).

## How to test

- Setup the HPB
- Create a public conversation
- With a browser, join the public conversation, start a call and enable the camera
- With the Android app, join the public conversation and join the call with video
- In the browser, share the screen

### Result with this pull request

The video is keeps running.

### Result without this pull request

The video is frozen.
