### PR TITLE
Fix call notifications

### DIFF
--- a/app/src/gplay/java/com/nextcloud/talk/services/firebase/MagicFirebaseMessagingService.kt
+++ b/app/src/gplay/java/com/nextcloud/talk/services/firebase/MagicFirebaseMessagingService.kt
@@ -302,7 +302,10 @@ class MagicFirebaseMessagingService : FirebaseMessagingService() {
         var hasParticipantsInCall = false
         var inCallOnDifferentDevice = false
 
-        val apiVersion = ApiUtils.getConversationApiVersion(signatureVerification.userEntity, intArrayOf(1))
+        val apiVersion = ApiUtils.getConversationApiVersion(
+            signatureVerification.userEntity,
+            intArrayOf(ApiUtils.APIv4, 1)
+        )
 
         ncApi.getPeersForCall(
             ApiUtils.getCredentials(signatureVerification.userEntity.username, signatureVerification.userEntity.token),


### PR DESCRIPTION
Call notifications don't work with a 22+ server

First you see this in the console log:
> Api call did not try conversation-v4 api

And afterwards the notification is killed with
> NoSupportedApiException