### PR TITLE
Show avatars for incoming pictures in group chats

### DIFF
--- a/app/src/main/res/layout/item_custom_incoming_preview_message.xml
+++ b/app/src/main/res/layout/item_custom_incoming_preview_message.xml
@@ -28,13 +28,21 @@
     android:layout_marginEnd="16dp"
     android:layout_marginBottom="2dp">
 
+    <com.facebook.drawee.view.SimpleDraweeView
+        android:id="@id/messageUserAvatar"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_alignParentTop="true"
+        android:layout_marginEnd="8dp"
+        app:roundAsCircle="true" />
+
     <com.google.android.flexbox.FlexboxLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:layout_marginBottom="8dp"
+        android:layout_toEndOf="@id/messageUserAvatar"
         android:orientation="vertical"
-        android:layout_alignParentStart="true"
         app:alignContent="stretch"
         app:alignItems="stretch"
         app:flexWrap="wrap"


### PR DESCRIPTION
I have noticed that avatars are not displayed when pictures from NC server are posted in a group chat.
<img src="https://user-images.githubusercontent.com/8277636/112377169-b52da900-8ce5-11eb-8771-5bc1d8c2b370.png" width="360">

Proposed change seems to fix this. The avatars are displayed correctly - only in group chats.
<img src="https://user-images.githubusercontent.com/8277636/112377289-d8f0ef00-8ce5-11eb-85df-bb22392906b7.png" width="360">

In one-to-one conversations this additional UI element is hidden by code already present in MagicPreviewMessageViewHolder.onBind method.
<img src="https://user-images.githubusercontent.com/8277636/112377666-574d9100-8ce6-11eb-8301-3d9b33a1aaa7.png" width="360">

It seems that the SimpleDraweeView (messageUserAvatar) has been accidentally deleted in this commit 2613c1f0749df0230d9032b732e19104841b3904
