### PR TITLE
[v8.0.x] Fix data channel suport with newer Janus versions

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/webrtc/MagicPeerConnectionWrapper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/MagicPeerConnectionWrapper.java
@@ -406,7 +406,7 @@ public class MagicPeerConnectionWrapper {
 
         @Override
         public void onDataChannel(DataChannel dataChannel) {
-            if (dataChannel.label().equals("status")) {
+            if (dataChannel.label().equals("status") || dataChannel.label().equals("JanusDataChannel")) {
                 magicDataChannel = dataChannel;
                 magicDataChannel.registerObserver(new MagicDataChannelObserver());
             }


### PR DESCRIPTION
See https://github.com/nextcloud/spreed/issues/3937

It will need to be forwardported.

Please note that, although the changes should work as expected, I have **not** tested this pull request. 

The HPB includes a patched Janus version, so it is not possible to test this against our cloud or the Talk testing server. This must be tested against _nextcloud-spreed-signaling_ paired with an upstream Janus package >= 0.7.0 (for example, the default Janus package from Ubuntu Focal (20.04), which is Janus 0.7.3). Unfortunately I can not do that from the machine with the Android development environment.

Also note that [the initial media status is still sent only when the `status` data channel is opened](https://github.com/nextcloud/talk-android/blob/6a5aaac2244aa207aae39a033dba170d257dbb29/app/src/main/java/com/nextcloud/talk/webrtc/MagicPeerConnectionWrapper.java#L246); it is not done when `JanusDataChannel` is opened too. That should work as expected, as Talk is explicitly opening the `status` data channel, but it would be better to verify it nevertheless :-)
