### PR TITLE
Accessibility participants list and grey tones

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/items/UserItem.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/UserItem.java
@@ -42,6 +42,8 @@ import java.util.regex.Pattern;
 
 import androidx.annotation.Nullable;
 
+import androidx.core.content.ContextCompat;
+import androidx.core.content.res.ResourcesCompat;
 import androidx.emoji.widget.EmojiTextView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -121,16 +123,18 @@ public class UserItem extends AbstractFlexibleItem<UserItem.UserItemViewHolder> 
         }
 
         if (!isOnline) {
-            if (holder.contactMentionId != null) {
-                holder.contactMentionId.setAlpha(0.38f);
-            }
-            holder.contactDisplayName.setAlpha(0.38f);
+            holder.contactDisplayName.setTextColor(ResourcesCompat.getColor(
+                    holder.contactDisplayName.getContext().getResources(),
+                    R.color.medium_emphasis_text,
+                    null)
+            );
             holder.simpleDraweeView.setAlpha(0.38f);
         } else {
-            if (holder.contactMentionId != null) {
-                holder.contactMentionId.setAlpha(1.0f);
-            }
-            holder.contactDisplayName.setAlpha(1.0f);
+            holder.contactDisplayName.setTextColor(ResourcesCompat.getColor(
+                    holder.contactDisplayName.getContext().getResources(),
+                    R.color.high_emphasis_text,
+                    null)
+            );
             holder.simpleDraweeView.setAlpha(1.0f);
         }
 
@@ -243,7 +247,6 @@ public class UserItem extends AbstractFlexibleItem<UserItem.UserItemViewHolder> 
 
                 if (!holder.contactMentionId.getText().equals(userType)) {
                     holder.contactMentionId.setText(userType);
-                    holder.contactMentionId.setTextColor(NextcloudTalkApplication.Companion.getSharedApplication().getResources().getColor(R.color.textColorMaxContrast));
                 }
             }
         }

--- a/app/src/main/java/com/nextcloud/talk/adapters/items/UserItem.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/UserItem.java
@@ -26,6 +26,10 @@ import android.text.TextUtils;
 import android.view.View;
 import android.widget.ImageView;
 
+import androidx.annotation.Nullable;
+import androidx.core.content.res.ResourcesCompat;
+import androidx.emoji.widget.EmojiTextView;
+
 import com.facebook.drawee.backends.pipeline.Fresco;
 import com.facebook.drawee.interfaces.DraweeController;
 import com.facebook.drawee.view.SimpleDraweeView;
@@ -40,11 +44,6 @@ import com.nextcloud.talk.utils.DisplayUtils;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import androidx.annotation.Nullable;
-
-import androidx.core.content.ContextCompat;
-import androidx.core.content.res.ResourcesCompat;
-import androidx.emoji.widget.EmojiTextView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import eu.davidea.flexibleadapter.FlexibleAdapter;
@@ -269,7 +268,6 @@ public class UserItem extends AbstractFlexibleItem<UserItem.UserItemViewHolder> 
         this.header = header;
     }
 
-
     static class UserItemViewHolder extends FlexibleViewHolder {
 
         @BindView(R.id.name_text)
@@ -297,6 +295,4 @@ public class UserItem extends AbstractFlexibleItem<UserItem.UserItemViewHolder> 
             ButterKnife.bind(this, view);
         }
     }
-
-
 }

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
@@ -78,7 +78,6 @@ import com.yarolegovich.mp.MaterialStandardPreference
 import com.yarolegovich.mp.MaterialSwitchPreference
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.common.SmoothScrollLinearLayoutManager
-import eu.davidea.flexibleadapter.items.AbstractFlexibleItem
 import io.reactivex.Observer
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
@@ -142,8 +141,8 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
     private var databaseStorageModule: DatabaseStorageModule? = null
     private var conversation: Conversation? = null
 
-    private var adapter: FlexibleAdapter<AbstractFlexibleItem<*>>? = null
-    private var recyclerViewItems: MutableList<AbstractFlexibleItem<*>> = ArrayList()
+    private var adapter: FlexibleAdapter<UserItem>? = null
+    private var recyclerViewItems: MutableList<UserItem> = ArrayList()
 
     private var saveStateHandler: LovelySaveStateHandler? = null
 
@@ -376,6 +375,7 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
             }
         }
 
+        Collections.sort(recyclerViewItems, UserItemComparator())
 
         if (ownUserItem != null) {
             recyclerViewItems.add(0, ownUserItem)
@@ -683,5 +683,21 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
     companion object {
 
         private const val ID_DELETE_CONVERSATION_DIALOG = 0
+    }
+
+    class UserItemComparator : Comparator<UserItem> {
+        override fun compare(left: UserItem, right: UserItem): Int {
+            if (left.isOnline && !right.isOnline) {
+                return -1
+            } else if (!left.isOnline && right.isOnline) {
+                return 1
+            }
+            if (Participant.ParticipantType.MODERATOR == left.model.type && Participant.ParticipantType.MODERATOR != right.model.type) {
+                return -1
+            } else if (Participant.ParticipantType.MODERATOR != left.model.type && Participant.ParticipantType.MODERATOR == right.model.type) {
+                return 1
+            }
+            return left.model.displayName.compareTo(right.model.displayName)
+        }
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
@@ -87,6 +87,7 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import java.util.*
 import javax.inject.Inject
+import kotlin.collections.ArrayList
 
 
 @AutoInjector(NextcloudTalkApplication::class)
@@ -695,12 +696,20 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
             } else if (!left.isOnline && right.isOnline) {
                 return 1
             }
-            if (Participant.ParticipantType.MODERATOR == left.model.type && Participant.ParticipantType.MODERATOR != right.model.type) {
+
+            val moderatorTypes = ArrayList<Participant.ParticipantType>()
+            moderatorTypes.add(Participant.ParticipantType.MODERATOR)
+            moderatorTypes.add(Participant.ParticipantType.OWNER)
+
+            if (moderatorTypes.contains(left.model.type) && !moderatorTypes.contains(right.model.type)) {
                 return -1
-            } else if (Participant.ParticipantType.MODERATOR != left.model.type && Participant.ParticipantType.MODERATOR == right.model.type) {
+            } else if (!moderatorTypes.contains(left.model.type) && moderatorTypes.contains(right.model.type)) {
                 return 1
             }
-            return left.model.displayName.compareTo(right.model.displayName)
+
+            return left.model.displayName.toLowerCase(Locale.ROOT).compareTo(
+                    right.model.displayName.toLowerCase(Locale.ROOT)
+            )
         }
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
@@ -685,6 +685,9 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
         private const val ID_DELETE_CONVERSATION_DIALOG = 0
     }
 
+    /**
+     * Comparator for participants, sorts by online-status, moderator-status and display name.
+     */
     class UserItemComparator : Comparator<UserItem> {
         override fun compare(left: UserItem, right: UserItem): Int {
             if (left.isOnline && !right.isOnline) {

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
@@ -700,6 +700,7 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
             val moderatorTypes = ArrayList<Participant.ParticipantType>()
             moderatorTypes.add(Participant.ParticipantType.MODERATOR)
             moderatorTypes.add(Participant.ParticipantType.OWNER)
+            moderatorTypes.add(Participant.ParticipantType.GUEST_MODERATOR)
 
             if (moderatorTypes.contains(left.model.type) && !moderatorTypes.contains(right.model.type)) {
                 return -1

--- a/app/src/main/java/com/nextcloud/talk/controllers/ProfileController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ProfileController.java
@@ -809,7 +809,7 @@ public class ProfileController extends BaseController {
                             this,
                             item.field,
                             holder.getAdapterPosition()).show());
-                    holder.scope.setAlpha(1.0f);
+                    holder.scope.setAlpha(0.87f); // active - high emphasis
                 } else {
                     holder.text.setEnabled(false);
                     holder.text.setFocusableInTouchMode(false);
@@ -817,7 +817,7 @@ public class ProfileController extends BaseController {
                     holder.text.setCursorVisible(false);
                     holder.text.setBackgroundTintList(ColorStateList.valueOf(Color.TRANSPARENT));
                     holder.scope.setOnClickListener(null);
-                    holder.scope.setAlpha(0.4f);
+                    holder.scope.setAlpha(0.6f); // incative - medium emphasis
                 }
             } else {
                 holder.container.setVisibility(View.GONE);

--- a/app/src/main/java/com/nextcloud/talk/controllers/ProfileController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ProfileController.java
@@ -817,7 +817,7 @@ public class ProfileController extends BaseController {
                     holder.text.setCursorVisible(false);
                     holder.text.setBackgroundTintList(ColorStateList.valueOf(Color.TRANSPARENT));
                     holder.scope.setOnClickListener(null);
-                    holder.scope.setAlpha(0.6f); // incative - medium emphasis
+                    holder.scope.setAlpha(0.6f); // inactive - medium emphasis
                 }
             } else {
                 holder.container.setVisibility(View.GONE);

--- a/app/src/main/java/com/nextcloud/talk/models/json/conversations/Conversation.java
+++ b/app/src/main/java/com/nextcloud/talk/models/json/conversations/Conversation.java
@@ -103,6 +103,7 @@ public class Conversation {
 
     public boolean isGuest() {
         return (Participant.ParticipantType.GUEST.equals(participantType) ||
+                Participant.ParticipantType.GUEST_MODERATOR.equals(participantType) ||
                 Participant.ParticipantType.USER_FOLLOWING_LINK.equals(participantType));
     }
 
@@ -116,8 +117,9 @@ public class Conversation {
     }
 
     public boolean isParticipantOwnerOrModerator() {
-        return Participant.ParticipantType.OWNER.equals(participantType)
-                || Participant.ParticipantType.MODERATOR.equals(participantType);
+        return (Participant.ParticipantType.OWNER.equals(participantType) ||
+                Participant.ParticipantType.GUEST_MODERATOR.equals(participantType) ||
+                Participant.ParticipantType.MODERATOR.equals(participantType));
     }
 
     public boolean shouldShowLobby(UserEntity conversationUser) {

--- a/app/src/main/java/com/nextcloud/talk/models/json/converters/EnumParticipantTypeConverter.java
+++ b/app/src/main/java/com/nextcloud/talk/models/json/converters/EnumParticipantTypeConverter.java
@@ -37,10 +37,11 @@ public class EnumParticipantTypeConverter extends IntBasedTypeConverter<Particip
                 return Participant.ParticipantType.GUEST;
             case 5:
                 return Participant.ParticipantType.USER_FOLLOWING_LINK;
+            case 6:
+                return Participant.ParticipantType.GUEST_MODERATOR;
             default:
                 return Participant.ParticipantType.DUMMY;
         }
-
     }
 
     @Override
@@ -58,6 +59,8 @@ public class EnumParticipantTypeConverter extends IntBasedTypeConverter<Particip
                 return 4;
             case USER_FOLLOWING_LINK:
                 return 5;
+            case GUEST_MODERATOR:
+                return 6;
             default:
                 return 0;
         }

--- a/app/src/main/java/com/nextcloud/talk/models/json/participants/Participant.java
+++ b/app/src/main/java/com/nextcloud/talk/models/json/participants/Participant.java
@@ -84,7 +84,8 @@ public class Participant {
         MODERATOR,
         USER,
         GUEST,
-        USER_FOLLOWING_LINK
+        USER_FOLLOWING_LINK,
+        GUEST_MODERATOR
     }
 
     public enum ParticipantFlags {

--- a/app/src/main/res/layout/controller_conversation_info.xml
+++ b/app/src/main/res/layout/controller_conversation_info.xml
@@ -127,7 +127,7 @@
                     android:id="@+id/recycler_view"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    tools:listitem="@layout/rv_item_contact" />
+                    tools:listitem="@layout/rv_item_conversation_info_participant" />
 
             </com.yarolegovich.mp.MaterialPreferenceCategory>
 

--- a/app/src/main/res/layout/controller_profile.xml
+++ b/app/src/main/res/layout/controller_profile.xml
@@ -37,7 +37,8 @@
             android:layout_marginStart="16dp"
             android:layout_marginTop="16dp"
             android:transitionName="userAvatar.transitionTag"
-            app:roundAsCircle="true" />
+            app:roundAsCircle="true"
+            tools:src="@tools:sample/avatars[0]" />
 
         <androidx.emoji.widget.EmojiTextView
             android:id="@+id/userinfo_fullName"
@@ -47,7 +48,6 @@
             android:layout_centerHorizontal="true"
             android:layout_marginTop="@dimen/margin_between_elements"
             android:ellipsize="end"
-            android:textColor="@color/nc_incoming_text_default"
             tools:text="John Doe" />
 
         <TextView
@@ -59,7 +59,6 @@
             android:layout_margin="4dp"
             android:ellipsize="end"
             android:lines="2"
-            android:textColor="@color/nc_incoming_text_default"
             tools:text="john@nextcloud.com" />
 
         <LinearLayout

--- a/app/src/main/res/layout/controller_profile.xml
+++ b/app/src/main/res/layout/controller_profile.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--  Nextcloud Android client application
 
-  Copyright (C) 2017 Andy Scherzinger
+  Copyright (C) 2017-2021 Andy Scherzinger
   Copyright (C) 2017 Nextcloud
 
   This program is free software; you can redistribute it and/or
@@ -59,6 +59,7 @@
             android:layout_margin="4dp"
             android:ellipsize="end"
             android:lines="2"
+            android:textColor="@color/medium_emphasis_text"
             tools:text="john@nextcloud.com" />
 
         <LinearLayout

--- a/app/src/main/res/layout/controller_settings.xml
+++ b/app/src/main/res/layout/controller_settings.xml
@@ -22,6 +22,7 @@
 
 <com.yarolegovich.mp.MaterialPreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:apc="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/settings_screen"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -60,7 +61,7 @@
                 android:layout_below="@id/avatar_image"
                 android:layout_centerHorizontal="true"
                 android:layout_marginTop="@dimen/margin_between_elements"
-                android:textColor="@color/nc_incoming_text_default" />
+                tools:text="Jane Doe" />
 
             <TextView
                 android:id="@+id/base_url_text"
@@ -69,7 +70,7 @@
                 android:layout_below="@id/display_name_text"
                 android:layout_centerHorizontal="true"
                 android:layout_margin="4dp"
-                android:textColor="@color/nc_incoming_text_default" />
+                tools:text="jane@nextcloud.com"/>
 
             <com.facebook.drawee.view.SimpleDraweeView
                 android:id="@+id/avatar_image"
@@ -77,7 +78,8 @@
                 android:layout_height="@dimen/avatar_size_big"
                 android:layout_centerHorizontal="true"
                 android:transitionName="userAvatar.transitionTag"
-                apc:roundAsCircle="true" />
+                apc:roundAsCircle="true"
+                tools:src="@tools:sample/avatars[0]" />
 
 
             <com.yarolegovich.mp.MaterialStandardPreference

--- a/app/src/main/res/layout/controller_settings.xml
+++ b/app/src/main/res/layout/controller_settings.xml
@@ -70,7 +70,8 @@
                 android:layout_below="@id/display_name_text"
                 android:layout_centerHorizontal="true"
                 android:layout_margin="4dp"
-                tools:text="jane@nextcloud.com"/>
+                android:textColor="@color/medium_emphasis_text"
+                tools:text="jane@nextcloud.com" />
 
             <com.facebook.drawee.view.SimpleDraweeView
                 android:id="@+id/avatar_image"

--- a/app/src/main/res/layout/rv_item_conversation_info_participant.xml
+++ b/app/src/main/res/layout/rv_item_conversation_info_participant.xml
@@ -73,7 +73,8 @@
             android:ellipsize="middle"
             android:singleLine="true"
             android:textAppearance="?android:attr/textAppearanceListItem"
-            tools:text="Call item text" />
+            android:textColor="@color/conversation_item_header"
+            tools:text="Jane Doe" />
 
         <androidx.emoji.widget.EmojiTextView
             android:id="@+id/secondary_text"
@@ -81,8 +82,8 @@
             android:layout_height="wrap_content"
             android:ellipsize="middle"
             android:singleLine="true"
-            android:textColor="@color/textColorMaxContrast"
-            tools:text="A week ago" />
+            android:textColor="?android:attr/textColorSecondary"
+            tools:text="Moderator" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/rv_item_conversation_with_last_message.xml
+++ b/app/src/main/res/layout/rv_item_conversation_with_last_message.xml
@@ -92,6 +92,7 @@
                 android:layout_height="18dp"
                 android:layout_alignParentEnd="true"
                 android:layout_marginStart="8dp"
+                android:clickable="false"
                 android:gravity="top"
                 android:lines="1"
                 android:textAppearance="@style/ChipUnreadMessagesTextAppearance"

--- a/app/src/main/res/layout/rv_item_mention.xml
+++ b/app/src/main/res/layout/rv_item_mention.xml
@@ -58,8 +58,7 @@
             android:layout_height="wrap_content"
             android:ellipsize="middle"
             android:singleLine="true"
-            android:textColor="@color/textColorMaxContrast"
-            android:textSize="16sp"
+            android:textAppearance="?android:attr/textAppearanceListItem"
             tools:text="Call item text" />
 
         <androidx.emoji.widget.EmojiTextView
@@ -68,8 +67,7 @@
             android:layout_height="wrap_content"
             android:ellipsize="middle"
             android:singleLine="true"
-            android:textColor="@color/nc_incoming_text_default"
-            android:textSize="12sp"
+            android:textColor="@color/textColorMaxContrast"
             tools:text="A week ago" />
 
     </LinearLayout>

--- a/app/src/main/res/layout/search_layout.xml
+++ b/app/src/main/res/layout/search_layout.xml
@@ -95,6 +95,7 @@
                     android:layout_width="48dp"
                     android:layout_height="48dp"
                     android:layout_gravity="center"
+                    android:contentDescription="@string/nc_settings"
                     android:scaleType="fitCenter"
                     android:transitionName="userAvatar.transitionTag"
                     app:cornerRadius="@dimen/button_corner_radius"

--- a/app/src/main/res/layout/user_info_details_table_item.xml
+++ b/app/src/main/res/layout/user_info_details_table_item.xml
@@ -39,7 +39,7 @@
     <EditText
         android:id="@+id/user_info_edit_text"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="48dp"
         android:layout_marginStart="@dimen/standard_double_margin"
         android:layout_marginEnd="@dimen/standard_margin"
         android:autofillHints="none"
@@ -56,9 +56,10 @@
 
     <ImageView
         android:id="@+id/scope"
-        android:layout_width="@dimen/iconized_single_line_item_icon_size"
-        android:layout_height="@dimen/iconized_single_line_item_icon_size"
-        android:layout_marginEnd="@dimen/standard_margin"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:padding="12dp"
+        android:layout_marginEnd="4dp"
         android:contentDescription="@string/scope_toggle"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/user_info_details_table_item.xml
+++ b/app/src/main/res/layout/user_info_details_table_item.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   Nextcloud Android client application
 
-  Copyright (C) 2018 Andy Scherzinger
+  Copyright (C) 2018-2021 Andy Scherzinger
   Copyright (C) 2018 Nextcloud
 
   This program is free software; you can redistribute it and/or

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -32,7 +32,10 @@
     <color name="appbar">#1E1E1E</color>
     <color name="fontAppbar">#FFFFFF</color>
 
-    <color name="conversation_item_header">#deffffff</color>
+    <!-- general text colors -->
+    <color name="high_emphasis_text">#deffffff</color>
+    <color name="medium_emphasis_text">#99ffffff</color>
+    <color name="low_emphasis_text">#61ffffff</color>
 
     <color name="bg_default">#121212</color>
     <color name="bg_inverse">@color/grey950</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -33,13 +33,18 @@
     <color name="fontAppbar">#666666</color>
     <color name="fontSecondaryAppbar">#A5A5A5</color>
 
+    <!-- general text colors -->
+    <color name="high_emphasis_text">#de000000</color>
+    <color name="medium_emphasis_text">#99000000</color>
+    <color name="low_emphasis_text">#61000000</color>
+
     <!-- Text color of sent messages -->
     <color name="nc_outcoming_text_default">#FFFFFF</color>
     <!-- Text color of received messages -->
     <color name="nc_incoming_text_default">#37505D</color>
 
     <!-- Name of person or group for the chat conversation -->
-    <color name="conversation_item_header">#000000</color>
+    <color name="conversation_item_header">@color/high_emphasis_text</color>
     <color name="conversation_unread_bubble">#DBDBDB</color>
     <color name="conversation_unread_bubble_text">#222222</color>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -37,6 +37,7 @@
         <item name="android:popupMenuStyle">@style/appActionBarPopupMenu</item>
         <item name="actionOverflowMenuStyle">@style/appActionBarPopupMenu</item>
         <item name="actionBarPopupTheme">@style/appActionBarPopupMenu</item>
+        <item name="android:actionMenuTextAppearance">@style/menuTextAppearance</item>
         <item name="searchViewStyle">@style/SearchView</item>
         <item name="android:navigationBarColor">@color/bg_default</item>
     </style>
@@ -70,6 +71,10 @@
         <item name="android:background">@color/appbar</item>
         <item name="android:textColor">@color/high_emphasis_text</item>
         <item name="iconTint">@color/fontAppbar</item>
+    </style>
+
+    <style name="menuTextAppearance" parent="TextAppearance.AppCompat.Widget.ActionBar.Menu">
+        <item name="android:textAllCaps">false</item>
     </style>
 
     <style name="SearchView" parent="Widget.AppCompat.SearchView">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -30,7 +30,7 @@
         <item name="colorAccent">@color/colorAccent</item>
         <item name="android:panelFullBackground">@color/colorPrimary</item>
         <item name="android:itemBackground">@color/nc_outcoming_text_default</item>
-        <item name="android:textColor">@color/nc_incoming_text_default</item>
+        <item name="android:textColor">@color/conversation_item_header</item>
         <item name="android:popupMenuStyle">@style/appActionBarPopupMenu</item>
         <item name="actionOverflowMenuStyle">@style/appActionBarPopupMenu</item>
         <item name="actionBarPopupTheme">@style/appActionBarPopupMenu</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -31,6 +31,9 @@
         <item name="android:panelFullBackground">@color/colorPrimary</item>
         <item name="android:itemBackground">@color/nc_outcoming_text_default</item>
         <item name="android:textColor">@color/conversation_item_header</item>
+        <item name="android:textColorPrimary">@color/high_emphasis_text</item>
+        <item name="android:textColorSecondary">@color/medium_emphasis_text</item>
+        <item name="android:textColorTertiary">@color/low_emphasis_text</item>
         <item name="android:popupMenuStyle">@style/appActionBarPopupMenu</item>
         <item name="actionOverflowMenuStyle">@style/appActionBarPopupMenu</item>
         <item name="actionBarPopupTheme">@style/appActionBarPopupMenu</item>
@@ -44,7 +47,7 @@
     </style>
 
     <style name="ListItem" parent="BottomSheet.ListItem.TextAppearance">
-        <item name="android:textColor">@color/conversation_item_header</item>
+        <item name="android:textColor">@color/high_emphasis_text</item>
         <item name="android:textSize">16sp</item>
     </style>
 
@@ -65,7 +68,7 @@
         <item name="android:colorPrimary">@color/fg_inverse</item>
         <item name="android:textColorSecondary">@color/fontAppbar</item>
         <item name="android:background">@color/appbar</item>
-        <item name="android:textColor">@color/conversation_item_header</item>
+        <item name="android:textColor">@color/high_emphasis_text</item>
         <item name="iconTint">@color/fontAppbar</item>
     </style>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -53,7 +53,7 @@
     </style>
 
     <style name="ChipIncomingTextAppearance" parent="TextAppearance.MaterialComponents.Chip">
-        <item name="android:textColor">@color/nc_incoming_text_default</item>
+        <item name="android:textColor">#de000000</item>
     </style>
 
     <style name="ChipOutgoingTextAppearance" parent="TextAppearance.MaterialComponents.Chip">

--- a/app/src/main/res/xml/chip_others.xml
+++ b/app/src/main/res/xml/chip_others.xml
@@ -22,5 +22,5 @@
 <chip xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:textAppearance="@style/ChipIncomingTextAppearance"
-    app:chipBackgroundColor="@color/white"
+    app:chipBackgroundColor="#deffffff"
     app:closeIconEnabled="false" />


### PR DESCRIPTION
Resolves #1129

Also 
* removes the dark-blue-grey headline color and replaces any occurrences with high-emphasis text color except for the chat bubbles, they have been kept as is for now (might change with a separate PR)
* Sorts the participants list in a hierarchical way: ownership, online, moderator, displayname (like the webUI)
* WCAG optimizations regarding inactive icons, hitbox size of min=48dp
* don't make toolbar menu item text all-caps

|Settings|User profile|
|---|---|
|<img width="540" alt="device-2021-04-14-184344" src="https://user-images.githubusercontent.com/1315170/114748014-bcc6f780-9d51-11eb-9f62-66bb67893d5d.png">|<img width="540" alt="device-2021-04-14-231748" src="https://user-images.githubusercontent.com/1315170/114780435-b186c280-9d77-11eb-8ca3-c8f3037f6d67.png">|

Also resolves #1131
|before|after|after|
|---|---|---|
|![device-2021-04-14-185814](https://user-images.githubusercontent.com/1315170/114749812-9d30ce80-9d53-11eb-938c-d84448fdd2f1.png)|![device-2021-04-14-232544](https://user-images.githubusercontent.com/1315170/114781822-7f766000-9d79-11eb-9ce9-46451e76c840.png)|![device-2021-04-14-232755](https://user-images.githubusercontent.com/1315170/114781834-84d3aa80-9d79-11eb-93f7-a6c8b12cef75.png)|

|before|after|after|
|---|---|---|
|![device-2021-04-14-185856](https://user-images.githubusercontent.com/1315170/114749825-a15cec00-9d53-11eb-9bd3-2b170cf68e8a.png)|![device-2021-04-14-232631](https://user-images.githubusercontent.com/1315170/114781909-9d43c500-9d79-11eb-88c4-099e5abcc383.png)|![device-2021-04-14-232711](https://user-images.githubusercontent.com/1315170/114781928-a2a10f80-9d79-11eb-9982-36388d66bba7.png)|