### PR TITLE
✉️ Add mail icon for mail users

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import androidx.core.content.ContextCompat;
+import androidx.core.content.res.ResourcesCompat;
 import androidx.emoji.widget.EmojiTextView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -108,6 +109,10 @@ public class ConversationItem extends AbstractFlexibleItem<ConversationItem.Conv
         Context appContext =
                 NextcloudTalkApplication.Companion.getSharedApplication().getApplicationContext();
         holder.dialogAvatar.setController(null);
+
+        holder.dialogName.setTextColor(ResourcesCompat.getColor(context.getResources(),
+                                                                R.color.conversation_item_header,
+                                                                null));
 
         if (adapter.hasFilter()) {
             FlexibleUtils.highlightText(holder.dialogName, conversation.getDisplayName(),

--- a/app/src/main/java/com/nextcloud/talk/adapters/items/UserItem.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/UserItem.java
@@ -152,8 +152,7 @@ public class UserItem extends AbstractFlexibleItem<UserItem.UserItemViewHolder> 
         if (participant.getActorType() == Participant.ActorType.GROUPS || "groups".equals(participant.getSource())) {
             holder.simpleDraweeView.setImageResource(R.drawable.ic_circular_group);
         } else if (participant.getActorType() == Participant.ActorType.EMAILS) {
-            // FIXME use an email icon
-            holder.simpleDraweeView.setImageResource(R.drawable.ic_circular_group);
+            holder.simpleDraweeView.setImageResource(R.drawable.ic_circular_mail);
         } else if (participant.getActorType() == Participant.ActorType.GUESTS ||
                 Participant.ParticipantType.GUEST.equals(participant.getType()) ||
                 Participant.ParticipantType.GUEST_MODERATOR.equals(participant.getType())) {

--- a/app/src/main/res/drawable/ic_circular_mail.xml
+++ b/app/src/main/res/drawable/ic_circular_mail.xml
@@ -1,0 +1,35 @@
+<!--
+  ~ Nextcloud Talk application
+  ~
+  ~ @author Andy Scherzinger
+  ~ Copyright (C) 2021 Andy Scherzinger <info@andy-scherzinger.de>
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/colorBackgroundDarker"
+        android:fillType="nonZero"
+        android:pathData="M12,0C5.4168,0 0,5.4168 0,12C0,18.5832 5.4168,24 12,24C18.5832,24 24,18.5832 24,12C24,5.4168 18.5832,0 12,0Z" />
+    <path
+        android:fillColor="#ffffff"
+        android:fillType="nonZero"
+        android:pathData="M6.6675,8.25C6.2985,8.25 6,8.55 6,8.9175L6,15.0825C6,15.4522 6.3,15.75 6.6675,15.75L17.3325,15.75C17.7015,15.75 18,15.45 18,15.0825L18,8.9175C18,8.5485 17.7,8.25 17.3325,8.25L6.6675,8.25ZM7.23,9.021L11.7922,13.5825L12.1875,13.5825L16.7708,9.021L17.229,9.4792L14.4998,12.249L16.5623,14.3527L16.104,14.811L14.0002,12.7072L12.48,14.2485L11.5215,14.2485L10.0013,12.7072L7.8975,14.8312L7.4385,14.352L9.522,12.2483L6.7725,9.4785L7.23,9.021Z" />
+</vector>

--- a/drawable_resources/other/circular_mail.svg
+++ b/drawable_resources/other/circular_mail.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(1.2,0,0,1.2,-2.4,-2.4)">
+        <path d="M12,2C6.514,2 2,6.514 2,12C2,17.486 6.514,22 12,22C17.486,22 22,17.486 22,12C22,6.514 17.486,2 12,2Z" style="fill-rule:nonzero;"/>
+    </g>
+    <g transform="matrix(0.75,0,0,0.75,6,6)">
+        <path d="M0.89,3C0.398,3 0,3.4 0,3.89L0,12.11C0,12.603 0.4,13 0.89,13L15.11,13C15.602,13 16,12.6 16,12.11L16,3.89C16,3.398 15.6,3 15.11,3L0.89,3ZM1.64,4.028L7.723,10.11L8.25,10.11L14.361,4.028L14.972,4.639L11.333,8.332L14.083,11.137L13.472,11.748L10.667,8.943L8.64,10.998L7.362,10.998L5.335,8.943L2.53,11.775L1.918,11.136L4.696,8.331L1.03,4.638L1.64,4.028Z" style="fill:white;fill-rule:nonzero;"/>
+    </g>
+</svg>


### PR DESCRIPTION
in the greyed out state (!)

light|dark
---|---
![light](https://user-images.githubusercontent.com/1315170/117713858-7ccf2500-b1d6-11eb-886c-5bfbf8b135d4.png)|![dark](https://user-images.githubusercontent.com/1315170/117713884-82c50600-b1d6-11eb-9ca5-51dbf51430e3.png)

...also fix conversation names visible when switching themes (without an app restart)

Signed-off-by: Andy Scherzinger <info@andy-scherzinger.de>