### PR TITLE
Adapt notification code to Android 8.0 (Oreo) and later

### DIFF
--- a/app/src/gplay/java/com/nextcloud/talk/services/firebase/MagicFirebaseMessagingService.kt
+++ b/app/src/gplay/java/com/nextcloud/talk/services/firebase/MagicFirebaseMessagingService.kt
@@ -23,14 +23,12 @@ import android.annotation.SuppressLint
 import android.app.Notification
 import android.app.PendingIntent
 import android.content.Intent
-import android.media.AudioAttributes
 import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
 import android.util.Base64
 import android.util.Log
 import androidx.core.app.NotificationCompat
-import androidx.core.app.NotificationManagerCompat
 import androidx.emoji.text.EmojiCompat
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
@@ -55,7 +53,6 @@ import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.NotificationUtils
 import com.nextcloud.talk.utils.NotificationUtils.cancelAllNotificationsForAccount
 import com.nextcloud.talk.utils.NotificationUtils.cancelExistingNotificationWithId
-import com.nextcloud.talk.utils.NotificationUtils.createNotificationChannel
 import com.nextcloud.talk.utils.NotificationUtils.getCallRingtoneUri
 import com.nextcloud.talk.utils.PushUtils
 import com.nextcloud.talk.utils.bundle.BundleKeys
@@ -200,27 +197,8 @@ class MagicFirebaseMessagingService : FirebaseMessagingService() {
                                 PendingIntent.FLAG_UPDATE_CURRENT
                             )
 
-                            val audioAttributesBuilder =
-                                AudioAttributes.Builder().setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                            audioAttributesBuilder.setUsage(AudioAttributes.USAGE_NOTIFICATION_COMMUNICATION_REQUEST)
-
-                            val soundUri = getCallRingtoneUri(applicationContext!!, appPreferences)
+                            val soundUri = getCallRingtoneUri(applicationContext!!, appPreferences!!)
                             val notificationChannelId = NotificationUtils.NOTIFICATION_CHANNEL_CALLS_V4
-                            createNotificationChannel(
-                                applicationContext!!,
-                                notificationChannelId,
-                                applicationContext.resources
-                                    .getString(R.string.nc_notification_channel_calls),
-                                applicationContext.resources
-                                    .getString(R.string.nc_notification_channel_calls_description),
-                                true,
-                                NotificationManagerCompat.IMPORTANCE_HIGH,
-                                soundUri!!,
-                                audioAttributesBuilder.build(),
-                                null,
-                                false
-                            )
-
                             val uri = Uri.parse(signatureVerification!!.userEntity.baseUrl)
                             val baseUrl = uri.host
 

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -2295,8 +2295,7 @@ public class CallActivity extends CallBaseActivity {
         stopCallingSound();
         Uri ringtoneUri;
         if (isIncomingCallFromNotification) {
-            ringtoneUri = Uri.parse("android.resource://" + getApplicationContext().getPackageName() +
-                                        "/raw/librem_by_feandesign_call");
+            ringtoneUri = NotificationUtils.INSTANCE.getCallRingtoneUri(getApplicationContext(), appPreferences);
         } else {
             ringtoneUri = Uri.parse("android.resource://" + getApplicationContext().getPackageName() + "/raw" +
                                         "/tr110_1_kap8_3_freiton1");

--- a/app/src/main/java/com/nextcloud/talk/activities/CallNotificationActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallNotificationActivity.java
@@ -32,11 +32,9 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
-import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
 
-import com.bluelinelabs.logansquare.LoganSquare;
 import com.facebook.common.executors.UiThreadImmediateExecutorService;
 import com.facebook.common.references.CloseableReference;
 import com.facebook.datasource.DataSource;
@@ -50,7 +48,6 @@ import com.nextcloud.talk.api.NcApi;
 import com.nextcloud.talk.application.NextcloudTalkApplication;
 import com.nextcloud.talk.databinding.CallNotificationActivityBinding;
 import com.nextcloud.talk.events.CallNotificationClick;
-import com.nextcloud.talk.models.RingtoneSettings;
 import com.nextcloud.talk.models.database.CapabilitiesUtil;
 import com.nextcloud.talk.models.database.UserEntity;
 import com.nextcloud.talk.models.json.conversations.Conversation;
@@ -60,6 +57,7 @@ import com.nextcloud.talk.models.json.participants.ParticipantsOverall;
 import com.nextcloud.talk.utils.ApiUtils;
 import com.nextcloud.talk.utils.DisplayUtils;
 import com.nextcloud.talk.utils.DoNotDisturbUtils;
+import com.nextcloud.talk.utils.NotificationUtils;
 import com.nextcloud.talk.utils.bundle.BundleKeys;
 import com.nextcloud.talk.utils.preferences.AppPreferences;
 
@@ -390,25 +388,7 @@ public class CallNotificationActivity extends CallBaseActivity {
     }
 
     private void playRingtoneSound() {
-        String callRingtonePreferenceString = appPreferences.getCallRingtoneUri();
-        Uri ringtoneUri;
-
-        if (TextUtils.isEmpty(callRingtonePreferenceString)) {
-            // play default sound
-            ringtoneUri = Uri.parse("android.resource://" + getApplicationContext().getPackageName() +
-                                        "/raw/librem_by_feandesign_call");
-        } else {
-            try {
-                RingtoneSettings ringtoneSettings = LoganSquare.parse(
-                    callRingtonePreferenceString, RingtoneSettings.class);
-                ringtoneUri = ringtoneSettings.getRingtoneUri();
-            } catch (IOException e) {
-                Log.e(TAG, "Failed to parse ringtone settings");
-                ringtoneUri = Uri.parse("android.resource://" + getApplicationContext().getPackageName() +
-                                            "/raw/librem_by_feandesign_call");
-            }
-        }
-
+        Uri ringtoneUri = NotificationUtils.INSTANCE.getCallRingtoneUri(getApplicationContext(), appPreferences);
         if (ringtoneUri != null) {
             mediaPlayer = new MediaPlayer();
             try {

--- a/app/src/main/java/com/nextcloud/talk/application/NextcloudTalkApplication.kt
+++ b/app/src/main/java/com/nextcloud/talk/application/NextcloudTalkApplication.kt
@@ -58,6 +58,7 @@ import com.nextcloud.talk.jobs.SignalingSettingsWorker
 import com.nextcloud.talk.utils.ClosedInterfaceImpl
 import com.nextcloud.talk.utils.DeviceUtils
 import com.nextcloud.talk.utils.DisplayUtils
+import com.nextcloud.talk.utils.NotificationUtils
 import com.nextcloud.talk.utils.OkHttpNetworkFetcherWithCache
 import com.nextcloud.talk.utils.database.arbitrarystorage.ArbitraryStorageModule
 import com.nextcloud.talk.utils.database.user.UserModule
@@ -188,6 +189,8 @@ class NextcloudTalkApplication : MultiDexApplication(), LifecycleObserver {
         val emojiCompat = EmojiCompat.init(config)
 
         EmojiManager.install(GoogleCompatEmojiProvider(emojiCompat))
+
+        NotificationUtils.registerNotificationChannels(applicationContext, appPreferences)
     }
 
     override fun onTerminate() {

--- a/app/src/main/java/com/nextcloud/talk/controllers/RingtoneSelectionController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/RingtoneSelectionController.java
@@ -45,6 +45,7 @@ import com.nextcloud.talk.adapters.items.NotificationSoundItem;
 import com.nextcloud.talk.application.NextcloudTalkApplication;
 import com.nextcloud.talk.controllers.base.BaseController;
 import com.nextcloud.talk.models.RingtoneSettings;
+import com.nextcloud.talk.utils.NotificationUtils;
 import com.nextcloud.talk.utils.bundle.BundleKeys;
 import com.nextcloud.talk.utils.preferences.AppPreferences;
 import eu.davidea.flexibleadapter.FlexibleAdapter;
@@ -180,13 +181,10 @@ public class RingtoneSelectionController extends BaseController implements Flexi
 
     private String getRingtoneString() {
         if (callNotificationSounds) {
-            return ("android.resource://" + context.getPackageName() +
-                    "/raw/librem_by_feandesign_call");
+            return NotificationUtils.INSTANCE.getDEFAULT_CALL_RINGTONE_URI();
         } else {
-            return ("android.resource://" + context.getPackageName() + "/raw" +
-                    "/librem_by_feandesign_message");
+            return NotificationUtils.INSTANCE.getDEFAULT_MESSAGE_RINGTONE_URI();
         }
-
     }
 
     private void fetchNotificationSounds() {

--- a/app/src/main/java/com/nextcloud/talk/controllers/SettingsController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/SettingsController.java
@@ -156,6 +156,8 @@ public class SettingsController extends BaseController {
     TextView serverAgeTextView;
     @BindView(R.id.server_age_warning_icon)
     ImageView serverAgeIcon;
+    @BindView(R.id.settings_notifications_category)
+    MaterialPreferenceCategory notificationsCategory;
     @BindView(R.id.settings_call_sound)
     MaterialStandardPreference settingsCallSound;
     @BindView(R.id.settings_message_sound)
@@ -512,6 +514,10 @@ public class SettingsController extends BaseController {
                 screenLockSwitchPreference.setAlpha(0.38f);
                 screenLockTimeoutChoicePreference.setAlpha(0.38f);
             }
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            notificationsCategory.setTitle(getResources().getString(R.string.nc_settings_notification_sounds_post_oreo));
         }
 
         Uri callRingtoneUri = NotificationUtils.INSTANCE.getCallRingtoneUri(view.getContext(), appPreferences);

--- a/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.java
@@ -491,6 +491,11 @@ public class NotificationWorker extends Worker {
         NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
         notificationManager.notify(notificationId, notification);
 
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            // On devices with Android 8.0 (Oreo) or later, notification sound will be handled by the system
+            // if notifications have not been disabled by the user.
+            return;
+        }
 
         if (!notification.category.equals(Notification.CATEGORY_CALL) || !muteCall) {
             String ringtonePreferencesString;

--- a/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.java
@@ -52,7 +52,6 @@ import com.nextcloud.talk.activities.CallActivity;
 import com.nextcloud.talk.activities.MainActivity;
 import com.nextcloud.talk.api.NcApi;
 import com.nextcloud.talk.application.NextcloudTalkApplication;
-import com.nextcloud.talk.models.RingtoneSettings;
 import com.nextcloud.talk.models.SignatureVerification;
 import com.nextcloud.talk.models.database.ArbitraryStorageEntity;
 import com.nextcloud.talk.models.database.UserEntity;
@@ -342,25 +341,8 @@ public class NotificationWorker extends Worker {
                 AudioAttributes.Builder audioAttributesBuilder = new AudioAttributes.Builder().setContentType
                         (AudioAttributes.CONTENT_TYPE_SONIFICATION);
                 audioAttributesBuilder.setUsage(AudioAttributes.USAGE_NOTIFICATION_COMMUNICATION_INSTANT);
-
-                String ringtonePreferencesString;
-                Uri soundUri;
-
-                ringtonePreferencesString = appPreferences.getMessageRingtoneUri();
-                if (TextUtils.isEmpty(ringtonePreferencesString)) {
-                    soundUri = Uri.parse("android.resource://" + context.getPackageName() +
-                            "/raw/librem_by_feandesign_message");
-                } else {
-                    try {
-                        RingtoneSettings ringtoneSettings = LoganSquare.parse
-                                (ringtonePreferencesString, RingtoneSettings.class);
-                        soundUri = ringtoneSettings.getRingtoneUri();
-                    } catch (IOException exception) {
-                        soundUri = Uri.parse("android.resource://" + context.getPackageName() +
-                                "/raw/librem_by_feandesign_message");
-                    }
-                }
-
+                Uri soundUri = NotificationUtils.INSTANCE.getMessageRingtoneUri(getApplicationContext(),
+                                                                                appPreferences);
                 NotificationUtils.INSTANCE.createNotificationChannel(context,
                         NotificationUtils.INSTANCE.getNOTIFICATION_CHANNEL_MESSAGES_V3(), context.getResources()
                                 .getString(R.string.nc_notification_channel_messages), context.getResources()
@@ -498,24 +480,8 @@ public class NotificationWorker extends Worker {
         }
 
         if (!notification.category.equals(Notification.CATEGORY_CALL) || !muteCall) {
-            String ringtonePreferencesString;
-            Uri soundUri;
-
-            ringtonePreferencesString = appPreferences.getMessageRingtoneUri();
-            if (TextUtils.isEmpty(ringtonePreferencesString)) {
-                soundUri = Uri.parse("android.resource://" + context.getPackageName() +
-                        "/raw/librem_by_feandesign_message");
-            } else {
-                try {
-                    RingtoneSettings ringtoneSettings = LoganSquare.parse
-                            (ringtonePreferencesString, RingtoneSettings.class);
-                    soundUri = ringtoneSettings.getRingtoneUri();
-                } catch (IOException exception) {
-                    soundUri = Uri.parse("android.resource://" + context.getPackageName() +
-                            "/raw/librem_by_feandesign_message");
-                }
-            }
-
+            Uri soundUri = NotificationUtils.INSTANCE.getMessageRingtoneUri(getApplicationContext(),
+                                                                            appPreferences);
             if (soundUri != null && !ApplicationWideCurrentRoomHolder.getInstance().isInCall() &&
                     (DoNotDisturbUtils.INSTANCE.shouldPlaySound() || importantConversation)) {
                 AudioAttributes.Builder audioAttributesBuilder = new AudioAttributes.Builder().setContentType

--- a/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.java
@@ -21,7 +21,6 @@
 package com.nextcloud.talk.jobs;
 
 import android.app.Notification;
-import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
@@ -332,34 +331,9 @@ public class NotificationWorker extends Worker {
         notificationBuilder.setExtras(notificationInfo);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-
-            /*NotificationUtils.createNotificationChannelGroup(context,
-                    Long.toString(crc32.getValue()),
-                    groupName);*/
-
             if (CHAT.equals(decryptedPushMessage.getType()) || ROOM.equals(decryptedPushMessage.getType())) {
-                AudioAttributes.Builder audioAttributesBuilder = new AudioAttributes.Builder().setContentType
-                        (AudioAttributes.CONTENT_TYPE_SONIFICATION);
-                audioAttributesBuilder.setUsage(AudioAttributes.USAGE_NOTIFICATION_COMMUNICATION_INSTANT);
-                Uri soundUri = NotificationUtils.INSTANCE.getMessageRingtoneUri(getApplicationContext(),
-                                                                                appPreferences);
-                NotificationUtils.INSTANCE.createNotificationChannel(context,
-                        NotificationUtils.INSTANCE.getNOTIFICATION_CHANNEL_MESSAGES_V3(), context.getResources()
-                                .getString(R.string.nc_notification_channel_messages), context.getResources()
-                                .getString(R.string.nc_notification_channel_messages), true,
-                        NotificationManager.IMPORTANCE_HIGH, soundUri, audioAttributesBuilder.build(), null, false);
-
                 notificationBuilder.setChannelId(NotificationUtils.INSTANCE.getNOTIFICATION_CHANNEL_MESSAGES_V3());
-            } else {
-                /*NotificationUtils.INSTANCE.createNotificationChannel(context,
-                        NotificationUtils.INSTANCE.getNOTIFICATION_CHANNEL_CALLS_V3(), context.getResources()
-                                .getString(R.string.nc_notification_channel_calls), context.getResources()
-                                .getString(R.string.nc_notification_channel_calls_description), true,
-                        NotificationManager.IMPORTANCE_HIGH);
-
-                notificationBuilder.setChannelId(NotificationUtils.INSTANCE.getNOTIFICATION_CHANNEL_CALLS_V3());*/
             }
-
         } else {
             // red color for the lights
             notificationBuilder.setLights(0xFFFF0000, 200, 200);

--- a/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
@@ -136,7 +136,7 @@ object NotificationUtils {
             context,
             NOTIFICATION_CHANNEL_MESSAGES_V3,
             context.resources.getString(R.string.nc_notification_channel_messages),
-            context.resources.getString(R.string.nc_notification_channel_messages),
+            context.resources.getString(R.string.nc_notification_channel_messages_description),
             true,
             NotificationManagerCompat.IMPORTANCE_HIGH,
             soundUri,

--- a/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
@@ -138,7 +138,7 @@ object NotificationUtils {
             context.resources.getString(R.string.nc_notification_channel_messages),
             context.resources.getString(R.string.nc_notification_channel_messages),
             true,
-            NotificationManager.IMPORTANCE_HIGH,
+            NotificationManagerCompat.IMPORTANCE_HIGH,
             soundUri,
             audioAttributes,
             null,

--- a/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
@@ -235,15 +235,19 @@ object NotificationUtils {
         context: Context,
         appPreferences: AppPreferences?
     ): Uri? {
-        return getRingtoneUri(context,
-            appPreferences!!.callRingtoneUri, DEFAULT_CALL_RINGTONE_URI, NOTIFICATION_CHANNEL_CALLS_V4)
+        return getRingtoneUri(
+            context,
+            appPreferences!!.callRingtoneUri, DEFAULT_CALL_RINGTONE_URI, NOTIFICATION_CHANNEL_CALLS_V4
+        )
     }
 
     fun getMessageRingtoneUri(
         context: Context,
         appPreferences: AppPreferences?
     ): Uri? {
-        return getRingtoneUri(context,
-            appPreferences!!.messageRingtoneUri, DEFAULT_MESSAGE_RINGTONE_URI, NOTIFICATION_CHANNEL_MESSAGES_V3)
+        return getRingtoneUri(
+            context,
+            appPreferences!!.messageRingtoneUri, DEFAULT_MESSAGE_RINGTONE_URI, NOTIFICATION_CHANNEL_MESSAGES_V3
+        )
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
@@ -23,17 +23,21 @@ package com.nextcloud.talk.utils
 import android.annotation.TargetApi
 import android.app.Notification
 import android.app.NotificationChannel
-import android.app.NotificationChannelGroup
 import android.app.NotificationManager
 import android.content.Context
 import android.media.AudioAttributes
 import android.net.Uri
 import android.os.Build
 import android.service.notification.StatusBarNotification
+import android.text.TextUtils
+import com.bluelinelabs.logansquare.LoganSquare
+import com.nextcloud.talk.BuildConfig
 import com.nextcloud.talk.R
+import com.nextcloud.talk.models.RingtoneSettings
 import com.nextcloud.talk.models.database.UserEntity
 import com.nextcloud.talk.utils.bundle.BundleKeys
-import java.util.Objects
+import com.nextcloud.talk.utils.preferences.AppPreferences
+import java.io.IOException
 
 object NotificationUtils {
     val NOTIFICATION_CHANNEL_CALLS = "NOTIFICATION_CHANNEL_CALLS"
@@ -42,32 +46,12 @@ object NotificationUtils {
     val NOTIFICATION_CHANNEL_MESSAGES_V2 = "NOTIFICATION_CHANNEL_MESSAGES_V2"
     val NOTIFICATION_CHANNEL_MESSAGES_V3 = "NOTIFICATION_CHANNEL_MESSAGES_V3"
     val NOTIFICATION_CHANNEL_CALLS_V3 = "NOTIFICATION_CHANNEL_CALLS_V3"
+    val NOTIFICATION_CHANNEL_CALLS_V4 = "NOTIFICATION_CHANNEL_CALLS_V4"
 
-    fun getVibrationEffectForCalls(): LongArray {
-        return longArrayOf(0L, 400L, 800L, 600L, 800L, 800L, 800L, 1000L)
-    }
-
-    fun getNotificationChannelId(
-        channelName: String,
-        channelDescription: String,
-        enableLights: Boolean,
-        importance: Int,
-        sound: Uri,
-        audioAttributes: AudioAttributes,
-        vibrationPattern: LongArray?,
-        bypassDnd: Boolean
-    ): String {
-        return Objects.hash(
-            channelName,
-            channelDescription,
-            enableLights,
-            importance,
-            sound,
-            audioAttributes,
-            vibrationPattern,
-            bypassDnd
-        ).toString()
-    }
+    val DEFAULT_CALL_RINGTONE_URI =
+        "android.resource://" + BuildConfig.APPLICATION_ID + "/raw/librem_by_feandesign_call"
+    val DEFAULT_MESSAGE_RINGTONE_URI =
+        "android.resource://" + BuildConfig.APPLICATION_ID + "/raw/librem_by_feandesign_message"
 
     @TargetApi(Build.VERSION_CODES.O)
     fun createNotificationChannel(
@@ -112,19 +96,15 @@ object NotificationUtils {
     }
 
     @TargetApi(Build.VERSION_CODES.O)
-    fun createNotificationChannelGroup(
+    fun getNotificationChannel(
         context: Context,
-        groupId: String,
-        groupName: CharSequence
-    ) {
+        channelId: String
+    ): NotificationChannel? {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-
-            val notificationChannelGroup = NotificationChannelGroup(groupId, groupName)
-            if (!notificationManager.notificationChannelGroups.contains(notificationChannelGroup)) {
-                notificationManager.createNotificationChannelGroup(notificationChannelGroup)
-            }
+            return notificationManager.getNotificationChannel(channelId)
         }
+        return null
     }
 
     fun cancelAllNotificationsForAccount(context: Context?, conversationUser: UserEntity) {
@@ -227,5 +207,43 @@ object NotificationUtils {
                 }
             }
         }
+    }
+
+    private fun getRingtoneUri(
+        context: Context,
+        ringtonePreferencesString: String?,
+        defaultRingtoneUri: String,
+        channelId: String
+    ): Uri? {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = getNotificationChannel(context, channelId)
+            return channel!!.sound
+        } else if (TextUtils.isEmpty(ringtonePreferencesString)) {
+            return Uri.parse(defaultRingtoneUri)
+        } else {
+            try {
+                val ringtoneSettings =
+                    LoganSquare.parse(ringtonePreferencesString, RingtoneSettings::class.java)
+                return ringtoneSettings.ringtoneUri
+            } catch (exception: IOException) {
+                return Uri.parse(defaultRingtoneUri)
+            }
+        }
+    }
+
+    fun getCallRingtoneUri(
+        context: Context,
+        appPreferences: AppPreferences?
+    ): Uri? {
+        return getRingtoneUri(context,
+            appPreferences!!.callRingtoneUri, DEFAULT_CALL_RINGTONE_URI, NOTIFICATION_CHANNEL_CALLS_V4)
+    }
+
+    fun getMessageRingtoneUri(
+        context: Context,
+        appPreferences: AppPreferences?
+    ): Uri? {
+        return getRingtoneUri(context,
+            appPreferences!!.messageRingtoneUri, DEFAULT_MESSAGE_RINGTONE_URI, NOTIFICATION_CHANNEL_MESSAGES_V3)
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
@@ -30,7 +30,6 @@ import android.net.Uri
 import android.os.Build
 import android.service.notification.StatusBarNotification
 import android.text.TextUtils
-import androidx.core.app.NotificationManagerCompat
 import com.bluelinelabs.logansquare.LoganSquare
 import com.nextcloud.talk.BuildConfig
 import com.nextcloud.talk.R
@@ -41,11 +40,11 @@ import com.nextcloud.talk.utils.preferences.AppPreferences
 import java.io.IOException
 
 object NotificationUtils {
-    val NOTIFICATION_CHANNEL_CALLS = "NOTIFICATION_CHANNEL_CALLS"
     val NOTIFICATION_CHANNEL_MESSAGES = "NOTIFICATION_CHANNEL_MESSAGES"
-    val NOTIFICATION_CHANNEL_CALLS_V2 = "NOTIFICATION_CHANNEL_CALLS_V2"
     val NOTIFICATION_CHANNEL_MESSAGES_V2 = "NOTIFICATION_CHANNEL_MESSAGES_V2"
     val NOTIFICATION_CHANNEL_MESSAGES_V3 = "NOTIFICATION_CHANNEL_MESSAGES_V3"
+    val NOTIFICATION_CHANNEL_CALLS = "NOTIFICATION_CHANNEL_CALLS"
+    val NOTIFICATION_CHANNEL_CALLS_V2 = "NOTIFICATION_CHANNEL_CALLS_V2"
     val NOTIFICATION_CHANNEL_CALLS_V3 = "NOTIFICATION_CHANNEL_CALLS_V3"
     val NOTIFICATION_CHANNEL_CALLS_V4 = "NOTIFICATION_CHANNEL_CALLS_V4"
 
@@ -60,12 +59,8 @@ object NotificationUtils {
         channelId: String,
         channelName: String,
         channelDescription: String,
-        enableLights: Boolean,
-        importance: Int,
         sound: Uri,
-        audioAttributes: AudioAttributes,
-        vibrationPattern: LongArray?,
-        bypassDnd: Boolean = false
+        audioAttributes: AudioAttributes
     ) {
 
         val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
@@ -74,23 +69,16 @@ object NotificationUtils {
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
             notificationManager.getNotificationChannel(channelId) == null
         ) {
-
             val channel = NotificationChannel(
                 channelId, channelName,
-                importance
+                NotificationManager.IMPORTANCE_HIGH
             )
 
             channel.description = channelDescription
-            channel.enableLights(enableLights)
+            channel.enableLights(true)
             channel.lightColor = R.color.colorPrimary
             channel.setSound(sound, audioAttributes)
-            if (vibrationPattern != null) {
-                channel.enableVibration(true)
-                channel.vibrationPattern = vibrationPattern
-            } else {
-                channel.enableVibration(false)
-            }
-            channel.setBypassDnd(bypassDnd)
+            channel.setBypassDnd(false)
 
             notificationManager.createNotificationChannel(channel)
         }
@@ -112,12 +100,8 @@ object NotificationUtils {
             NOTIFICATION_CHANNEL_CALLS_V4,
             context.resources.getString(R.string.nc_notification_channel_calls),
             context.resources.getString(R.string.nc_notification_channel_calls_description),
-            true,
-            NotificationManagerCompat.IMPORTANCE_HIGH,
             soundUri,
-            audioAttributes,
-            null,
-            false
+            audioAttributes
         )
     }
 
@@ -137,12 +121,8 @@ object NotificationUtils {
             NOTIFICATION_CHANNEL_MESSAGES_V3,
             context.resources.getString(R.string.nc_notification_channel_messages),
             context.resources.getString(R.string.nc_notification_channel_messages_description),
-            true,
-            NotificationManagerCompat.IMPORTANCE_HIGH,
             soundUri,
-            audioAttributes,
-            null,
-            false
+            audioAttributes
         )
     }
 

--- a/app/src/main/res/layout/controller_settings.xml
+++ b/app/src/main/res/layout/controller_settings.xml
@@ -161,6 +161,7 @@
     </com.yarolegovich.mp.MaterialPreferenceCategory>
 
     <com.yarolegovich.mp.MaterialPreferenceCategory
+        android:id="@+id/settings_notifications_category"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:animateLayoutChanges="true"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,10 +94,11 @@
     <string name="nc_settings_no_talk_installed">Talk app is not installed on the server you tried to authenticate against</string>
     <string name="nc_settings_account_updated">Your already existing account was updated, instead of adding a new one</string>
     <string name="nc_account_scheduled_for_deletion">The account is scheduled for deletion, and cannot be changed</string>
-    <string name="nc_settings_notification_sounds">Sound</string>
+    <string name="nc_settings_notification_sounds">Notification sounds</string>
+    <string name="nc_settings_notification_sounds_post_oreo">Notifications</string>
     <string name="nc_settings_call_ringtone">Calls</string>
     <string name="nc_settings_call_ringtone_key" translatable="false">call_ringtone</string>
-    <string name="nc_settings_other_notifications_ringtone">Notifications</string>
+    <string name="nc_settings_other_notifications_ringtone">Messages</string>
     <string name="nc_settings_message_ringtone_key" translatable="false">message_ringtone</string>
     <string name="nc_settings_default_ringtone" translatable="false">Librem by feandesign</string>
     <string name="nc_settings_no_ringtone">No sound</string>
@@ -227,9 +228,10 @@
 
     <!-- Notification channels -->
     <string name="nc_notification_channel">%1$s on %2$s notification channel</string>
-    <string name="nc_notification_channel_calls">Calls notification channel</string>
-    <string name="nc_notification_channel_messages">Messages notification channel</string>
-    <string name="nc_notification_channel_calls_description">Shows incoming calls</string>
+    <string name="nc_notification_channel_calls">Calls</string>
+    <string name="nc_notification_channel_messages">Messages</string>
+    <string name="nc_notification_channel_calls_description">Notify about incoming calls</string>
+    <string name="nc_notification_channel_messages_description">Notify about incoming messages</string>
     <string name="nc_notification_settings">Notification settings</string>
     <string name="nc_plain_old_messages">Messages</string>
     <string name="nc_notify_me_always">Always notify</string>


### PR DESCRIPTION
Trying to fix #756 and #892

This seems to be caused by the fact that since Android 8 (Oreo) notification sounds are handled by the system - as described in this article: [Create and Manage Notification Channels](https://developer.android.com/training/notify-user/channels).

Changes to implement - most should apply only to devices running Android 8 (Oreo) or later:

- [x] [Do not play notification sounds (system will do that)](https://github.com/nextcloud/talk-android/pull/1728/commits/65f0a777a6acd9caa7afcb6b4d1bf4f1c009b420).
- [x] [Provide UI to change notification settings from application settings (app preferences do not affect system settings)](https://github.com/nextcloud/talk-android/pull/1728/commits/622a266b6fc7ddefb5f4fc91ef186c65efa09b04).
Addtional notes:
* I have refactored sound selection code to cover differences between old (pre Oreo) and new devices.
* I have changed the notification channel handling code to always use the same notification channel for calls. Previous implementation used a hash of the notification parameters as a channel ID. This prevented users from configuring call notification settings in the system UI.
- [x] [Register notification channels on application start-up](https://github.com/nextcloud/talk-android/pull/1728/commits/541ffecccd2006fb14433763f265bf8c9b70f2c1).
Plus some refactoring - move more notification related code into NotificationUtils.
- [x] [Implement changes to the UI related to notifications and simplify channel name - as described below](https://github.com/nextcloud/talk-android/pull/1728/commits/24cf3caf455bc88fa101fe37b8d93e12a2e95b58).
- [ ] _(Optional)_ Check using **NotificationManagerCompat.areNotificationsEnabled** to signal the user that notifications will not be available.

I would like to suggest some changes to the UI related to notifications.

Currently the notification/sounds related section in the app settings looks like this:
<img src="https://user-images.githubusercontent.com/8277636/145284707-3dec1b1f-f4e0-4179-aa7a-9c73e58a168b.png" width=33% height=33%>
On old devices (pre Oreo) I would suggest to change it to:
<img src="https://user-images.githubusercontent.com/8277636/145285034-3e322c95-d785-4c75-9d41-7d58137299e3.png" width=33% height=33%>
On new devices (Oreo and later) these UI elements are used to open system notification settings, so I would suggest:
<img src="https://user-images.githubusercontent.com/8277636/145285239-3d2e079c-edf1-4bb1-992e-f009dcd4f01d.png" width=33% height=33%>

I would also suggest to simplify names of the notification channels. Currently the channels look like this in the system settings:

<img src="https://user-images.githubusercontent.com/8277636/145285501-db6c882e-c2da-48dc-addf-a258846d6cf2.png" width=33% height=33%>

I suggest changing it to:

<img src="https://user-images.githubusercontent.com/8277636/145285695-68a91efd-dc91-4ea8-8aaa-eb284963c074.png" width=33% height=33%>
