### PR TITLE
Show a temporary messages when sending and keep it on error

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
@@ -102,23 +102,7 @@ class OutcomingTextMessageViewHolder(itemView: View) : OutcomingTextMessageViewH
             binding.messageQuote.quotedChatMessageView.visibility = View.GONE
         }
 
-        val readStatusDrawableInt = when (message.readStatus) {
-            ReadStatus.READ -> R.drawable.ic_check_all
-            ReadStatus.SENT -> R.drawable.ic_check
-            ReadStatus.SENDING -> R.drawable.ic_sending
-            ReadStatus.FAILED -> R.drawable.ic_warning_white
-            else -> null
-        }
-
-        val readStatusContentDescriptionString = when (message.readStatus) {
-            ReadStatus.READ -> context?.resources?.getString(R.string.nc_message_read)
-            ReadStatus.SENT -> context?.resources?.getString(R.string.nc_message_sent)
-            ReadStatus.SENDING -> context?.resources?.getString(R.string.nc_message_sending)
-            ReadStatus.FAILED -> context?.resources?.getString(R.string.nc_message_send_error)
-            else -> null
-        }
-
-        readStatusDrawableInt?.let { drawableInt ->
+        readStatusDrawableInt(message)?.let { drawableInt ->
             ResourcesCompat.getDrawable(context!!.resources, drawableInt, null)?.let {
                 binding.checkMark.setImageDrawable(it)
                 binding.checkMark.setColorFilter(
@@ -127,7 +111,7 @@ class OutcomingTextMessageViewHolder(itemView: View) : OutcomingTextMessageViewH
             }
         }
 
-        binding.checkMark.setContentDescription(readStatusContentDescriptionString)
+        binding.checkMark.setContentDescription(readStatusContentDescriptionString(message))
 
         itemView.setTag(MessageSwipeCallback.REPLYABLE_VIEW_TAG, message.replyable)
 
@@ -149,6 +133,24 @@ class OutcomingTextMessageViewHolder(itemView: View) : OutcomingTextMessageViewH
     private fun clickOnReaction(chatMessage: ChatMessage, emoji: String) {
         commonMessageInterface.onClickReaction(chatMessage, emoji)
     }
+
+    private fun readStatusContentDescriptionString(message: ChatMessage) =
+        when (message.readStatus) {
+            ReadStatus.READ -> context?.resources?.getString(R.string.nc_message_read)
+            ReadStatus.SENT -> context?.resources?.getString(R.string.nc_message_sent)
+            ReadStatus.SENDING -> context?.resources?.getString(R.string.nc_message_sending)
+            ReadStatus.FAILED -> context?.resources?.getString(R.string.nc_message_send_error)
+            else -> null
+        }
+
+    private fun readStatusDrawableInt(message: ChatMessage) =
+        when (message.readStatus) {
+            ReadStatus.READ -> R.drawable.ic_check_all
+            ReadStatus.SENT -> R.drawable.ic_check
+            ReadStatus.SENDING -> R.drawable.ic_sending
+            ReadStatus.FAILED -> R.drawable.ic_warning_white
+            else -> null
+        }
 
     private fun processParentMessage(message: ChatMessage) {
         val parentChatMessage = message.parentMessage

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
@@ -105,12 +105,16 @@ class OutcomingTextMessageViewHolder(itemView: View) : OutcomingTextMessageViewH
         val readStatusDrawableInt = when (message.readStatus) {
             ReadStatus.READ -> R.drawable.ic_check_all
             ReadStatus.SENT -> R.drawable.ic_check
+            ReadStatus.SENDING -> R.drawable.ic_sending
+            ReadStatus.FAILED -> R.drawable.ic_warning_white
             else -> null
         }
 
         val readStatusContentDescriptionString = when (message.readStatus) {
             ReadStatus.READ -> context?.resources?.getString(R.string.nc_message_read)
             ReadStatus.SENT -> context?.resources?.getString(R.string.nc_message_sent)
+            ReadStatus.SENDING -> context?.resources?.getString(R.string.nc_message_sending)
+            ReadStatus.FAILED -> context?.resources?.getString(R.string.nc_message_send_error)
             else -> null
         }
 

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -2128,7 +2128,6 @@ class ChatController(args: Bundle) :
         messObj.timestamp = tsLong
         messObj.jsonMessageId = 0 - tsLong.toInt()
 
-
         messObj.readStatus = ReadStatus.SENDING
 
         if (conversationUser!!.userId != "?") {
@@ -3046,11 +3045,12 @@ class ChatController(args: Bundle) :
     fun replyPrivately(message: IMessage?) {
         val apiVersion =
             ApiUtils.getConversationApiVersion(
-                            conversationUser, intArrayOf(
-                                ApiUtils.APIv4,
-                                1
-                            )
-                        )
+                conversationUser,
+                intArrayOf(
+                    ApiUtils.APIv4,
+                    1
+                )
+            )
         val retrofitBucket = ApiUtils.getRetrofitBucketForCreateRoom(
             apiVersion,
             conversationUser?.baseUrl,
@@ -3108,20 +3108,20 @@ class ChatController(args: Bundle) :
                                 )
                             }
 
-                                            override fun onError(e: Throwable) {
-                                                Log.e(TAG, e.message, e)
-                                            }
+                            override fun onError(e: Throwable) {
+                                Log.e(TAG, e.message, e)
+                            }
 
-                                            override fun onComplete() {// unused atm
+                            override fun onComplete() { // unused atm
                             }
                         })
                 }
 
-                                override fun onError(e: Throwable) {
-                                    Log.e(TAG, e.message, e)
-                                }
+                override fun onError(e: Throwable) {
+                    Log.e(TAG, e.message, e)
+                }
 
-                                override fun onComplete() {
+                override fun onComplete() {
                     // unused atm
                 }
             })

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -207,6 +207,7 @@ import retrofit2.Response
 import java.io.File
 import java.io.IOException
 import java.net.HttpURLConnection
+import java.security.MessageDigest
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -2120,6 +2121,47 @@ class ChatController(args: Bundle) :
     }
 
     private fun sendMessage(message: CharSequence, replyTo: Int?, sendWithoutNotification: Boolean) {
+        val messObj = ChatMessage()
+        messObj.message = message.toString()
+        messObj.activeUser = conversationUser
+        val tsLong = System.currentTimeMillis() / 1000
+        messObj.timestamp = tsLong
+        messObj.jsonMessageId = 0 - tsLong.toInt()
+
+
+        messObj.readStatus = ReadStatus.SENDING
+
+        if (conversationUser!!.userId != "?") {
+            // Logged in user
+            messObj.actorType = "users"
+            messObj.actorId = conversationUser.userId
+            messObj.actorDisplayName = conversationUser.username
+        } else if (currentConversation!!.actorType != null) {
+            // API v3 or later
+            messObj.actorType = currentConversation!!.actorType
+            messObj.actorId = currentConversation!!.actorId
+            messObj.actorDisplayName = ""
+        } else {
+            // API v1 or v2 as a guest
+            messObj.actorType = "guests"
+
+            val messageDigest: MessageDigest = MessageDigest.getInstance("SHA-1")
+            val digest: ByteArray = messageDigest.digest(currentConversation!!.sessionId!!.toByteArray())
+            val sha1: StringBuilder = StringBuilder()
+            val i = digest.iterator()
+            while (i.hasNext()) {
+                sha1.append(String.format("%02X", i.next()))
+            }
+
+            messObj.actorId = sha1.toString()
+            messObj.actorDisplayName = ""
+        }
+
+        adapter!!.addToStart(
+            messObj,
+            true
+        )
+
         if (conversationUser != null) {
             val apiVersion = ApiUtils.getChatApiVersion(conversationUser, intArrayOf(1))
 
@@ -2140,6 +2182,8 @@ class ChatController(args: Bundle) :
 
                     @Suppress("Detekt.TooGenericExceptionCaught")
                     override fun onNext(genericOverall: GenericOverall) {
+                        adapter!!.delete(messObj)
+
                         myFirstMessage = message
 
                         try {
@@ -2156,6 +2200,11 @@ class ChatController(args: Bundle) :
                     }
 
                     override fun onError(e: Throwable) {
+                        Log.e(TAG, "An error occured while sending the chat message: " + e.message)
+
+                        messObj.readStatus = ReadStatus.FAILED
+                        adapter!!.updateAndMoveToStart(messObj)
+
                         if (e is HttpException) {
                             val code = e.code()
                             if (code.toString().startsWith("2")) {
@@ -2996,7 +3045,12 @@ class ChatController(args: Bundle) :
 
     fun replyPrivately(message: IMessage?) {
         val apiVersion =
-            ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(ApiUtils.APIv4, 1))
+            ApiUtils.getConversationApiVersion(
+                            conversationUser, intArrayOf(
+                                ApiUtils.APIv4,
+                                1
+                            )
+                        )
         val retrofitBucket = ApiUtils.getRetrofitBucketForCreateRoom(
             apiVersion,
             conversationUser?.baseUrl,
@@ -3054,21 +3108,20 @@ class ChatController(args: Bundle) :
                                 )
                             }
 
-                            override fun onError(e: Throwable) {
-                                Log.e(TAG, e.message, e)
-                            }
+                                            override fun onError(e: Throwable) {
+                                                Log.e(TAG, e.message, e)
+                                            }
 
-                            override fun onComplete() {
-                                // unused atm
+                                            override fun onComplete() {// unused atm
                             }
                         })
                 }
 
-                override fun onError(e: Throwable) {
-                    Log.e(TAG, e.message, e)
-                }
+                                override fun onError(e: Throwable) {
+                                    Log.e(TAG, e.message, e)
+                                }
 
-                override fun onComplete() {
+                                override fun onComplete() {
                     // unused atm
                 }
             })

--- a/app/src/main/java/com/nextcloud/talk/models/json/chat/ReadStatus.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/chat/ReadStatus.kt
@@ -20,5 +20,9 @@
 package com.nextcloud.talk.models.json.chat
 
 enum class ReadStatus {
-    NONE, SENT, READ
+    NONE,
+    SENT,
+    READ,
+    SENDING,
+    FAILED
 }

--- a/app/src/main/res/drawable/ic_sending.xml
+++ b/app/src/main/res/drawable/ic_sending.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M9,5v2h6.59L4,18.59L5.41,20L17,8.41V15h2V5H9z"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -339,6 +339,8 @@
     <string name="nc_message_read">Message read</string>
     <string name="nc_message_sent">Message sent</string>
     <string name="nc_message_failed_to_send">Failed to send message:</string>
+    <string name="nc_message_sending">Message sending</string>
+    <string name="nc_message_send_error">Error while sending</string>
     <string name="nc_remote_audio_off">Remote audio off</string>
     <string name="nc_add_attachment">Add attachment</string>
     <string name="emoji_category_recent">Recent</string>


### PR DESCRIPTION
Success (bonus weird scrolling) | Error case (with copy/paste option)
---|---
![Peek 2021-05-17 12-00](https://user-images.githubusercontent.com/213943/118473373-2e57e400-b70a-11eb-83a0-87448ffdec7a.gif) | ![Peek 2021-05-17 12-01](https://user-images.githubusercontent.com/213943/118473409-39127900-b70a-11eb-8277-c0dbdbf6fa0a.gif)

I have no clue why the scrolling freaks out like this.

### Code changes to help testing
Modify your Talk install to make the response slower:
```diff
diff --git a/lib/Controller/ChatController.php b/lib/Controller/ChatController.php
index f8e0f19a6..e71bd1d81 100644
--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -226,6 +226,7 @@ class ChatController extends AEnvironmentAwareController {
         *         found".
         */
        public function sendMessage(string $message, string $actorDisplayName = '', string $referenceId = '', int $replyTo = 0): DataResponse {
+               sleep(1);
                [$actorType, $actorId] = $this->getActorInfo($actorDisplayName);
                if (!$actorId) {
                        return new DataResponse([], Http::STATUS_NOT_FOUND);

```
And use the follow change to create a slow error
```diff
diff --git a/lib/Controller/ChatController.php b/lib/Controller/ChatController.php
index f8e0f19a6..e71bd1d81 100644
--- a/lib/Controller/ChatController.php
+++ b/lib/Controller/ChatController.php
@@ -226,6 +226,8 @@ class ChatController extends AEnvironmentAwareController {
         *         found".
         */
        public function sendMessage(string $message, string $actorDisplayName = '', string $referenceId = '', int $replyTo = 0): DataResponse {
+               sleep(1);
+               return new DataResponse([], Http::STATUS_BAD_REQUEST);
                [$actorType, $actorId] = $this->getActorInfo($actorDisplayName);
                if (!$actorId) {
                        return new DataResponse([], Http::STATUS_NOT_FOUND);
```


### Follow up todos
- [ ] Fix scrolling (I have no idea where it goes wild)
- [ ] Messages can have a reference id which should be set and the temporary messages only be removed by the fetching of messages when there is a reference id match.

Fix #838
