### PR TITLE
add WebAuthn support using hwsecurity-fido2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -253,7 +253,8 @@ dependencies {
     implementation "io.coil-kt:coil-svg:${coilKtVersion}"
     implementation 'com.github.natario1:Autocomplete:v1.1.0'
 
-    implementation 'com.github.cotechde.hwsecurity:hwsecurity-fido:2.4.5'
+    implementation 'com.github.cotechde.hwsecurity:hwsecurity-fido:4.2.1'
+    implementation 'com.github.cotechde.hwsecurity:hwsecurity-fido2:4.2.1'
 
     implementation 'com.novoda:merlin:1.2.1'
 


### PR DESCRIPTION
Adds WebAuthn support like in https://github.com/nextcloud/android/pull/6395

Updates hwsecurity to 4.2.1. The latest 4.4.0 artifact is somehow not available on Jitpack. I just wrote the Jitpack support...

Signed-off-by: Dominik Schürmann <dominik@schuermann.eu>