### PR TITLE
Don't mirror check icon in RTL

### DIFF
--- a/app/src/gplay/java/com/nextcloud/talk/services/firebase/MagicFirebaseMessagingService.kt
+++ b/app/src/gplay/java/com/nextcloud/talk/services/firebase/MagicFirebaseMessagingService.kt
@@ -341,7 +341,8 @@ class MagicFirebaseMessagingService : FirebaseMessagingService() {
                     if (hasParticipantsInCall) {
                         for (participant in participantList) {
                             if (participant.actorId == signatureVerification.userEntity.userId &&
-                                participant.actorType == Participant.ActorType.USERS) {
+                                participant.actorType == Participant.ActorType.USERS
+                            ) {
                                 inCallOnDifferentDevice = true
                                 break
                             }

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -323,7 +323,8 @@ class ChatController(args: Bundle) :
                     override fun onNext(roomOverall: RoomOverall) {
                         currentConversation = roomOverall.ocs.data
                         Log.d(
-                            TAG, "getRoomInfo. token: " + currentConversation?.getToken() +
+                            TAG,
+                            "getRoomInfo. token: " + currentConversation?.getToken() +
                                 " sessionId: " + currentConversation?.sessionId
                         )
                         loadAvatarForStatusBar()

--- a/app/src/main/res/drawable/ic_check_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_check_black_24dp.xml
@@ -18,7 +18,7 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<vector android:autoMirrored="true" android:height="24dp"
+<vector android:autoMirrored="false" android:height="24dp"
     android:viewportHeight="24.0" android:viewportWidth="24.0"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="#FF000000" android:pathData="M9,16.17L4.83,12l-1.42,1.41L9,19 21,7l-1.41,-1.41z"/>


### PR DESCRIPTION
The check icon for selection in the contact listwas inverted.
Now correct orientation (✅) is used in LTR and RTL.

Signed-off-by: Tim Krüger <t@timkrueger.me>