### PR TITLE
dont show deletion option for attachments

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -1800,6 +1800,8 @@ class ChatController(args: Bundle) :
 
         if (message.isDeleted) return false
 
+        if (message.hasFileAttachment()) return false
+
         val sixHoursInMillis = 6 * 3600 * 1000
         val isOlderThanSixHours = message.createdAt?.before(Date(System.currentTimeMillis() - sixHoursInMillis)) == true
         if (isOlderThanSixHours) return false

--- a/app/src/main/java/com/nextcloud/talk/models/json/chat/ChatMessage.java
+++ b/app/src/main/java/com/nextcloud/talk/models/json/chat/ChatMessage.java
@@ -91,7 +91,7 @@ public class ChatMessage implements IMessage, MessageContentType, MessageContent
             MessageType.SYSTEM_MESSAGE, MessageType.SINGLE_LINK_VIDEO_MESSAGE,
             MessageType.SINGLE_LINK_AUDIO_MESSAGE, MessageType.SINGLE_LINK_MESSAGE);
 
-    private boolean hasFileAttachment() {
+    public boolean hasFileAttachment() {
         if (messageParameters != null && messageParameters.size() > 0) {
             for (String key : messageParameters.keySet()) {
                 Map<String, String> individualHashMap = messageParameters.get(key);
@@ -100,7 +100,6 @@ public class ChatMessage implements IMessage, MessageContentType, MessageContent
                 }
             }
         }
-
         return false;
     }
 


### PR DESCRIPTION
fix  #1281 

deletion for attachments in talk is not supported by server. Because of this the delete option must be suppressed in the available options when the user long clicks next to an attachment.

Signed-off-by: Marcel Hibbe <dev@mhibbe.de>