### PR TITLE
Add missing .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,41 @@
+# see http://EditorConfig.org
+
+# This is the file in the root of the project.
+# For sub folders you can have other files that override only some settings.
+# For these, this settings should be false.
+root=true
+
+[*]
+max_line_length=120
+# use spaces, not tabs.
+indent_style=space
+indent_size=4
+
+[*.yml]
+max_line_length=150
+
+charset=utf-8
+
+# Trimming is good for consistency
+trim_trailing_whitespace=true
+# I've seen cases where a missing new_line was ignored on *nix systems.
+# Never again with this setting!
+insert_final_newline=true
+
+[*.properties]
+# Exception for Java properties files should be encoded latin1 (aka iso8859-1)
+charset=latin1
+
+[*.{cmd,bat}]
+# batch files on Windows should stay with CRLF
+end_of_line=crlf
+
+[*.md]
+trim_trailing_whitespace=false
+
+[.drone.yml]
+indent_size=2
+
+[*.{kt,kts}]
+# IDE does not follow this Ktlint rule strictly, but the default ordering is pretty good anyway, so let's ditch it
+disabled_rules=import-ordering


### PR DESCRIPTION
If an developer have a own '.editorconfig' in some location above the repostires
directory it will used in the gradle build and formatting checks can be fail.

To avoid this an get an more uniform code style between Nextclouds Android apps
the '.editorconfig' from the Nextcloud Android app is used.

Because of defining 'root=true' the developers own '.editorconfig' is not used
anymore.

 Signed-off-by: Tim Krüger <t@timkrueger.me>