### PR TITLE
Make sure "unread messages" bubble text is always white 

### DIFF
--- a/app/src/main/res/layout/controller_chat.xml
+++ b/app/src/main/res/layout/controller_chat.xml
@@ -133,6 +133,6 @@
         app:pb_backgroundColor="@color/colorPrimary"
         app:pb_icon="@drawable/ic_baseline_arrow_downward_24px"
         app:pb_text="@string/nc_new_messages"
-        app:pb_textColor="@color/white" />
+        app:pb_textColor="@color/textColorOnPrimaryBackground" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/controller_chat.xml
+++ b/app/src/main/res/layout/controller_chat.xml
@@ -133,6 +133,6 @@
         app:pb_backgroundColor="@color/colorPrimary"
         app:pb_icon="@drawable/ic_baseline_arrow_downward_24px"
         app:pb_text="@string/nc_new_messages"
-        app:pb_textColor="@color/fg_inverse" />
+        app:pb_textColor="@color/white" />
 
 </RelativeLayout>


### PR DESCRIPTION
(also in dark mode)

found by @nickvergessen and fixed via this PR. The unread messages text should always be white-colored no matter the theme

Issue:
![1024-2219](https://user-images.githubusercontent.com/1315170/115625456-61ba7500-a2fc-11eb-92a1-d7290a55ec45.jpg)


Signed-off-by: Andy Scherzinger <info@andy-scherzinger.de>