### PR TITLE
v4️⃣ - Add option for APIv4 compatibility

### DIFF
--- a/app/src/gplay/java/com/nextcloud/talk/services/firebase/MagicFirebaseMessagingService.kt
+++ b/app/src/gplay/java/com/nextcloud/talk/services/firebase/MagicFirebaseMessagingService.kt
@@ -305,11 +305,6 @@ class MagicFirebaseMessagingService : FirebaseMessagingService() {
 
         val apiVersion = ApiUtils.getConversationApiVersion(signatureVerification.userEntity, intArrayOf(1))
 
-        if (apiVersion == null) {
-            Log.e(TAG, "No supported API version found")
-            return
-        }
-
         ncApi.getPeersForCall(
             ApiUtils.getCredentials(signatureVerification.userEntity.username, signatureVerification.userEntity.token),
             ApiUtils.getUrlForCall(

--- a/app/src/gplay/java/com/nextcloud/talk/services/firebase/MagicFirebaseMessagingService.kt
+++ b/app/src/gplay/java/com/nextcloud/talk/services/firebase/MagicFirebaseMessagingService.kt
@@ -302,9 +302,18 @@ class MagicFirebaseMessagingService : FirebaseMessagingService() {
         var hasParticipantsInCall = false
         var inCallOnDifferentDevice = false
 
+
+        val apiVersion = ApiUtils.getApiVersion(signatureVerification.userEntity, "conversation", intArrayOf(1))
+
+        if (apiVersion == null) {
+            Log.e(TAG, "No supported API version found")
+            return
+        }
+
         ncApi.getPeersForCall(
             ApiUtils.getCredentials(signatureVerification.userEntity.username, signatureVerification.userEntity.token),
             ApiUtils.getUrlForCall(
+                apiVersion,
                 signatureVerification.userEntity.baseUrl,
                 decryptedPushMessage.id
             )
@@ -346,5 +355,11 @@ class MagicFirebaseMessagingService : FirebaseMessagingService() {
                 override fun onComplete() {
                 }
             })
+    }
+
+    companion object {
+
+        private val TAG = "MagicFirebaseMessagingService"
+        private const val ID_DELETE_CONVERSATION_DIALOG = 0
     }
 }

--- a/app/src/gplay/java/com/nextcloud/talk/services/firebase/MagicFirebaseMessagingService.kt
+++ b/app/src/gplay/java/com/nextcloud/talk/services/firebase/MagicFirebaseMessagingService.kt
@@ -302,7 +302,6 @@ class MagicFirebaseMessagingService : FirebaseMessagingService() {
         var hasParticipantsInCall = false
         var inCallOnDifferentDevice = false
 
-
         val apiVersion = ApiUtils.getConversationApiVersion(signatureVerification.userEntity, intArrayOf(1))
 
         if (apiVersion == null) {

--- a/app/src/gplay/java/com/nextcloud/talk/services/firebase/MagicFirebaseMessagingService.kt
+++ b/app/src/gplay/java/com/nextcloud/talk/services/firebase/MagicFirebaseMessagingService.kt
@@ -292,6 +292,7 @@ class MagicFirebaseMessagingService : FirebaseMessagingService() {
         }
     }
 
+    @SuppressLint("LongLogTag")
     private fun checkIfCallIsActive(
         signatureVerification: SignatureVerification,
         decryptedPushMessage: DecryptedPushMessage

--- a/app/src/gplay/java/com/nextcloud/talk/services/firebase/MagicFirebaseMessagingService.kt
+++ b/app/src/gplay/java/com/nextcloud/talk/services/firebase/MagicFirebaseMessagingService.kt
@@ -303,7 +303,7 @@ class MagicFirebaseMessagingService : FirebaseMessagingService() {
         var inCallOnDifferentDevice = false
 
 
-        val apiVersion = ApiUtils.getApiVersion(signatureVerification.userEntity, "conversation", intArrayOf(1))
+        val apiVersion = ApiUtils.getConversationApiVersion(signatureVerification.userEntity, intArrayOf(1))
 
         if (apiVersion == null) {
             Log.e(TAG, "No supported API version found")

--- a/app/src/gplay/java/com/nextcloud/talk/services/firebase/MagicFirebaseMessagingService.kt
+++ b/app/src/gplay/java/com/nextcloud/talk/services/firebase/MagicFirebaseMessagingService.kt
@@ -292,7 +292,6 @@ class MagicFirebaseMessagingService : FirebaseMessagingService() {
         }
     }
 
-    @SuppressLint("LongLogTag")
     private fun checkIfCallIsActive(
         signatureVerification: SignatureVerification,
         decryptedPushMessage: DecryptedPushMessage
@@ -350,11 +349,5 @@ class MagicFirebaseMessagingService : FirebaseMessagingService() {
                 override fun onComplete() {
                 }
             })
-    }
-
-    companion object {
-
-        private val TAG = "MagicFirebaseMessagingService"
-        private const val ID_DELETE_CONVERSATION_DIALOG = 0
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
@@ -231,12 +231,6 @@ class MainActivity : BaseActivity(), ActionBarProvider {
         val currentUser = userUtils.currentUser ?: return
 
         val apiVersion = ApiUtils.getConversationApiVersion(currentUser, intArrayOf(1))
-
-        if (apiVersion == null) {
-            Log.e(TAG, "No supported API version found")
-            return
-        }
-
         val credentials = ApiUtils.getCredentials(currentUser.username, currentUser.token)
         val retrofitBucket = ApiUtils.getRetrofitBucketForCreateRoom(
             apiVersion, currentUser.baseUrl, roomType,
@@ -257,13 +251,6 @@ class MainActivity : BaseActivity(), ActionBarProvider {
                     bundle.putString(KEY_ROOM_TOKEN, roomOverall.ocs.data.token)
                     bundle.putString(KEY_ROOM_ID, roomOverall.ocs.data.roomId)
                     if (currentUser.hasSpreedFeatureCapability("chat-v2")) {
-                        val apiVersion = ApiUtils.getConversationApiVersion(currentUser, intArrayOf(1))
-
-                        if (apiVersion == null) {
-                            Log.e(TAG, "No supported API version found")
-                            return
-                        }
-
                         ncApi.getRoom(
                             credentials,
                             ApiUtils.getUrlForRoom(

--- a/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
@@ -49,7 +49,6 @@ import com.nextcloud.talk.R
 import com.nextcloud.talk.api.NcApi
 import com.nextcloud.talk.application.NextcloudTalkApplication
 import com.nextcloud.talk.controllers.CallNotificationController
-import com.nextcloud.talk.controllers.ChatController
 import com.nextcloud.talk.controllers.ConversationsListController
 import com.nextcloud.talk.controllers.LockedController
 import com.nextcloud.talk.controllers.ServerSelectionController

--- a/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
@@ -231,7 +231,7 @@ class MainActivity : BaseActivity(), ActionBarProvider {
         val roomType = "1"
         val currentUser = userUtils.currentUser ?: return
 
-        val apiVersion = ApiUtils.getApiVersion(currentUser, "conversation", intArrayOf(1))
+        val apiVersion = ApiUtils.getConversationApiVersion(currentUser, intArrayOf(1))
 
         if (apiVersion == null) {
             Log.e(TAG, "No supported API version found")
@@ -258,7 +258,7 @@ class MainActivity : BaseActivity(), ActionBarProvider {
                     bundle.putString(KEY_ROOM_TOKEN, roomOverall.ocs.data.token)
                     bundle.putString(KEY_ROOM_ID, roomOverall.ocs.data.roomId)
                     if (currentUser.hasSpreedFeatureCapability("chat-v2")) {
-                        val apiVersion = ApiUtils.getApiVersion(currentUser, "conversation", intArrayOf(1))
+                        val apiVersion = ApiUtils.getConversationApiVersion(currentUser, intArrayOf(1))
 
                         if (apiVersion == null) {
                             Log.e(TAG, "No supported API version found")

--- a/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
@@ -28,6 +28,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.provider.ContactsContract
 import android.text.TextUtils
+import android.util.Log
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import autodagger.AutoInjector
@@ -48,6 +49,7 @@ import com.nextcloud.talk.R
 import com.nextcloud.talk.api.NcApi
 import com.nextcloud.talk.application.NextcloudTalkApplication
 import com.nextcloud.talk.controllers.CallNotificationController
+import com.nextcloud.talk.controllers.ChatController
 import com.nextcloud.talk.controllers.ConversationsListController
 import com.nextcloud.talk.controllers.LockedController
 import com.nextcloud.talk.controllers.ServerSelectionController
@@ -249,9 +251,17 @@ class MainActivity : BaseActivity(), ActionBarProvider {
                     bundle.putString(KEY_ROOM_TOKEN, roomOverall.ocs.data.token)
                     bundle.putString(KEY_ROOM_ID, roomOverall.ocs.data.roomId)
                     if (currentUser.hasSpreedFeatureCapability("chat-v2")) {
+                        val apiVersion = ApiUtils.getApiVersion(currentUser, "conversation", intArrayOf(1))
+
+                        if (apiVersion == null) {
+                            Log.e(TAG, "No supported API version found")
+                            return
+                        }
+
                         ncApi.getRoom(
                             credentials,
-                            ApiUtils.getRoom(
+                            ApiUtils.getUrlForRoom(
+                                apiVersion,
                                 currentUser.baseUrl,
                                 roomOverall.ocs.data.token
                             )

--- a/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
@@ -231,9 +231,16 @@ class MainActivity : BaseActivity(), ActionBarProvider {
         val roomType = "1"
         val currentUser = userUtils.currentUser ?: return
 
+        val apiVersion = ApiUtils.getApiVersion(currentUser, "conversation", intArrayOf(1))
+
+        if (apiVersion == null) {
+            Log.e(TAG, "No supported API version found")
+            return
+        }
+
         val credentials = ApiUtils.getCredentials(currentUser.username, currentUser.token)
         val retrofitBucket = ApiUtils.getRetrofitBucketForCreateRoom(
-            currentUser.baseUrl, roomType,
+            apiVersion, currentUser.baseUrl, roomType,
             userId, null
         )
         ncApi.createRoom(

--- a/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
@@ -28,7 +28,6 @@ import android.os.Bundle
 import android.os.Handler
 import android.provider.ContactsContract
 import android.text.TextUtils
-import android.util.Log
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import autodagger.AutoInjector

--- a/app/src/main/java/com/nextcloud/talk/controllers/CallController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/CallController.java
@@ -441,7 +441,14 @@ public class CallController extends BaseController {
     }
 
     private void handleFromNotification() {
-        ncApi.getRooms(credentials, ApiUtils.getUrlForGetRooms(baseUrl))
+        Integer apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation", new int[] {1});
+
+        if (apiVersion == null) {
+            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
+            return;
+        }
+
+        ncApi.getRooms(credentials, ApiUtils.getUrlForRooms(apiVersion, baseUrl))
                 .retry(3)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
@@ -1234,9 +1241,16 @@ public class CallController extends BaseController {
     private void joinRoomAndCall() {
         callSession = ApplicationWideCurrentRoomHolder.getInstance().getSession();
 
+        Integer apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation",
+                                                    new int[] {1});
+        if (apiVersion == null) {
+            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
+            return;
+        }
+
         if (TextUtils.isEmpty(callSession)) {
-            ncApi.joinRoom(credentials, ApiUtils.getUrlForSettingMyselfAsActiveParticipant(baseUrl,
-                                                                                           roomToken), conversationPassword)
+            ncApi.joinRoom(credentials, ApiUtils.getUrlForParticipantsActive(apiVersion, baseUrl, roomToken),
+                           conversationPassword)
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())
                     .retry(3)
@@ -1648,7 +1662,14 @@ public class CallController extends BaseController {
     }
 
     private void leaveRoom(boolean shutDownView) {
-        ncApi.leaveRoom(credentials, ApiUtils.getUrlForSettingMyselfAsActiveParticipant(baseUrl, roomToken))
+        Integer apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation",
+                                                    new int[] {1});
+        if (apiVersion == null) {
+            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
+            return;
+        }
+
+        ncApi.leaveRoom(credentials, ApiUtils.getUrlForParticipantsActive(apiVersion, baseUrl, roomToken))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(new Observer<GenericOverall>() {

--- a/app/src/main/java/com/nextcloud/talk/controllers/CallController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/CallController.java
@@ -441,7 +441,7 @@ public class CallController extends BaseController {
     }
 
     private void handleFromNotification() {
-        Integer apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation", new int[] {1});
+        Integer apiVersion = ApiUtils.getConversationApiVersion(conversationUser, new int[] {1});
 
         if (apiVersion == null) {
             Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
@@ -1248,8 +1248,7 @@ public class CallController extends BaseController {
     private void joinRoomAndCall() {
         callSession = ApplicationWideCurrentRoomHolder.getInstance().getSession();
 
-        Integer apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation",
-                                                    new int[] {1});
+        Integer apiVersion = ApiUtils.getConversationApiVersion(conversationUser,  new int[] {1});
         if (apiVersion == null) {
             Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
             return;
@@ -1309,7 +1308,7 @@ public class CallController extends BaseController {
             inCallFlag = (int) Participant.ParticipantFlags.IN_CALL_WITH_AUDIO_AND_VIDEO.getValue();
         }
 
-        Integer apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation", new int[] {1});
+        Integer apiVersion = ApiUtils.getConversationApiVersion(conversationUser, new int[] {1});
 
         if (apiVersion == null) {
             Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
@@ -1648,7 +1647,7 @@ public class CallController extends BaseController {
     }
 
     private void hangupNetworkCalls(boolean shutDownView) {
-        Integer apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation", new int[] {1});
+        Integer apiVersion = ApiUtils.getConversationApiVersion(conversationUser, new int[] {1});
 
         if (apiVersion == null) {
             Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
@@ -1690,8 +1689,7 @@ public class CallController extends BaseController {
     }
 
     private void leaveRoom(boolean shutDownView) {
-        Integer apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation",
-                                                    new int[] {1});
+        Integer apiVersion = ApiUtils.getConversationApiVersion(conversationUser, new int[] {1});
         if (apiVersion == null) {
             Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
             return;
@@ -1790,7 +1788,7 @@ public class CallController extends BaseController {
 
     private void getPeersForCall() {
         Log.d(TAG, "getPeersForCall");
-        Integer apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation", new int[] {1});
+        Integer apiVersion = ApiUtils.getConversationApiVersion(conversationUser, new int[] {1});
 
         if (apiVersion == null) {
             Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));

--- a/app/src/main/java/com/nextcloud/talk/controllers/CallController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/CallController.java
@@ -441,12 +441,7 @@ public class CallController extends BaseController {
     }
 
     private void handleFromNotification() {
-        Integer apiVersion = ApiUtils.getConversationApiVersion(conversationUser, new int[] {1});
-
-        if (apiVersion == null) {
-            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
-            return;
-        }
+        int apiVersion = ApiUtils.getConversationApiVersion(conversationUser, new int[] {1});
 
         ncApi.getRooms(credentials, ApiUtils.getUrlForRooms(apiVersion, baseUrl))
                 .retry(3)
@@ -1104,12 +1099,7 @@ public class CallController extends BaseController {
     }
 
     private void fetchSignalingSettings() {
-        Integer apiVersion = ApiUtils.getSignalingApiVersion(conversationUser, new int[] {2, 1});
-
-        if (apiVersion == null) {
-            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
-            return;
-        }
+        int apiVersion = ApiUtils.getSignalingApiVersion(conversationUser, new int[] {2, 1});
 
         ncApi.getSignalingSettings(credentials, ApiUtils.getUrlForSignalingSettings(apiVersion, baseUrl))
                 .subscribeOn(Schedulers.io())
@@ -1248,11 +1238,7 @@ public class CallController extends BaseController {
     private void joinRoomAndCall() {
         callSession = ApplicationWideCurrentRoomHolder.getInstance().getSession();
 
-        Integer apiVersion = ApiUtils.getConversationApiVersion(conversationUser,  new int[] {1});
-        if (apiVersion == null) {
-            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
-            return;
-        }
+        int apiVersion = ApiUtils.getConversationApiVersion(conversationUser,  new int[] {1});
 
         if (TextUtils.isEmpty(callSession)) {
             ncApi.joinRoom(credentials, ApiUtils.getUrlForParticipantsActive(apiVersion, baseUrl, roomToken),
@@ -1308,12 +1294,7 @@ public class CallController extends BaseController {
             inCallFlag = (int) Participant.ParticipantFlags.IN_CALL_WITH_AUDIO_AND_VIDEO.getValue();
         }
 
-        Integer apiVersion = ApiUtils.getConversationApiVersion(conversationUser, new int[] {1});
-
-        if (apiVersion == null) {
-            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
-            return;
-        }
+        int apiVersion = ApiUtils.getConversationApiVersion(conversationUser, new int[] {1});
 
         ncApi.joinCall(credentials, ApiUtils.getUrlForCall(apiVersion, baseUrl, roomToken), inCallFlag)
                 .subscribeOn(Schedulers.io())
@@ -1375,12 +1356,7 @@ public class CallController extends BaseController {
                             }
 
                             if (!hasExternalSignalingServer) {
-                                Integer apiVersion = ApiUtils.getSignalingApiVersion(conversationUser, new int[] {2, 1});
-
-                                if (apiVersion == null) {
-                                    Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
-                                    return;
-                                }
+                                int apiVersion = ApiUtils.getSignalingApiVersion(conversationUser, new int[] {2, 1});
 
                                 ncApi.pullSignalingMessages(credentials, ApiUtils.getUrlForSignaling(apiVersion,
                                                                                                      baseUrl, urlToken))
@@ -1647,12 +1623,7 @@ public class CallController extends BaseController {
     }
 
     private void hangupNetworkCalls(boolean shutDownView) {
-        Integer apiVersion = ApiUtils.getConversationApiVersion(conversationUser, new int[] {1});
-
-        if (apiVersion == null) {
-            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
-            return;
-        }
+        int apiVersion = ApiUtils.getConversationApiVersion(conversationUser, new int[] {1});
 
         ncApi.leaveCall(credentials, ApiUtils.getUrlForCall(apiVersion, baseUrl, roomToken))
                 .subscribeOn(Schedulers.io())
@@ -1689,11 +1660,7 @@ public class CallController extends BaseController {
     }
 
     private void leaveRoom(boolean shutDownView) {
-        Integer apiVersion = ApiUtils.getConversationApiVersion(conversationUser, new int[] {1});
-        if (apiVersion == null) {
-            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
-            return;
-        }
+        int apiVersion = ApiUtils.getConversationApiVersion(conversationUser, new int[] {1});
 
         ncApi.leaveRoom(credentials, ApiUtils.getUrlForParticipantsActive(apiVersion, baseUrl, roomToken))
                 .subscribeOn(Schedulers.io())
@@ -1788,12 +1755,7 @@ public class CallController extends BaseController {
 
     private void getPeersForCall() {
         Log.d(TAG, "getPeersForCall");
-        Integer apiVersion = ApiUtils.getConversationApiVersion(conversationUser, new int[] {1});
-
-        if (apiVersion == null) {
-            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
-            return;
-        }
+        int apiVersion = ApiUtils.getConversationApiVersion(conversationUser, new int[] {1});
 
         ncApi.getPeersForCall(credentials, ApiUtils.getUrlForCall(apiVersion, baseUrl, roomToken))
                 .subscribeOn(Schedulers.io())
@@ -2099,12 +2061,7 @@ public class CallController extends BaseController {
                 urlToken = roomToken;
             }
 
-            Integer apiVersion = ApiUtils.getSignalingApiVersion(conversationUser, new int[] {2, 1});
-
-            if (apiVersion == null) {
-                Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
-                return;
-            }
+            int apiVersion = ApiUtils.getSignalingApiVersion(conversationUser, new int[] {2, 1});
 
             ncApi.sendSignalingMessages(credentials, ApiUtils.getUrlForSignaling(apiVersion, baseUrl, urlToken),
                                         strings.toString())

--- a/app/src/main/java/com/nextcloud/talk/controllers/CallController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/CallController.java
@@ -1104,7 +1104,14 @@ public class CallController extends BaseController {
     }
 
     private void fetchSignalingSettings() {
-        ncApi.getSignalingSettings(credentials, ApiUtils.getUrlForSignalingSettings(baseUrl))
+        Integer apiVersion = ApiUtils.getSignalingApiVersion(conversationUser, new int[] {2, 1});
+
+        if (apiVersion == null) {
+            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
+            return;
+        }
+
+        ncApi.getSignalingSettings(credentials, ApiUtils.getUrlForSignalingSettings(apiVersion, baseUrl))
                 .subscribeOn(Schedulers.io())
                 .retry(3)
                 .observeOn(AndroidSchedulers.mainThread())
@@ -1369,7 +1376,15 @@ public class CallController extends BaseController {
                             }
 
                             if (!hasExternalSignalingServer) {
-                                ncApi.pullSignalingMessages(credentials, ApiUtils.getUrlForSignaling(baseUrl, urlToken))
+                                Integer apiVersion = ApiUtils.getSignalingApiVersion(conversationUser, new int[] {2, 1});
+
+                                if (apiVersion == null) {
+                                    Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
+                                    return;
+                                }
+
+                                ncApi.pullSignalingMessages(credentials, ApiUtils.getUrlForSignaling(apiVersion,
+                                                                                                     baseUrl, urlToken))
                                         .subscribeOn(Schedulers.io())
                                         .observeOn(AndroidSchedulers.mainThread())
                                         .repeatWhen(observable -> observable)
@@ -2086,7 +2101,14 @@ public class CallController extends BaseController {
                 urlToken = roomToken;
             }
 
-            ncApi.sendSignalingMessages(credentials, ApiUtils.getUrlForSignaling(baseUrl, urlToken),
+            Integer apiVersion = ApiUtils.getSignalingApiVersion(conversationUser, new int[] {2, 1});
+
+            if (apiVersion == null) {
+                Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
+                return;
+            }
+
+            ncApi.sendSignalingMessages(credentials, ApiUtils.getUrlForSignaling(apiVersion, baseUrl, urlToken),
                                         strings.toString())
                     .retry(3)
                     .subscribeOn(Schedulers.io())

--- a/app/src/main/java/com/nextcloud/talk/controllers/CallController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/CallController.java
@@ -1302,8 +1302,14 @@ public class CallController extends BaseController {
             inCallFlag = (int) Participant.ParticipantFlags.IN_CALL_WITH_AUDIO_AND_VIDEO.getValue();
         }
 
-        ncApi.joinCall(credentials,
-                       ApiUtils.getUrlForCall(baseUrl, roomToken), inCallFlag)
+        Integer apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation", new int[] {1});
+
+        if (apiVersion == null) {
+            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
+            return;
+        }
+
+        ncApi.joinCall(credentials, ApiUtils.getUrlForCall(apiVersion, baseUrl, roomToken), inCallFlag)
                 .subscribeOn(Schedulers.io())
                 .retry(3)
                 .observeOn(AndroidSchedulers.mainThread())
@@ -1627,7 +1633,14 @@ public class CallController extends BaseController {
     }
 
     private void hangupNetworkCalls(boolean shutDownView) {
-        ncApi.leaveCall(credentials, ApiUtils.getUrlForCall(baseUrl, roomToken))
+        Integer apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation", new int[] {1});
+
+        if (apiVersion == null) {
+            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
+            return;
+        }
+
+        ncApi.leaveCall(credentials, ApiUtils.getUrlForCall(apiVersion, baseUrl, roomToken))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(new Observer<GenericOverall>() {
@@ -1762,7 +1775,14 @@ public class CallController extends BaseController {
 
     private void getPeersForCall() {
         Log.d(TAG, "getPeersForCall");
-        ncApi.getPeersForCall(credentials, ApiUtils.getUrlForCall(baseUrl, roomToken))
+        Integer apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation", new int[] {1});
+
+        if (apiVersion == null) {
+            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
+            return;
+        }
+
+        ncApi.getPeersForCall(credentials, ApiUtils.getUrlForCall(apiVersion, baseUrl, roomToken))
                 .subscribeOn(Schedulers.io())
                 .subscribe(new Observer<ParticipantsOverall>() {
                     @Override

--- a/app/src/main/java/com/nextcloud/talk/controllers/CallNotificationController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/CallNotificationController.java
@@ -210,12 +210,7 @@ public class CallNotificationController extends BaseController {
 
     @SuppressLint("LongLogTag")
     private void checkIfAnyParticipantsRemainInRoom() {
-        Integer apiVersion = ApiUtils.getConversationApiVersion(userBeingCalled, new int[] {1});
-
-        if (apiVersion == null) {
-            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
-            return;
-        }
+        int apiVersion = ApiUtils.getConversationApiVersion(userBeingCalled, new int[] {1});
 
         ncApi.getPeersForCall(credentials, ApiUtils.getUrlForCall(apiVersion, userBeingCalled.getBaseUrl(),
                                                                   currentConversation.getToken()))
@@ -267,11 +262,7 @@ public class CallNotificationController extends BaseController {
 
     @SuppressLint("LongLogTag")
     private void handleFromNotification() {
-        Integer apiVersion = ApiUtils.getConversationApiVersion(userBeingCalled, new int[] {4, 3, 1});
-        if (apiVersion == null) {
-            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
-            return;
-        }
+        int apiVersion = ApiUtils.getConversationApiVersion(userBeingCalled, new int[] {4, 3, 1});
 
         ncApi.getRoom(credentials, ApiUtils.getUrlForRoom(apiVersion, userBeingCalled.getBaseUrl(), roomId))
                 .subscribeOn(Schedulers.io())

--- a/app/src/main/java/com/nextcloud/talk/controllers/CallNotificationController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/CallNotificationController.java
@@ -263,7 +263,7 @@ public class CallNotificationController extends BaseController {
             return;
         }
 
-        ncApi.getRoom(credentials, ApiUtils.getRoom(apiVersion, userBeingCalled.getBaseUrl(), roomId))
+        ncApi.getRoom(credentials, ApiUtils.getUrlForRoom(apiVersion, userBeingCalled.getBaseUrl(), roomId))
                 .subscribeOn(Schedulers.io())
                 .retry(3)
                 .observeOn(AndroidSchedulers.mainThread())

--- a/app/src/main/java/com/nextcloud/talk/controllers/CallNotificationController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/CallNotificationController.java
@@ -208,7 +208,6 @@ public class CallNotificationController extends BaseController {
                                                  .pushChangeHandler(new HorizontalChangeHandler()));
     }
 
-    @SuppressLint("LongLogTag")
     private void checkIfAnyParticipantsRemainInRoom() {
         int apiVersion = ApiUtils.getConversationApiVersion(userBeingCalled, new int[] {1});
 
@@ -260,7 +259,6 @@ public class CallNotificationController extends BaseController {
 
     }
 
-    @SuppressLint("LongLogTag")
     private void handleFromNotification() {
         int apiVersion = ApiUtils.getConversationApiVersion(userBeingCalled, new int[] {4, 3, 1});
 

--- a/app/src/main/java/com/nextcloud/talk/controllers/CallNotificationController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/CallNotificationController.java
@@ -257,9 +257,11 @@ public class CallNotificationController extends BaseController {
 
     }
 
+    @SuppressLint("LongLogTag")
     private void handleFromNotification() {
         Integer apiVersion = ApiUtils.getApiVersion(userBeingCalled, "conversation", new int[] {4, 3, 1});
         if (apiVersion == null) {
+            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
             return;
         }
 

--- a/app/src/main/java/com/nextcloud/talk/controllers/CallNotificationController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/CallNotificationController.java
@@ -258,23 +258,27 @@ public class CallNotificationController extends BaseController {
     }
 
     private void handleFromNotification() {
-        boolean isConversationApiV3 = userBeingCalled.hasSpreedFeatureCapability("conversation-v3");
-        if (isConversationApiV3) {
-            ncApi.getRoom(credentials, ApiUtils.getRoomV3(userBeingCalled.getBaseUrl(), roomId))
-                    .subscribeOn(Schedulers.io())
-                    .retry(3)
-                    .observeOn(AndroidSchedulers.mainThread())
-                    .subscribe(new Observer<RoomOverall>() {
-                        @Override
-                        public void onSubscribe(Disposable d) {
-                            disposablesList.add(d);
-                        }
+        Integer apiVersion = ApiUtils.getApiVersion(userBeingCalled, "conversation", new int[] {4, 3, 1});
+        if (apiVersion == null) {
+            return;
+        }
 
-                        @Override
-                        public void onNext(@NotNull RoomOverall roomOverall) {
-                            currentConversation = roomOverall.getOcs().data;
-                            runAllThings();
+        ncApi.getRoom(credentials, ApiUtils.getRoom(apiVersion, userBeingCalled.getBaseUrl(), roomId))
+                .subscribeOn(Schedulers.io())
+                .retry(3)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(new Observer<RoomOverall>() {
+                    @Override
+                    public void onSubscribe(Disposable d) {
+                        disposablesList.add(d);
+                    }
 
+                    @Override
+                    public void onNext(@NotNull RoomOverall roomOverall) {
+                        currentConversation = roomOverall.getOcs().data;
+                        runAllThings();
+
+                        if (apiVersion >= 3) {
                             boolean hasCallFlags = userBeingCalled.hasSpreedFeatureCapability("conversation-call-flags");
                             if (hasCallFlags) {
                                 if (isInCallWithVideo(currentConversation.callFlag)) {
@@ -286,46 +290,19 @@ public class CallNotificationController extends BaseController {
                                 }
                             }
                         }
+                    }
 
-                        @Override
-                        public void onError(Throwable e) {
+                    @SuppressLint("LongLogTag")
+                    @Override
+                    public void onError(Throwable e) {
+                        Log.e(TAG, e.getMessage(), e);
+                    }
 
-                        }
+                    @Override
+                    public void onComplete() {
 
-                        @Override
-                        public void onComplete() {
-
-                        }
-                    });
-        } else {
-            ncApi.getRoom(credentials, ApiUtils.getRoom(userBeingCalled.getBaseUrl(), roomId))
-                    .subscribeOn(Schedulers.io())
-                    .retry(3)
-                    .observeOn(AndroidSchedulers.mainThread())
-                    .subscribe(new Observer<RoomOverall>() {
-                        @Override
-                        public void onSubscribe(Disposable d) {
-                            disposablesList.add(d);
-                        }
-
-                        @SuppressLint("LongLogTag")
-                        @Override
-                        public void onNext(@NotNull RoomOverall roomOverall) {
-                            currentConversation = roomOverall.getOcs().data;
-                            runAllThings();
-                        }
-
-                        @Override
-                        public void onError(Throwable e) {
-
-                        }
-
-                        @Override
-                        public void onComplete() {
-
-                        }
-                    });
-        }
+                    }
+                });
     }
 
     private boolean isInCallWithVideo(int callFlag) {

--- a/app/src/main/java/com/nextcloud/talk/controllers/CallNotificationController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/CallNotificationController.java
@@ -210,7 +210,7 @@ public class CallNotificationController extends BaseController {
 
     @SuppressLint("LongLogTag")
     private void checkIfAnyParticipantsRemainInRoom() {
-        Integer apiVersion = ApiUtils.getApiVersion(userBeingCalled, "conversation", new int[] {1});
+        Integer apiVersion = ApiUtils.getConversationApiVersion(userBeingCalled, new int[] {1});
 
         if (apiVersion == null) {
             Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
@@ -267,7 +267,7 @@ public class CallNotificationController extends BaseController {
 
     @SuppressLint("LongLogTag")
     private void handleFromNotification() {
-        Integer apiVersion = ApiUtils.getApiVersion(userBeingCalled, "conversation", new int[] {4, 3, 1});
+        Integer apiVersion = ApiUtils.getConversationApiVersion(userBeingCalled, new int[] {4, 3, 1});
         if (apiVersion == null) {
             Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
             return;

--- a/app/src/main/java/com/nextcloud/talk/controllers/CallNotificationController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/CallNotificationController.java
@@ -208,8 +208,16 @@ public class CallNotificationController extends BaseController {
                                                  .pushChangeHandler(new HorizontalChangeHandler()));
     }
 
+    @SuppressLint("LongLogTag")
     private void checkIfAnyParticipantsRemainInRoom() {
-        ncApi.getPeersForCall(credentials, ApiUtils.getUrlForCall(userBeingCalled.getBaseUrl(),
+        Integer apiVersion = ApiUtils.getApiVersion(userBeingCalled, "conversation", new int[] {1});
+
+        if (apiVersion == null) {
+            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
+            return;
+        }
+
+        ncApi.getPeersForCall(credentials, ApiUtils.getUrlForCall(apiVersion, userBeingCalled.getBaseUrl(),
                                                                   currentConversation.getToken()))
                 .subscribeOn(Schedulers.io())
                 .takeWhile(observable -> !leavingScreen)

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -1654,8 +1654,12 @@ class ChatController(args: Bundle) :
                         val apiVersion = ApiUtils.getChatApiVersion(conversationUser, intArrayOf(1))
                         ncApi?.deleteChatMessage(
                             credentials,
-                            ApiUtils.getUrlForChatMessage(apiVersion, conversationUser?.baseUrl, roomToken,
-                                message?.id)
+                            ApiUtils.getUrlForChatMessage(
+                                apiVersion,
+                                conversationUser?.baseUrl,
+                                roomToken,
+                                message?.id
+                            )
                         )?.subscribeOn(Schedulers.io())
                             ?.observeOn(AndroidSchedulers.mainThread())
                             ?.subscribe(object : Observer<ChatOverallSingleMessage> {

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -294,7 +294,7 @@ class ChatController(args: Bundle) :
         }
 
         if (conversationUser != null) {
-            val apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation", intArrayOf(1))
+            val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
 
             if (apiVersion == null) {
                 Log.e(TAG, "No supported API version found")
@@ -344,7 +344,7 @@ class ChatController(args: Bundle) :
             return
         }
 
-        val apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation", intArrayOf(1))
+        val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
 
         if (apiVersion == null) {
             Log.e(TAG, "No supported API version found")
@@ -977,7 +977,7 @@ class ChatController(args: Bundle) :
         if (currentConversation == null || TextUtils.isEmpty(currentConversation?.sessionId) ||
             currentConversation?.sessionId == "0"
         ) {
-            val apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation", intArrayOf(1))
+            val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
 
             if (apiVersion == null) {
                 Log.e(TAG, "No supported API version found")
@@ -1051,7 +1051,7 @@ class ChatController(args: Bundle) :
     }
 
     private fun leaveRoom() {
-        val apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation", intArrayOf(1))
+        val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
 
         if (apiVersion == null) {
             Log.e(TAG, "No supported API version found")
@@ -1806,7 +1806,7 @@ class ChatController(args: Bundle) :
             currentConversation?.name != userMentionClickEvent.userId
         ) {
 
-            val apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation", intArrayOf(1))
+            val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
 
             if (apiVersion == null) {
                 Log.e(TAG, "No supported API version found")

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -82,7 +82,6 @@ import com.facebook.imagepipeline.image.CloseableImage
 import com.google.android.flexbox.FlexboxLayout
 import com.nextcloud.talk.R
 import com.nextcloud.talk.activities.MagicCallActivity
-import com.nextcloud.talk.activities.MainActivity
 import com.nextcloud.talk.adapters.messages.MagicIncomingTextMessageViewHolder
 import com.nextcloud.talk.adapters.messages.MagicOutcomingTextMessageViewHolder
 import com.nextcloud.talk.adapters.messages.MagicPreviewMessageViewHolder
@@ -116,6 +115,7 @@ import com.nextcloud.talk.utils.DateUtils
 import com.nextcloud.talk.utils.DisplayUtils
 import com.nextcloud.talk.utils.KeyboardUtils
 import com.nextcloud.talk.utils.MagicCharPolicy
+import com.nextcloud.talk.utils.NoSupportedApiException
 import com.nextcloud.talk.utils.NotificationUtils
 import com.nextcloud.talk.utils.UriUtils
 import com.nextcloud.talk.utils.bundle.BundleKeys
@@ -296,11 +296,6 @@ class ChatController(args: Bundle) :
         if (conversationUser != null) {
             val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
 
-            if (apiVersion == null) {
-                Log.e(TAG, "No supported API version found")
-                return
-            }
-
             ncApi?.getRoom(credentials, ApiUtils.getUrlForRoom(apiVersion, conversationUser.baseUrl, roomToken))
                 ?.subscribeOn(Schedulers.io())
                 ?.observeOn(AndroidSchedulers.mainThread())
@@ -345,11 +340,6 @@ class ChatController(args: Bundle) :
         }
 
         val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
-
-        if (apiVersion == null) {
-            Log.e(TAG, "No supported API version found")
-            return
-        }
 
         ncApi?.getRooms(credentials, ApiUtils.getUrlForRooms(apiVersion, conversationUser?.baseUrl))
             ?.subscribeOn(Schedulers.io())?.observeOn(AndroidSchedulers.mainThread())
@@ -979,11 +969,6 @@ class ChatController(args: Bundle) :
         ) {
             val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
 
-            if (apiVersion == null) {
-                Log.e(TAG, "No supported API version found")
-                return
-            }
-
             ncApi?.joinRoom(
                 credentials,
                 ApiUtils.getUrlForParticipantsActive(apiVersion, conversationUser?.baseUrl, roomToken),
@@ -1052,11 +1037,6 @@ class ChatController(args: Bundle) :
 
     private fun leaveRoom() {
         val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
-
-        if (apiVersion == null) {
-            Log.e(TAG, "No supported API version found")
-            return
-        }
 
         ncApi?.leaveRoom(
             credentials,
@@ -1143,11 +1123,6 @@ class ChatController(args: Bundle) :
 
         if (conversationUser != null) {
             val apiVersion = ApiUtils.getChatApiVersion(conversationUser, intArrayOf(1))
-
-            if (apiVersion == null) {
-                Log.e(TAG, "No supported API version found")
-                return
-            }
 
             ncApi!!.sendChatMessage(
                 credentials,
@@ -1251,16 +1226,11 @@ class ChatController(args: Bundle) :
         }
 
         if (!wasDetached) {
-            var apiVersion: Int?
+            var apiVersion: Int
             // FIXME this is a best guess, guests would need to get the capabilities themselves
             apiVersion = 1
             if (conversationUser != null) {
                 apiVersion = ApiUtils.getChatApiVersion(conversationUser, intArrayOf(1))
-
-                if (apiVersion == null) {
-                    Log.e(TAG, "No supported API version found")
-                    return
-                }
             }
 
             if (lookIntoFuture > 0) {
@@ -1687,11 +1657,6 @@ class ChatController(args: Bundle) :
                     }
                     R.id.action_delete_message -> {
                         val apiVersion = ApiUtils.getChatApiVersion(conversationUser, intArrayOf(1))
-
-                        if (apiVersion == null) {
-                            Log.e(TAG, "No supported API version found")
-                        }
-
                         ncApi?.deleteChatMessage(
                             credentials,
                             ApiUtils.getUrlForChatMessage(apiVersion, conversationUser?.baseUrl, roomToken,
@@ -1806,11 +1771,6 @@ class ChatController(args: Bundle) :
         ) {
 
             val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
-
-            if (apiVersion == null) {
-                Log.e(TAG, "No supported API version found")
-                return
-            }
 
             val retrofitBucket = ApiUtils.getRetrofitBucketForCreateRoom(
                 apiVersion, conversationUser?.baseUrl, "1",

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -1692,7 +1692,6 @@ class ChatController(args: Bundle) :
                             Log.e(TAG, "No supported API version found")
                         }
 
-
                         ncApi?.deleteChatMessage(
                             credentials,
                             ApiUtils.getUrlForChatMessage(apiVersion, conversationUser?.baseUrl, roomToken,

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -977,9 +977,17 @@ class ChatController(args: Bundle) :
         if (currentConversation == null || TextUtils.isEmpty(currentConversation?.sessionId) ||
             currentConversation?.sessionId == "0"
         ) {
+            val apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation", intArrayOf(1))
+
+            if (apiVersion == null) {
+                Log.e(TAG, "No supported API version found")
+                return
+            }
+
             ncApi?.joinRoom(
                 credentials,
-                ApiUtils.getUrlForSettingMyselfAsActiveParticipant(conversationUser?.baseUrl, roomToken), roomPassword
+                ApiUtils.getUrlForParticipantsActive(apiVersion, conversationUser?.baseUrl, roomToken),
+                roomPassword
             )
                 ?.subscribeOn(Schedulers.io())
                 ?.observeOn(AndroidSchedulers.mainThread())
@@ -1043,9 +1051,17 @@ class ChatController(args: Bundle) :
     }
 
     private fun leaveRoom() {
+        val apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation", intArrayOf(1))
+
+        if (apiVersion == null) {
+            Log.e(TAG, "No supported API version found")
+            return
+        }
+
         ncApi?.leaveRoom(
             credentials,
-            ApiUtils.getUrlForSettingMyselfAsActiveParticipant(
+            ApiUtils.getUrlForParticipantsActive(
+                apiVersion,
                 conversationUser?.baseUrl,
                 roomToken
             )
@@ -1762,8 +1778,16 @@ class ChatController(args: Bundle) :
         if (currentConversation?.type != Conversation.ConversationType.ROOM_TYPE_ONE_TO_ONE_CALL ||
             currentConversation?.name != userMentionClickEvent.userId
         ) {
+
+            val apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation", intArrayOf(1))
+
+            if (apiVersion == null) {
+                Log.e(TAG, "No supported API version found")
+                return
+            }
+
             val retrofitBucket = ApiUtils.getRetrofitBucketForCreateRoom(
-                conversationUser?.baseUrl, "1",
+                apiVersion, conversationUser?.baseUrl, "1",
                 userMentionClickEvent.userId, null
             )
 

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -334,7 +334,11 @@ class ChatController(args: Bundle) :
     }
 
     private fun handleFromNotification() {
-        val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
+        var apiVersion = 1
+        // FIXME Can this be called for guests?
+        if (conversationUser != null) {
+            apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
+        }
 
         ncApi?.getRooms(credentials, ApiUtils.getUrlForRooms(apiVersion, conversationUser?.baseUrl))
             ?.subscribeOn(Schedulers.io())?.observeOn(AndroidSchedulers.mainThread())
@@ -962,7 +966,11 @@ class ChatController(args: Bundle) :
         if (currentConversation == null || TextUtils.isEmpty(currentConversation?.sessionId) ||
             currentConversation?.sessionId == "0"
         ) {
-            val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
+            var apiVersion = 1
+            // FIXME Fix API checking with guests?
+            if (conversationUser != null) {
+                apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
+            }
 
             ncApi?.joinRoom(
                 credentials,
@@ -1031,7 +1039,11 @@ class ChatController(args: Bundle) :
     }
 
     private fun leaveRoom() {
-        val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
+        var apiVersion = 1
+        // FIXME Fix API checking with guests?
+        if (conversationUser != null) {
+            apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
+        }
 
         ncApi?.leaveRoom(
             credentials,
@@ -1221,9 +1233,8 @@ class ChatController(args: Bundle) :
         }
 
         if (!wasDetached) {
-            var apiVersion: Int
+            var apiVersion = 1
             // FIXME this is a best guess, guests would need to get the capabilities themselves
-            apiVersion = 1
             if (conversationUser != null) {
                 apiVersion = ApiUtils.getChatApiVersion(conversationUser, intArrayOf(1))
             }
@@ -1651,7 +1662,12 @@ class ChatController(args: Bundle) :
                         true
                     }
                     R.id.action_delete_message -> {
-                        val apiVersion = ApiUtils.getChatApiVersion(conversationUser, intArrayOf(1))
+                        var apiVersion = 1
+                        // FIXME Fix API checking with guests?
+                        if (conversationUser != null) {
+                            apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
+                        }
+
                         ncApi?.deleteChatMessage(
                             credentials,
                             ApiUtils.getUrlForChatMessage(
@@ -1769,7 +1785,11 @@ class ChatController(args: Bundle) :
             currentConversation?.name != userMentionClickEvent.userId
         ) {
 
-            val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
+            var apiVersion = 1
+            // FIXME Fix API checking with guests?
+            if (conversationUser != null) {
+                apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
+            }
 
             val retrofitBucket = ApiUtils.getRetrofitBucketForCreateRoom(
                 apiVersion, conversationUser?.baseUrl, "1",

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -115,7 +115,6 @@ import com.nextcloud.talk.utils.DateUtils
 import com.nextcloud.talk.utils.DisplayUtils
 import com.nextcloud.talk.utils.KeyboardUtils
 import com.nextcloud.talk.utils.MagicCharPolicy
-import com.nextcloud.talk.utils.NoSupportedApiException
 import com.nextcloud.talk.utils.NotificationUtils
 import com.nextcloud.talk.utils.UriUtils
 import com.nextcloud.talk.utils.bundle.BundleKeys
@@ -335,10 +334,6 @@ class ChatController(args: Bundle) :
     }
 
     private fun handleFromNotification() {
-        if (ncApi == null) {
-            return
-        }
-
         val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
 
         ncApi?.getRooms(credentials, ApiUtils.getUrlForRooms(apiVersion, conversationUser?.baseUrl))

--- a/app/src/main/java/com/nextcloud/talk/controllers/ContactsController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ContactsController.java
@@ -308,9 +308,12 @@ public class ContactsController extends BaseController implements SearchView.OnQ
                                 bundle.putString(BundleKeys.INSTANCE.getKEY_ROOM_TOKEN(), roomOverall.getOcs().getData().getToken());
                                 bundle.putString(BundleKeys.INSTANCE.getKEY_ROOM_ID(), roomOverall.getOcs().getData().getRoomId());
 
-                                if (currentUser.hasSpreedFeatureCapability("chat-v2")) {
+                                Integer apiVersion = ApiUtils.getApiVersion(currentUser, "conversation",
+                                                                           new int[] {1});
+                                if (apiVersion != null && currentUser.hasSpreedFeatureCapability("chat-v2")) {
+
                                     ncApi.getRoom(credentials,
-                                            ApiUtils.getRoom(currentUser.getBaseUrl(),
+                                            ApiUtils.getUrlForRoom(apiVersion, currentUser.getBaseUrl(),
                                                     roomOverall.getOcs().getData().getToken()))
                                             .subscribeOn(Schedulers.io())
                                             .observeOn(AndroidSchedulers.mainThread())

--- a/app/src/main/java/com/nextcloud/talk/controllers/ContactsController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ContactsController.java
@@ -312,9 +312,7 @@ public class ContactsController extends BaseController implements SearchView.OnQ
                                 bundle.putString(BundleKeys.INSTANCE.getKEY_ROOM_TOKEN(), roomOverall.getOcs().getData().getToken());
                                 bundle.putString(BundleKeys.INSTANCE.getKEY_ROOM_ID(), roomOverall.getOcs().getData().getRoomId());
 
-                                int apiVersion = ApiUtils.getConversationApiVersion(currentUser, new int[] {1});
                                 if (currentUser.hasSpreedFeatureCapability("chat-v2")) {
-
                                     ncApi.getRoom(credentials,
                                             ApiUtils.getUrlForRoom(apiVersion, currentUser.getBaseUrl(),
                                                     roomOverall.getOcs().getData().getToken()))

--- a/app/src/main/java/com/nextcloud/talk/controllers/ContactsController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ContactsController.java
@@ -288,13 +288,7 @@ public class ContactsController extends BaseController implements SearchView.OnQ
                     userId = selectedUserIds.iterator().next();
                 }
 
-                Integer apiVersion = ApiUtils.getConversationApiVersion(currentUser, new int[] {1});
-
-                if (apiVersion == null) {
-                    Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
-                    return;
-                }
-
+                int apiVersion = ApiUtils.getConversationApiVersion(currentUser, new int[] {1});
                 RetrofitBucket retrofitBucket = ApiUtils.getRetrofitBucketForCreateRoom(apiVersion,
                                                                                         currentUser.getBaseUrl(),
                                                                                         roomType,
@@ -318,8 +312,8 @@ public class ContactsController extends BaseController implements SearchView.OnQ
                                 bundle.putString(BundleKeys.INSTANCE.getKEY_ROOM_TOKEN(), roomOverall.getOcs().getData().getToken());
                                 bundle.putString(BundleKeys.INSTANCE.getKEY_ROOM_ID(), roomOverall.getOcs().getData().getRoomId());
 
-                                Integer apiVersion = ApiUtils.getConversationApiVersion(currentUser, new int[] {1});
-                                if (apiVersion != null && currentUser.hasSpreedFeatureCapability("chat-v2")) {
+                                int apiVersion = ApiUtils.getConversationApiVersion(currentUser, new int[] {1});
+                                if (currentUser.hasSpreedFeatureCapability("chat-v2")) {
 
                                     ncApi.getRoom(credentials,
                                             ApiUtils.getUrlForRoom(apiVersion, currentUser.getBaseUrl(),
@@ -860,12 +854,7 @@ public class ContactsController extends BaseController implements SearchView.OnQ
                     roomType = "2";
                 }
 
-                Integer apiVersion = ApiUtils.getConversationApiVersion(currentUser, new int[] {1});
-
-                if (apiVersion == null) {
-                    Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
-                    return false;
-                }
+                int apiVersion = ApiUtils.getConversationApiVersion(currentUser, new int[] {1});
 
                 RetrofitBucket retrofitBucket = ApiUtils.getRetrofitBucketForCreateRoom(apiVersion,
                                                                                         currentUser.getBaseUrl(),

--- a/app/src/main/java/com/nextcloud/talk/controllers/ContactsController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ContactsController.java
@@ -288,8 +288,18 @@ public class ContactsController extends BaseController implements SearchView.OnQ
                     userId = selectedUserIds.iterator().next();
                 }
 
-                RetrofitBucket retrofitBucket = ApiUtils.getRetrofitBucketForCreateRoom(currentUser.getBaseUrl(), roomType,
-                        userId, null);
+                Integer apiVersion = ApiUtils.getApiVersion(currentUser, "conversation", new int[] {1});
+
+                if (apiVersion == null) {
+                    Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
+                    return;
+                }
+
+                RetrofitBucket retrofitBucket = ApiUtils.getRetrofitBucketForCreateRoom(apiVersion,
+                                                                                        currentUser.getBaseUrl(),
+                                                                                        roomType,
+                                                                                        userId,
+                                                                                        null);
                 ncApi.createRoom(credentials,
                         retrofitBucket.getUrl(), retrofitBucket.getQueryMap())
                         .subscribeOn(Schedulers.io())
@@ -851,7 +861,18 @@ public class ContactsController extends BaseController implements SearchView.OnQ
                     roomType = "2";
                 }
 
-                RetrofitBucket retrofitBucket = ApiUtils.getRetrofitBucketForCreateRoom(currentUser.getBaseUrl(), roomType, userItem.getModel().getUserId(), null);
+                Integer apiVersion = ApiUtils.getApiVersion(currentUser, "conversation", new int[] {1});
+
+                if (apiVersion == null) {
+                    Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
+                    return false;
+                }
+
+                RetrofitBucket retrofitBucket = ApiUtils.getRetrofitBucketForCreateRoom(apiVersion,
+                                                                                        currentUser.getBaseUrl(),
+                                                                                        roomType,
+                                                                                        userItem.getModel().getUserId(),
+                                                                                        null);
 
                 ncApi.createRoom(credentials,
                         retrofitBucket.getUrl(), retrofitBucket.getQueryMap())

--- a/app/src/main/java/com/nextcloud/talk/controllers/ContactsController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ContactsController.java
@@ -288,7 +288,7 @@ public class ContactsController extends BaseController implements SearchView.OnQ
                     userId = selectedUserIds.iterator().next();
                 }
 
-                Integer apiVersion = ApiUtils.getApiVersion(currentUser, "conversation", new int[] {1});
+                Integer apiVersion = ApiUtils.getConversationApiVersion(currentUser, new int[] {1});
 
                 if (apiVersion == null) {
                     Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
@@ -318,8 +318,7 @@ public class ContactsController extends BaseController implements SearchView.OnQ
                                 bundle.putString(BundleKeys.INSTANCE.getKEY_ROOM_TOKEN(), roomOverall.getOcs().getData().getToken());
                                 bundle.putString(BundleKeys.INSTANCE.getKEY_ROOM_ID(), roomOverall.getOcs().getData().getRoomId());
 
-                                Integer apiVersion = ApiUtils.getApiVersion(currentUser, "conversation",
-                                                                           new int[] {1});
+                                Integer apiVersion = ApiUtils.getConversationApiVersion(currentUser, new int[] {1});
                                 if (apiVersion != null && currentUser.hasSpreedFeatureCapability("chat-v2")) {
 
                                     ncApi.getRoom(credentials,
@@ -861,7 +860,7 @@ public class ContactsController extends BaseController implements SearchView.OnQ
                     roomType = "2";
                 }
 
-                Integer apiVersion = ApiUtils.getApiVersion(currentUser, "conversation", new int[] {1});
+                Integer apiVersion = ApiUtils.getConversationApiVersion(currentUser, new int[] {1});
 
                 if (apiVersion == null) {
                     Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
@@ -448,6 +448,7 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
         }
     }
 
+    @SuppressLint("LongLogTag")
     private fun getListOfParticipants() {
         val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
 
@@ -544,6 +545,7 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
         router.setBackstack(backstack, HorizontalChangeHandler())
     }
 
+    @SuppressLint("LongLogTag")
     private fun fetchRoomInfo() {
         val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
 
@@ -695,6 +697,7 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
         }
     }
 
+    @SuppressLint("LongLogTag")
     override fun onItemClick(view: View?, position: Int): Boolean {
         val userItem = adapter?.getItem(position) as UserItem
         val participant = userItem.model

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
@@ -20,13 +20,11 @@
 
 package com.nextcloud.talk.controllers
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.LayerDrawable
 import android.os.Bundle
 import android.text.TextUtils
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
@@ -300,7 +298,6 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
         }
     }
 
-    @SuppressLint("LongLogTag")
     fun submitLobbyChanges() {
         val state = if (
             (
@@ -443,7 +440,6 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
         }
     }
 
-    @SuppressLint("LongLogTag")
     private fun getListOfParticipants() {
         val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
 
@@ -535,7 +531,6 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
         router.setBackstack(backstack, HorizontalChangeHandler())
     }
 
-    @SuppressLint("LongLogTag")
     private fun fetchRoomInfo() {
         val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
 
@@ -682,7 +677,6 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
         }
     }
 
-    @SuppressLint("LongLogTag")
     override fun onItemClick(view: View?, position: Int): Boolean {
         val userItem = adapter?.getItem(position) as UserItem
         val participant = userItem.model
@@ -794,7 +788,6 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
 
     companion object {
 
-        private val TAG = "ConversationInfoController"
         private const val ID_DELETE_CONVERSATION_DIALOG = 0
     }
 

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
@@ -736,8 +736,11 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
                             if (participant.type == Participant.ParticipantType.MODERATOR) {
                                 ncApi.demoteModeratorToUser(
                                     credentials,
-                                    ApiUtils.getUrlForRoomModerators(apiVersion, conversationUser.baseUrl,
-                                        conversation!!.token),
+                                    ApiUtils.getUrlForRoomModerators(
+                                        apiVersion,
+                                        conversationUser.baseUrl,
+                                        conversation!!.token
+                                    ),
                                     participant.userId
                                 )
                                     .subscribeOn(Schedulers.io())
@@ -748,8 +751,11 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
                             } else if (participant.type == Participant.ParticipantType.USER) {
                                 ncApi.promoteUserToModerator(
                                     credentials,
-                                    ApiUtils.getUrlForRoomModerators(apiVersion, conversationUser.baseUrl,
-                                        conversation!!.token),
+                                    ApiUtils.getUrlForRoomModerators(
+                                        apiVersion,
+                                        conversationUser.baseUrl,
+                                        conversation!!.token
+                                    ),
                                     participant.userId
                                 )
                                     .subscribeOn(Schedulers.io())

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
@@ -312,11 +312,6 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
 
         val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
 
-        if (apiVersion == null) {
-            Log.e(TAG, "No supported API version found")
-            return
-        }
-
         ncApi.setLobbyForConversation(
             ApiUtils.getCredentials(conversationUser!!.username, conversationUser.token),
             ApiUtils.getUrlForRoomWebinaryLobby(apiVersion, conversationUser.baseUrl, conversation!!.token),
@@ -452,11 +447,6 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
     private fun getListOfParticipants() {
         val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
 
-        if (apiVersion == null) {
-            Log.e(TAG, "No supported API version found")
-            return
-        }
-
         ncApi.getPeersForCall(
             credentials,
             ApiUtils.getUrlForParticipants(apiVersion, conversationUser!!.baseUrl, conversationToken)
@@ -548,11 +538,6 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
     @SuppressLint("LongLogTag")
     private fun fetchRoomInfo() {
         val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
-
-        if (apiVersion == null) {
-            Log.e(TAG, "No supported API version found")
-            return
-        }
 
         ncApi.getRoom(credentials, ApiUtils.getUrlForRoom(apiVersion, conversationUser!!.baseUrl, conversationToken))
             .subscribeOn(Schedulers.io())
@@ -730,10 +715,6 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
                     listItemsWithImage(items = items) { dialog, index, _ ->
 
                         val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
-
-                        if (apiVersion == null) {
-                            Log.e(TAG, "No supported API version found")
-                        }
 
                         if (index == 0) {
                             if (participant.type == Participant.ParticipantType.MODERATOR) {

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
@@ -310,7 +310,7 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
                 ).isChecked
         ) 1 else 0
 
-        val apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation", intArrayOf(1))
+        val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
 
         if (apiVersion == null) {
             Log.e(TAG, "No supported API version found")
@@ -449,7 +449,7 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
     }
 
     private fun getListOfParticipants() {
-        val apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation", intArrayOf(1))
+        val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
 
         if (apiVersion == null) {
             Log.e(TAG, "No supported API version found")
@@ -545,7 +545,7 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
     }
 
     private fun fetchRoomInfo() {
-        val apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation", intArrayOf(1))
+        val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
 
         if (apiVersion == null) {
             Log.e(TAG, "No supported API version found")
@@ -726,7 +726,7 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
                     title(text = participant.displayName)
                     listItemsWithImage(items = items) { dialog, index, _ ->
 
-                        val apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation", intArrayOf(1))
+                        val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
 
                         if (apiVersion == null) {
                             Log.e(TAG, "No supported API version found")

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
@@ -441,7 +441,11 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
     }
 
     private fun getListOfParticipants() {
-        val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
+        var apiVersion = 1
+        // FIXME Fix API checking with guests?
+        if (conversationUser != null) {
+            apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
+        }
 
         ncApi.getPeersForCall(
             credentials,
@@ -532,7 +536,11 @@ class ConversationInfoController(args: Bundle) : BaseController(args), FlexibleA
     }
 
     private fun fetchRoomInfo() {
-        val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
+        var apiVersion = 1
+        // FIXME Fix API checking with guests?
+        if (conversationUser != null) {
+            apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(1))
+        }
 
         ncApi.getRoom(credentials, ApiUtils.getUrlForRoom(apiVersion, conversationUser!!.baseUrl, conversationToken))
             .subscribeOn(Schedulers.io())

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
@@ -418,7 +418,7 @@ public class ConversationsListController extends BaseController implements Searc
 
         callItems = new ArrayList<>();
 
-        Integer apiVersion = ApiUtils.getApiVersion(currentUser, "conversation", new int[] {4, 1});
+        Integer apiVersion = ApiUtils.getConversationApiVersion(currentUser, new int[] {4, 1});
         if (apiVersion == null) {
             Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
             return;

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
@@ -23,6 +23,7 @@
 package com.nextcloud.talk.controllers;
 
 import android.animation.AnimatorInflater;
+import android.annotation.SuppressLint;
 import android.app.SearchManager;
 import android.content.Context;
 import android.content.Intent;
@@ -409,6 +410,7 @@ public class ConversationsListController extends BaseController implements Searc
         searchItem.expandActionView();
     }
 
+    @SuppressLint("LongLogTag")
     private void fetchData(boolean fromBottomSheet) {
         dispose(null);
 

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
@@ -418,7 +418,15 @@ public class ConversationsListController extends BaseController implements Searc
 
         callItems = new ArrayList<>();
 
-        roomsQueryDisposable = ncApi.getRooms(credentials, ApiUtils.getUrlForGetRooms(currentUser.getBaseUrl()))
+        Integer apiVersion = ApiUtils.getApiVersion(currentUser, "conversation", new int[] {4, 1});
+        if (apiVersion == null) {
+            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
+            return;
+        }
+
+
+        roomsQueryDisposable = ncApi.getRooms(credentials, ApiUtils.getUrlForRooms(apiVersion,
+                                                                                   currentUser.getBaseUrl()))
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(roomsOverall -> {

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
@@ -23,7 +23,6 @@
 package com.nextcloud.talk.controllers;
 
 import android.animation.AnimatorInflater;
-import android.annotation.SuppressLint;
 import android.app.SearchManager;
 import android.content.Context;
 import android.content.Intent;
@@ -33,7 +32,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.text.InputType;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -410,7 +408,6 @@ public class ConversationsListController extends BaseController implements Searc
         searchItem.expandActionView();
     }
 
-    @SuppressLint("LongLogTag")
     private void fetchData(boolean fromBottomSheet) {
         dispose(null);
 

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
@@ -32,6 +32,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.text.InputType;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
@@ -418,12 +418,7 @@ public class ConversationsListController extends BaseController implements Searc
 
         callItems = new ArrayList<>();
 
-        Integer apiVersion = ApiUtils.getConversationApiVersion(currentUser, new int[] {4, 1});
-        if (apiVersion == null) {
-            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
-            return;
-        }
-
+        int apiVersion = ApiUtils.getConversationApiVersion(currentUser, new int[] {4, 1});
 
         roomsQueryDisposable = ncApi.getRooms(credentials, ApiUtils.getUrlForRooms(apiVersion,
                                                                                    currentUser.getBaseUrl()))

--- a/app/src/main/java/com/nextcloud/talk/controllers/bottomsheet/OperationsMenuController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/bottomsheet/OperationsMenuController.java
@@ -196,7 +196,7 @@ public class OperationsMenuController extends BaseController {
             Integer apiVersion = ApiUtils.getApiVersion(currentUser, "conversation",
                                                         new int[] {1});
 
-            if(apiVersion == null) {
+            if (apiVersion == null) {
                 Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
                 return;
             }
@@ -285,7 +285,7 @@ public class OperationsMenuController extends BaseController {
 
                     if (conversationType.equals(Conversation.ConversationType.ROOM_PUBLIC_CALL) ||
                             !currentUser.hasSpreedFeatureCapability("empty-group-room")) {
-                        retrofitBucket = ApiUtils.getRetrofitBucketForCreateRoom(currentUser.getBaseUrl(),
+                        retrofitBucket = ApiUtils.getRetrofitBucketForCreateRoom(apiVersion, currentUser.getBaseUrl(),
                                 "3", invite, conversationName);
                     } else {
                         String roomType = "2";
@@ -294,7 +294,7 @@ public class OperationsMenuController extends BaseController {
                             roomType = "3";
                         }
 
-                        retrofitBucket = ApiUtils.getRetrofitBucketForCreateRoom(currentUser.getBaseUrl(),
+                        retrofitBucket = ApiUtils.getRetrofitBucketForCreateRoom(apiVersion, currentUser.getBaseUrl(),
                                 roomType, invite, conversationName);
                     }
 
@@ -405,7 +405,7 @@ public class OperationsMenuController extends BaseController {
         Integer apiVersion = ApiUtils.getApiVersion(currentUser, "conversation",
                                                     new int[] {1});
 
-        if(apiVersion == null) {
+        if (apiVersion == null) {
             Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
             return;
         }
@@ -558,6 +558,7 @@ public class OperationsMenuController extends BaseController {
                 });
     }
 
+    @SuppressLint("LongLogTag")
     private void inviteUsersToAConversation() {
         RetrofitBucket retrofitBucket;
         final ArrayList<String> localInvitedUsers = invitedUsers;
@@ -566,11 +567,20 @@ public class OperationsMenuController extends BaseController {
             localInvitedGroups.remove(0);
         }
 
+        Integer apiVersion = ApiUtils.getApiVersion(currentUser, "conversation", new int[] {1});
+
+        if (apiVersion == null) {
+            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
+            return;
+        }
+
         if (localInvitedUsers.size() > 0 || (localInvitedGroups.size() > 0 && currentUser.hasSpreedFeatureCapability("invite-groups-and-mails"))) {
             if ((localInvitedGroups.size() > 0 && currentUser.hasSpreedFeatureCapability("invite-groups-and-mails"))) {
                 for (int i = 0; i < localInvitedGroups.size(); i++) {
                     final String groupId = localInvitedGroups.get(i);
-                    retrofitBucket = ApiUtils.getRetrofitBucketForAddGroupParticipant(currentUser.getBaseUrl(), conversation.getToken(),
+                    retrofitBucket = ApiUtils.getRetrofitBucketForAddGroupParticipant(apiVersion,
+                                                                                      currentUser.getBaseUrl(),
+                                                                                      conversation.getToken(),
                             groupId);
 
                     ncApi.addParticipant(credentials, retrofitBucket.getUrl(), retrofitBucket.getQueryMap())
@@ -610,8 +620,10 @@ public class OperationsMenuController extends BaseController {
 
             for (int i = 0; i < localInvitedUsers.size(); i++) {
                 final String userId = invitedUsers.get(i);
-                retrofitBucket = ApiUtils.getRetrofitBucketForAddParticipant(currentUser.getBaseUrl(), conversation.getToken(),
-                        userId);
+                retrofitBucket = ApiUtils.getRetrofitBucketForAddParticipant(apiVersion,
+                                                                             currentUser.getBaseUrl(),
+                                                                             conversation.getToken(),
+                                                                             userId);
 
                 ncApi.addParticipant(credentials, retrofitBucket.getUrl(), retrofitBucket.getQueryMap())
                         .subscribeOn(Schedulers.io())

--- a/app/src/main/java/com/nextcloud/talk/controllers/bottomsheet/OperationsMenuController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/bottomsheet/OperationsMenuController.java
@@ -20,7 +20,6 @@
 
 package com.nextcloud.talk.controllers.bottomsheet;
 
-import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
@@ -82,8 +81,6 @@ import retrofit2.HttpException;
 
 @AutoInjector(NextcloudTalkApplication.class)
 public class OperationsMenuController extends BaseController {
-
-    private static final String TAG = "OperationsMenuController";
 
     @BindView(R.id.progress_bar)
     ProgressBar progressBar;
@@ -172,7 +169,6 @@ public class OperationsMenuController extends BaseController {
         processOperation();
     }
 
-    @SuppressLint("LongLogTag")
     private void processOperation() {
         currentUser = userUtils.getCurrentUser();
         OperationsObserver operationsObserver = new OperationsObserver();
@@ -393,9 +389,7 @@ public class OperationsMenuController extends BaseController {
         }
     }
 
-    @SuppressLint("LongLogTag")
     private void performGroupCallWorkaround(String credentials) {
-
         int apiVersion = ApiUtils.getConversationApiVersion(currentUser, new int[] {1});
 
         ncApi.makeRoomPrivate(credentials, ApiUtils.getUrlForRoomPublic(apiVersion, currentUser.getBaseUrl(),
@@ -546,7 +540,6 @@ public class OperationsMenuController extends BaseController {
                 });
     }
 
-    @SuppressLint("LongLogTag")
     private void inviteUsersToAConversation() {
         RetrofitBucket retrofitBucket;
         final ArrayList<String> localInvitedUsers = invitedUsers;

--- a/app/src/main/java/com/nextcloud/talk/controllers/bottomsheet/OperationsMenuController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/bottomsheet/OperationsMenuController.java
@@ -185,11 +185,15 @@ public class OperationsMenuController extends BaseController {
         if (currentUser != null) {
             credentials = ApiUtils.getCredentials(currentUser.getUsername(), currentUser.getToken());
 
+            int apiVersion;
             if (!TextUtils.isEmpty(baseUrl) && !baseUrl.equals(currentUser.getBaseUrl())) {
                 credentials = null;
+                // FIXME joining a public link we need to check other capabilities
+                apiVersion = 1;
+            } else {
+                apiVersion = ApiUtils.getConversationApiVersion(currentUser, new int[] {1});
             }
 
-            int apiVersion = ApiUtils.getConversationApiVersion(currentUser, new int[] {1});
 
             switch (operationCode) {
                 case 2:

--- a/app/src/main/java/com/nextcloud/talk/controllers/bottomsheet/OperationsMenuController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/bottomsheet/OperationsMenuController.java
@@ -193,12 +193,7 @@ public class OperationsMenuController extends BaseController {
                 credentials = null;
             }
 
-            Integer apiVersion = ApiUtils.getConversationApiVersion(currentUser, new int[] {1});
-
-            if (apiVersion == null) {
-                Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
-                return;
-            }
+            int apiVersion = ApiUtils.getConversationApiVersion(currentUser, new int[] {1});
 
             switch (operationCode) {
                 case 2:
@@ -401,12 +396,7 @@ public class OperationsMenuController extends BaseController {
     @SuppressLint("LongLogTag")
     private void performGroupCallWorkaround(String credentials) {
 
-        Integer apiVersion = ApiUtils.getConversationApiVersion(currentUser, new int[] {1});
-
-        if (apiVersion == null) {
-            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
-            return;
-        }
+        int apiVersion = ApiUtils.getConversationApiVersion(currentUser, new int[] {1});
 
         ncApi.makeRoomPrivate(credentials, ApiUtils.getUrlForRoomPublic(apiVersion, currentUser.getBaseUrl(),
                                                                             conversation.getToken()))
@@ -565,12 +555,7 @@ public class OperationsMenuController extends BaseController {
             localInvitedGroups.remove(0);
         }
 
-        Integer apiVersion = ApiUtils.getConversationApiVersion(currentUser, new int[] {1});
-
-        if (apiVersion == null) {
-            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
-            return;
-        }
+        int apiVersion = ApiUtils.getConversationApiVersion(currentUser, new int[] {1});
 
         if (localInvitedUsers.size() > 0 || (localInvitedGroups.size() > 0 && currentUser.hasSpreedFeatureCapability("invite-groups-and-mails"))) {
             if ((localInvitedGroups.size() > 0 && currentUser.hasSpreedFeatureCapability("invite-groups-and-mails"))) {

--- a/app/src/main/java/com/nextcloud/talk/controllers/bottomsheet/OperationsMenuController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/bottomsheet/OperationsMenuController.java
@@ -193,8 +193,7 @@ public class OperationsMenuController extends BaseController {
                 credentials = null;
             }
 
-            Integer apiVersion = ApiUtils.getApiVersion(currentUser, "conversation",
-                                                        new int[] {1});
+            Integer apiVersion = ApiUtils.getConversationApiVersion(currentUser, new int[] {1});
 
             if (apiVersion == null) {
                 Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
@@ -402,8 +401,7 @@ public class OperationsMenuController extends BaseController {
     @SuppressLint("LongLogTag")
     private void performGroupCallWorkaround(String credentials) {
 
-        Integer apiVersion = ApiUtils.getApiVersion(currentUser, "conversation",
-                                                    new int[] {1});
+        Integer apiVersion = ApiUtils.getConversationApiVersion(currentUser, new int[] {1});
 
         if (apiVersion == null) {
             Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
@@ -567,7 +565,7 @@ public class OperationsMenuController extends BaseController {
             localInvitedGroups.remove(0);
         }
 
-        Integer apiVersion = ApiUtils.getApiVersion(currentUser, "conversation", new int[] {1});
+        Integer apiVersion = ApiUtils.getConversationApiVersion(currentUser, new int[] {1});
 
         if (apiVersion == null) {
             Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));

--- a/app/src/main/java/com/nextcloud/talk/jobs/AddParticipantsToConversation.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/AddParticipantsToConversation.java
@@ -73,12 +73,7 @@ public class AddParticipantsToConversation extends Worker {
         String[] selectedGroupIds = data.getStringArray(BundleKeys.INSTANCE.getKEY_SELECTED_GROUPS());
         UserEntity user = userUtils.getUserWithInternalId(data.getLong(BundleKeys.INSTANCE.getKEY_INTERNAL_USER_ID(), -1));
 
-        Integer apiVersion = ApiUtils.getConversationApiVersion(user, new int[] {1});
-
-        if (apiVersion == null) {
-            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
-            return Result.failure();
-        }
+        int apiVersion = ApiUtils.getConversationApiVersion(user, new int[] {1});
 
         String conversationToken = data.getString(BundleKeys.INSTANCE.getKEY_TOKEN());
         String credentials = ApiUtils.getCredentials(user.getUsername(), user.getToken());

--- a/app/src/main/java/com/nextcloud/talk/jobs/AddParticipantsToConversation.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/AddParticipantsToConversation.java
@@ -70,7 +70,7 @@ public class AddParticipantsToConversation extends Worker {
     public Result doWork() {
         UserEntity user = userUtils.getUserWithInternalId(data.getLong(BundleKeys.INSTANCE.getKEY_INTERNAL_USER_ID(), -1));
 
-        Integer apiVersion = ApiUtils.getApiVersion(user, "conversation", new int[] {1});
+        Integer apiVersion = ApiUtils.getConversationApiVersion(user, new int[] {1});
 
         if (apiVersion == null) {
             Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));

--- a/app/src/main/java/com/nextcloud/talk/jobs/AddParticipantsToConversation.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/AddParticipantsToConversation.java
@@ -20,9 +20,7 @@
 
 package com.nextcloud.talk.jobs;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
-import android.util.Log;
 
 import com.nextcloud.talk.api.NcApi;
 import com.nextcloud.talk.application.NextcloudTalkApplication;
@@ -35,8 +33,6 @@ import com.nextcloud.talk.utils.database.user.UserUtils;
 
 import org.greenrobot.eventbus.EventBus;
 
-import java.util.ArrayList;
-
 import javax.inject.Inject;
 
 import androidx.annotation.NonNull;
@@ -48,8 +44,6 @@ import io.reactivex.schedulers.Schedulers;
 
 @AutoInjector(NextcloudTalkApplication.class)
 public class AddParticipantsToConversation extends Worker {
-    private static final String TAG = "AddParticipantsToConversation";
-
     @Inject
     NcApi ncApi;
 
@@ -64,7 +58,6 @@ public class AddParticipantsToConversation extends Worker {
         NextcloudTalkApplication.Companion.getSharedApplication().getComponentApplication().inject(this);
     }
 
-    @SuppressLint("LongLogTag")
     @NonNull
     @Override
     public Result doWork() {

--- a/app/src/main/java/com/nextcloud/talk/jobs/AddParticipantsToConversation.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/AddParticipantsToConversation.java
@@ -68,6 +68,9 @@ public class AddParticipantsToConversation extends Worker {
     @NonNull
     @Override
     public Result doWork() {
+        Data data = getInputData();
+        String[] selectedUserIds = data.getStringArray(BundleKeys.INSTANCE.getKEY_SELECTED_USERS());
+        String[] selectedGroupIds = data.getStringArray(BundleKeys.INSTANCE.getKEY_SELECTED_GROUPS());
         UserEntity user = userUtils.getUserWithInternalId(data.getLong(BundleKeys.INSTANCE.getKEY_INTERNAL_USER_ID(), -1));
 
         Integer apiVersion = ApiUtils.getConversationApiVersion(user, new int[] {1});
@@ -77,9 +80,6 @@ public class AddParticipantsToConversation extends Worker {
             return Result.failure();
         }
 
-        Data data = getInputData();
-        String[] selectedUserIds = data.getStringArray(BundleKeys.INSTANCE.getKEY_SELECTED_USERS());
-        String[] selectedGroupIds = data.getStringArray(BundleKeys.INSTANCE.getKEY_SELECTED_GROUPS());
         String conversationToken = data.getString(BundleKeys.INSTANCE.getKEY_TOKEN());
         String credentials = ApiUtils.getCredentials(user.getUsername(), user.getToken());
 

--- a/app/src/main/java/com/nextcloud/talk/jobs/DeleteConversationWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/DeleteConversationWorker.java
@@ -80,8 +80,7 @@ public class DeleteConversationWorker extends Worker {
         UserEntity operationUser = userUtils.getUserWithId(operationUserId);
 
         if (operationUser != null) {
-            Integer apiVersion = ApiUtils.getApiVersion(operationUser, "conversation",
-                                                        new int[] {1});
+            Integer apiVersion = ApiUtils.getConversationApiVersion(operationUser,  new int[] {1});
 
             if (apiVersion == null) {
                 Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));

--- a/app/src/main/java/com/nextcloud/talk/jobs/DeleteConversationWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/DeleteConversationWorker.java
@@ -20,10 +20,7 @@
 
 package com.nextcloud.talk.jobs;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
-import android.util.Log;
-
 import androidx.annotation.NonNull;
 import androidx.work.Data;
 import androidx.work.Worker;
@@ -50,7 +47,6 @@ import java.net.CookieManager;
 
 @AutoInjector(NextcloudTalkApplication.class)
 public class DeleteConversationWorker extends Worker {
-    private static final String TAG = "DeleteConversationWorker";
     @Inject
     Retrofit retrofit;
 
@@ -70,7 +66,6 @@ public class DeleteConversationWorker extends Worker {
         NextcloudTalkApplication.Companion.getSharedApplication().getComponentApplication().inject(this);
     }
 
-    @SuppressLint("LongLogTag")
     @NonNull
     @Override
     public Result doWork() {

--- a/app/src/main/java/com/nextcloud/talk/jobs/DeleteConversationWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/DeleteConversationWorker.java
@@ -80,12 +80,7 @@ public class DeleteConversationWorker extends Worker {
         UserEntity operationUser = userUtils.getUserWithId(operationUserId);
 
         if (operationUser != null) {
-            Integer apiVersion = ApiUtils.getConversationApiVersion(operationUser,  new int[] {1});
-
-            if (apiVersion == null) {
-                Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
-                return Result.failure();
-            }
+            int apiVersion = ApiUtils.getConversationApiVersion(operationUser,  new int[] {1});
 
             String credentials = ApiUtils.getCredentials(operationUser.getUsername(), operationUser.getToken());
             ncApi = retrofit.newBuilder().client(okHttpClient.newBuilder().cookieJar(new

--- a/app/src/main/java/com/nextcloud/talk/jobs/LeaveConversationWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/LeaveConversationWorker.java
@@ -87,8 +87,7 @@ public class LeaveConversationWorker extends Worker {
             EventStatus eventStatus = new EventStatus(operationUser.getId(),
                     EventStatus.EventType.CONVERSATION_UPDATE, true);
 
-            Integer apiVersion = ApiUtils.getApiVersion(operationUser, "conversation",
-                                                        new int[] {1});
+            Integer apiVersion = ApiUtils.getConversationApiVersion(operationUser, new int[] {1});
 
             if (apiVersion == null) {
                 Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));

--- a/app/src/main/java/com/nextcloud/talk/jobs/LeaveConversationWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/LeaveConversationWorker.java
@@ -87,12 +87,7 @@ public class LeaveConversationWorker extends Worker {
             EventStatus eventStatus = new EventStatus(operationUser.getId(),
                     EventStatus.EventType.CONVERSATION_UPDATE, true);
 
-            Integer apiVersion = ApiUtils.getConversationApiVersion(operationUser, new int[] {1});
-
-            if (apiVersion == null) {
-                Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
-                return Result.failure();
-            }
+            int apiVersion = ApiUtils.getConversationApiVersion(operationUser, new int[] {1});
 
             ncApi.removeSelfFromRoom(credentials, ApiUtils.getUrlForParticipantsSelf(apiVersion,
                                                                                      operationUser.getBaseUrl(),

--- a/app/src/main/java/com/nextcloud/talk/jobs/LeaveConversationWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/LeaveConversationWorker.java
@@ -21,8 +21,6 @@
 package com.nextcloud.talk.jobs;
 
 import android.content.Context;
-import android.util.Log;
-
 import androidx.annotation.NonNull;
 import androidx.work.Data;
 import androidx.work.Worker;
@@ -49,8 +47,6 @@ import java.net.CookieManager;
 
 @AutoInjector(NextcloudTalkApplication.class)
 public class LeaveConversationWorker extends Worker {
-
-    private static final String TAG = "LeaveConversationWorker";
 
     @Inject
     Retrofit retrofit;

--- a/app/src/main/java/com/nextcloud/talk/jobs/LeaveConversationWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/LeaveConversationWorker.java
@@ -90,7 +90,7 @@ public class LeaveConversationWorker extends Worker {
             Integer apiVersion = ApiUtils.getApiVersion(operationUser, "conversation",
                                                         new int[] {1});
 
-            if(apiVersion == null) {
+            if (apiVersion == null) {
                 Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
                 return Result.failure();
             }

--- a/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.java
@@ -152,13 +152,7 @@ public class NotificationWorker extends Worker {
             importantConversation = Boolean.parseBoolean(arbitraryStorageEntity.getValue());
         }
 
-        Integer apiVersion = ApiUtils.getConversationApiVersion(userEntity, new int[] {1});
-
-        if (apiVersion == null) {
-            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
-            return;
-        }
-
+        int apiVersion = ApiUtils.getConversationApiVersion(userEntity, new int[] {1});
 
         ncApi.getRoom(credentials, ApiUtils.getUrlForRoom(apiVersion, userEntity.getBaseUrl(),
                 intent.getExtras().getString(BundleKeys.INSTANCE.getKEY_ROOM_TOKEN())))

--- a/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.java
@@ -152,8 +152,16 @@ public class NotificationWorker extends Worker {
             importantConversation = Boolean.parseBoolean(arbitraryStorageEntity.getValue());
         }
 
+        Integer apiVersion = ApiUtils.getApiVersion(userEntity, "conversation",
+                                                    new int[] {1});
 
-        ncApi.getRoom(credentials, ApiUtils.getRoom(userEntity.getBaseUrl(),
+        if (apiVersion == null) {
+            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
+            return;
+        }
+
+
+        ncApi.getRoom(credentials, ApiUtils.getUrlForRoom(apiVersion, userEntity.getBaseUrl(),
                 intent.getExtras().getString(BundleKeys.INSTANCE.getKEY_ROOM_TOKEN())))
                 .blockingSubscribe(new Observer<RoomOverall>() {
                     @Override

--- a/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.java
@@ -152,8 +152,7 @@ public class NotificationWorker extends Worker {
             importantConversation = Boolean.parseBoolean(arbitraryStorageEntity.getValue());
         }
 
-        Integer apiVersion = ApiUtils.getApiVersion(userEntity, "conversation",
-                                                    new int[] {1});
+        Integer apiVersion = ApiUtils.getConversationApiVersion(userEntity, new int[] {1});
 
         if (apiVersion == null) {
             Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));

--- a/app/src/main/java/com/nextcloud/talk/jobs/SignalingSettingsWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/SignalingSettingsWorker.java
@@ -81,8 +81,16 @@ public class SignalingSettingsWorker extends Worker {
         for (int i = 0; i < userEntityList.size(); i++) {
             userEntity = userEntityList.get(i);
             UserEntity finalUserEntity = userEntity;
+
+            Integer apiVersion = ApiUtils.getSignalingApiVersion(finalUserEntity, new int[] {2, 1});
+
+            if (apiVersion == null) {
+                Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
+                continue;
+            }
+
             ncApi.getSignalingSettings(ApiUtils.getCredentials(userEntity.getUsername(), userEntity.getToken()),
-                    ApiUtils.getUrlForSignalingSettings(userEntity.getBaseUrl()))
+                    ApiUtils.getUrlForSignalingSettings(apiVersion, userEntity.getBaseUrl()))
                     .blockingSubscribe(new Observer<SignalingSettingsOverall>() {
                         @Override
                         public void onSubscribe(Disposable d) {

--- a/app/src/main/java/com/nextcloud/talk/jobs/SignalingSettingsWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/SignalingSettingsWorker.java
@@ -82,12 +82,7 @@ public class SignalingSettingsWorker extends Worker {
             userEntity = userEntityList.get(i);
             UserEntity finalUserEntity = userEntity;
 
-            Integer apiVersion = ApiUtils.getSignalingApiVersion(finalUserEntity, new int[] {2, 1});
-
-            if (apiVersion == null) {
-                Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
-                continue;
-            }
+            int apiVersion = ApiUtils.getSignalingApiVersion(finalUserEntity, new int[] {2, 1});
 
             ncApi.getSignalingSettings(ApiUtils.getCredentials(userEntity.getUsername(), userEntity.getToken()),
                     ApiUtils.getUrlForSignalingSettings(apiVersion, userEntity.getBaseUrl()))

--- a/app/src/main/java/com/nextcloud/talk/presenters/MentionAutocompletePresenter.java
+++ b/app/src/main/java/com/nextcloud/talk/presenters/MentionAutocompletePresenter.java
@@ -20,9 +20,7 @@
 
 package com.nextcloud.talk.presenters;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
-import android.util.Log;
 import android.view.View;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
@@ -49,7 +47,6 @@ import java.util.List;
 
 @AutoInjector(NextcloudTalkApplication.class)
 public class MentionAutocompletePresenter extends RecyclerViewPresenter<Mention> implements FlexibleAdapter.OnItemClickListener {
-    private static final String TAG = "MentionAutocompletePresenter";
     @Inject
     NcApi ncApi;
     @Inject
@@ -84,7 +81,6 @@ public class MentionAutocompletePresenter extends RecyclerViewPresenter<Mention>
         return adapter;
     }
 
-    @SuppressLint("LongLogTag")
     @Override
     protected void onQuery(@Nullable CharSequence query) {
 

--- a/app/src/main/java/com/nextcloud/talk/presenters/MentionAutocompletePresenter.java
+++ b/app/src/main/java/com/nextcloud/talk/presenters/MentionAutocompletePresenter.java
@@ -20,7 +20,9 @@
 
 package com.nextcloud.talk.presenters;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
+import android.util.Log;
 import android.view.View;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
@@ -47,6 +49,7 @@ import java.util.List;
 
 @AutoInjector(NextcloudTalkApplication.class)
 public class MentionAutocompletePresenter extends RecyclerViewPresenter<Mention> implements FlexibleAdapter.OnItemClickListener {
+    private static final String TAG = "MentionAutocompletePresenter";
     @Inject
     NcApi ncApi;
     @Inject
@@ -81,6 +84,7 @@ public class MentionAutocompletePresenter extends RecyclerViewPresenter<Mention>
         return adapter;
     }
 
+    @SuppressLint("LongLogTag")
     @Override
     protected void onQuery(@Nullable CharSequence query) {
 
@@ -91,9 +95,17 @@ public class MentionAutocompletePresenter extends RecyclerViewPresenter<Mention>
             queryString = "";
         }
 
+        Integer apiVersion = ApiUtils.getChatApiVersion(currentUser, new int[] {1});
+
+        if (apiVersion == null) {
+            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
+            return;
+        }
+
         adapter.setFilter(queryString);
-        ncApi.getMentionAutocompleteSuggestions(ApiUtils.getCredentials(currentUser.getUsername(), currentUser
-                        .getToken()), ApiUtils.getUrlForMentionSuggestions(currentUser.getBaseUrl(), roomToken),
+        ncApi.getMentionAutocompleteSuggestions(
+                ApiUtils.getCredentials(currentUser.getUsername(), currentUser.getToken()),
+                ApiUtils.getUrlForMentionSuggestions(apiVersion, currentUser.getBaseUrl(), roomToken),
                 queryString, 5)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())

--- a/app/src/main/java/com/nextcloud/talk/presenters/MentionAutocompletePresenter.java
+++ b/app/src/main/java/com/nextcloud/talk/presenters/MentionAutocompletePresenter.java
@@ -95,12 +95,7 @@ public class MentionAutocompletePresenter extends RecyclerViewPresenter<Mention>
             queryString = "";
         }
 
-        Integer apiVersion = ApiUtils.getChatApiVersion(currentUser, new int[] {1});
-
-        if (apiVersion == null) {
-            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
-            return;
-        }
+        int apiVersion = ApiUtils.getChatApiVersion(currentUser, new int[] {1});
 
         adapter.setFilter(queryString);
         ncApi.getMentionAutocompleteSuggestions(

--- a/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
@@ -155,18 +155,31 @@ public class ApiUtils {
     }
 
     public static Integer getApiVersion(UserEntity capabilities, String apiName, int[] versions) {
-        boolean checkedConversationV4 = !apiName.equals("conversation");
+         if (apiName.equals("conversation")) {
+             boolean hasApiV4 = false;
+             for (int version : versions) {
+                 hasApiV4 |= version == 4;
+             }
+
+             if (!hasApiV4) {
+                 Exception e = new Exception("Api call did not try conversation-v4 api");
+                 Log.d(TAG, e.getMessage(), e);
+             }
+         }
 
         for (int version : versions) {
-            checkedConversationV4 |= version == 4;
-
             if (capabilities.hasSpreedFeatureCapability(apiName + "-v" + version)) {
-                if (!checkedConversationV4) {
-                    Exception e = new Exception("Api call did not try conversation-v4 api");
-                    Log.e(TAG, e.getMessage(), e);
-                }
-
                 return version;
+            }
+
+            // Fallback for old API versions
+            if (apiName.equals("conversation") && (version == 1 || version == 2)) {
+                if (capabilities.hasSpreedFeatureCapability(apiName + "-v2")) {
+                    return version;
+                }
+                if (version == 1  && capabilities.hasSpreedFeatureCapability(apiName)) {
+                    return version;
+                }
             }
         }
         return null;

--- a/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
@@ -109,7 +109,7 @@ public class ApiUtils {
         return baseUrl + ocsApiVersion + "/cloud/capabilities";
     }
 
-    public static Integer getConversationApiVersion(UserEntity capabilities, int[] versions) {
+    public static int getConversationApiVersion(UserEntity capabilities, int[] versions) throws NoSupportedApiException {
         boolean hasApiV4 = false;
         for (int version : versions) {
             hasApiV4 |= version == 4;
@@ -135,10 +135,10 @@ public class ApiUtils {
                 }
             }
         }
-        return null;
+        throw new NoSupportedApiException();
     }
 
-    public static Integer getSignalingApiVersion(UserEntity capabilities, int[] versions) {
+    public static int getSignalingApiVersion(UserEntity capabilities, int[] versions) throws NoSupportedApiException {
         for (int version : versions) {
             if (version == 2 && capabilities.hasSpreedFeatureCapability("sip-support")) {
                 return version;
@@ -149,17 +149,17 @@ public class ApiUtils {
                 return version;
             }
         }
-        return null;
+        throw new NoSupportedApiException();
     }
 
-    public static Integer getChatApiVersion(UserEntity capabilities, int[] versions) {
+    public static int getChatApiVersion(UserEntity capabilities, int[] versions) throws NoSupportedApiException {
         for (int version : versions) {
             if (version == 1 && capabilities.hasSpreedFeatureCapability("chat-v2")) {
                 // Do not question that chat-v2 capability shows the availability of api/v1/ endpoint *see no evil*
                 return version;
             }
         }
-        return null;
+        throw new NoSupportedApiException();
     }
 
     protected static String getUrlForApi(int version, String baseUrl) {

--- a/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
@@ -52,12 +52,12 @@ public class ApiUtils {
      */
     @Deprecated
     public static String getUrlForLobbyForConversation(String baseUrl, String token) {
-        return getRoom(baseUrl, token) + "/webinary/lobby";
+        return getUrlForRoomWebinaryLobby(1, baseUrl, token);
     }
 
     @Deprecated
     public static String getUrlForRemovingParticipantFromConversation(String baseUrl, String roomToken, boolean isGuest) {
-        String url = getUrlForParticipants(baseUrl, roomToken);
+        String url = getUrlForParticipants(1, baseUrl, roomToken);
 
         if (isGuest) {
             url += "/guests";
@@ -110,20 +110,11 @@ public class ApiUtils {
 
     /**
      * @deprecated Please specify the api version you want to use via
-     * {@link ApiUtils#getUrlForRoomNotificationLevel(int, String, String)} instead.
-     */
-    @Deprecated
-    public static String getUrlForSettingNotificationlevel(String baseUrl, String token) {
-        return getRoom(baseUrl, token) + "/notify";
-    }
-
-    /**
-     * @deprecated Please specify the api version you want to use via
      * {@link ApiUtils#getUrlForParticipantsActive(int, String, String)} instead.
      */
     @Deprecated
     public static String getUrlForSettingMyselfAsActiveParticipant(String baseUrl, String token) {
-        return getRoom(baseUrl, token) + "/participants/active";
+        return getUrlForParticipantsActive(1, baseUrl, token);
     }
 
 
@@ -187,8 +178,32 @@ public class ApiUtils {
         return getUrlForParticipants(version, baseUrl, token) + "/active";
     }
 
+    public static String getUrlForParticipantsSelf(int version, String baseUrl, String token) {
+        return getUrlForParticipants(version, baseUrl, token) + "/self";
+    }
+
+    public static String getUrlForRoomFavorite(int version, String baseUrl, String token) {
+        return getUrlForRoom(version, baseUrl, token) + "/favorite";
+    }
+
+    public static String getUrlForRoomModerators(int version, String baseUrl, String token) {
+        return getUrlForRoom(version, baseUrl, token) + "/moderators";
+    }
+
     public static String getUrlForRoomNotificationLevel(int version, String baseUrl, String token) {
         return getUrlForRoom(version, baseUrl, token) + "/notify";
+    }
+
+    public static String getUrlForRoomPublic(int version, String baseUrl, String token) {
+        return getUrlForRoom(version, baseUrl, token) + "/public";
+    }
+
+    public static String getUrlForRoomPassword(int version, String baseUrl, String token) {
+        return getUrlForRoom(version, baseUrl, token) + "/password";
+    }
+
+    public static String getUrlForRoomReadOnlyState(int version, String baseUrl, String token) {
+        return getUrlForRoom(version, baseUrl, token) + "/read-only";
     }
 
     public static String getUrlForRoomWebinaryLobby(int version, String baseUrl, String token) {
@@ -245,17 +260,8 @@ public class ApiUtils {
     }
 
     @Deprecated
-    public static String getUrlForRemoveSelfFromRoom(String baseUrl, String token) {
-        return baseUrl + ocsApiVersion + spreedApiVersion + "/room/" + token + "/participants/self";
-    }
-
-    @Deprecated
-    public static String getUrlForRoomVisibility(String baseUrl, String token) {
-        return baseUrl + ocsApiVersion + spreedApiVersion + "/room/" + token + "/public";
-    }
-
-    @Deprecated
     public static String getUrlForCall(String baseUrl, String token) {
+        // FIXME user APIv4
         return baseUrl + ocsApiVersion + spreedApiVersion + "/call/" + token;
 
     }
@@ -265,23 +271,22 @@ public class ApiUtils {
         return getUrlForCall(baseUrl, token) + "/ping";
     }
 
-    @Deprecated
     public static String getUrlForChat(String baseUrl, String token) {
         return baseUrl + ocsApiVersion + spreedApiVersion + "/chat/" + token;
     }
 
     @Deprecated
     public static String getUrlForExternalServerAuthBackend(String baseUrl) {
-        return baseUrl + ocsApiVersion + spreedApiVersion + "/signaling/backend";
+        return getUrlForSignaling(baseUrl, null) + "/backend";
     }
 
-    @Deprecated
     public static String getUrlForMentionSuggestions(String baseUrl, String token) {
         return getUrlForChat(baseUrl, token) + "/mentions";
     }
 
     @Deprecated
     public static String getUrlForSignaling(String baseUrl, @Nullable String token) {
+        // FIXME use APIv2 ?
         String signalingUrl = baseUrl + ocsApiVersion + spreedApiVersion + "/signaling";
         if (token == null) {
             return signalingUrl;
@@ -290,9 +295,13 @@ public class ApiUtils {
         }
     }
 
+    /**
+     * @deprecated Please specify the api version you want to use via
+     * {@link ApiUtils#getUrlForRoomModerators(int, String, String)} instead.
+     */
     @Deprecated
     public static String getUrlForModerators(String baseUrl, String roomToken) {
-        return getRoom(baseUrl, roomToken) + "/moderators";
+        return getUrlForRoomModerators(1, baseUrl, roomToken);
     }
 
     @Deprecated
@@ -309,7 +318,6 @@ public class ApiUtils {
         return baseUrl + ocsApiVersion + "/cloud/users/" + userId;
     }
 
-    @Deprecated
     public static String getUrlForUserSettings(String baseUrl) {
         return baseUrl + ocsApiVersion + spreedApiVersion + "/settings/user";
     }
@@ -337,11 +345,6 @@ public class ApiUtils {
         return baseUrl + "/index.php/avatar/guest/" + Uri.encode(name) + "/" + avatarSize;
     }
 
-    @Deprecated
-    public static String getUrlForPassword(String baseUrl, String token) {
-        return baseUrl + ocsApiVersion + spreedApiVersion + "/room/" + token + "/password";
-    }
-
     public static String getCredentials(String username, String token) {
         if (TextUtils.isEmpty(username) && TextUtils.isEmpty(token)) {
             return null;
@@ -358,18 +361,8 @@ public class ApiUtils {
                 getApplicationContext().getResources().getString(R.string.nc_push_server_url) + "/devices";
     }
 
-    @Deprecated
-    public static String getUrlForConversationFavorites(String baseUrl, String roomToken) {
-        return baseUrl + ocsApiVersion + spreedApiVersion + "/room/" + roomToken + "/favorite";
-    }
-
     public static String getUrlForNotificationWithId(String baseUrl, String notificationId) {
         return baseUrl + ocsApiVersion + "/apps/notifications/api/v2/notifications/" + notificationId;
-    }
-
-    @Deprecated
-    public static String getUrlForReadOnlyState(String baseUrl, String roomToken) {
-        return baseUrl + ocsApiVersion + spreedApiVersion + "/room/" + roomToken + "/read-only";
     }
 
     public static String getUrlForSearchByNumber(String baseUrl) {
@@ -384,9 +377,8 @@ public class ApiUtils {
         return baseUrl + "/remote.php/dav/files/" + user + "/" + remotePath;
     }
 
-    @Deprecated
     public static String getUrlForMessageDeletion(String baseUrl, String token, String messageId) {
-        return baseUrl + ocsApiVersion + spreedApiVersion + "/chat/" + token + "/" + messageId;
+        return getUrlForChat(baseUrl, token) + "/" + messageId;
     }
 
     public static String getUrlForTempAvatar(String baseUrl) {

--- a/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
@@ -154,6 +154,16 @@ public class ApiUtils {
         return null;
     }
 
+    public static Integer getChatApiVersion(UserEntity capabilities, int[] versions) {
+        for (int version : versions) {
+            if (version == 1 && capabilities.hasSpreedFeatureCapability("chat-v2")) {
+                // Do not question that chat-v2 capability shows the availability of api/v1/ endpoint *see no evil*
+                return version;
+            }
+        }
+        return null;
+    }
+
     protected static String getUrlForApi(int version, String baseUrl) {
         return baseUrl + spreedApiBase + version;
     }
@@ -212,6 +222,16 @@ public class ApiUtils {
 
     public static String getUrlForCall(int version, String baseUrl, String token) {
         return getUrlForApi(version, baseUrl) + "/call/" + token;
+    }
+    public static String getUrlForChat(int version, String baseUrl, String token) {
+        return getUrlForApi(version, baseUrl) + "/chat/" + token;
+    }
+
+    public static String getUrlForMentionSuggestions(int version, String baseUrl, String token) {
+        return getUrlForChat(version, baseUrl, token) + "/mentions";
+    }
+    public static String getUrlForChatMessage(int version, String baseUrl, String token, String messageId) {
+        return getUrlForChat(version, baseUrl, token) + "/" + messageId;
     }
 
     public static String getUrlForSignaling(int version, String baseUrl) {
@@ -285,16 +305,6 @@ public class ApiUtils {
         return getUrlForCall(1, baseUrl, token) + "/ping";
     }
 
-    public static String getUrlForChat(String baseUrl, String token) {
-        // FIXME Introduce API version
-        return baseUrl + ocsApiVersion + spreedApiVersion + "/chat/" + token;
-    }
-
-    public static String getUrlForMentionSuggestions(String baseUrl, String token) {
-        // FIXME Introduce API version
-        return getUrlForChat(baseUrl, token) + "/mentions";
-    }
-
     public static String getUrlForUserProfile(String baseUrl) {
         return baseUrl + ocsApiVersion + "/cloud/user";
     }
@@ -361,10 +371,6 @@ public class ApiUtils {
 
     public static String getUrlForFileDownload(String baseUrl, String user, String remotePath) {
         return baseUrl + "/remote.php/dav/files/" + user + "/" + remotePath;
-    }
-
-    public static String getUrlForMessageDeletion(String baseUrl, String token, String messageId) {
-        return getUrlForChat(baseUrl, token) + "/" + messageId;
     }
 
     public static String getUrlForTempAvatar(String baseUrl) {

--- a/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
@@ -196,6 +196,10 @@ public class ApiUtils {
         return getUrlForRoom(version, baseUrl, token) + "/webinary/lobby";
     }
 
+    public static String getUrlForCall(int version, String baseUrl, String token) {
+        return getUrlForApi(version, baseUrl) + "/call/" + token;
+    }
+
     public static RetrofitBucket getRetrofitBucketForCreateRoom(int version, String baseUrl, String roomType,
                                                                 @Nullable String invite,
                                                                 @Nullable String conversationName) {
@@ -243,15 +247,12 @@ public class ApiUtils {
         return retrofitBucket;
     }
 
-    public static String getUrlForCall(String baseUrl, String token) {
-        // FIXME Introduce API version
-        return baseUrl + ocsApiVersion + spreedApiVersion + "/call/" + token;
-
-    }
-
+    /**
+     * @deprecated Method is only needed before Talk 4 which is from 2018 => todrop
+     */
+    @Deprecated
     public static String getUrlForCallPing(String baseUrl, String token) {
-        // FIXME Introduce API version
-        return getUrlForCall(baseUrl, token) + "/ping";
+        return getUrlForCall(1, baseUrl, token) + "/ping";
     }
 
     public static String getUrlForChat(String baseUrl, String token) {

--- a/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
@@ -29,10 +29,7 @@ import com.nextcloud.talk.application.NextcloudTalkApplication;
 import com.nextcloud.talk.models.RetrofitBucket;
 import com.nextcloud.talk.models.database.UserEntity;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import androidx.annotation.DimenRes;
@@ -41,18 +38,18 @@ import okhttp3.Credentials;
 
 public class ApiUtils {
     private static final String TAG = "ApiUtils";
-    private static String ocsApiVersion = "/ocs/v2.php";
-    private static String spreedApiVersion = "/apps/spreed/api/v1";
-    private static String spreedApiBase = ocsApiVersion + "/apps/spreed/api/v";
+    private static final String ocsApiVersion = "/ocs/v2.php";
+    private static final String spreedApiVersion = "/apps/spreed/api/v1";
+    private static final String spreedApiBase = ocsApiVersion + "/apps/spreed/api/v";
 
-    private static String userAgent = "Mozilla/5.0 (Android) Nextcloud-Talk v";
+    private static final String userAgent = "Mozilla/5.0 (Android) Nextcloud-Talk v";
 
     public static String getUserAgent() {
         return userAgent + BuildConfig.VERSION_NAME;
     }
 
     /**
-     * @deprecated Please specify the api version you want to use via
+     * @deprecated This is only supported on API v1-3, in API v4+ please use
      * {@link ApiUtils#getUrlForAttendees(int, String, String)} instead.
      */
     @Deprecated
@@ -108,26 +105,8 @@ public class ApiUtils {
         return retrofitBucket;
     }
 
-    /**
-     * @deprecated Please specify the api version you want to use via
-     * {@link ApiUtils#getUrlForParticipantsActive(int, String, String)} instead.
-     */
-    @Deprecated
-    public static String getUrlForSettingMyselfAsActiveParticipant(String baseUrl, String token) {
-        return getUrlForParticipantsActive(1, baseUrl, token);
-    }
-
     public static String getUrlForCapabilities(String baseUrl) {
         return baseUrl + ocsApiVersion + "/cloud/capabilities";
-    }
-
-    /**
-     * @deprecated Please specify the api version you want to use via
-     * {@link ApiUtils#getUrlForRooms(int, String)} instead.
-     */
-    @Deprecated
-    public static String getUrlForGetRooms(String baseUrl) {
-        return getUrlForRooms(1, baseUrl);
     }
 
     public static Integer getApiVersion(UserEntity capabilities, String apiName, int[] versions) {
@@ -217,12 +196,11 @@ public class ApiUtils {
         return getUrlForRoom(version, baseUrl, token) + "/webinary/lobby";
     }
 
-    @Deprecated
-    public static RetrofitBucket getRetrofitBucketForCreateRoom(String baseUrl, String roomType,
+    public static RetrofitBucket getRetrofitBucketForCreateRoom(int version, String baseUrl, String roomType,
                                                                 @Nullable String invite,
                                                                 @Nullable String conversationName) {
         RetrofitBucket retrofitBucket = new RetrofitBucket();
-        retrofitBucket.setUrl(baseUrl + ocsApiVersion + spreedApiVersion + "/room");
+        retrofitBucket.setUrl(getUrlForRooms(version, baseUrl));
         Map<String, String> queryMap = new HashMap<>();
 
         queryMap.put("roomType", roomType);
@@ -239,10 +217,9 @@ public class ApiUtils {
         return retrofitBucket;
     }
 
-    @Deprecated
-    public static RetrofitBucket getRetrofitBucketForAddParticipant(String baseUrl, String token, String user) {
+    public static RetrofitBucket getRetrofitBucketForAddParticipant(int version, String baseUrl, String token, String user) {
         RetrofitBucket retrofitBucket = new RetrofitBucket();
-        retrofitBucket.setUrl(baseUrl + ocsApiVersion + spreedApiVersion + "/room/" + token + "/participants");
+        retrofitBucket.setUrl(getUrlForParticipants(version, baseUrl, token));
 
         Map<String, String> queryMap = new HashMap<>();
 
@@ -254,46 +231,46 @@ public class ApiUtils {
 
     }
 
-    public static RetrofitBucket getRetrofitBucketForAddGroupParticipant(String baseUrl, String token, String group) {
-        RetrofitBucket retrofitBucket = getRetrofitBucketForAddParticipant(baseUrl, token, group);
+    public static RetrofitBucket getRetrofitBucketForAddGroupParticipant(int version, String baseUrl, String token, String group) {
+        RetrofitBucket retrofitBucket = getRetrofitBucketForAddParticipant(version, baseUrl, token, group);
         retrofitBucket.getQueryMap().put("source", "groups");
         return retrofitBucket;
     }
 
-    public static RetrofitBucket getRetrofitBucketForAddMailParticipant(String baseUrl, String token, String mail) {
-        RetrofitBucket retrofitBucket = getRetrofitBucketForAddParticipant(baseUrl, token, mail);
+    public static RetrofitBucket getRetrofitBucketForAddMailParticipant(int version, String baseUrl, String token, String mail) {
+        RetrofitBucket retrofitBucket = getRetrofitBucketForAddParticipant(version, baseUrl, token, mail);
         retrofitBucket.getQueryMap().put("source", "emails");
         return retrofitBucket;
     }
 
-    @Deprecated
     public static String getUrlForCall(String baseUrl, String token) {
-        // FIXME user APIv4
+        // FIXME Introduce API version
         return baseUrl + ocsApiVersion + spreedApiVersion + "/call/" + token;
 
     }
 
-    @Deprecated
     public static String getUrlForCallPing(String baseUrl, String token) {
+        // FIXME Introduce API version
         return getUrlForCall(baseUrl, token) + "/ping";
     }
 
     public static String getUrlForChat(String baseUrl, String token) {
+        // FIXME Introduce API version
         return baseUrl + ocsApiVersion + spreedApiVersion + "/chat/" + token;
     }
 
-    @Deprecated
     public static String getUrlForExternalServerAuthBackend(String baseUrl) {
+        // FIXME Introduce API version
         return getUrlForSignaling(baseUrl, null) + "/backend";
     }
 
     public static String getUrlForMentionSuggestions(String baseUrl, String token) {
+        // FIXME Introduce API version
         return getUrlForChat(baseUrl, token) + "/mentions";
     }
 
-    @Deprecated
     public static String getUrlForSignaling(String baseUrl, @Nullable String token) {
-        // FIXME use APIv2 ?
+        // FIXME Introduce API version
         String signalingUrl = baseUrl + ocsApiVersion + spreedApiVersion + "/signaling";
         if (token == null) {
             return signalingUrl;
@@ -302,17 +279,8 @@ public class ApiUtils {
         }
     }
 
-    /**
-     * @deprecated Please specify the api version you want to use via
-     * {@link ApiUtils#getUrlForRoomModerators(int, String, String)} instead.
-     */
-    @Deprecated
-    public static String getUrlForModerators(String baseUrl, String roomToken) {
-        return getUrlForRoomModerators(1, baseUrl, roomToken);
-    }
-
-    @Deprecated
     public static String getUrlForSignalingSettings(String baseUrl) {
+        // FIXME Introduce API version
         return getUrlForSignaling(baseUrl, null) + "/settings";
     }
 
@@ -326,6 +294,7 @@ public class ApiUtils {
     }
 
     public static String getUrlForUserSettings(String baseUrl) {
+        // FIXME Introduce API version
         return baseUrl + ocsApiVersion + spreedApiVersion + "/settings/user";
     }
 

--- a/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
@@ -26,6 +26,7 @@ import com.nextcloud.talk.BuildConfig;
 import com.nextcloud.talk.R;
 import com.nextcloud.talk.application.NextcloudTalkApplication;
 import com.nextcloud.talk.models.RetrofitBucket;
+import com.nextcloud.talk.models.database.UserEntity;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -37,6 +38,7 @@ import okhttp3.Credentials;
 public class ApiUtils {
     private static String ocsApiVersion = "/ocs/v2.php";
     private static String spreedApiVersion = "/apps/spreed/api/v1";
+    private static String spreedApiBase = ocsApiVersion + "/apps/spreed/api/v";
 
     private static String userAgent = "Mozilla/5.0 (Android) Nextcloud-Talk v";
 
@@ -122,12 +124,30 @@ public class ApiUtils {
         return baseUrl + ocsApiVersion + spreedApiVersion + "/room";
     }
 
+    /**
+     * @deprecated Please specify the api version you want to use via
+     * {@link ApiUtils#getRoom(int, String, String)} instead.
+     */
+    @Deprecated
     public static String getRoom(String baseUrl, String token) {
-        return baseUrl + ocsApiVersion + spreedApiVersion + "/room/" + token;
+        return getRoom(1, baseUrl, token);
     }
 
-    public static String getRoomV3(String baseUrl, String token) {
-        return baseUrl + ocsApiVersion + "/apps/spreed/api/v3" + "/room/" + token;
+    public static Integer getApiVersion(UserEntity capabilities, String apiName, int[] versions) {
+        for (int version : versions) {
+            if (capabilities.hasSpreedFeatureCapability(apiName + "-v" + version)) {
+                return version;
+            }
+        }
+        return null;
+    }
+
+    protected static String getApi(int version, String baseUrl) {
+        return baseUrl + spreedApiBase + version;
+    }
+
+    public static String getRoom(int version, String baseUrl, String token) {
+        return getApi(version, baseUrl) + "/room/" + token;
     }
 
     public static RetrofitBucket getRetrofitBucketForCreateRoom(String baseUrl, String roomType,

--- a/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
@@ -129,7 +129,7 @@ public class ApiUtils {
      */
     @Deprecated
     public static String getUrlForParticipants(String baseUrl, String token) {
-        return getRoom(baseUrl, token) + "/participants";
+        return getUrlForParticipants(1, baseUrl, token);
     }
 
     public static String getUrlForCapabilities(String baseUrl) {
@@ -142,7 +142,7 @@ public class ApiUtils {
      */
     @Deprecated
     public static String getUrlForGetRooms(String baseUrl) {
-        return baseUrl + ocsApiVersion + spreedApiVersion + "/room";
+        return getUrlForRooms(1, baseUrl);
     }
 
     /**

--- a/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
@@ -140,6 +140,20 @@ public class ApiUtils {
         return null;
     }
 
+    public static Integer getSignalingApiVersion(UserEntity capabilities, int[] versions) {
+        for (int version : versions) {
+            if (version == 2 && capabilities.hasSpreedFeatureCapability("sip-support")) {
+                return version;
+            }
+
+            if (version == 1) {
+                // Has no capability, we just assume it is always there for now.
+                return version;
+            }
+        }
+        return null;
+    }
+
     protected static String getUrlForApi(int version, String baseUrl) {
         return baseUrl + spreedApiBase + version;
     }
@@ -198,6 +212,22 @@ public class ApiUtils {
 
     public static String getUrlForCall(int version, String baseUrl, String token) {
         return getUrlForApi(version, baseUrl) + "/call/" + token;
+    }
+
+    public static String getUrlForSignaling(int version, String baseUrl) {
+        return getUrlForApi(version, baseUrl) + "/signaling";
+    }
+
+    public static String getUrlForSignalingBackend(int version, String baseUrl) {
+        return getUrlForSignaling(version, baseUrl) + "/backend";
+    }
+
+    public static String getUrlForSignalingSettings(int version, String baseUrl) {
+        return getUrlForSignaling(version, baseUrl) + "/settings";
+    }
+
+    public static String getUrlForSignaling(int version, String baseUrl, String token) {
+        return getUrlForSignaling(version, baseUrl) + "/" + token;
     }
 
     public static RetrofitBucket getRetrofitBucketForCreateRoom(int version, String baseUrl, String roomType,
@@ -260,31 +290,10 @@ public class ApiUtils {
         return baseUrl + ocsApiVersion + spreedApiVersion + "/chat/" + token;
     }
 
-    public static String getUrlForExternalServerAuthBackend(String baseUrl) {
-        // FIXME Introduce API version
-        return getUrlForSignaling(baseUrl, null) + "/backend";
-    }
-
     public static String getUrlForMentionSuggestions(String baseUrl, String token) {
         // FIXME Introduce API version
         return getUrlForChat(baseUrl, token) + "/mentions";
     }
-
-    public static String getUrlForSignaling(String baseUrl, @Nullable String token) {
-        // FIXME Introduce API version
-        String signalingUrl = baseUrl + ocsApiVersion + spreedApiVersion + "/signaling";
-        if (token == null) {
-            return signalingUrl;
-        } else {
-            return signalingUrl + "/" + token;
-        }
-    }
-
-    public static String getUrlForSignalingSettings(String baseUrl) {
-        // FIXME Introduce API version
-        return getUrlForSignaling(baseUrl, null) + "/settings";
-    }
-
 
     public static String getUrlForUserProfile(String baseUrl) {
         return baseUrl + ocsApiVersion + "/cloud/user";

--- a/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
@@ -109,30 +109,28 @@ public class ApiUtils {
         return baseUrl + ocsApiVersion + "/cloud/capabilities";
     }
 
-    public static Integer getApiVersion(UserEntity capabilities, String apiName, int[] versions) {
-         if (apiName.equals("conversation")) {
-             boolean hasApiV4 = false;
-             for (int version : versions) {
-                 hasApiV4 |= version == 4;
-             }
+    public static Integer getConversationApiVersion(UserEntity capabilities, int[] versions) {
+        boolean hasApiV4 = false;
+        for (int version : versions) {
+            hasApiV4 |= version == 4;
+        }
 
-             if (!hasApiV4) {
-                 Exception e = new Exception("Api call did not try conversation-v4 api");
-                 Log.d(TAG, e.getMessage(), e);
-             }
-         }
+        if (!hasApiV4) {
+            Exception e = new Exception("Api call did not try conversation-v4 api");
+            Log.d(TAG, e.getMessage(), e);
+        }
 
         for (int version : versions) {
-            if (capabilities.hasSpreedFeatureCapability(apiName + "-v" + version)) {
+            if (capabilities.hasSpreedFeatureCapability("conversation-v" + version)) {
                 return version;
             }
 
             // Fallback for old API versions
-            if (apiName.equals("conversation") && (version == 1 || version == 2)) {
-                if (capabilities.hasSpreedFeatureCapability(apiName + "-v2")) {
+            if ((version == 1 || version == 2)) {
+                if (capabilities.hasSpreedFeatureCapability("conversation-v2")) {
                     return version;
                 }
-                if (version == 1  && capabilities.hasSpreedFeatureCapability(apiName)) {
+                if (version == 1  && capabilities.hasSpreedFeatureCapability("conversation")) {
                     return version;
                 }
             }

--- a/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
@@ -46,10 +46,16 @@ public class ApiUtils {
         return userAgent + BuildConfig.VERSION_NAME;
     }
 
+    /**
+     * @deprecated Please specify the api version you want to use via
+     * {@link ApiUtils#getUrlForRoomWebinaryLobby(int, String, String)} instead.
+     */
+    @Deprecated
     public static String getUrlForLobbyForConversation(String baseUrl, String token) {
         return getRoom(baseUrl, token) + "/webinary/lobby";
     }
 
+    @Deprecated
     public static String getUrlForRemovingParticipantFromConversation(String baseUrl, String roomToken, boolean isGuest) {
         String url = getUrlForParticipants(baseUrl, roomToken);
 
@@ -102,16 +108,30 @@ public class ApiUtils {
         return retrofitBucket;
     }
 
-
+    /**
+     * @deprecated Please specify the api version you want to use via
+     * {@link ApiUtils#getUrlForRoomNotificationLevel(int, String, String)} instead.
+     */
+    @Deprecated
     public static String getUrlForSettingNotificationlevel(String baseUrl, String token) {
         return getRoom(baseUrl, token) + "/notify";
     }
 
+    /**
+     * @deprecated Please specify the api version you want to use via
+     * {@link ApiUtils#getUrlForParticipantsActive(int, String, String)} instead.
+     */
+    @Deprecated
     public static String getUrlForSettingMyselfAsActiveParticipant(String baseUrl, String token) {
         return getRoom(baseUrl, token) + "/participants/active";
     }
 
 
+    /**
+     * @deprecated Please specify the api version you want to use via
+     * {@link ApiUtils#getUrlForParticipants(int, String, String)} instead.
+     */
+    @Deprecated
     public static String getUrlForParticipants(String baseUrl, String token) {
         return getRoom(baseUrl, token) + "/participants";
     }
@@ -120,17 +140,22 @@ public class ApiUtils {
         return baseUrl + ocsApiVersion + "/cloud/capabilities";
     }
 
+    /**
+     * @deprecated Please specify the api version you want to use via
+     * {@link ApiUtils#getUrlForRooms(int, String)} instead.
+     */
+    @Deprecated
     public static String getUrlForGetRooms(String baseUrl) {
         return baseUrl + ocsApiVersion + spreedApiVersion + "/room";
     }
 
     /**
      * @deprecated Please specify the api version you want to use via
-     * {@link ApiUtils#getRoom(int, String, String)} instead.
+     * {@link ApiUtils#getUrlForRoom(int, String, String)} instead.
      */
     @Deprecated
     public static String getRoom(String baseUrl, String token) {
-        return getRoom(1, baseUrl, token);
+        return getUrlForRoom(1, baseUrl, token);
     }
 
     public static Integer getApiVersion(UserEntity capabilities, String apiName, int[] versions) {
@@ -142,14 +167,35 @@ public class ApiUtils {
         return null;
     }
 
-    protected static String getApi(int version, String baseUrl) {
+    protected static String getUrlForApi(int version, String baseUrl) {
         return baseUrl + spreedApiBase + version;
     }
 
-    public static String getRoom(int version, String baseUrl, String token) {
-        return getApi(version, baseUrl) + "/room/" + token;
+    public static String getUrlForRooms(int version, String baseUrl) {
+        return getUrlForApi(version, baseUrl) + "/room";
     }
 
+    public static String getUrlForRoom(int version, String baseUrl, String token) {
+        return getUrlForRooms(version, baseUrl) + "/" + token;
+    }
+
+    public static String getUrlForParticipants(int version, String baseUrl, String token) {
+        return getUrlForRoom(version, baseUrl, token) + "/participants";
+    }
+
+    public static String getUrlForParticipantsActive(int version, String baseUrl, String token) {
+        return getUrlForParticipants(version, baseUrl, token) + "/active";
+    }
+
+    public static String getUrlForRoomNotificationLevel(int version, String baseUrl, String token) {
+        return getUrlForRoom(version, baseUrl, token) + "/notify";
+    }
+
+    public static String getUrlForRoomWebinaryLobby(int version, String baseUrl, String token) {
+        return getUrlForRoom(version, baseUrl, token) + "/webinary/lobby";
+    }
+
+    @Deprecated
     public static RetrofitBucket getRetrofitBucketForCreateRoom(String baseUrl, String roomType,
                                                                 @Nullable String invite,
                                                                 @Nullable String conversationName) {
@@ -171,6 +217,7 @@ public class ApiUtils {
         return retrofitBucket;
     }
 
+    @Deprecated
     public static RetrofitBucket getRetrofitBucketForAddParticipant(String baseUrl, String token, String user) {
         RetrofitBucket retrofitBucket = new RetrofitBucket();
         retrofitBucket.setUrl(baseUrl + ocsApiVersion + spreedApiVersion + "/room/" + token + "/participants");
@@ -197,35 +244,43 @@ public class ApiUtils {
         return retrofitBucket;
     }
 
+    @Deprecated
     public static String getUrlForRemoveSelfFromRoom(String baseUrl, String token) {
         return baseUrl + ocsApiVersion + spreedApiVersion + "/room/" + token + "/participants/self";
     }
 
+    @Deprecated
     public static String getUrlForRoomVisibility(String baseUrl, String token) {
         return baseUrl + ocsApiVersion + spreedApiVersion + "/room/" + token + "/public";
     }
 
+    @Deprecated
     public static String getUrlForCall(String baseUrl, String token) {
         return baseUrl + ocsApiVersion + spreedApiVersion + "/call/" + token;
 
     }
 
+    @Deprecated
     public static String getUrlForCallPing(String baseUrl, String token) {
         return getUrlForCall(baseUrl, token) + "/ping";
     }
 
+    @Deprecated
     public static String getUrlForChat(String baseUrl, String token) {
         return baseUrl + ocsApiVersion + spreedApiVersion + "/chat/" + token;
     }
 
+    @Deprecated
     public static String getUrlForExternalServerAuthBackend(String baseUrl) {
         return baseUrl + ocsApiVersion + spreedApiVersion + "/signaling/backend";
     }
 
+    @Deprecated
     public static String getUrlForMentionSuggestions(String baseUrl, String token) {
         return getUrlForChat(baseUrl, token) + "/mentions";
     }
 
+    @Deprecated
     public static String getUrlForSignaling(String baseUrl, @Nullable String token) {
         String signalingUrl = baseUrl + ocsApiVersion + spreedApiVersion + "/signaling";
         if (token == null) {
@@ -235,10 +290,12 @@ public class ApiUtils {
         }
     }
 
+    @Deprecated
     public static String getUrlForModerators(String baseUrl, String roomToken) {
         return getRoom(baseUrl, roomToken) + "/moderators";
     }
 
+    @Deprecated
     public static String getUrlForSignalingSettings(String baseUrl) {
         return getUrlForSignaling(baseUrl, null) + "/settings";
     }
@@ -252,6 +309,7 @@ public class ApiUtils {
         return baseUrl + ocsApiVersion + "/cloud/users/" + userId;
     }
 
+    @Deprecated
     public static String getUrlForUserSettings(String baseUrl) {
         return baseUrl + ocsApiVersion + spreedApiVersion + "/settings/user";
     }
@@ -279,6 +337,7 @@ public class ApiUtils {
         return baseUrl + "/index.php/avatar/guest/" + Uri.encode(name) + "/" + avatarSize;
     }
 
+    @Deprecated
     public static String getUrlForPassword(String baseUrl, String token) {
         return baseUrl + ocsApiVersion + spreedApiVersion + "/room/" + token + "/password";
     }
@@ -299,6 +358,7 @@ public class ApiUtils {
                 getApplicationContext().getResources().getString(R.string.nc_push_server_url) + "/devices";
     }
 
+    @Deprecated
     public static String getUrlForConversationFavorites(String baseUrl, String roomToken) {
         return baseUrl + ocsApiVersion + spreedApiVersion + "/room/" + roomToken + "/favorite";
     }
@@ -307,6 +367,7 @@ public class ApiUtils {
         return baseUrl + ocsApiVersion + "/apps/notifications/api/v2/notifications/" + notificationId;
     }
 
+    @Deprecated
     public static String getUrlForReadOnlyState(String baseUrl, String roomToken) {
         return baseUrl + ocsApiVersion + spreedApiVersion + "/room/" + roomToken + "/read-only";
     }
@@ -323,6 +384,7 @@ public class ApiUtils {
         return baseUrl + "/remote.php/dav/files/" + user + "/" + remotePath;
     }
 
+    @Deprecated
     public static String getUrlForMessageDeletion(String baseUrl, String token, String messageId) {
         return baseUrl + ocsApiVersion + spreedApiVersion + "/chat/" + token + "/" + messageId;
     }

--- a/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
@@ -53,13 +53,8 @@ public class ApiUtils {
 
     /**
      * @deprecated Please specify the api version you want to use via
-     * {@link ApiUtils#getUrlForRoomWebinaryLobby(int, String, String)} instead.
+     * {@link ApiUtils#getUrlForAttendees(int, String, String)} instead.
      */
-    @Deprecated
-    public static String getUrlForLobbyForConversation(String baseUrl, String token) {
-        return getUrlForRoomWebinaryLobby(1, baseUrl, token);
-    }
-
     @Deprecated
     public static String getUrlForRemovingParticipantFromConversation(String baseUrl, String roomToken, boolean isGuest) {
         String url = getUrlForParticipants(1, baseUrl, roomToken);
@@ -122,16 +117,6 @@ public class ApiUtils {
         return getUrlForParticipantsActive(1, baseUrl, token);
     }
 
-
-    /**
-     * @deprecated Please specify the api version you want to use via
-     * {@link ApiUtils#getUrlForParticipants(int, String, String)} instead.
-     */
-    @Deprecated
-    public static String getUrlForParticipants(String baseUrl, String token) {
-        return getUrlForParticipants(1, baseUrl, token);
-    }
-
     public static String getUrlForCapabilities(String baseUrl) {
         return baseUrl + ocsApiVersion + "/cloud/capabilities";
     }
@@ -143,15 +128,6 @@ public class ApiUtils {
     @Deprecated
     public static String getUrlForGetRooms(String baseUrl) {
         return getUrlForRooms(1, baseUrl);
-    }
-
-    /**
-     * @deprecated Please specify the api version you want to use via
-     * {@link ApiUtils#getUrlForRoom(int, String, String)} instead.
-     */
-    @Deprecated
-    public static String getRoom(String baseUrl, String token) {
-        return getUrlForRoom(1, baseUrl, token);
     }
 
     public static Integer getApiVersion(UserEntity capabilities, String apiName, int[] versions) {
@@ -195,6 +171,10 @@ public class ApiUtils {
 
     public static String getUrlForRoom(int version, String baseUrl, String token) {
         return getUrlForRooms(version, baseUrl) + "/" + token;
+    }
+
+    public static String getUrlForAttendees(int version, String baseUrl, String token) {
+        return getUrlForRoom(version, baseUrl, token) + "/attendees";
     }
 
     public static String getUrlForParticipants(int version, String baseUrl, String token) {

--- a/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
@@ -21,6 +21,7 @@ package com.nextcloud.talk.utils;
 
 import android.net.Uri;
 import android.text.TextUtils;
+import android.util.Log;
 
 import com.nextcloud.talk.BuildConfig;
 import com.nextcloud.talk.R;
@@ -28,7 +29,10 @@ import com.nextcloud.talk.application.NextcloudTalkApplication;
 import com.nextcloud.talk.models.RetrofitBucket;
 import com.nextcloud.talk.models.database.UserEntity;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import androidx.annotation.DimenRes;
@@ -36,6 +40,7 @@ import androidx.annotation.Nullable;
 import okhttp3.Credentials;
 
 public class ApiUtils {
+    private static final String TAG = "ApiUtils";
     private static String ocsApiVersion = "/ocs/v2.php";
     private static String spreedApiVersion = "/apps/spreed/api/v1";
     private static String spreedApiBase = ocsApiVersion + "/apps/spreed/api/v";
@@ -150,8 +155,17 @@ public class ApiUtils {
     }
 
     public static Integer getApiVersion(UserEntity capabilities, String apiName, int[] versions) {
+        boolean checkedConversationV4 = !apiName.equals("conversation");
+
         for (int version : versions) {
+            checkedConversationV4 |= version == 4;
+
             if (capabilities.hasSpreedFeatureCapability(apiName + "-v" + version)) {
+                if (!checkedConversationV4) {
+                    Exception e = new Exception("Api call did not try conversation-v4 api");
+                    Log.e(TAG, e.getMessage(), e);
+                }
+
                 return version;
             }
         }

--- a/app/src/main/java/com/nextcloud/talk/utils/NoSupportedApiException.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/NoSupportedApiException.kt
@@ -1,0 +1,3 @@
+package com.nextcloud.talk.utils
+
+class NoSupportedApiException : RuntimeException("No supported API version found")

--- a/app/src/main/java/com/nextcloud/talk/utils/NoSupportedApiException.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/NoSupportedApiException.kt
@@ -1,3 +1,23 @@
+/*
+ * Nextcloud Talk application
+ *
+ * @author Joas Schilling
+ * Copyright (C) 2021 Joas Schilling <coding@schilljs.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.nextcloud.talk.utils
 
 class NoSupportedApiException : RuntimeException("No supported API version found")

--- a/app/src/main/java/com/nextcloud/talk/utils/preferences/preferencestorage/DatabaseStorageModule.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/preferences/preferencestorage/DatabaseStorageModule.java
@@ -97,10 +97,7 @@ public class DatabaseStorageModule implements StorageModule {
                             intValue = 0;
                     }
 
-                    Integer apiVersion = ApiUtils.getConversationApiVersion(conversationUser, new int[] {4, 1});
-                    if (apiVersion == null) {
-                        Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
-                    }
+                    int apiVersion = ApiUtils.getConversationApiVersion(conversationUser, new int[] {4, 1});
 
                     ncApi.setNotificationLevel(ApiUtils.getCredentials(conversationUser.getUsername(), conversationUser.getToken()),
                             ApiUtils.getUrlForRoomNotificationLevel(apiVersion, conversationUser.getBaseUrl(),

--- a/app/src/main/java/com/nextcloud/talk/utils/preferences/preferencestorage/DatabaseStorageModule.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/preferences/preferencestorage/DatabaseStorageModule.java
@@ -22,8 +22,6 @@ package com.nextcloud.talk.utils.preferences.preferencestorage;
 
 import android.os.Bundle;
 import android.text.TextUtils;
-import android.util.Log;
-
 import autodagger.AutoInjector;
 import com.nextcloud.talk.api.NcApi;
 import com.nextcloud.talk.application.NextcloudTalkApplication;
@@ -42,8 +40,6 @@ import java.util.Set;
 
 @AutoInjector(NextcloudTalkApplication.class)
 public class DatabaseStorageModule implements StorageModule {
-    private static final String TAG = "DatabaseStorageModule";
-
     @Inject
     ArbitraryStorageUtils arbitraryStorageUtils;
 

--- a/app/src/main/java/com/nextcloud/talk/utils/preferences/preferencestorage/DatabaseStorageModule.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/preferences/preferencestorage/DatabaseStorageModule.java
@@ -97,7 +97,7 @@ public class DatabaseStorageModule implements StorageModule {
                             intValue = 0;
                     }
 
-                    Integer apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation", new int[] {4, 1});
+                    Integer apiVersion = ApiUtils.getConversationApiVersion(conversationUser, new int[] {4, 1});
                     if (apiVersion == null) {
                         Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
                     }

--- a/app/src/main/java/com/nextcloud/talk/utils/preferences/preferencestorage/DatabaseStorageModule.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/preferences/preferencestorage/DatabaseStorageModule.java
@@ -22,6 +22,8 @@ package com.nextcloud.talk.utils.preferences.preferencestorage;
 
 import android.os.Bundle;
 import android.text.TextUtils;
+import android.util.Log;
+
 import autodagger.AutoInjector;
 import com.nextcloud.talk.api.NcApi;
 import com.nextcloud.talk.application.NextcloudTalkApplication;
@@ -40,6 +42,8 @@ import java.util.Set;
 
 @AutoInjector(NextcloudTalkApplication.class)
 public class DatabaseStorageModule implements StorageModule {
+    private static final String TAG = "DatabaseStorageModule";
+
     @Inject
     ArbitraryStorageUtils arbitraryStorageUtils;
 
@@ -53,6 +57,7 @@ public class DatabaseStorageModule implements StorageModule {
     private boolean lobbyValue;
 
     private String messageNotificationLevel;
+
     public DatabaseStorageModule(UserEntity conversationUser, String conversationToken) {
         NextcloudTalkApplication.Companion.getSharedApplication().getComponentApplication().inject(this);
 
@@ -92,8 +97,14 @@ public class DatabaseStorageModule implements StorageModule {
                             intValue = 0;
                     }
 
+                    Integer apiVersion = ApiUtils.getApiVersion(conversationUser, "conversation", new int[] {4, 1});
+                    if (apiVersion == null) {
+                        Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
+                    }
+
                     ncApi.setNotificationLevel(ApiUtils.getCredentials(conversationUser.getUsername(), conversationUser.getToken()),
-                            ApiUtils.getUrlForSettingNotificationlevel(conversationUser.getBaseUrl(), conversationToken),
+                            ApiUtils.getUrlForRoomNotificationLevel(apiVersion, conversationUser.getBaseUrl(),
+                                                                    conversationToken),
                             intValue)
                             .subscribeOn(Schedulers.io())
                             .subscribe(new Observer<GenericOverall>() {

--- a/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketConnectionHelper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketConnectionHelper.java
@@ -20,9 +20,6 @@
 
 package com.nextcloud.talk.webrtc;
 
-import android.annotation.SuppressLint;
-import android.util.Log;
-
 import autodagger.AutoInjector;
 import com.nextcloud.talk.application.NextcloudTalkApplication;
 import com.nextcloud.talk.models.database.UserEntity;
@@ -37,8 +34,6 @@ import java.util.Map;
 
 @AutoInjector(NextcloudTalkApplication.class)
 public class WebSocketConnectionHelper {
-    private static final String TAG = "WebSocketConnectionHelper";
-
     private static Map<Long, MagicWebSocketInstance> magicWebSocketInstanceMap = new HashMap<>();
 
     @Inject
@@ -92,7 +87,6 @@ public class WebSocketConnectionHelper {
         }
     }
 
-    @SuppressLint("LongLogTag")
     HelloOverallWebSocketMessage getAssembledHelloModel(UserEntity userEntity, String ticket) {
         int apiVersion = ApiUtils.getSignalingApiVersion(userEntity, new int[] {2, 1});
 

--- a/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketConnectionHelper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketConnectionHelper.java
@@ -94,12 +94,7 @@ public class WebSocketConnectionHelper {
 
     @SuppressLint("LongLogTag")
     HelloOverallWebSocketMessage getAssembledHelloModel(UserEntity userEntity, String ticket) {
-        Integer apiVersion = ApiUtils.getSignalingApiVersion(userEntity, new int[] {2, 1});
-
-        if (apiVersion == null) {
-            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
-            return null;
-        }
+        int apiVersion = ApiUtils.getSignalingApiVersion(userEntity, new int[] {2, 1});
 
         HelloOverallWebSocketMessage helloOverallWebSocketMessage = new HelloOverallWebSocketMessage();
         helloOverallWebSocketMessage.setType("hello");

--- a/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketConnectionHelper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketConnectionHelper.java
@@ -20,6 +20,9 @@
 
 package com.nextcloud.talk.webrtc;
 
+import android.annotation.SuppressLint;
+import android.util.Log;
+
 import autodagger.AutoInjector;
 import com.nextcloud.talk.application.NextcloudTalkApplication;
 import com.nextcloud.talk.models.database.UserEntity;
@@ -34,6 +37,8 @@ import java.util.Map;
 
 @AutoInjector(NextcloudTalkApplication.class)
 public class WebSocketConnectionHelper {
+    private static final String TAG = "WebSocketConnectionHelper";
+
     private static Map<Long, MagicWebSocketInstance> magicWebSocketInstanceMap = new HashMap<>();
 
     @Inject
@@ -87,13 +92,21 @@ public class WebSocketConnectionHelper {
         }
     }
 
+    @SuppressLint("LongLogTag")
     HelloOverallWebSocketMessage getAssembledHelloModel(UserEntity userEntity, String ticket) {
+        Integer apiVersion = ApiUtils.getSignalingApiVersion(userEntity, new int[] {2, 1});
+
+        if (apiVersion == null) {
+            Log.e(TAG, "No supported API version found", new Exception("No supported API version found"));
+            return null;
+        }
+
         HelloOverallWebSocketMessage helloOverallWebSocketMessage = new HelloOverallWebSocketMessage();
         helloOverallWebSocketMessage.setType("hello");
         HelloWebSocketMessage helloWebSocketMessage = new HelloWebSocketMessage();
         helloWebSocketMessage.setVersion("1.0");
         AuthWebSocketMessage authWebSocketMessage = new AuthWebSocketMessage();
-        authWebSocketMessage.setUrl(ApiUtils.getUrlForExternalServerAuthBackend(userEntity.getBaseUrl()));
+        authWebSocketMessage.setUrl(ApiUtils.getUrlForSignalingBackend(apiVersion, userEntity.getBaseUrl()));
         AuthParametersWebSocketMessage authParametersWebSocketMessage = new AuthParametersWebSocketMessage();
         authParametersWebSocketMessage.setTicket(ticket);
         authParametersWebSocketMessage.setUserid(userEntity.getUserId());


### PR DESCRIPTION
So there are quite some breaking changes with the upcoming APIv4 of the Talk server for Nextcloud 22, most of all it's multiple sessions per participant.

So I wanted to check and help migrating to APIv4, and now I wonder how we want to do this even.

As you can see in this PR there is one place which has duplicate logic for APIv3 and APIv1 already.

to deduplicate some logic and e.g. not have getRoom, getRoomV3, getRoomV4 functions and further on multiplying all methods in ApiUtils.java like e.g. getUrlForParticipants, I wonder if the version should be an (or even the first) argument to all the methods instead.

Also instead of code like:
```java
boolean isConversationApiV3 = userBeingCalled.hasSpreedFeatureCapability("conversation-v3");
        boolean isConversationApiV4 = userBeingCalled.hasSpreedFeatureCapability("conversation-v4");
        if(isConversationApiV4 || isConversationApiV3) {
```
I would add a method in the `userBeingCalled` class which returns the API we should use, so we don't duplicate those capabilities checks all the time everywhere.