### PR TITLE
Remove kotlin-stdLib since it is added by default since kotlin 1.4.x

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -229,7 +229,6 @@ dependencies {
     implementation 'eu.davidea:flexible-adapter:5.1.0'
     implementation 'eu.davidea:flexible-adapter-ui:1.0.0'
     implementation 'org.webrtc:google-webrtc:1.0.32006'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}"
     implementation 'com.yarolegovich:lovely-dialog:1.1.1'
     implementation 'com.yarolegovich:mp:1.1.6'
     implementation 'me.zhanghai.android.effortlesspermissions:library:1.1.0'


### PR DESCRIPTION
Starting from [Kotlin 1.4](https://kotlinlang.org/docs/whatsnew14.html#dependency-on-the-standard-library-added-by-default) the dependency on the standard library added by default. So a follow-up task due to #1148

Signed-off-by: Andy Scherzinger <info@andy-scherzinger.de>