### PR TITLE
differentiate unread counters

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.java
@@ -42,6 +42,7 @@ import com.facebook.drawee.view.SimpleDraweeView;
 import com.google.android.material.chip.Chip;
 import com.nextcloud.talk.R;
 import com.nextcloud.talk.application.NextcloudTalkApplication;
+import com.nextcloud.talk.models.database.CapabilitiesUtil;
 import com.nextcloud.talk.models.database.UserEntity;
 import com.nextcloud.talk.models.json.chat.ChatMessage;
 import com.nextcloud.talk.models.json.conversations.Conversation;
@@ -136,20 +137,45 @@ public class ConversationItem extends AbstractFlexibleItem<ConversationItem.Conv
                 holder.dialogUnreadBubble.setText(R.string.tooManyUnreadMessages);
             }
 
-            if (conversation.isUnreadMention() || conversation.type == Conversation.ConversationType.ROOM_TYPE_ONE_TO_ONE_CALL) {
+            ColorStateList lightBubbleFillColor = ColorStateList.valueOf(
+                ContextCompat.getColor(context,
+                R.color.conversation_unread_bubble));
+            int lightBubbleTextColor = ContextCompat.getColor(
+                context,
+                R.color.conversation_unread_bubble_text);
+            ColorStateList lightBubbleStrokeColor = ColorStateList.valueOf(
+                ContextCompat.getColor(context,
+                R.color.colorPrimary));
+
+            if (conversation.type == Conversation.ConversationType.ROOM_TYPE_ONE_TO_ONE_CALL) {
                 holder.dialogUnreadBubble.setChipBackgroundColorResource(R.color.colorPrimary);
                 holder.dialogUnreadBubble.setTextColor(Color.WHITE);
+            } else if (conversation.isUnreadMention()) {
+                if (CapabilitiesUtil.hasSpreedFeatureCapability(userEntity, "direct-mention-flag")){
+                    if (conversation.getUnreadMentionDirect()) {
+                        holder.dialogUnreadBubble.setChipBackgroundColorResource(R.color.colorPrimary);
+                        holder.dialogUnreadBubble.setTextColor(Color.WHITE);
+                    } else {
+                        holder.dialogUnreadBubble.setChipBackgroundColor(ColorStateList.valueOf(
+                            ContextCompat.getColor(context, R.color.white)));
+                        holder.dialogUnreadBubble.setTextColor(ContextCompat.getColor(
+                            context,
+                            R.color.colorPrimary));
+                        holder.dialogUnreadBubble.setChipStrokeWidth(6.0f);
+                        holder.dialogUnreadBubble.setChipStrokeColor(lightBubbleStrokeColor);
+                    }
+                } else {
+                    holder.dialogUnreadBubble.setChipBackgroundColorResource(R.color.colorPrimary);
+                    holder.dialogUnreadBubble.setTextColor(Color.WHITE);
+                }
             } else {
-                holder.dialogUnreadBubble.setChipBackgroundColor(
-                        ColorStateList.valueOf(ContextCompat.getColor(context, R.color.conversation_unread_bubble)));
-                holder.dialogUnreadBubble.setTextColor(
-                        ContextCompat.getColor(context, R.color.conversation_unread_bubble_text));
+                holder.dialogUnreadBubble.setChipBackgroundColor(lightBubbleFillColor);
+                holder.dialogUnreadBubble.setTextColor(lightBubbleTextColor);
             }
         } else {
             holder.dialogName.setTypeface(null, Typeface.NORMAL);
             holder.dialogDate.setTypeface(null, Typeface.NORMAL);
             holder.dialogLastMessage.setTypeface(null, Typeface.NORMAL);
-
             holder.dialogUnreadBubble.setVisibility(View.GONE);
         }
 

--- a/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.java
@@ -128,7 +128,6 @@ public class ConversationItem extends AbstractFlexibleItem<ConversationItem.Conv
 
         if (conversation.getUnreadMessages() > 0) {
             holder.dialogName.setTypeface(holder.dialogName.getTypeface(), Typeface.BOLD);
-            holder.dialogDate.setTypeface(holder.dialogDate.getTypeface(), Typeface.BOLD);
             holder.dialogLastMessage.setTypeface(holder.dialogLastMessage.getTypeface(), Typeface.BOLD);
             holder.dialogUnreadBubble.setVisibility(View.VISIBLE);
             if (conversation.getUnreadMessages() < 1000) {

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
@@ -631,7 +631,7 @@ public class ConversationsListController extends BaseController implements Searc
             Conversation conversationItem = ((ConversationItem) flexItem).getModel();
             int position = adapter.getGlobalPositionOf(flexItem);
             if (conversationItem.unreadMention && position > lastVisibleItem) {
-                if(!newMentionPopupBubble.isShown()){
+                if (!newMentionPopupBubble.isShown()){
                     newMentionPopupBubble.show();
                 }
                 return;

--- a/app/src/main/java/com/nextcloud/talk/models/json/conversations/Conversation.java
+++ b/app/src/main/java/com/nextcloud/talk/models/json/conversations/Conversation.java
@@ -98,6 +98,9 @@ public class Conversation {
     @JsonField(name = "canDeleteConversation")
     public Boolean canDeleteConversation;
 
+    @JsonField(name = "unreadMentionDirect")
+    public Boolean unreadMentionDirect;
+
     public boolean isPublic() {
         return (ConversationType.ROOM_PUBLIC_CALL.equals(type));
     }
@@ -254,6 +257,10 @@ public class Conversation {
         return this.callFlag;
     }
 
+    public Boolean getUnreadMentionDirect() {
+        return unreadMentionDirect;
+    }
+
     public void setRoomId(String roomId) {
         this.roomId = roomId;
     }
@@ -357,6 +364,10 @@ public class Conversation {
 
     public void setCallFlag(int callFlag) {
         this.callFlag = callFlag;
+    }
+
+    public void setUnreadMentionDirect(Boolean unreadMentionDirect) {
+        this.unreadMentionDirect = unreadMentionDirect;
     }
 
     @Override


### PR DESCRIPTION
resolve #1559 

differentiate unread counters for group mentions and direct mentions

before | after (server with new capability) | after (server without new capability)
------- | -------- | ---------- 
![grafik](https://user-images.githubusercontent.com/2932790/134313062-1e6fd14e-e8c8-4798-b38d-7e3aa1664ed4.png) | ![grafik](https://user-images.githubusercontent.com/2932790/134365547-f3627d75-c0f5-409b-bda6-aa9ab0360733.png) | ![grafik](https://user-images.githubusercontent.com/2932790/134318104-5531cd27-06f4-437d-bab9-305a03bc961b.png) | 




Signed-off-by: Marcel Hibbe <dev@mhibbe.de>