### PR TITLE
Make links clickable in conversation description

### DIFF
--- a/app/src/main/res/layout/controller_conversation_info.xml
+++ b/app/src/main/res/layout/controller_conversation_info.xml
@@ -99,6 +99,7 @@
                     android:layout_centerHorizontal="true"
                     android:layout_margin="@dimen/standard_margin"
                     android:layout_marginTop="@dimen/margin_between_elements"
+                    android:autoLink="web"
                     tools:text="Hello world!" />
             </com.yarolegovich.mp.MaterialPreferenceCategory>
 


### PR DESCRIPTION
Set attribute 'andorid:autoLink' to 'all' for converting all possible
urls (email, map, phone, web) to clickable links.

Resolves: #1243

Signed-off-by: Tim Krüger <t@timkrueger.me>