### PR TITLE
Add shimmer for chat content loading

### DIFF
--- a/app/src/main/res/layout/controller_chat.xml
+++ b/app/src/main/res/layout/controller_chat.xml
@@ -46,20 +46,21 @@
         tools:visibility="visible"
         />
 
-    <ProgressBar
+    <LinearLayout
         android:id="@+id/progressBar"
-        android:layout_width="@dimen/item_height"
-        android:layout_height="@dimen/item_height"
-        android:layout_centerInParent="true"
-        android:layout_marginStart="@dimen/activity_horizontal_margin"
-        android:layout_marginLeft="@dimen/activity_horizontal_margin"
-        android:layout_marginEnd="@dimen/activity_horizontal_margin"
-        android:layout_marginRight="@dimen/activity_horizontal_margin"
-        android:indeterminate="true"
-        android:indeterminateTint="@color/colorPrimary"
-        android:indeterminateTintMode="src_in"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingTop="@dimen/standard_padding"
         android:visibility="gone"
-        tools:visibility="visible"/>
+        tools:visibility="visible">
+
+        <include layout="@layout/item_custom_incoming_text_message_shimmer" />
+
+        <include layout="@layout/item_custom_incoming_text_message_shimmer" />
+
+        <include layout="@layout/item_custom_incoming_text_message_shimmer" />
+    </LinearLayout>
 
     <View
         android:id="@+id/separator"

--- a/app/src/main/res/layout/item_custom_incoming_text_message_shimmer.xml
+++ b/app/src/main/res/layout/item_custom_incoming_text_message_shimmer.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Nextcloud Talk application
+  ~
+  ~ @author Andy Scherzinger
+  ~ Copyright (C) 2021 Andy Scherzinger <info@andy-scherzinger.de>
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginLeft="@dimen/standard_margin"
+    android:layout_marginTop="2dp"
+    android:layout_marginRight="@dimen/standard_margin"
+    android:layout_marginBottom="24dp">
+
+    <com.elyeproj.loaderviewlibrary.LoaderImageView
+        android:id="@+id/messageUserAvatar"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:layout_alignParentTop="true"
+        android:layout_marginEnd="@dimen/standard_half_margin"
+        android:contentDescription="@null"
+        app:corners="100"
+        app:custom_color="@color/nc_shimmer_default_color" />
+
+    <com.google.android.flexbox.FlexboxLayout
+        android:id="@id/bubble"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="40dp"
+        android:layout_toEndOf="@id/messageUserAvatar"
+        android:orientation="vertical"
+        app:alignContent="stretch"
+        app:alignItems="stretch"
+        app:flexWrap="wrap"
+        app:justifyContent="flex_end">
+
+        <com.elyeproj.loaderviewlibrary.LoaderTextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="128dp"
+            android:textStyle="bold"
+            app:custom_color="@color/nc_shimmer_default_color" />
+
+        <com.elyeproj.loaderviewlibrary.LoaderTextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:layout_marginEnd="@dimen/standard_half_margin"
+            android:textStyle="bold"
+            app:custom_color="@color/nc_shimmer_default_color" />
+
+        <com.elyeproj.loaderviewlibrary.LoaderTextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:layout_marginEnd="@dimen/standard_half_margin"
+            android:textStyle="bold"
+            app:custom_color="@color/nc_shimmer_default_color" />
+
+        <com.elyeproj.loaderviewlibrary.LoaderTextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:layout_marginEnd="76dp"
+            android:textStyle="bold"
+            app:custom_color="@color/nc_shimmer_default_color" />
+
+    </com.google.android.flexbox.FlexboxLayout>
+</RelativeLayout>


### PR DESCRIPTION
Before we had a centered, circular spinner which is now replaced by shimmer messages, like we use in other places in the app already and also like we do on the web UI:

![chat shimmer](https://user-images.githubusercontent.com/1315170/123708869-6ce5d000-d86c-11eb-88b8-f9a44678476e.png)

Signed-off-by: Andy Scherzinger <info@andy-scherzinger.de>