### PR TITLE
enable keyguard for toggle chat

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/MagicCallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MagicCallActivity.kt
@@ -22,7 +22,9 @@
 
 package com.nextcloud.talk.activities
 
+import android.app.KeyguardManager
 import android.content.res.Configuration
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.view.Window
@@ -56,11 +58,10 @@ class MagicCallActivity : BaseActivity() {
         setTheme(R.style.CallTheme)
 
         requestWindowFeature(Window.FEATURE_NO_TITLE)
+        dismissKeyguard()
         window.addFlags(
             WindowManager.LayoutParams.FLAG_FULLSCREEN or
-                WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON or
-                WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD or WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or
-                WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
+                WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
         )
         window.decorView.systemUiVisibility = systemUiVisibility
 
@@ -99,6 +100,7 @@ class MagicCallActivity : BaseActivity() {
     }
 
     fun showChat() {
+        enableKeyguard()
         binding.chatControllerView.visibility = View.VISIBLE
         binding.controllerContainer.visibility = View.GONE
         chatController.wasDetached = false
@@ -114,6 +116,33 @@ class MagicCallActivity : BaseActivity() {
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
         eventBus.post(ConfigurationChangeEvent())
+    }
+
+    private fun dismissKeyguard() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            setShowWhenLocked(true)
+            setTurnScreenOn(true)
+            val keyguardManager = getSystemService(KEYGUARD_SERVICE) as KeyguardManager
+            keyguardManager.requestDismissKeyguard(this, null)
+        } else {
+            window.addFlags(
+                WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD or
+                    WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or
+                    WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
+            )
+        }
+    }
+
+    private fun enableKeyguard() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            setShowWhenLocked(false)
+        } else {
+            window.clearFlags(
+                WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD or
+                    WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or
+                    WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
+            )
+        }
     }
 
     companion object {


### PR DESCRIPTION
show the lockscreen when switching to chat in a call that was opened by notification before the phone was unlocked.

Signed-off-by: Marcel Hibbe <dev@mhibbe.de>