### PR TITLE
Skip QA build if keystore not available

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -8,12 +8,18 @@ jobs:
     qa:
         runs-on: ubuntu-latest
         steps:
+            -   name: Check if secrets are available
+                run: echo "::set-output name=ok::${{ secrets.KS_PASS != '' }}"
+                id: check-secrets
             -   uses: actions/checkout@v2
+                if: ${{ steps.check-secrets.outputs.ok == 'true' }}
             -   name: set up JDK 1.8
+                if: ${{ steps.check-secrets.outputs.ok == 'true' }}
                 uses: actions/setup-java@v1
                 with:
                     java-version: 1.8
             -   name: Build QA
+                if: ${{ steps.check-secrets.outputs.ok == 'true' }}
                 env:
                     KS_PASS: ${{ secrets.KS_PASS }}
                     KEY_PASS: ${{ secrets.KEY_PASS }}


### PR DESCRIPTION
Copied solution from the Nextcloud Files for Android app from commit
6863a8 [1].

From Álvaro's commit message:

> There is no way to skip the whole workflow depending on whether it is
> a PR from a fork or not. The only workaround is to check whether secrets are present or not.
>
> So, I've added a step to check if KS_PASS is empty, and set an output depending on that.
> If it is empty, we just skip the rest of the steps.

[1] https://github.com/nextcloud/android/commit/6863a8a637d4a02dd7a2a908e75d3b7b6f7901e2

Signed-off-by: Tim Krüger <t@timkrueger.me>