### PR TITLE
Clear message field after sharing

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
@@ -199,14 +199,13 @@ public class ConversationsListController extends BaseController implements Searc
     private Bundle conversationMenuBundle = null;
 
     private boolean showShareToScreen = false;
-    private boolean shareToScreenWasShown = false;
 
     private ArrayList<String> filesToShare;
     private Conversation selectedConversation;
 
     private String textToPaste = "";
 
-    private boolean forwardMessage = false;
+    private boolean forwardMessage;
 
     private SmoothScrollLinearLayoutManager layoutManager;
 
@@ -347,7 +346,7 @@ public class ConversationsListController extends BaseController implements Searc
 
         searchView = (SearchView) MenuItemCompat.getActionView(searchItem);
 
-        showShareToScreen = !shareToScreenWasShown && hasActivityActionSendIntent();
+        showShareToScreen = !showShareToScreen && hasActivityActionSendIntent();
 
 
         if (showShareToScreen) {
@@ -786,10 +785,11 @@ public class ConversationsListController extends BaseController implements Searc
         selectedConversation = getConversation(position);
         if (selectedConversation != null && getActivity() != null) {
             if (showShareToScreen) {
-                shareToScreenWasShown = true;
                 handleSharedData();
+                showShareToScreen = false;
             } else if (forwardMessage) {
                 openConversation(bundle.getString(BundleKeys.INSTANCE.getKEY_FORWARD_MSG_TEXT()));
+                forwardMessage = false;
             } else {
                 openConversation();
             }


### PR DESCRIPTION
After the Android sharing functionality was used, the shared text sticks
in the message composing field in the conversation. Also if an text was
forwared to the same conversation the text which was shared before
sticks in the message composing field.

Now the message composing field is empty after sharing or forwarding
something.

Signed-off-by: Tim Krüger <t@timkrueger.me>