### PR TITLE
Fix own peer handling when HPB is used

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/CallController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/CallController.java
@@ -1707,7 +1707,7 @@ public class CallController extends BaseController {
         }
 
         for (String sessionId : newSessions) {
-            getPeerConnectionWrapperForSessionIdAndType(sessionId, "video", hasMCU && sessionId.equals(webSocketClient.getSessionId()));
+            getPeerConnectionWrapperForSessionIdAndType(sessionId, "video", false);
         }
 
         if (newSessions.size() > 0 && !currentCallStatus.equals(CallStatus.IN_CONVERSATION)) {

--- a/app/src/main/java/com/nextcloud/talk/controllers/CallController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/CallController.java
@@ -1655,6 +1655,8 @@ public class CallController extends BaseController {
         List<String> newSessions = new ArrayList<>();
         Set<String> oldSesssions = new HashSet<>();
 
+        hasMCU = hasExternalSignalingServer && webSocketClient != null && webSocketClient.hasMCU();
+
         for (HashMap<String, Object> participant : users) {
             if (!participant.get("sessionId").equals(callSession)) {
                 Object inCallObject = participant.get("inCall");
@@ -1692,8 +1694,6 @@ public class CallController extends BaseController {
         if (newSessions.size() > 0 && !hasMCU) {
             getPeersForCall();
         }
-
-        hasMCU = hasExternalSignalingServer && webSocketClient != null && webSocketClient.hasMCU();
 
         for (String sessionId : newSessions) {
             getPeerConnectionWrapperForSessionIdAndType(sessionId, "video", hasMCU && sessionId.equals(webSocketClient.getSessionId()));

--- a/app/src/main/java/com/nextcloud/talk/controllers/CallController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/CallController.java
@@ -1657,8 +1657,14 @@ public class CallController extends BaseController {
 
         hasMCU = hasExternalSignalingServer && webSocketClient != null && webSocketClient.hasMCU();
 
+        // The signaling session is the same as the Nextcloud session only when the MCU is not used.
+        String currentSessiondId = callSession;
+        if (hasMCU) {
+            currentSessiondId = webSocketClient.getSessionId();
+        }
+
         for (HashMap<String, Object> participant : users) {
-            if (!participant.get("sessionId").equals(callSession)) {
+            if (!participant.get("sessionId").equals(currentSessiondId)) {
                 Object inCallObject = participant.get("inCall");
                 boolean isNewSession;
                 if (inCallObject instanceof Boolean) {
@@ -1693,6 +1699,11 @@ public class CallController extends BaseController {
 
         if (newSessions.size() > 0 && !hasMCU) {
             getPeersForCall();
+        }
+
+        if (hasMCU) {
+            // Ensure that own publishing peer is set up.
+            getPeerConnectionWrapperForSessionIdAndType(webSocketClient.getSessionId(), "video", true);
         }
 
         for (String sessionId : newSessions) {


### PR DESCRIPTION
When processing the participants in a room the signaling sessions of the participants were compared against the Nextcloud session of the local participant to find out which were the remote sessions. However, when the HPB is used the signaling session is not the same as the Nextcloud session, so the signaling session of the local participant never matched her Nextcloud session, so it was always seen as a remote participant.

This caused the call state to be changed to `in conversation` (which, for example, stopped the calling sound), when only the local participant was in the call.

## How to test

- Setup the HPB
- Open the Talk Android app from scratch (otherwise currently there could be dangling sessions, something to be fixed later)
- Open a conversation
- Start a call

### Result with this pull request

The calling sound plays.

### Result without this pull request

The calling sound does not play (or plays briefly and then stops).
