### PR TITLE
Conversation view stuck in loading state when opened from notification

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
@@ -29,6 +29,7 @@ import android.os.Build
 import android.os.Bundle
 import android.provider.ContactsContract
 import android.text.TextUtils
+import android.util.Log
 import androidx.annotation.RequiresApi
 import autodagger.AutoInjector
 import com.bluelinelabs.conductor.Conductor
@@ -87,6 +88,8 @@ class MainActivity : BaseActivity(), ActionBarProvider {
     private var router: Router? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        Log.d(TAG, "onCreate: Activity: " + System.identityHashCode(this).toString())
+
         super.onCreate(savedInstanceState)
         // Set the default theme to replace the launch screen theme.
         setTheme(R.style.AppTheme)
@@ -162,12 +165,29 @@ class MainActivity : BaseActivity(), ActionBarProvider {
     }
 
     override fun onStart() {
+        Log.d(TAG, "onStart: Activity: " + System.identityHashCode(this).toString())
+
         super.onStart()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             checkIfWeAreSecure()
         }
 
         handleActionFromContact(intent)
+    }
+
+    override fun onResume() {
+        Log.d(TAG, "onResume: Activity: " + System.identityHashCode(this).toString())
+        super.onResume()
+    }
+
+    override fun onPause() {
+        Log.d(TAG, "onPause: Activity: " + System.identityHashCode(this).toString())
+        super.onPause()
+    }
+
+    override fun onStop() {
+        Log.d(TAG, "onStop: Activity: " + System.identityHashCode(this).toString())
+        super.onStop()
     }
 
     fun resetConversationsList() {
@@ -305,6 +325,7 @@ class MainActivity : BaseActivity(), ActionBarProvider {
     }
 
     override fun onNewIntent(intent: Intent) {
+        Log.d(TAG, "onNewIntent Activity: " + System.identityHashCode(this).toString())
         super.onNewIntent(intent)
         handleActionFromContact(intent)
         if (intent.hasExtra(BundleKeys.KEY_FROM_NOTIFICATION_START_CALL)) {

--- a/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
@@ -87,6 +87,8 @@ class MainActivity : BaseActivity(), ActionBarProvider {
 
     private var router: Router? = null
 
+    var ignoreNextDetach: Boolean = false
+
     override fun onCreate(savedInstanceState: Bundle?) {
         Log.d(TAG, "onCreate: Activity: " + System.identityHashCode(this).toString())
 
@@ -178,6 +180,10 @@ class MainActivity : BaseActivity(), ActionBarProvider {
     override fun onResume() {
         Log.d(TAG, "onResume: Activity: " + System.identityHashCode(this).toString())
         super.onResume()
+        if (hasWindowFocus()) {
+            Log.d(TAG, "onResume: clear ignoreNextDetach")
+            ignoreNextDetach = false
+        }
     }
 
     override fun onPause() {
@@ -334,6 +340,8 @@ class MainActivity : BaseActivity(), ActionBarProvider {
                 intent.extras?.let { callNotificationIntent.putExtras(it) }
                 startActivity(callNotificationIntent)
             } else {
+                Log.d(TAG, "onNewIntent set ignoreNextDetach")
+                ignoreNextDetach = true
                 ConductorRemapping.remapChatController(
                     router!!, intent.getLongExtra(BundleKeys.KEY_INTERNAL_USER_ID, -1),
                     intent.getStringExtra(KEY_ROOM_TOKEN)!!, intent.extras!!, false

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -269,7 +269,7 @@ class ChatController(args: Bundle) :
     var currentlyPlayedVoiceMessage: ChatMessage? = null
 
     init {
-        Log.d(TAG, "init ChatController")
+        Log.d(TAG, "init ChatController: " + System.identityHashCode(this).toString())
 
         setHasOptionsMenu(true)
         NextcloudTalkApplication.sharedApplication!!.componentApplication.inject(this)
@@ -438,6 +438,7 @@ class ChatController(args: Bundle) :
         .ROOM_TYPE_ONE_TO_ONE_CALL
 
     override fun onViewBound(view: View) {
+        Log.d(TAG, "onViewBound: " + System.identityHashCode(this).toString())
         actionBar?.show()
         var adapterWasNull = false
 
@@ -1500,7 +1501,8 @@ class ChatController(args: Bundle) :
 
     override fun onAttach(view: View) {
         super.onAttach(view)
-        Log.d(TAG, "onAttach")
+        Log.d(TAG, "onAttach: Controller: " + System.identityHashCode(this).toString() +
+            " Activity: " + System.identityHashCode(activity).toString())
         eventBus?.register(this)
 
         if (conversationUser?.userId != "?" &&
@@ -1576,7 +1578,9 @@ class ChatController(args: Bundle) :
 
     override fun onDetach(view: View) {
         super.onDetach(view)
-        Log.d(TAG, "onDetach")
+        Log.d(TAG, "onDetach: Controller: " + System.identityHashCode(this).toString() +
+            " Activity: " + System.identityHashCode(activity).toString())
+
         eventBus?.unregister(this)
 
         if (activity != null) {

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -1593,9 +1593,16 @@ class ChatController(args: Bundle) :
             !ApplicationWideCurrentRoomHolder.getInstance().isInCall &&
             !ApplicationWideCurrentRoomHolder.getInstance().isDialing
         ) {
-            ApplicationWideCurrentRoomHolder.getInstance().clear()
-            wasDetached = true
-            leaveRoom()
+            val mainActivity = activity as MainActivity
+            if (mainActivity.ignoreNextDetach) {
+                Log.d(TAG, "onDetach: ignoring Detach event Controller: " + System.identityHashCode(this).toString() +
+                    " Activity: " + System.identityHashCode(activity).toString())
+                mainActivity.ignoreNextDetach = false
+            } else {
+                ApplicationWideCurrentRoomHolder.getInstance().clear()
+                wasDetached = true
+                leaveRoom()
+            }
         }
 
         if (mentionAutocomplete != null && mentionAutocomplete!!.isPopupShowing) {


### PR DESCRIPTION
Trying to fix #1765 

I have been diagnosing this issue and it seems that such behaviour is caused by an unexpected sequence of events when opening the chat view from a notification on the lock screen.

I have added logging code to diagnose the issue and got the following (without **okhttp** messages to make the logs easier to read).

> 01-09 23:11:08.611 24968 24968 D MainActivity: onNewIntent Activity: 17744351
> 01-09 23:11:08.616 24968 24968 D ChatController: init ChatController: 87535416
> 01-09 23:11:08.616 24968 24968 D ChatController:    roomToken = 4j47to4h
> 01-09 23:11:08.660 24968 24968 D ChatController: onViewBound: 87535416
> 01-09 23:11:08.660 24968 24968 D ChatController: Initialize TalkMessagesListAdapter with senderId: users/test12
> 01-09 23:11:08.668 24968 24968 D ChatController: onAttach: Controller: 87535416 Activity: 17744351
> 01-09 23:11:08.681 24968 24968 D MainActivity: onStart: Activity: 17744351
> 01-09 23:11:08.688 24968 24968 D MainActivity: onResume: Activity: 17744351
> **01-09 23:11:08.690 24968 24968 D MainActivity: onPause: Activity: 17744351
> 01-09 23:11:08.731 24968 24968 D MainActivity: onStop: Activity: 17744351
> 01-09 23:11:08.735 24968 24968 D ChatController: onDetach: Controller: 87535416 Activity: 17744351
> 01-09 23:11:08.735 24968 24968 D ChatController: leaveRoom**
> 01-09 23:11:08.794 24968 24968 D ChatController: getRoomInfo. token: 4j47to4h sessionId: 0
> 01-09 23:11:08.846 24968 24968 E ChatController: magicWebSocketInstance or currentConversation were null! Failed to leave the room!
> 01-09 23:11:09.081 24968 24968 D MainActivity: onStart: Activity: 17744351
> 01-09 23:11:09.088 24968 24968 D ChatController: onAttach: Controller: 87535416 Activity: 17744351
> 01-09 23:11:09.097 24968 24968 D MainActivity: onResume: Activity: 17744351

While in principle this is a valid sequence of events: **onStart - onResume - onPause - onStop - onStart - onResume**, the fact they are generated in quick succession (~500 ms total in this case) and there is asynchronous processing involved in the process (joining the room, getting the messages), the **ChatController** ends up in some indeterminate state and does not load the messages.

The key problem here seems to be the **onStop** event on the **MainActivity** that triggers **onDetach** on the **ChatController**, that in turn invokes **leaveRoom**.

It is important to note that the sequence of events is different when the notification is opened on the active screen:

> 01-09 23:48:52.042 25269 25269 D MainActivity: onPause: Activity: 160849992
> 01-09 23:48:52.042 25269 25269 D MainActivity: onNewIntent Activity: 160849992
> 01-09 23:48:52.043 25269 25269 D ChatController: init ChatController: 19466598
> 01-09 23:48:52.043 25269 25269 D ChatController:    roomToken = 4j47to4h
> 01-09 23:48:52.070 25269 25269 D ChatController: onViewBound: 19466598
> 01-09 23:48:52.071 25269 25269 D ChatController: Initialize TalkMessagesListAdapter with senderId: users/test12
> 01-09 23:48:52.078 25269 25269 D ChatController: onAttach: Controller: 19466598 Activity: 160849992
> 01-09 23:48:52.088 25269 25269 D MainActivity: onResume: Activity: 160849992
> 01-09 23:48:52.222 25269 25269 D ChatController: getRoomInfo. token: 4j47to4h sessionId: 0
> 01-09 23:48:52.371 25269 25269 D WebSocketConnectionHelper: no magicWebSocketInstance found
> 01-09 23:48:52.371 25269 25269 D ChatController: magicWebSocketInstance became null

In this case this is just: **onPause - onResume**. There is no **onStop - onStart** and the **MainActivity** becomes visible when the (first and only) **onResume** is triggered.

Apparently this is a known behaviour of Android:
https://stackoverflow.com/questions/57759267/duplicated-activity-lifecycle-when-app-is-launched-with-screen-turned-off
https://stackoverflow.com/questions/25369909/onpause-and-onstop-called-immediately-after-starting-activity

I have prepared an initial fix/work-around based on [this answer](https://stackoverflow.com/a/25474853). The idea is to skip the **leaveRoom** call during **onDetach** when we expect that the **ChatController** will be shown back soon.

This is done by setting a special variable on the **MainActivity**: **ignoreNextDetach**. We set this variable in **onNewIntent** and clear it when the **MainActivity** is visible (has focus) in **onResume**. When this variable is set on the **MainActivity** we skip the **leaveRoom** call in **onDetach**.

This seems to work. I am aware of some cases that are not yet handled correctly, but I would like to know what you think about this approach.