### PR TITLE
Remove new line from translatable string

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -336,8 +336,7 @@
     <string name="nc_lobby">Lobby</string>
     <string name="nc_start_time">Start time</string>
     <string name="nc_lobby_waiting">You are currently waiting in the lobby.</string>
-    <string name="nc_lobby_waiting_with_date">You are currently waiting in the lobby.\n This
-        meeting is scheduled for %1$s.</string>
+    <string name="nc_lobby_waiting_with_date">You are currently waiting in the lobby.\n This meeting is scheduled for %1$s.</string>
     <string name="nc_manual">Not set</string>
 
     <!-- Errors -->


### PR DESCRIPTION
Due to our poor mans XML concatenation new lines are not kept and cause invalid XML. See https://github.com/nextcloud/docker-ci/pull/280/files#diff-9d28cba068f86de5b086c8b5e7ba5e44df1f4d5d299421e2bf5eb168551af078R68 for the XML concatenation. THis is a quick fix and better should be handled by just properly parse and combine the XML.

Found after https://github.com/nextcloud/docker-ci/pull/280 

cc @AndyScherzinger @tobiasKaminsky 