### PR TITLE
Use proper activity context to grab themed color for mentions

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/items/MentionAutocompleteItem.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/MentionAutocompleteItem.java
@@ -21,6 +21,7 @@
 package com.nextcloud.talk.adapters.items;
 
 import android.annotation.SuppressLint;
+import android.content.Context;
 import android.view.View;
 
 import com.facebook.drawee.backends.pipeline.Fresco;
@@ -34,6 +35,7 @@ import com.nextcloud.talk.utils.DisplayUtils;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import androidx.core.content.res.ResourcesCompat;
 import eu.davidea.flexibleadapter.FlexibleAdapter;
 import eu.davidea.flexibleadapter.items.AbstractFlexibleItem;
 import eu.davidea.flexibleadapter.items.IFilterable;
@@ -47,12 +49,18 @@ public class MentionAutocompleteItem extends AbstractFlexibleItem<UserItem.UserI
     private String displayName;
     private String source;
     private UserEntity currentUser;
+    private Context context;
 
-    public MentionAutocompleteItem(String objectId, String displayName, String source, UserEntity currentUser) {
+    public MentionAutocompleteItem(String objectId,
+                                   String displayName,
+                                   String source,
+                                   UserEntity currentUser,
+                                   Context activityContext) {
         this.objectId = objectId;
         this.displayName = displayName;
         this.source = source;
         this.currentUser = currentUser;
+        this.context = activityContext;
     }
 
     public String getSource() {
@@ -96,6 +104,9 @@ public class MentionAutocompleteItem extends AbstractFlexibleItem<UserItem.UserI
     @Override
     public void bindViewHolder(FlexibleAdapter<IFlexible> adapter, UserItem.UserItemViewHolder holder, int position, List<Object> payloads) {
 
+        holder.contactDisplayName.setTextColor(ResourcesCompat.getColor(context.getResources(),
+                                                                R.color.conversation_item_header,
+                                                                null));
         if (adapter.hasFilter()) {
             FlexibleUtils.highlightText(holder.contactDisplayName, displayName,
                     String.valueOf(adapter.getFilter(String.class)), NextcloudTalkApplication.Companion.getSharedApplication()

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -801,7 +801,7 @@ class ChatController(args: Bundle) :
         val elevation = 6f
         resources?.let {
             val backgroundDrawable = ColorDrawable(it.getColor(R.color.bg_default))
-            val presenter = MentionAutocompletePresenter(applicationContext, roomToken)
+            val presenter = MentionAutocompletePresenter(activity, roomToken)
             val callback = MentionAutocompleteCallback(
                 activity,
                 conversationUser, messageInput

--- a/app/src/main/java/com/nextcloud/talk/presenters/MentionAutocompletePresenter.java
+++ b/app/src/main/java/com/nextcloud/talk/presenters/MentionAutocompletePresenter.java
@@ -22,9 +22,7 @@ package com.nextcloud.talk.presenters;
 
 import android.content.Context;
 import android.view.View;
-import androidx.annotation.Nullable;
-import androidx.recyclerview.widget.RecyclerView;
-import autodagger.AutoInjector;
+
 import com.nextcloud.talk.adapters.items.MentionAutocompleteItem;
 import com.nextcloud.talk.api.NcApi;
 import com.nextcloud.talk.application.NextcloudTalkApplication;
@@ -34,16 +32,21 @@ import com.nextcloud.talk.models.json.mention.MentionOverall;
 import com.nextcloud.talk.utils.ApiUtils;
 import com.nextcloud.talk.utils.database.user.UserUtils;
 import com.otaliastudios.autocomplete.RecyclerViewPresenter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.RecyclerView;
+import autodagger.AutoInjector;
 import eu.davidea.flexibleadapter.FlexibleAdapter;
 import eu.davidea.flexibleadapter.items.AbstractFlexibleItem;
 import io.reactivex.Observer;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
-
-import javax.inject.Inject;
-import java.util.ArrayList;
-import java.util.List;
 
 @AutoInjector(NextcloudTalkApplication.class)
 public class MentionAutocompletePresenter extends RecyclerViewPresenter<Mention> implements FlexibleAdapter.OnItemClickListener {
@@ -118,7 +121,7 @@ public class MentionAutocompletePresenter extends RecyclerViewPresenter<Mention>
                                 internalAbstractFlexibleItemList.add(
                                         new MentionAutocompleteItem(mention.getId(),
                                                 mention.getLabel(), mention.getSource(),
-                                                currentUser));
+                                                currentUser, context));
                             }
 
                             if (adapter.getItemCount() != 0) {

--- a/app/src/main/java/com/nextcloud/talk/presenters/MentionAutocompletePresenter.java
+++ b/app/src/main/java/com/nextcloud/talk/presenters/MentionAutocompletePresenter.java
@@ -2,6 +2,8 @@
  * Nextcloud Talk application
  *
  * @author Mario Danic
+ * @author Andy Scherzinger
+ * Copyright (C) 2021 Andy Scherzinger <info@andy-scherzinger.de>
  * Copyright (C) 2017-2018 Mario Danic <mario@lovelyhq.com>
  *
  * This program is free software: you can redistribute it and/or modify
@@ -32,6 +34,8 @@ import com.nextcloud.talk.models.json.mention.MentionOverall;
 import com.nextcloud.talk.utils.ApiUtils;
 import com.nextcloud.talk.utils.database.user.UserUtils;
 import com.otaliastudios.autocomplete.RecyclerViewPresenter;
+
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -106,11 +110,12 @@ public class MentionAutocompletePresenter extends RecyclerViewPresenter<Mention>
                 .retry(3)
                 .subscribe(new Observer<MentionOverall>() {
                     @Override
-                    public void onSubscribe(Disposable d) {
+                    public void onSubscribe(@NotNull Disposable d) {
+                        // no actions atm
                     }
 
                     @Override
-                    public void onNext(MentionOverall mentionOverall) {
+                    public void onNext(@NotNull MentionOverall mentionOverall) {
                         List<Mention> mentionsList = mentionOverall.getOcs().getData();
 
                         if (mentionsList.size() == 0) {
@@ -119,9 +124,12 @@ public class MentionAutocompletePresenter extends RecyclerViewPresenter<Mention>
                             List<AbstractFlexibleItem> internalAbstractFlexibleItemList = new ArrayList<>();
                             for (Mention mention : mentionsList) {
                                 internalAbstractFlexibleItemList.add(
-                                        new MentionAutocompleteItem(mention.getId(),
-                                                mention.getLabel(), mention.getSource(),
-                                                currentUser, context));
+                                        new MentionAutocompleteItem(
+                                                mention.getId(),
+                                                mention.getLabel(),
+                                                mention.getSource(),
+                                                currentUser,
+                                                context));
                             }
 
                             if (adapter.getItemCount() != 0) {
@@ -133,17 +141,16 @@ public class MentionAutocompletePresenter extends RecyclerViewPresenter<Mention>
                     }
 
                     @Override
-                    public void onError(Throwable e) {
+                    public void onError(@NotNull Throwable e) {
                         adapter.clear();
                     }
 
                     @Override
                     public void onComplete() {
-
+                        // no actions atm
                     }
                 });
     }
-
 
     @Override
     public boolean onItemClick(View view, int position) {

--- a/app/src/main/res/layout/rv_item_mention.xml
+++ b/app/src/main/res/layout/rv_item_mention.xml
@@ -58,7 +58,7 @@
             android:layout_height="wrap_content"
             android:ellipsize="middle"
             android:singleLine="true"
-            android:textAppearance="?android:attr/textAppearanceListItem"
+            android:textAppearance="@style/ListItem"
             tools:text="Call item text" />
 
         <androidx.emoji.widget.EmojiTextView


### PR DESCRIPTION
due to a recent change the mentioned pop-up when typing a message is also dark for dark themes. Unfortunately the list items header line text was black which worked for light but not dark theme. This PR fixes it by setting the color explicitly and using "the right" context (which is the activity's context _not_ the application contenxt).

Signed-off-by: Andy Scherzinger <info@andy-scherzinger.de>