### PR TITLE
Start the reauth webview also when there is no getParentController()

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
@@ -263,7 +263,9 @@ public class ConversationsListController extends BaseController implements Searc
     @Override
     protected void onAttach(@NonNull View view) {
         super.onAttach(view);
-        eventBus.register(this);
+        if (!eventBus.isRegistered(this)) {
+            eventBus.register(this);
+        }
 
         currentUser = userUtils.getCurrentUser();
 
@@ -480,12 +482,10 @@ public class ConversationsListController extends BaseController implements Searc
                         HttpException exception = (HttpException) throwable;
                         switch (exception.code()) {
                             case 401:
-                                if (getParentController() != null &&
-                                        getParentController().getRouter() != null) {
+                                if (getParentController() != null && getParentController().getRouter() != null) {
                                     Log.d(TAG, "Starting reauth webview via getParentController()");
                                     getParentController().getRouter().pushController((RouterTransaction.with
-                                            (new WebViewLoginController(currentUser.getBaseUrl(),
-                                                                        true))
+                                            (new WebViewLoginController(currentUser.getBaseUrl(), true))
                                             .pushChangeHandler(new VerticalChangeHandler())
                                             .popChangeHandler(new VerticalChangeHandler())));
                                 } else {
@@ -827,6 +827,7 @@ public class ConversationsListController extends BaseController implements Searc
                     .setIcon(DisplayUtils.getTintedDrawable(context.getResources(),
                                                             R.drawable.ic_delete_black_24dp, R.color.bg_default))
                     .setPositiveButtonColor(context.getResources().getColor(R.color.nc_darkRed))
+                    .setCancelable(false)
                     .setTitle(R.string.nc_dialog_invalid_password)
                     .setMessage(R.string.nc_dialog_reauth_or_delete)
                     .setPositiveButton(R.string.nc_delete, new View.OnClickListener() {

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
@@ -23,6 +23,7 @@
 package com.nextcloud.talk.controllers;
 
 import android.animation.AnimatorInflater;
+import android.annotation.SuppressLint;
 import android.app.SearchManager;
 import android.content.Context;
 import android.content.Intent;
@@ -32,6 +33,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.text.InputType;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -400,6 +402,7 @@ public class ConversationsListController extends BaseController implements Searc
         searchItem.expandActionView();
     }
 
+    @SuppressLint("LongLogTag")
     private void fetchData(boolean fromBottomSheet) {
         dispose(null);
 
@@ -478,11 +481,18 @@ public class ConversationsListController extends BaseController implements Searc
                             case 401:
                                 if (getParentController() != null &&
                                         getParentController().getRouter() != null) {
+                                    Log.d(TAG, "Starting reauth webview via getParentController()");
                                     getParentController().getRouter().pushController((RouterTransaction.with
                                             (new WebViewLoginController(currentUser.getBaseUrl(),
                                                     true))
                                             .pushChangeHandler(new VerticalChangeHandler())
                                             .popChangeHandler(new VerticalChangeHandler())));
+                                } else {
+                                    Log.d(TAG, "Starting reauth webview via ConversationsListController");
+                                    getRouter().pushController(RouterTransaction.with(
+                                            new WebViewLoginController(currentUser.getBaseUrl(), true))
+                                                                       .pushChangeHandler(new VerticalChangeHandler())
+                                                                       .popChangeHandler(new VerticalChangeHandler()));
                                 }
                                 break;
                             default:

--- a/app/src/main/java/com/nextcloud/talk/controllers/WebViewLoginController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/WebViewLoginController.java
@@ -35,6 +35,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.*;
 import android.widget.ProgressBar;
+
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.res.ResourcesCompat;
@@ -42,6 +43,7 @@ import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkManager;
 import autodagger.AutoInjector;
 import butterknife.BindView;
+
 import com.bluelinelabs.conductor.RouterTransaction;
 import com.bluelinelabs.conductor.changehandler.HorizontalChangeHandler;
 import com.nextcloud.talk.R;
@@ -64,9 +66,11 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
 import io.requery.Persistable;
 import io.requery.reactivex.ReactiveEntityStore;
+
 import org.greenrobot.eventbus.EventBus;
 
 import javax.inject.Inject;
+
 import java.lang.reflect.Field;
 import java.net.CookieManager;
 import java.net.URLDecoder;
@@ -233,9 +237,9 @@ public class WebViewLoginController extends BaseController {
                             webView.loadUrl("javascript:var justStore = document.getElementById('user').value = '" + username + "';");
                         } else {
                             webView.loadUrl("javascript: {" +
-                                    "document.getElementById('user').value = '" + username + "';" +
-                                    "document.getElementById('password').value = '" + password + "';" +
-                                    "document.getElementById('submit').click(); };");
+                                                    "document.getElementById('user').value = '" + username + "';" +
+                                                    "document.getElementById('password').value = '" + password + "';" +
+                                                    "document.getElementById('submit').click(); };");
                         }
                     }
                 }
@@ -406,6 +410,9 @@ public class WebViewLoginController extends BaseController {
                     }
                 } else {
                     if (finalMessageType != null) {
+                        // FIXME when the user registers a new account that was setup before (aka
+                        //  ApplicationWideMessageHolder.MessageType.ACCOUNT_UPDATED_NOT_ADDED)
+                        //  The token is not updated in the database and therefor the account not visible/usable
                         ApplicationWideMessageHolder.getInstance().setMessageType(finalMessageType);
                     }
                     getRouter().popToRoot();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -409,4 +409,6 @@
     <string name="failed_to_save">Failed to save %1$s</string>
     <string name="selected_list_item">selected</string>
     <string name="filename_progress">%1$s (%2$d)</string>
+    <string name="nc_dialog_invalid_password">Invalid password</string>
+    <string name="nc_dialog_reauth_or_delete">Do you want to reauthorize or delete this account?</string>
 </resources>


### PR DESCRIPTION
### Steps

1. Setup an account in the mobile app
2. In the web UI revoke the device token
3. In the app pull down to refresh the conversation list

### Before
⬜️ or ⬛  Nothing happens

### After
* A dialog asks whether the account:
    +  Should reauthenticate and enter a new password
    + The account should be deleted

- [x] Show reauth webview when a 401 is received on the conversation list
- [x] Add an intermediate step when there is no getParentController, so you can
  * remove the account instead of being stuck in a loop to reauth.
  * switch to another account or create another one