### PR TITLE
jsr250 lib has moved from annotation to annotation-api

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -188,7 +188,7 @@ dependencies {
     kapt "com.google.dagger:dagger-compiler:$daggerVersion"
     implementation 'com.github.lukaspili.autodagger2:autodagger2:1.1'
     kapt 'com.github.lukaspili.autodagger2:autodagger2-compiler:1.1'
-    compileOnly 'javax.annotation:jsr250-api:1.0'
+    compileOnly 'javax.annotation:javax.annotation-api:1.3.2'
     // Android only
     implementation 'org.greenrobot:eventbus:3.1.1'
     implementation 'io.requery:requery:1.5.1'

--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,8 @@ buildscript {
     repositories {
         google()
         jcenter()
-        maven {
-            url 'https://jitpack.io'
-        }
+        maven { url 'https://jitpack.io' }
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.0'
@@ -50,13 +49,10 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven {
-            url 'https://oss.sonatype.org/content/repositories/snapshots'
-        }
-        maven {
-            url 'https://jitpack.io'
-        }
+        maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+        maven { url 'https://jitpack.io' }
         maven { url 'https://maven.google.com' }
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
* bump to 1.3.2

For (short) info about the move see: https://mvnrepository.com/artifact/javax.annotation/jsr250-api

Signed-off-by: Andy Scherzinger <info@andy-scherzinger.de>