### PR TITLE
Fix unread indirect mention bg color

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.java
@@ -155,8 +155,7 @@ public class ConversationItem extends AbstractFlexibleItem<ConversationItem.Conv
                         holder.dialogUnreadBubble.setChipBackgroundColorResource(R.color.colorPrimary);
                         holder.dialogUnreadBubble.setTextColor(Color.WHITE);
                     } else {
-                        holder.dialogUnreadBubble.setChipBackgroundColor(ColorStateList.valueOf(
-                            ContextCompat.getColor(context, R.color.white)));
+                        holder.dialogUnreadBubble.setChipBackgroundColorResource(R.color.bg_default);
                         holder.dialogUnreadBubble.setTextColor(ContextCompat.getColor(
                             context,
                             R.color.colorPrimary));


### PR DESCRIPTION
The background color for the indirect unread mention counter was alwasys
white. Also in dark mode.

Now the background color is defined via the 'bg_default' color.

Signed-off-by: Tim Krüger <t@timkrueger.me>

![image](https://user-images.githubusercontent.com/606665/145983307-85caef5d-d6f3-41a4-b1d0-4f31ea8f287b.png)
