### PR TITLE
Harden Chat Title Calculation

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -1270,7 +1270,11 @@ class ChatController(args: Bundle) :
     override val title: String
         get() =
             if (currentConversation?.displayName != null) {
-                " " + EmojiCompat.get().process(currentConversation?.displayName as CharSequence).toString()
+                try {
+                    " " + EmojiCompat.get().process(currentConversation?.displayName as CharSequence).toString()
+                } catch (e: IllegalStateException) {
+                    " " + currentConversation?.displayName
+                }
             } else {
                 ""
             }


### PR DESCRIPTION
Catch IllegalStateException in case EmojiCompat hasn't been initialized yet, hit more than 700 users, already present in v11

Fixes #1371

Signed-off-by: Andy Scherzinger <info@andy-scherzinger.de>