### PR TITLE
Replace 'mute calls' by 'call notifications'

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/api/NcApi.java
+++ b/app/src/main/java/com/nextcloud/talk/api/NcApi.java
@@ -4,8 +4,10 @@
  *
  *   @author Mario Danic
  *   @author Marcel Hibbe
+ *   @author Tim Krüger
  *   Copyright (C) 2017 Mario Danic (mario@lovelyhq.com)
  *   Copyright (C) 2021 Marcel Hibbe <dev@mhibbe.de>
+ *   Copyright (C) 2021 Tim Krüger <t@timkrueger.me>
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -418,4 +420,9 @@ public interface NcApi {
 
     @DELETE
     Observable<GenericOverall> clearChatHistory(@Header("Authorization") String authorization, @Url String url);
+
+    @FormUrlEncoded
+    @POST
+    Observable<GenericOverall> notificationCalls(@Header("Authorization") String authorization, @Url String url,
+                                                 @Field("level") Integer level);
 }

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
@@ -3,6 +3,8 @@
  *
  * @author Mario Danic
  * @author Andy Scherzinger
+ * @author Tim Krüger
+ * Copyright (C) 2021 Tim Krüger <t@timkrueger.me>
  * Copyright (C) 2021 Andy Scherzinger (info@andy-scherzinger.de)
  * Copyright (C) 2017-2018 Mario Danic <mario@lovelyhq.com>
  *
@@ -609,7 +611,14 @@ class ConversationInfoController(args: Bundle) :
                             }
 
                             if (Conversation.ConversationType.ROOM_SYSTEM == conversation!!.type) {
-                                binding.notificationSettingsView.muteCalls.visibility = View.GONE
+                                binding.notificationSettingsView.callNotifications.visibility = View.GONE
+                            }
+
+                            if (conversation!!.notificationCalls === null) {
+                                binding.notificationSettingsView.callNotifications.visibility = View.GONE
+                            } else {
+                                binding.notificationSettingsView.callNotifications.value =
+                                    conversationCopy.notificationCalls == 1
                             }
 
                             getListOfParticipants()

--- a/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.java
@@ -143,11 +143,6 @@ public class NotificationWorker extends Worker {
         ArbitraryStorageEntity arbitraryStorageEntity;
 
         if ((arbitraryStorageEntity = arbitraryStorageUtils.getStorageSetting(userEntity.getId(),
-                "mute_calls", intent.getExtras().getString(BundleKeys.INSTANCE.getKEY_ROOM_TOKEN()))) != null) {
-            muteCall = Boolean.parseBoolean(arbitraryStorageEntity.getValue());
-        }
-
-        if ((arbitraryStorageEntity = arbitraryStorageUtils.getStorageSetting(userEntity.getId(),
                 "important_conversation", intent.getExtras().getString(BundleKeys.INSTANCE.getKEY_ROOM_TOKEN()))) != null) {
             importantConversation = Boolean.parseBoolean(arbitraryStorageEntity.getValue());
         }
@@ -183,6 +178,8 @@ public class NotificationWorker extends Worker {
                                 showNotification(intent);
                             }
                         }
+
+                        muteCall = !(conversation.notificationCalls == 1);
                     }
 
                     @Override

--- a/app/src/main/java/com/nextcloud/talk/models/json/conversations/Conversation.java
+++ b/app/src/main/java/com/nextcloud/talk/models/json/conversations/Conversation.java
@@ -3,6 +3,8 @@
  *   Nextcloud Talk application
  *
  *   @author Mario Danic
+ *   @author Tim Krüger
+ *   Copyright (C) 2021 Tim Krüger <t@timkrueger.me>
  *   Copyright (C) 2017 Mario Danic (mario@lovelyhq.com)
  *
  *   This program is free software: you can redistribute it and/or modify
@@ -35,6 +37,7 @@ import com.nextcloud.talk.models.json.participants.Participant;
 import org.parceler.Parcel;
 
 import java.util.HashMap;
+import java.util.Objects;
 
 @Parcel
 @JsonObject
@@ -100,6 +103,9 @@ public class Conversation {
 
     @JsonField(name = "unreadMentionDirect")
     public Boolean unreadMentionDirect;
+
+    @JsonField(name = "notificationCalls")
+    public Integer notificationCalls;
 
     public boolean isPublic() {
         return (ConversationType.ROOM_PUBLIC_CALL.equals(type));
@@ -261,6 +267,8 @@ public class Conversation {
         return unreadMentionDirect;
     }
 
+    public Integer getNotificationCalls() { return notificationCalls; }
+
     public void setRoomId(String roomId) {
         this.roomId = roomId;
     }
@@ -370,6 +378,7 @@ public class Conversation {
         this.unreadMentionDirect = unreadMentionDirect;
     }
 
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -405,46 +414,46 @@ public class Conversation {
         if (callFlag != that.callFlag) {
             return false;
         }
-        if (roomId != null ? !roomId.equals(that.roomId) : that.roomId != null) {
+        if (!Objects.equals(roomId, that.roomId)) {
             return false;
         }
         if (!token.equals(that.token)) {
             return false;
         }
-        if (name != null ? !name.equals(that.name) : that.name != null) {
+        if (!Objects.equals(name, that.name)) {
             return false;
         }
-        if (displayName != null ? !displayName.equals(that.displayName) : that.displayName != null) {
+        if (!Objects.equals(displayName, that.displayName)) {
             return false;
         }
-        if (description != null ? !description.equals(that.description) : that.description != null) {
+        if (!Objects.equals(description, that.description)) {
             return false;
         }
         if (type != that.type) {
             return false;
         }
-        if (participants != null ? !participants.equals(that.participants) : that.participants != null) {
+        if (!Objects.equals(participants, that.participants)) {
             return false;
         }
         if (participantType != that.participantType) {
             return false;
         }
-        if (sessionId != null ? !sessionId.equals(that.sessionId) : that.sessionId != null) {
+        if (!Objects.equals(sessionId, that.sessionId)) {
             return false;
         }
-        if (actorId != null ? !actorId.equals(that.actorId) : that.actorId != null) {
+        if (!Objects.equals(actorId, that.actorId)) {
             return false;
         }
-        if (actorType != null ? !actorType.equals(that.actorType) : that.actorType != null) {
+        if (!Objects.equals(actorType, that.actorType)) {
             return false;
         }
-        if (password != null ? !password.equals(that.password) : that.password != null) {
+        if (!Objects.equals(password, that.password)) {
             return false;
         }
-        if (lastMessage != null ? !lastMessage.equals(that.lastMessage) : that.lastMessage != null) {
+        if (!Objects.equals(lastMessage, that.lastMessage)) {
             return false;
         }
-        if (objectType != null ? !objectType.equals(that.objectType) : that.objectType != null) {
+        if (!Objects.equals(objectType, that.objectType)) {
             return false;
         }
         if (notificationLevel != that.notificationLevel) {
@@ -456,13 +465,16 @@ public class Conversation {
         if (lobbyState != that.lobbyState) {
             return false;
         }
-        if (lobbyTimer != null ? !lobbyTimer.equals(that.lobbyTimer) : that.lobbyTimer != null) {
+        if (!Objects.equals(lobbyTimer, that.lobbyTimer)) {
             return false;
         }
-        if (canLeaveConversation != null ? !canLeaveConversation.equals(that.canLeaveConversation) : that.canLeaveConversation != null) {
+        if (!Objects.equals(canLeaveConversation, that.canLeaveConversation)) {
             return false;
         }
-        return canDeleteConversation != null ? canDeleteConversation.equals(that.canDeleteConversation) : that.canDeleteConversation == null;
+        if (!Objects.equals(notificationCalls, that.notificationCalls)) {
+            return false;
+        }
+        return Objects.equals(canDeleteConversation, that.canDeleteConversation);
     }
 
     protected boolean canEqual(final Object other) {
@@ -499,6 +511,7 @@ public class Conversation {
         result = 31 * result + callFlag;
         result = 31 * result + (canLeaveConversation != null ? canLeaveConversation.hashCode() : 0);
         result = 31 * result + (canDeleteConversation != null ? canDeleteConversation.hashCode() : 0);
+        result = 31 * result + (notificationCalls != null ? notificationCalls.hashCode() : 0);
         return result;
     }
 
@@ -533,6 +546,7 @@ public class Conversation {
                 ", callFlag=" + callFlag +
                 ", canLeaveConversation=" + canLeaveConversation +
                 ", canDeleteConversation=" + canDeleteConversation +
+                ", notificationCalls=" + notificationCalls +
                 '}';
     }
 

--- a/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
@@ -2,6 +2,8 @@
  * Nextcloud Talk application
  *
  * @author Mario Danic
+ * @author Tim Krüger
+ * Copyright (C) 2021 Tim Krüger <t@timkrueger.me>
  * Copyright (C) 2017-2018 Mario Danic <mario@lovelyhq.com>
  *
  * This program is free software: you can redistribute it and/or modify
@@ -232,6 +234,10 @@ public class ApiUtils {
 
     public static String getUrlForRoomWebinaryLobby(int version, String baseUrl, String token) {
         return getUrlForRoom(version, baseUrl, token) + "/webinary/lobby";
+    }
+
+    public static String getUrlForRoomNotificationCalls(int version, String baseUrl, String token) {
+        return getUrlForRoom(version, baseUrl, token) + "/notify-calls";
     }
 
     public static String getUrlForCall(int version, String baseUrl, String token) {

--- a/app/src/main/res/layout/notification_settings_item.xml
+++ b/app/src/main/res/layout/notification_settings_item.xml
@@ -54,13 +54,12 @@
             apc:mp_title="@string/nc_plain_old_messages" />
 
         <com.yarolegovich.mp.MaterialSwitchPreference
-            android:id="@+id/muteCalls"
+            android:id="@+id/callNotifications"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            apc:mp_default_value="false"
-            apc:mp_key="mute_calls"
-            apc:mp_title="@string/nc_mute_calls"
-            apc:mp_summary="@string/nc_mute_calls_desc"/>
+            apc:mp_default_value="true"
+            apc:mp_key="call_notifications"
+            apc:mp_title="@string/nc_call_notifications" />
 
     </com.yarolegovich.mp.MaterialPreferenceCategory>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -231,8 +231,7 @@
     <string name="nc_notify_me_always">Always notify</string>
     <string name="nc_notify_me_mention">Notify when mentioned</string>
     <string name="nc_notify_me_never">Never notify</string>
-    <string name="nc_mute_calls">Mute calls</string>
-    <string name="nc_mute_calls_desc">Incoming calls will be silenced</string>
+    <string name="nc_call_notifications">Call notifications</string>
     <string name="nc_important_conversation">Important conversation</string>
     <string name="nc_important_conversation_desc">Notifications in this conversation will override Do Not Disturb settings</string>
 


### PR DESCRIPTION
The 'mute calls' setting was only stored locally on the device. The new
'call notifications' setting is stored on the Nextcloud server and
shared over all devices.

See:
  - https://github.com/nextcloud/spreed/pull/6338

Signed-off-by: Tim Krüger <t@timkrueger.me>