### PR TITLE
Fix capability check for 14-18

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
@@ -138,7 +138,8 @@ public class ApiUtils {
                     return version;
                 }
                 if (version == 1  &&
-                        CapabilitiesUtil.hasSpreedFeatureCapability(user, "conversation")) {
+                        CapabilitiesUtil.hasSpreedFeatureCapability(user, "mention-flag") &&
+                        !CapabilitiesUtil.hasSpreedFeatureCapability(user, "conversation-v4")) {
                     return version;
                 }
             }


### PR DESCRIPTION
Fix #1429

Not sure what my head did, but there was no `conversation` capability ... ever...
https://github.com/nextcloud/spreed/blob/master/docs/capabilities.md#40
So now we use `mention-flag` which is influencing the conversation api and a anti-check for api-v4 as v1 routes are there all that time.
Might need to bump this to also exclude future versions, if v5 would drop v4 e.g.