### PR TITLE
add workaround to start videocalls when PIP is disabled

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallBaseActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallBaseActivity.java
@@ -22,11 +22,14 @@ public abstract class CallBaseActivity extends BaseActivity {
 
     public PictureInPictureParams.Builder mPictureInPictureParamsBuilder;
     public Boolean isInPipMode = false;
+    long onCreateTime;
 
     @SuppressLint("ClickableViewAccessibility")
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        onCreateTime = System.currentTimeMillis();
 
         requestWindowFeature(Window.FEATURE_NO_TITLE);
         dismissKeyguard();
@@ -88,7 +91,15 @@ public abstract class CallBaseActivity extends BaseActivity {
 
     @Override
     protected void onUserLeaveHint() {
-        enterPipMode();
+        long onUserLeaveHintTime = System.currentTimeMillis();
+        long diff = onUserLeaveHintTime - onCreateTime;
+        Log.d(TAG, "onUserLeaveHintTime - onCreateTime: " + diff);
+
+        if (diff < 3000) {
+            Log.d(TAG, "enterPipMode skipped");
+        } else {
+            enterPipMode();
+        }
     }
 
     void enterPipMode() {


### PR DESCRIPTION
this is a dirty workaround for issue #1677

Somehow onUserLeaveHint is executed when the user starts a videocall. If PIP is disabled, the logic inside enterPipMode would finish the activity right after it was started.
This workaround suppresses the execution of enterPipMode right after the activity was started.
However if a user would press the home button in the first three seconds, the call would continue in background without the ability to recover the UI.

To better fix this bug it must be found out why onUserLeaveHint is executed on start (this should not happen!).

Signed-off-by: Marcel Hibbe <dev@mhibbe.de>