### PR TITLE
fix displaying of message delete-button

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -2421,7 +2421,7 @@ class ChatController(args: Bundle) :
         val isUserAllowedByPrivileges = if (message.actorId == conversationUser.userId) {
             true
         } else {
-            currentConversation!!.isParticipantOwnerOrModerator
+            currentConversation!!.canModerate(conversationUser)
         }
         if (!isUserAllowedByPrivileges) return false
 


### PR DESCRIPTION
this will fix to hide the delete-button when the message is not from the current user and the user not a moderator.
see https://nextcloud-talk.readthedocs.io/en/latest/chat/#deleting-a-chat-message

before the delete option was shown even if the user was only the owner. When tapping on "delete", an error 403 was received.



Signed-off-by: Marcel Hibbe <dev@mhibbe.de>