### PR TITLE
Align file browser layout and folder icon with files client

### DIFF
--- a/app/src/main/res/drawable/ic_mimetype_folder.xml
+++ b/app/src/main/res/drawable/ic_mimetype_folder.xml
@@ -1,32 +1,26 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Nextcloud Talk application
-  ~
-  ~ @author Mario Danic
-  ~ Copyright (C) 2017-2019 Mario Danic <mario@lovelyhq.com>
-  ~
-  ~ This program is free software: you can redistribute it and/or modify
-  ~ it under the terms of the GNU General Public License as published by
-  ~ the Free Software Foundation, either version 3 of the License, or
-  ~ at your option) any later version.
-  ~
-  ~ This program is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  ~ GNU General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU General Public License
-  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
-  -->
+    @author Google LLC
+    Copyright (C) 2018 Google LLC
 
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="16dp"
-    android:height="16dp"
-    android:viewportWidth="16"
-    android:viewportHeight="16">
-
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#0082c9"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
     <path
-        android:fillColor="#0082c9"
-        android:pathData="M1.5,2 C1.25,2,1,2.25,1,2.5 L1,13.5 C1,13.76,1.24,14,1.5,14 L14.5,14
-C14.76,14,15,13.759,15,13.5 L15,4.5 C15,4.25,14.75,4,14.5,4 L8,4 L6,2 Z" />
+        android:fillColor="#FF000000"
+        android:pathData="M10,4H4c-1.1,0 -1.99,0.9 -1.99,2L2,18c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2V8c0,-1.1 -0.9,-2 -2,-2h-8l-2,-2z" />
 </vector>

--- a/app/src/main/res/layout/rv_item_browser_file.xml
+++ b/app/src/main/res/layout/rv_item_browser_file.xml
@@ -23,13 +23,15 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="@dimen/double_margin_between_elements"
+    android:layout_marginTop="@dimen/standard_margin"
+    android:layout_marginStart="@dimen/standard_margin"
+    android:layout_marginBottom="@dimen/standard_margin"
     android:background="@color/bg_default">
 
     <CheckBox
         android:id="@+id/select_file_checkbox"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_alignParentEnd="true"
         android:layout_centerVertical="true"
         android:clickable="true"
@@ -93,10 +95,10 @@
 
     <com.facebook.drawee.view.SimpleDraweeView
         android:id="@+id/file_icon"
-        android:layout_width="@dimen/small_item_height"
-        android:layout_height="@dimen/small_item_height"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
         android:layout_centerVertical="true"
-        android:layout_marginEnd="8dp"
+        android:layout_marginEnd="@dimen/standard_margin"
         app:actualImageScaleType="fitCenter"
         app:placeholderImageScaleType="fitCenter" />
 


### PR DESCRIPTION
* replace folder icon with files-client/material one
* align icon size and whitespace with files-client/material ones
* made checkbox a 48x48dp hitbox for improved accessibility (48dp is the min size according to Google's accessibility guidelines for clickable elements)

labelled for back-porting so the upcoming release is even further aligned UI/experience-wise between the clients 

Signed-off-by: Andy Scherzinger <info@andy-scherzinger.de>