### PR TITLE
fix to keep session

### DIFF
--- a/app/src/gplay/java/com/nextcloud/talk/services/firebase/MagicFirebaseMessagingService.kt
+++ b/app/src/gplay/java/com/nextcloud/talk/services/firebase/MagicFirebaseMessagingService.kt
@@ -63,6 +63,7 @@ import com.nextcloud.talk.utils.bundle.BundleKeys
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_FROM_NOTIFICATION_START_CALL
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_USER_ENTITY
 import com.nextcloud.talk.utils.preferences.AppPreferences
+import com.nextcloud.talk.utils.singletons.ApplicationWideCurrentRoomHolder
 import io.reactivex.Observable
 import io.reactivex.Observer
 import io.reactivex.disposables.Disposable
@@ -126,6 +127,7 @@ class MagicFirebaseMessagingService : FirebaseMessagingService() {
         Log.d(TAG, "onDestroy")
         isServiceInForeground = false
         eventBus?.unregister(this)
+        ApplicationWideCurrentRoomHolder.getInstance().isIncoming = false
         stopForeground(true)
         handler.removeCallbacksAndMessages(null)
         super.onDestroy()
@@ -276,6 +278,7 @@ class MagicFirebaseMessagingService : FirebaseMessagingService() {
                             notification.flags = notification.flags or Notification.FLAG_INSISTENT
                             isServiceInForeground = true
                             checkIfCallIsActive(signatureVerification!!, decryptedPushMessage!!)
+                            ApplicationWideCurrentRoomHolder.getInstance().isIncoming = true
                             startForeground(decryptedPushMessage!!.timestamp.toInt(), notification)
                         } else {
                             val messageData = Data.Builder()
@@ -349,6 +352,7 @@ class MagicFirebaseMessagingService : FirebaseMessagingService() {
                     }
                     if (!hasParticipantsInCall || inCallOnDifferentDevice) {
                         Log.d(TAG, "no participants in call OR inCallOnDifferentDevice")
+                        ApplicationWideCurrentRoomHolder.getInstance().isIncoming = false
                         stopForeground(true)
                         handler.removeCallbacksAndMessages(null)
                     }

--- a/app/src/main/java/com/nextcloud/talk/activities/CallNotificationActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallNotificationActivity.java
@@ -62,6 +62,7 @@ import com.nextcloud.talk.utils.DisplayUtils;
 import com.nextcloud.talk.utils.DoNotDisturbUtils;
 import com.nextcloud.talk.utils.bundle.BundleKeys;
 import com.nextcloud.talk.utils.preferences.AppPreferences;
+import com.nextcloud.talk.utils.singletons.ApplicationWideCurrentRoomHolder;
 
 import org.greenrobot.eventbus.EventBus;
 import org.parceler.Parcels;
@@ -171,12 +172,14 @@ public class CallNotificationActivity extends CallBaseActivity {
     private void initClickListeners() {
         binding.callAnswerVoiceOnlyView.setOnClickListener(l -> {
             Log.d(TAG, "accept call (voice only)");
+            ApplicationWideCurrentRoomHolder.getInstance().setIncoming(false);
             originalBundle.putBoolean(BundleKeys.INSTANCE.getKEY_CALL_VOICE_ONLY(), true);
             proceedToCall();
         });
 
         binding.callAnswerCameraView.setOnClickListener(l -> {
             Log.d(TAG, "accept call (with video)");
+            ApplicationWideCurrentRoomHolder.getInstance().setIncoming(false);
             originalBundle.putBoolean(BundleKeys.INSTANCE.getKEY_CALL_VOICE_ONLY(), false);
             proceedToCall();
         });
@@ -200,6 +203,7 @@ public class CallNotificationActivity extends CallBaseActivity {
 
     @OnClick(R.id.hangupButton)
     void hangup() {
+        ApplicationWideCurrentRoomHolder.getInstance().setIncoming(false);
         leavingScreen = true;
         finish();
     }

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -1579,7 +1579,8 @@ class ChatController(args: Bundle) :
             activity != null &&
             !activity?.isChangingConfigurations!! &&
             !ApplicationWideCurrentRoomHolder.getInstance().isInCall &&
-            !ApplicationWideCurrentRoomHolder.getInstance().isDialing
+            !ApplicationWideCurrentRoomHolder.getInstance().isDialing &&
+            !ApplicationWideCurrentRoomHolder.getInstance().isIncoming
         ) {
             ApplicationWideCurrentRoomHolder.getInstance().clear()
             wasDetached = true

--- a/app/src/main/java/com/nextcloud/talk/utils/singletons/ApplicationWideCurrentRoomHolder.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/singletons/ApplicationWideCurrentRoomHolder.java
@@ -29,6 +29,7 @@ public class ApplicationWideCurrentRoomHolder {
     private UserEntity userInRoom = new UserEntity();
     private boolean inCall = false;
     private boolean isDialing = false;
+    private boolean isIncoming = false;
     private String session = "";
 
     public static ApplicationWideCurrentRoomHolder getInstance() {
@@ -40,6 +41,7 @@ public class ApplicationWideCurrentRoomHolder {
         userInRoom = new UserEntity();
         inCall = false;
         isDialing = false;
+        isIncoming = false;
         currentRoomToken = "";
         session = "";
     }
@@ -82,6 +84,14 @@ public class ApplicationWideCurrentRoomHolder {
 
     public void setDialing(boolean dialing) {
         isDialing = dialing;
+    }
+
+    public boolean isIncoming() {
+        return isIncoming;
+    }
+
+    public void setIncoming(boolean incoming) {
+        isIncoming = incoming;
     }
 
     public String getSession() {


### PR DESCRIPTION
WIP, will be improved.

when you were in a chat and received a call notification, then in onDetach of the chatview the session was removed by leaving the room. This fix will check if a call notification is ongoing and suppress to leave the room.




leaving the room in "onDetach" might cause more problems..(for example on first call when granting permissions?!)

TODO: 
- [ ] check which issues might be related to the onDetach& leaveRoom handling


Signed-off-by: Marcel Hibbe <dev@mhibbe.de>