### PR TITLE
Shortened launcher label

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/AccountVerificationController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/AccountVerificationController.java
@@ -244,8 +244,10 @@ public class AccountVerificationController extends BaseController {
                             fetchProfile(credentials);
                         } else {
                             if (getActivity() != null && getResources() != null) {
-                                getActivity().runOnUiThread(() -> progressText.setText(String.format(getResources().getString(
-                                        R.string.nc_nextcloud_talk_app_not_installed), getResources().getString(R.string.nc_app_name))));
+                                getActivity().runOnUiThread(() -> progressText.setText(
+                                        String.format(
+                                                getResources().getString(R.string.nc_nextcloud_talk_app_not_installed),
+                                                getResources().getString(R.string.nc_app_product_name))));
                             }
 
                             ApplicationWideMessageHolder.getInstance().setMessageType(
@@ -258,8 +260,10 @@ public class AccountVerificationController extends BaseController {
                     @Override
                     public void onError(Throwable e) {
                         if (getActivity() != null && getResources() != null) {
-                            getActivity().runOnUiThread(() -> progressText.setText(String.format(getResources().getString(
-                                    R.string.nc_nextcloud_talk_app_not_installed), getResources().getString(R.string.nc_app_name))));
+                            getActivity().runOnUiThread(() -> progressText.setText(
+                                    String.format(
+                                            getResources().getString(R.string.nc_nextcloud_talk_app_not_installed),
+                                            getResources().getString(R.string.nc_app_product_name))));
                         }
 
                         ApplicationWideMessageHolder.getInstance().setMessageType(

--- a/app/src/main/java/com/nextcloud/talk/controllers/CallController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/CallController.java
@@ -2344,7 +2344,7 @@ public class CallController extends BaseController {
     }
 
     private String getDescriptionForCallType() {
-        String appName = getResources().getString(R.string.nc_app_name);
+        String appName = getResources().getString(R.string.nc_app_product_name);
         if (isVoiceOnlyCall) {
             return String.format(getResources().getString(R.string.nc_call_voice), appName);
         } else {

--- a/app/src/main/java/com/nextcloud/talk/controllers/CallNotificationController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/CallNotificationController.java
@@ -284,11 +284,13 @@ public class CallNotificationController extends BaseController {
                                                                                 "conversation-call-flags");
                             if (hasCallFlags) {
                                 if (isInCallWithVideo(currentConversation.callFlag)) {
-                                    incomingCallVoiceOrVideoTextView.setText(String.format(getResources().getString(R.string.nc_call_video),
-                                                                                           getResources().getString(R.string.nc_app_name)));
+                                    incomingCallVoiceOrVideoTextView.setText(
+                                            String.format(getResources().getString(R.string.nc_call_video),
+                                                          getResources().getString(R.string.nc_app_product_name)));
                                 } else {
-                                    incomingCallVoiceOrVideoTextView.setText(String.format(getResources().getString(R.string.nc_call_voice),
-                                                                                           getResources().getString(R.string.nc_app_name)));
+                                    incomingCallVoiceOrVideoTextView.setText(
+                                            String.format(getResources().getString(R.string.nc_call_voice),
+                                                          getResources().getString(R.string.nc_app_product_name)));
                                 }
                             }
                         }
@@ -328,8 +330,9 @@ public class CallNotificationController extends BaseController {
         super.onViewBound(view);
 
         String callDescriptionWithoutTypeInfo =
-                String.format(getResources().getString(R.string.nc_call_unknown), getResources().getString(R.string.nc_app_name));
-
+                String.format(
+                        getResources().getString(R.string.nc_call_unknown),
+                        getResources().getString(R.string.nc_app_product_name));
 
         incomingCallVoiceOrVideoTextView.setText(callDescriptionWithoutTypeInfo);
 

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -2145,7 +2145,10 @@ class ChatController(args: Bundle) :
                     R.id.action_copy_message -> {
                         val clipboardManager =
                             activity?.getSystemService(Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
-                        val clipData = ClipData.newPlainText(resources?.getString(R.string.nc_app_name), message?.text)
+                        val clipData = ClipData.newPlainText(
+                            resources?.getString(R.string.nc_app_product_name),
+                            message?.text
+                        )
                         clipboardManager.setPrimaryClip(clipData)
                         true
                     }

--- a/app/src/main/java/com/nextcloud/talk/controllers/ContactsController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ContactsController.java
@@ -815,7 +815,7 @@ public class ContactsController extends BaseController implements SearchView.OnQ
         } else if (isNewConversationView) {
             return getResources().getString(R.string.nc_select_participants);
         } else {
-            return getResources().getString(R.string.nc_app_name);
+            return getResources().getString(R.string.nc_app_product_name);
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
@@ -737,7 +737,7 @@ public class ConversationsListController extends BaseController implements Searc
 
     @Override
     protected String getTitle() {
-        return getResources().getString(R.string.nc_app_name);
+        return getResources().getString(R.string.nc_app_product_name);
     }
 
     @Override

--- a/app/src/main/java/com/nextcloud/talk/controllers/LockedController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/LockedController.kt
@@ -99,7 +99,7 @@ class LockedController : NewBaseController(R.layout.controller_locked) {
                 .setTitle(
                     String.format(
                         context.getString(R.string.nc_biometric_unlock),
-                        context.getString(R.string.nc_app_name)
+                        context.getString(R.string.nc_app_product_name)
                     )
                 )
                 .setNegativeButtonText(context.getString(R.string.nc_cancel))

--- a/app/src/main/java/com/nextcloud/talk/controllers/ServerSelectionController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ServerSelectionController.java
@@ -265,7 +265,7 @@ public class ServerSelectionController extends BaseController {
                     } else if (!status.getVersion().startsWith("13.")) {
                         setErrorText(String.format(getResources().
                                         getString(R.string.nc_server_version),
-                                getResources().getString(R.string.nc_app_name),
+                                getResources().getString(R.string.nc_app_product_name),
                                 productName));
                     }
 

--- a/app/src/main/java/com/nextcloud/talk/controllers/SettingsController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/SettingsController.java
@@ -276,7 +276,7 @@ public class SettingsController extends BaseController {
         } else {
             screenLockSwitchPreference.setSummary(String.format(Locale.getDefault(),
                     getResources().getString(R.string.nc_settings_screen_lock_desc),
-                    getResources().getString(R.string.nc_app_name)));
+                    getResources().getString(R.string.nc_app_product_name)));
         }
 
 

--- a/app/src/main/java/com/nextcloud/talk/controllers/WebViewLoginController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/WebViewLoginController.java
@@ -149,7 +149,7 @@ public class WebViewLoginController extends BaseController {
     private String getWebLoginUserAgent() {
         return Build.MANUFACTURER.substring(0, 1).toUpperCase(Locale.getDefault()) +
                 Build.MANUFACTURER.substring(1).toLowerCase(Locale.getDefault()) + " " + Build.MODEL + " ("
-                + getResources().getString(R.string.nc_app_name) + ")";
+                + getResources().getString(R.string.nc_app_product_name) + ")";
     }
 
     @Override

--- a/app/src/main/java/com/nextcloud/talk/controllers/base/BaseController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/base/BaseController.java
@@ -260,6 +260,6 @@ public abstract class BaseController extends ButterKnifeController {
     }
 
     public String getSearchHint() {
-        return context.getString(R.string.appbar_search_in, context.getString(R.string.nc_app_name));
+        return context.getString(R.string.appbar_search_in, context.getString(R.string.nc_app_product_name));
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/controllers/base/NewBaseController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/base/NewBaseController.kt
@@ -300,7 +300,7 @@ abstract class NewBaseController(@LayoutRes var layoutRes: Int, args: Bundle? = 
     open val appBarLayoutType: AppBarLayoutType
         get() = AppBarLayoutType.TOOLBAR
     val searchHint: String
-        get() = context!!.getString(R.string.appbar_search_in, context!!.getString(R.string.nc_app_name))
+        get() = context!!.getString(R.string.appbar_search_in, context!!.getString(R.string.nc_app_product_name))
 
     companion object {
         private val TAG = BaseController::class.java.simpleName

--- a/app/src/main/java/com/nextcloud/talk/controllers/bottomsheet/CallMenuController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/bottomsheet/CallMenuController.java
@@ -133,7 +133,7 @@ public class CallMenuController extends BaseController implements FlexibleAdapte
         shareIntent = new Intent(Intent.ACTION_SEND);
         shareIntent.setType("text/plain");
         shareIntent.putExtra(Intent.EXTRA_SUBJECT, String.format(getResources().getString(R.string.nc_share_subject),
-                getResources().getString(R.string.nc_app_name)));
+                getResources().getString(R.string.nc_app_product_name)));
     }
 
     private void prepareMenu() {

--- a/app/src/main/java/com/nextcloud/talk/dagger/modules/DatabaseModule.java
+++ b/app/src/main/java/com/nextcloud/talk/dagger/modules/DatabaseModule.java
@@ -44,7 +44,7 @@ public class DatabaseModule {
     @Singleton
     public SqlCipherDatabaseSource provideSqlCipherDatabaseSource(@NonNull final Context context) {
         return new SqlCipherDatabaseSource(context, Models.DEFAULT,
-                context.getResources().getString(R.string.nc_app_name).toLowerCase()
+                context.getResources().getString(R.string.nc_app_product_name).toLowerCase()
                         .replace(" ", "_").trim() + ".sqlite",
                 context.getString(R.string.nc_talk_database_encryption_key), 6);
     }

--- a/app/src/main/java/com/nextcloud/talk/jobs/ContactAddressBookWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/ContactAddressBookWorker.kt
@@ -79,7 +79,7 @@ class ContactAddressBookWorker(val context: Context, workerParameters: WorkerPar
 
         val currentUser = userUtils.currentUser
 
-        accountName = context.getString(R.string.nc_app_name)
+        accountName = context.getString(R.string.nc_app_product_name)
         accountType = BuildConfig.APPLICATION_ID
 
         if (currentUser == null) {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -141,7 +141,7 @@
             app:navigationIconTint="@color/fontAppbar"
             app:popupTheme="@style/appActionBarPopupMenu"
             app:titleTextColor="@color/fontAppbar"
-            tools:title="@string/nc_app_name">
+            tools:title="@string/nc_app_product_name">
 
             <ProgressBar
                 android:id="@+id/toolbarProgressBar"

--- a/app/src/main/res/layout/controller_conversations_rv.xml
+++ b/app/src/main/res/layout/controller_conversations_rv.xml
@@ -53,7 +53,7 @@
             android:id="@+id/empty_list_icon"
             android:layout_width="match_parent"
             android:layout_height="72dp"
-            android:contentDescription="@string/nc_app_name"
+            android:contentDescription="@string/nc_app_product_name"
             android:src="@drawable/ic_logo"
             app:tint="#989898" />
 

--- a/app/src/main/res/layout/controller_locked.xml
+++ b/app/src/main/res/layout/controller_locked.xml
@@ -39,7 +39,7 @@
             android:id="@+id/appLogo"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:contentDescription="@string/nc_app_name"
+            android:contentDescription="@string/nc_app_product_name"
             android:src="@drawable/ic_logo" />
 
         <ImageView

--- a/app/src/main/res/layout/controller_server_selection.xml
+++ b/app/src/main/res/layout/controller_server_selection.xml
@@ -43,7 +43,7 @@
             android:layout_width="96dp"
             android:layout_height="96dp"
             android:layout_marginBottom="@dimen/standard_margin"
-            android:contentDescription="@string/nc_app_name"
+            android:contentDescription="@string/nc_app_product_name"
             android:scaleType="fitXY"
             app:srcCompat="@drawable/ic_logo" />
 

--- a/app/src/main/res/layout/controller_settings.xml
+++ b/app/src/main/res/layout/controller_settings.xml
@@ -368,7 +368,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             apc:mp_summary="v0.1"
-            apc:mp_title="@string/nc_app_name" />
+            apc:mp_title="@string/nc_app_product_name" />
 
     </com.yarolegovich.mp.MaterialPreferenceCategory>
 

--- a/app/src/main/res/values/setup.xml
+++ b/app/src/main/res/values/setup.xml
@@ -25,7 +25,8 @@
     <string name="nc_talk_login_scheme" translatable="false">nc</string>
     <bool name="nc_is_debug">false</bool>
 
-    <string name="nc_app_name">Nextcloud Talk</string>
+    <string name="nc_app_name">Talk</string>
+    <string name="nc_app_product_name">Nextcloud Talk</string>
     <string name="nc_server_product_name">Nextcloud</string>
 
     <string name="nc_push_server_url" translatable="false">https://push-notifications.nextcloud.com</string>

--- a/app/src/main/res/xml/auth.xml
+++ b/app/src/main/res/xml/auth.xml
@@ -23,4 +23,4 @@
     android:accountType="com.nextcloud.talk2"
     android:icon="@mipmap/ic_launcher"
     android:smallIcon="@mipmap/ic_launcher"
-    android:label="@string/nc_app_name"/>
+    android:label="@string/nc_app_product_name"/>

--- a/app/src/qa/res/values/setup.xml
+++ b/app/src/qa/res/values/setup.xml
@@ -20,6 +20,7 @@
   -->
 
 <resources>
-    <string name="nc_app_name">Nextcloud Talk QA</string>
+    <string name="nc_app_name">Talk QA</string>
+    <string name="nc_app_product_name">Nextcloud Talk QA</string>
     <string name="nc_server_product_name">Nextcloud</string>
 </resources>


### PR DESCRIPTION
shorten app label Nextcloud Talk -> Talk while keeping "Nextcloud Talk" as a label within the app itself

**TODO**

_Brander needs to adapt to additional string in ```setup.xml```_ 
ping @tobiasKaminsky for details on the brander.

❗ **Should only be backported to 12.1 _if_ the brander is going to support it within the next days** ❗

I suggest to postpone this to 12.2 (at least), also cc @nickvergessen since this PR creates a change demand for brander - to be managed/timed

Signed-off-by: Andy Scherzinger <info@andy-scherzinger.de>