### PR TITLE
Image keyboard support in chat

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -148,6 +148,7 @@ import com.nextcloud.talk.utils.ConductorRemapping.remapChatController
 import com.nextcloud.talk.utils.ContactUtils
 import com.nextcloud.talk.utils.DateUtils
 import com.nextcloud.talk.utils.DisplayUtils
+import com.nextcloud.talk.utils.ImageEmojiEditText
 import com.nextcloud.talk.utils.KeyboardUtils
 import com.nextcloud.talk.utils.MagicCharPolicy
 import com.nextcloud.talk.utils.NotificationUtils
@@ -667,6 +668,12 @@ class ChatController(args: Bundle) :
             override fun afterTextChanged(s: Editable) {
             }
         })
+
+        // Image keyboard support
+        // See: https://developer.android.com/guide/topics/text/image-keyboard
+        (binding.messageInputView.inputEditText as ImageEmojiEditText).onCommitContentListener = {
+            uploadFiles(mutableListOf(it.toString()), false)
+        }
 
         showMicrophoneButton(true)
 

--- a/app/src/main/java/com/nextcloud/talk/utils/ImageEmojiEditText.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/ImageEmojiEditText.kt
@@ -71,5 +71,4 @@ class ImageEmojiEditText : EmojiEditText {
 
         return InputConnectionCompat.createWrapper(ic, editorInfo, callback)
     }
-
 }

--- a/app/src/main/java/com/nextcloud/talk/utils/ImageEmojiEditText.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/ImageEmojiEditText.kt
@@ -1,0 +1,75 @@
+/*
+ * Nextcloud Talk application
+ *
+ * @author Dariusz Olszewski
+ * Copyright (C) 2021 Dariusz Olszewski <starypatyk@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.nextcloud.talk.utils
+
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import android.util.AttributeSet
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputConnection
+import androidx.core.view.inputmethod.EditorInfoCompat
+import androidx.core.view.inputmethod.InputConnectionCompat
+import androidx.emoji.widget.EmojiEditText
+
+/*
+Subclass of EmojiEditText with support for image keyboards - primarily for GIF handling. ;-)
+Implementation based on this example:
+https://developer.android.com/guide/topics/text/image-keyboard
+ */
+class ImageEmojiEditText : EmojiEditText {
+
+    // Callback function to be called when the user selects an image, pass image Uri
+    lateinit var onCommitContentListener: ((Uri) -> Unit)
+
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
+
+    override fun onCreateInputConnection(editorInfo: EditorInfo): InputConnection {
+
+        val ic: InputConnection = super.onCreateInputConnection(editorInfo)
+
+        EditorInfoCompat.setContentMimeTypes(editorInfo, arrayOf("image/gif", "image/jpeg", "image/png"))
+
+        val callback =
+            InputConnectionCompat.OnCommitContentListener { inputContentInfo, flags, _ ->
+
+                val lacksPermission = (flags and InputConnectionCompat.INPUT_CONTENT_GRANT_READ_URI_PERMISSION) != 0
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1 && lacksPermission) {
+                    try {
+                        inputContentInfo.requestPermission()
+                    } catch (e: Exception) {
+                        return@OnCommitContentListener false
+                    }
+                }
+
+                if (::onCommitContentListener.isInitialized) {
+                    onCommitContentListener.invoke(inputContentInfo.contentUri)
+                    return@OnCommitContentListener true
+                } else {
+                    return@OnCommitContentListener false
+                }
+            }
+
+        return InputConnectionCompat.createWrapper(ic, editorInfo, callback)
+    }
+
+}

--- a/app/src/main/res/layout/view_message_input.xml
+++ b/app/src/main/res/layout/view_message_input.xml
@@ -65,7 +65,7 @@
             app:tint="?attr/colorControlNormal"
             android:contentDescription="@string/nc_add_emojis" />
 
-        <androidx.emoji.widget.EmojiEditText
+        <com.nextcloud.talk.utils.ImageEmojiEditText
             android:id="@id/messageInput"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"


### PR DESCRIPTION
Should resolve #411

Added support for images received from keyboard as described here:
https://developer.android.com/guide/topics/text/image-keyboard

When a keyboard (like Google Keyboard) sends an image - usually a GIF 😜 - to the text entry field, the code uploads the image to the current chat.

Implementation is a bit tricky, since it "injects" a new class _ImageEmojiEditText_ into a part of the layout managed by external **ChatKit** component. However since the _ImageEmojiEditText_ inherits from _EmojiEditText_ used originally, **ChatKit** seems to work just fine. And we can attach the required callback in the _ChatController_ class.