### PR TITLE
Show lobby timer and description in lobby screen 

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -1127,7 +1127,8 @@ class ChatController(args: Bundle) :
                         DateUtils.getLocalDateStringFromTimestampForLobby(
                             currentConversation?.lobbyTimer
                                 ?: 0
-                        )
+                        ),
+                        currentConversation!!.description
                     )
                 } else {
                     binding.lobby.lobbyTextView.setText(R.string.nc_lobby_waiting)

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -1119,20 +1119,26 @@ class ChatController(args: Bundle) :
                 binding.messageInputView.visibility = View.GONE
                 binding.progressBar.visibility = View.GONE
 
+                val sb = StringBuilder()
+                sb.append(resources!!.getText(R.string.nc_lobby_waiting))
+                    .append("\n\n")
+
                 if (currentConversation?.lobbyTimer != null && currentConversation?.lobbyTimer !=
                     0L
                 ) {
-                    binding.lobby.lobbyTextView.text = String.format(
-                        resources!!.getString(R.string.nc_lobby_waiting_with_date),
-                        DateUtils.getLocalDateStringFromTimestampForLobby(
-                            currentConversation?.lobbyTimer
-                                ?: 0
-                        ),
-                        currentConversation!!.description
+                    val timestamp = currentConversation?.lobbyTimer ?: 0
+                    val stringWithStartDate = String.format(
+                        resources!!.getString(R.string.nc_lobby_start_date),
+                        DateUtils.getLocalDateStringFromTimestampForLobby(timestamp)
                     )
-                } else {
-                    binding.lobby.lobbyTextView.setText(R.string.nc_lobby_waiting)
+                    val relativeTime = DateUtils.relativeStartTimeForLobby(timestamp, resources!!)
+
+                    sb.append("$stringWithStartDate - $relativeTime")
+                        .append("\n\n")
                 }
+
+                sb.append(currentConversation!!.description)
+                binding.lobby.lobbyTextView.text = sb.toString()
             } else {
                 binding.lobby.lobbyView.visibility = View.GONE
                 binding.messagesListView.visibility = View.VISIBLE

--- a/app/src/main/res/layout/lobby_view.xml
+++ b/app/src/main/res/layout/lobby_view.xml
@@ -47,6 +47,7 @@
         android:text="@string/nc_lobby_waiting"
         android:textAlignment="center"
         android:textColor="@color/grey_600"
-        android:textSize="16sp" />
+        android:textSize="16sp"
+        android:autoLink="web" />
 
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -350,8 +350,8 @@
     <string name="nc_lobby">Lobby</string>
     <string name="nc_start_time">Start time</string>
     <string name="nc_lobby_waiting">You are currently waiting in the lobby.</string>
-    <string name="nc_lobby_waiting_with_date">You are currently waiting in the lobby.\n\nThis meeting is scheduled for
-        %1$s.\n\n%2$s</string>
+    <string name="nc_lobby_start_date">This meeting is scheduled for %1$s</string>
+    <string name="nc_lobby_start_soon">The meeting will start soon</string>
     <string name="nc_manual">Not set</string>
 
     <!-- Errors -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -350,7 +350,8 @@
     <string name="nc_lobby">Lobby</string>
     <string name="nc_start_time">Start time</string>
     <string name="nc_lobby_waiting">You are currently waiting in the lobby.</string>
-    <string name="nc_lobby_waiting_with_date">You are currently waiting in the lobby.\n This meeting is scheduled for %1$s.</string>
+    <string name="nc_lobby_waiting_with_date">You are currently waiting in the lobby.\n\nThis meeting is scheduled for
+        %1$s.\n\n%2$s</string>
     <string name="nc_manual">Not set</string>
 
     <!-- Errors -->


### PR DESCRIPTION
resolve #1557

I didn't get it the way like in [iOS](https://github.com/nextcloud/talk-ios/pull/615#issue-987829178). So stay with the timer like in spreed. Is that OK?

Days | Hours | Minutes | Soon
------- | -------- | ---------- | --------
![days](https://user-images.githubusercontent.com/606665/134010569-60d879fc-49da-44e9-9136-b6798c6d30d8.png) | ![hours](https://user-images.githubusercontent.com/606665/134010568-16fe4a0b-b72b-4897-a838-98ad79fc953e.png) | ![minutes](https://user-images.githubusercontent.com/606665/134010567-0d3afade-5324-44b1-9226-2393c023bff0.png) | ![soon](https://user-images.githubusercontent.com/606665/134010565-88709079-45f4-458c-9453-af2fb5c69374.png)



