### PR TITLE
Additional fixes related to notification channels

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/RingtoneSelectionController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/RingtoneSelectionController.java
@@ -181,9 +181,9 @@ public class RingtoneSelectionController extends BaseController implements Flexi
 
     private String getRingtoneString() {
         if (callNotificationSounds) {
-            return NotificationUtils.INSTANCE.getDEFAULT_CALL_RINGTONE_URI();
+            return NotificationUtils.DEFAULT_CALL_RINGTONE_URI;
         } else {
-            return NotificationUtils.INSTANCE.getDEFAULT_MESSAGE_RINGTONE_URI();
+            return NotificationUtils.DEFAULT_MESSAGE_RINGTONE_URI;
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/controllers/SettingsController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/SettingsController.java
@@ -302,7 +302,7 @@ public class SettingsController extends BaseController {
                 Intent intent = new Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS);
                 intent.putExtra(Settings.EXTRA_APP_PACKAGE, BuildConfig.APPLICATION_ID);
                 intent.putExtra(Settings.EXTRA_CHANNEL_ID,
-                                NotificationUtils.INSTANCE.getNOTIFICATION_CHANNEL_CALLS_V4());
+                                NotificationUtils.NOTIFICATION_CHANNEL_CALLS_V4);
                 startActivity(intent);
             });
 
@@ -310,7 +310,7 @@ public class SettingsController extends BaseController {
                 Intent intent = new Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS);
                 intent.putExtra(Settings.EXTRA_APP_PACKAGE, BuildConfig.APPLICATION_ID);
                 intent.putExtra(Settings.EXTRA_CHANNEL_ID,
-                                NotificationUtils.INSTANCE.getNOTIFICATION_CHANNEL_MESSAGES_V3());
+                                NotificationUtils.NOTIFICATION_CHANNEL_MESSAGES_V4);
                 startActivity(intent);
             });
 
@@ -445,8 +445,8 @@ public class SettingsController extends BaseController {
     private String getRingtoneName(Context context, Uri ringtoneUri) {
         if (ringtoneUri == null) {
             return getResources().getString(R.string.nc_settings_no_ringtone);
-        } else if (ringtoneUri.toString().equals(NotificationUtils.INSTANCE.getDEFAULT_CALL_RINGTONE_URI()) ||
-            ringtoneUri.toString().equals(NotificationUtils.INSTANCE.getDEFAULT_MESSAGE_RINGTONE_URI())) {
+        } else if (ringtoneUri.toString().equals(NotificationUtils.DEFAULT_CALL_RINGTONE_URI) ||
+            ringtoneUri.toString().equals(NotificationUtils.DEFAULT_MESSAGE_RINGTONE_URI)) {
             return getResources().getString(R.string.nc_settings_default_ringtone);
         } else  {
             Ringtone r = RingtoneManager.getRingtone(context, ringtoneUri);

--- a/app/src/main/java/com/nextcloud/talk/controllers/SettingsController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/SettingsController.java
@@ -445,8 +445,8 @@ public class SettingsController extends BaseController {
     private String getRingtoneName(Context context, Uri ringtoneUri) {
         if (ringtoneUri == null) {
             return getResources().getString(R.string.nc_settings_no_ringtone);
-        } else if (ringtoneUri.toString().equals(NotificationUtils.DEFAULT_CALL_RINGTONE_URI) ||
-            ringtoneUri.toString().equals(NotificationUtils.DEFAULT_MESSAGE_RINGTONE_URI)) {
+        } else if (NotificationUtils.DEFAULT_CALL_RINGTONE_URI.equals(ringtoneUri.toString()) ||
+            NotificationUtils.DEFAULT_MESSAGE_RINGTONE_URI.equals(ringtoneUri.toString())) {
             return getResources().getString(R.string.nc_settings_default_ringtone);
         } else  {
             Ringtone r = RingtoneManager.getRingtone(context, ringtoneUri);

--- a/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.java
@@ -332,7 +332,7 @@ public class NotificationWorker extends Worker {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             if (CHAT.equals(decryptedPushMessage.getType()) || ROOM.equals(decryptedPushMessage.getType())) {
-                notificationBuilder.setChannelId(NotificationUtils.INSTANCE.getNOTIFICATION_CHANNEL_MESSAGES_V3());
+                notificationBuilder.setChannelId(NotificationUtils.NOTIFICATION_CHANNEL_MESSAGES_V4);
             }
         } else {
             // red color for the lights

--- a/app/src/main/java/com/nextcloud/talk/receivers/PackageReplacedReceiver.kt
+++ b/app/src/main/java/com/nextcloud/talk/receivers/PackageReplacedReceiver.kt
@@ -20,73 +20,19 @@
 
 package com.nextcloud.talk.receivers
 
-import android.app.NotificationManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
-import android.os.Build
-import android.util.Log
-import autodagger.AutoInjector
-import com.nextcloud.talk.application.NextcloudTalkApplication
 import com.nextcloud.talk.utils.NotificationUtils
-import com.nextcloud.talk.utils.database.user.UserUtils
-import com.nextcloud.talk.utils.preferences.AppPreferences
-import javax.inject.Inject
 
-@AutoInjector(NextcloudTalkApplication::class)
 class PackageReplacedReceiver : BroadcastReceiver() {
 
-    @Inject
-    lateinit var userUtils: UserUtils
-
-    @Inject
-    lateinit var appPreferences: AppPreferences
-
     override fun onReceive(context: Context, intent: Intent?) {
-        NextcloudTalkApplication.sharedApplication!!.componentApplication.inject(this)
 
         if (intent != null && intent.action != null &&
             intent.action == "android.intent.action.MY_PACKAGE_REPLACED"
         ) {
-            try {
-                val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
-                if (packageInfo.versionCode > 43 && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    val notificationManager = context.getSystemService(
-                        Context
-                            .NOTIFICATION_SERVICE
-                    ) as NotificationManager
-
-                    if (!appPreferences.isNotificationChannelUpgradedToV2) {
-                        for (
-                            notificationChannelGroup in notificationManager.notificationChannelGroups
-                        ) {
-                            notificationManager.deleteNotificationChannelGroup(notificationChannelGroup.id)
-                        }
-
-                        notificationManager.deleteNotificationChannel(NotificationUtils.NOTIFICATION_CHANNEL_CALLS)
-                        notificationManager.deleteNotificationChannel(NotificationUtils.NOTIFICATION_CHANNEL_MESSAGES)
-
-                        appPreferences.setNotificationChannelIsUpgradedToV2(true)
-                    }
-
-                    if (!appPreferences.isNotificationChannelUpgradedToV3 && packageInfo.versionCode > 51) {
-                        notificationManager
-                            .deleteNotificationChannel(NotificationUtils.NOTIFICATION_CHANNEL_MESSAGES_V2)
-                        notificationManager
-                            .deleteNotificationChannel(NotificationUtils.NOTIFICATION_CHANNEL_CALLS_V2)
-                        appPreferences.setNotificationChannelIsUpgradedToV3(true)
-                    }
-
-                    notificationManager.deleteNotificationChannel(NotificationUtils.NOTIFICATION_CHANNEL_CALLS_V3)
-                }
-            } catch (e: PackageManager.NameNotFoundException) {
-                Log.e(TAG, "Failed to fetch package info")
-            }
+            NotificationUtils.removeOldNotificationChannels(context)
         }
-    }
-
-    companion object {
-        private val TAG = "PackageReplacedReceiver"
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
@@ -40,17 +40,23 @@ import com.nextcloud.talk.utils.preferences.AppPreferences
 import java.io.IOException
 
 object NotificationUtils {
-    val NOTIFICATION_CHANNEL_MESSAGES = "NOTIFICATION_CHANNEL_MESSAGES"
-    val NOTIFICATION_CHANNEL_MESSAGES_V2 = "NOTIFICATION_CHANNEL_MESSAGES_V2"
-    val NOTIFICATION_CHANNEL_MESSAGES_V3 = "NOTIFICATION_CHANNEL_MESSAGES_V3"
-    val NOTIFICATION_CHANNEL_CALLS = "NOTIFICATION_CHANNEL_CALLS"
-    val NOTIFICATION_CHANNEL_CALLS_V2 = "NOTIFICATION_CHANNEL_CALLS_V2"
-    val NOTIFICATION_CHANNEL_CALLS_V3 = "NOTIFICATION_CHANNEL_CALLS_V3"
-    val NOTIFICATION_CHANNEL_CALLS_V4 = "NOTIFICATION_CHANNEL_CALLS_V4"
 
-    val DEFAULT_CALL_RINGTONE_URI =
+    // Notification channel IDs commented below are no longer used.
+    // All old notification channels get deleted when the app is upgraded to the current version.
+    //
+    // val NOTIFICATION_CHANNEL_MESSAGES = "NOTIFICATION_CHANNEL_MESSAGES"
+    // val NOTIFICATION_CHANNEL_MESSAGES_V2 = "NOTIFICATION_CHANNEL_MESSAGES_V2"
+    // val NOTIFICATION_CHANNEL_MESSAGES_V3 = "NOTIFICATION_CHANNEL_MESSAGES_V3"
+    // val NOTIFICATION_CHANNEL_CALLS = "NOTIFICATION_CHANNEL_CALLS"
+    // val NOTIFICATION_CHANNEL_CALLS_V2 = "NOTIFICATION_CHANNEL_CALLS_V2"
+    // val NOTIFICATION_CHANNEL_CALLS_V3 = "NOTIFICATION_CHANNEL_CALLS_V3"
+
+    const val NOTIFICATION_CHANNEL_MESSAGES_V4 = "NOTIFICATION_CHANNEL_MESSAGES_V4"
+    const val NOTIFICATION_CHANNEL_CALLS_V4 = "NOTIFICATION_CHANNEL_CALLS_V4"
+
+    const val DEFAULT_CALL_RINGTONE_URI =
         "android.resource://" + BuildConfig.APPLICATION_ID + "/raw/librem_by_feandesign_call"
-    val DEFAULT_MESSAGE_RINGTONE_URI =
+    const val DEFAULT_MESSAGE_RINGTONE_URI =
         "android.resource://" + BuildConfig.APPLICATION_ID + "/raw/librem_by_feandesign_message"
 
     @TargetApi(Build.VERSION_CODES.O)
@@ -118,7 +124,7 @@ object NotificationUtils {
 
         createNotificationChannel(
             context,
-            NOTIFICATION_CHANNEL_MESSAGES_V3,
+            NOTIFICATION_CHANNEL_MESSAGES_V4,
             context.resources.getString(R.string.nc_notification_channel_messages),
             context.resources.getString(R.string.nc_notification_channel_messages_description),
             soundUri,
@@ -132,6 +138,28 @@ object NotificationUtils {
     ) {
         createCallsNotificationChannel(context, appPreferences)
         createMessagesNotificationChannel(context, appPreferences)
+    }
+
+    @TargetApi(Build.VERSION_CODES.O)
+    fun removeOldNotificationChannels(context: Context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+            // Current version does not use notification channel groups - delete all groups
+            for (channelGroup in notificationManager.notificationChannelGroups) {
+                notificationManager.deleteNotificationChannelGroup(channelGroup.id)
+            }
+
+            // Delete all notification channels created by previous versions
+            for (channel in notificationManager.notificationChannels) {
+                if (
+                    channel.id != NOTIFICATION_CHANNEL_CALLS_V4 &&
+                    channel.id != NOTIFICATION_CHANNEL_MESSAGES_V4
+                ) {
+                    notificationManager.deleteNotificationChannel(channel.id)
+                }
+            }
+        }
     }
 
     @TargetApi(Build.VERSION_CODES.O)
@@ -291,7 +319,7 @@ object NotificationUtils {
     ): Uri {
         return getRingtoneUri(
             context,
-            appPreferences.messageRingtoneUri, DEFAULT_MESSAGE_RINGTONE_URI, NOTIFICATION_CHANNEL_MESSAGES_V3
+            appPreferences.messageRingtoneUri, DEFAULT_MESSAGE_RINGTONE_URI, NOTIFICATION_CHANNEL_MESSAGES_V4
         )
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
@@ -65,7 +65,7 @@ object NotificationUtils {
         channelId: String,
         channelName: String,
         channelDescription: String,
-        sound: Uri,
+        sound: Uri?,
         audioAttributes: AudioAttributes
     ) {
 
@@ -281,7 +281,7 @@ object NotificationUtils {
         ringtonePreferencesString: String?,
         defaultRingtoneUri: String,
         channelId: String
-    ): Uri {
+    ): Uri? {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = getNotificationChannel(context, channelId)
             if (channel != null) {
@@ -296,7 +296,7 @@ object NotificationUtils {
             try {
                 val ringtoneSettings =
                     LoganSquare.parse(ringtonePreferencesString, RingtoneSettings::class.java)
-                return ringtoneSettings.ringtoneUri!!
+                return ringtoneSettings.ringtoneUri
             } catch (exception: IOException) {
                 return Uri.parse(defaultRingtoneUri)
             }
@@ -306,7 +306,7 @@ object NotificationUtils {
     fun getCallRingtoneUri(
         context: Context,
         appPreferences: AppPreferences
-    ): Uri {
+    ): Uri? {
         return getRingtoneUri(
             context,
             appPreferences.callRingtoneUri, DEFAULT_CALL_RINGTONE_URI, NOTIFICATION_CHANNEL_CALLS_V4
@@ -316,7 +316,7 @@ object NotificationUtils {
     fun getMessageRingtoneUri(
         context: Context,
         appPreferences: AppPreferences
-    ): Uri {
+    ): Uri? {
         return getRingtoneUri(
             context,
             appPreferences.messageRingtoneUri, DEFAULT_MESSAGE_RINGTONE_URI, NOTIFICATION_CHANNEL_MESSAGES_V4


### PR DESCRIPTION
Additions to PR #1728

**1. Remove unused notification channels during upgrade**

I have not correctly considered app upgrade. There were the following unintended side-effects when upgrading:

- the old "Calls notification channel" was still visible in the system UI but not used,
- the channel "Message notification channel" was not renamed to "Messages" as expected (registering the channel again with the same ID but a new name does not change the name of the channel).

The new code:

- removes all unused notification channels,
- uses a new ID (NOTIFICATION_CHANNEL_MESSAGES_V4) for the "Messages" channel.

**2. App would crash on pre-Oreo devices with "No sound" setting**

Null ringtone Uri must be allowed.