### PR TITLE
Bump coil to 1.2.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -126,7 +126,7 @@ android {
 }
 
 ext {
-    coilKtVersion = "0.9.1"
+    coilKtVersion = "1.2.0"
     daggerVersion = "2.34.1"
     powermockVersion = "2.0.9"
     workVersion = "2.3.0"
@@ -225,8 +225,8 @@ dependencies {
     implementation 'com.github.mario.fresco:imagepipeline-okhttp3:111'
     implementation  group: 'joda-time', name: 'joda-time', version: '2.10.3'
     implementation "io.coil-kt:coil:${coilKtVersion}"
-    implementation("io.coil-kt:coil-gif:${coilKtVersion}")
-    implementation("io.coil-kt:coil-svg:${coilKtVersion}")
+    implementation "io.coil-kt:coil-gif:${coilKtVersion}"
+    implementation "io.coil-kt:coil-svg:${coilKtVersion}"
     implementation 'com.github.natario1:Autocomplete:v1.1.0'
 
     implementation 'com.github.cotechde.hwsecurity:hwsecurity-fido:2.4.5'

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/MagicIncomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/MagicIncomingTextMessageViewHolder.kt
@@ -38,7 +38,7 @@ import androidx.emoji.widget.EmojiTextView
 import autodagger.AutoInjector
 import butterknife.BindView
 import butterknife.ButterKnife
-import coil.api.load
+import coil.load
 import coil.transform.CircleCropTransformation
 import com.amulyakhare.textdrawable.TextDrawable
 import com.facebook.drawee.view.SimpleDraweeView

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/MagicOutcomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/MagicOutcomingTextMessageViewHolder.kt
@@ -35,7 +35,7 @@ import androidx.emoji.widget.EmojiTextView
 import autodagger.AutoInjector
 import butterknife.BindView
 import butterknife.ButterKnife
-import coil.api.load
+import coil.load
 import coil.transform.CircleCropTransformation
 import com.google.android.flexbox.FlexboxLayout
 import com.nextcloud.talk.R

--- a/app/src/main/java/com/nextcloud/talk/application/NextcloudTalkApplication.kt
+++ b/app/src/main/java/com/nextcloud/talk/application/NextcloudTalkApplication.kt
@@ -110,7 +110,6 @@ class NextcloudTalkApplication : MultiDexApplication(), LifecycleObserver {
         } catch (e: UnsatisfiedLinkError) {
             Log.w(TAG, e)
         }
-
     }
 
     //endregion
@@ -132,7 +131,7 @@ class NextcloudTalkApplication : MultiDexApplication(), LifecycleObserver {
 
         componentApplication.inject(this)
 
-        Coil.setDefaultImageLoader(::buildDefaultImageLoader)
+        Coil.setImageLoader(buildDefaultImageLoader())
         setAppTheme(appPreferences.theme)
         super.onCreate()
 
@@ -196,19 +195,19 @@ class NextcloudTalkApplication : MultiDexApplication(), LifecycleObserver {
     }
 
     private fun buildDefaultImageLoader(): ImageLoader {
-        return ImageLoader(applicationContext) {
-            availableMemoryPercentage(0.5) // Use 50% of the application's available memory.
-            crossfade(true) // Show a short crossfade when loading images from network or disk into an ImageView.
-            componentRegistry {
-                if (SDK_INT >= P) {
-                    add(ImageDecoderDecoder())
-                } else {
-                    add(GifDecoder())
+        return ImageLoader.Builder(applicationContext)
+                .availableMemoryPercentage(0.5) // Use 50% of the application's available memory.
+                .crossfade(true) // Show a short crossfade when loading images from network or disk into an ImageView.
+                .componentRegistry {
+                    if (SDK_INT >= P) {
+                        add(ImageDecoderDecoder(applicationContext))
+                    } else {
+                        add(GifDecoder())
+                    }
+                    add(SvgDecoder(applicationContext))
                 }
-                add(SvgDecoder(applicationContext))
-            }
-            okHttpClient(okHttpClient)
-        }
+                .okHttpClient(okHttpClient)
+                .build()
     }
     companion object {
         private val TAG = NextcloudTalkApplication::class.java.simpleName

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -54,7 +54,7 @@ import androidx.work.WorkManager
 import autodagger.AutoInjector
 import butterknife.BindView
 import butterknife.OnClick
-import coil.api.load
+import coil.load
 import coil.transform.CircleCropTransformation
 import com.bluelinelabs.conductor.RouterTransaction
 import com.bluelinelabs.conductor.changehandler.HorizontalChangeHandler


### PR DESCRIPTION
successor of #1126

* unifies the version code for all coil-libs
* updates code to new coil API

svg/gif loading have been tested via the chat messages where coil is utilized