### PR TITLE
Gradle should log plain

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ steps:
 - name: generic
   image: nextcloudci/android:android-44
   commands:
-    - ./gradlew assembleGeneric
+    - ./gradlew --console=plain assembleGeneric
 
 trigger:
   branch:
@@ -22,7 +22,7 @@ steps:
 - name: gplay
   image: nextcloudci/android:android-44
   commands:
-    - ./gradlew assembleGplay
+    - ./gradlew --console=plain assembleGplay
 
 trigger:
   branch:

--- a/scripts/analysis/findbugs-up.rb
+++ b/scripts/analysis/findbugs-up.rb
@@ -47,16 +47,16 @@ require 'xmlsimple'
 
 # run FindBugs
 puts "running FindBugs..."
-system './gradlew assembleGplayDebug 1>/dev/null'
+system './gradlew --console=plain assembleGplayDebug 1>/dev/null'
 
 # confirm that assemble ran w/out error
 result = $?.to_i
 if result != 0
-    puts "FAIL: failed to run ./gradlew assembleGplayDebug"
+    puts "FAIL: failed to run ./gradlew --console=plain assembleGplayDebug"
     exit 1
 end
 
-system './gradlew spotbugsGplayDebugReport 1>/dev/null 2>&1'
+system './gradlew --console=plain spotbugsGplayDebugReport 1>/dev/null 2>&1'
 
 # find FindBugs report file
 findbugs_reports = Dir.glob(FINDBUGS_REPORT_FILE)

--- a/scripts/analysis/lint-up.rb
+++ b/scripts/analysis/lint-up.rb
@@ -56,12 +56,12 @@ end
 
 # run Lint
 puts "running Lint..."
-system './gradlew clean lintGplayDebug'
+system './gradlew --console=plain clean lintGplayDebug'
 
 # confirm that Lint ran w/out error
 result = $?.to_i
 if result != 0
-    puts "FAIL: failed to run ./gradlew clean lintGplayDebug"
+    puts "FAIL: failed to run ./gradlew --console=plain clean lintGplayDebug"
     exit 1
 end
 


### PR DESCRIPTION
With the parameter '--console=plain' Gradle produces a plain text log without
charachter garbage which is created by animations.

Signed-off-by: Tim Krüger <t@timkrueger.me>