### PR TITLE
bump alpha version to "12.0.0 Alpha 11"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,8 +54,8 @@ android {
 
         // mayor.minor.hotfix.increment (for increment: 1-50=Alpha / 51-89=RC / 90-99=stable)
         // xx   .xxx  .xx    .xx
-        versionCode 120000008
-        versionName "12.0.0 Alpha 08"
+        versionCode 120000011
+        versionName "12.0.0 Alpha 11"
 
         flavorDimensions "default"
         renderscriptTargetApi 19


### PR DESCRIPTION
necessary to fix version-code for playstore

Signed-off-by: Marcel Hibbe <dev@mhibbe.de>