### PR TITLE
remove ExtraTranslation flags

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -276,8 +276,8 @@
     <string name="nc_sent_an_audio" formatted="true">%1$s sent an audio.</string>
     <string name="nc_sent_a_video" formatted="true">%1$s sent a video.</string>
     <string name="nc_sent_an_image" formatted="true">%1$s sent an image.</string>
-    <string name="nc_sent_a_link_you" tools:ignore="ExtraTranslation">You sent a link.</string>
-    <string name="nc_sent_a_gif_you" tools:ignore="ExtraTranslation">You sent a GIF.</string>
+    <string name="nc_sent_a_link_you">You sent a link.</string>
+    <string name="nc_sent_a_gif_you">You sent a GIF.</string>
     <string name="nc_sent_an_attachment_you">You sent an attachment.</string>
     <string name="nc_sent_an_audio_you">You sent an audio.</string>
     <string name="nc_sent_a_video_you">You sent a video.</string>


### PR DESCRIPTION
... since linter config should already cover this

Signed-off-by: Andy Scherzinger <info@andy-scherzinger.de>