### PR TITLE
[backport] set proper colors for unread-messages for edge case of theme switch

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.java
@@ -23,6 +23,7 @@
 package com.nextcloud.talk.adapters.items;
 
 import android.content.Context;
+import android.content.res.ColorStateList;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.BitmapDrawable;
@@ -146,7 +147,8 @@ public class ConversationItem extends AbstractFlexibleItem<ConversationItem.Conv
                 holder.dialogUnreadBubble.setChipBackgroundColorResource(R.color.colorPrimary);
                 holder.dialogUnreadBubble.setTextColor(Color.WHITE);
             } else {
-                holder.dialogUnreadBubble.setChipBackgroundColorResource(R.color.conversation_unread_bubble);
+                holder.dialogUnreadBubble.setChipBackgroundColor(
+                        ColorStateList.valueOf(ContextCompat.getColor(context, R.color.conversation_unread_bubble)));
                 holder.dialogUnreadBubble.setTextColor(
                         ContextCompat.getColor(context, R.color.conversation_unread_bubble_text));
             }


### PR DESCRIPTION
Manual backport and theme switch follow-up PR.

Besides the conversation name also the unread messages bubble/text haven't refreshed properly (the unread, but no mentions bubble as-in grey, not blue)

Signed-off-by: Andy Scherzinger <info@andy-scherzinger.de>