### PR TITLE
Enable enlarging the image more than default 3x maximumScale.

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/FullScreenImageActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/FullScreenImageActivity.kt
@@ -94,6 +94,11 @@ class FullScreenImageActivity : AppCompatActivity() {
             toggleFullscreen()
         }
 
+        // Enable enlarging the image more than default 3x maximumScale.
+        // Medium scale adapted to make double-tap behaviour more consistent.
+        photoView.maximumScale = 6.0f
+        photoView.mediumScale = 2.45f
+
         val fileName = intent.getStringExtra("FILE_NAME")
         val isGif = intent.getBooleanExtra("IS_GIF", false)
 


### PR DESCRIPTION
I have just tested the new image preview - works great... :smiley: Thanks!

However I have found that sometimes it would be good to be able to enlarge the image more than the default 3x set in the PhotoView library. This applies esp. when posting photos directly from the phone.

This change enables zooming the image 6x rather than just 3x. Since the default double-tap handler uses the max/medium scale parameter, I have also adjusted the mediumScale to make double-tab more consistent/predictable.