### PR TITLE
Properly parse encryption/favorite flags

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/components/filebrowser/models/properties/NCEncrypted.java
+++ b/app/src/main/java/com/nextcloud/talk/components/filebrowser/models/properties/NCEncrypted.java
@@ -61,7 +61,7 @@ public class NCEncrypted implements Property {
             try {
                 String text = XmlUtils.INSTANCE.readText(xmlPullParser);
                 if (!TextUtils.isEmpty(text)) {
-                    return new NCEncrypted(Boolean.parseBoolean(text));
+                    return new NCEncrypted("1".equals(text));
                 }
             } catch (IOException | XmlPullParserException e) {
                 Log.e("NCEncrypted", "failed to create property", e);

--- a/app/src/main/java/com/nextcloud/talk/components/filebrowser/models/properties/OCFavorite.java
+++ b/app/src/main/java/com/nextcloud/talk/components/filebrowser/models/properties/OCFavorite.java
@@ -61,7 +61,7 @@ public class OCFavorite implements Property {
             try {
                 String text = XmlUtils.INSTANCE.readText(xmlPullParser);
                 if (!TextUtils.isEmpty(text)) {
-                    return new OCFavorite(Boolean.parseBoolean(text));
+                    return new OCFavorite("1".equals(text));
                 }
             } catch (IOException | XmlPullParserException e) {
                 Log.e("OCFavorite", "failed to create property", e);


### PR DESCRIPTION
encryption and favorite property are delivered via 0/1 values not TRUE/FALSE thus the parser needs to check for that.

To test simply have files on your Nextcloud marked as favorite and try to add a file via Nextcloud in the chat. 
Before: No start icon
After: star icon

Signed-off-by: Andy Scherzinger <info@andy-scherzinger.de>