### PR TITLE
Fix handling offers in already established connections

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/webrtc/MagicPeerConnectionWrapper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/MagicPeerConnectionWrapper.java
@@ -465,7 +465,7 @@ public class MagicPeerConnectionWrapper {
         @Override
         public void onSetSuccess() {
             if (peerConnection != null) {
-                if (peerConnection.getLocalDescription() == null) {
+                if (peerConnection.signalingState() == PeerConnection.SignalingState.HAVE_REMOTE_OFFER) {
                     peerConnection.createAnswer(magicSdpObserver, sdpConstraints);
                 }
 


### PR DESCRIPTION
Needed for https://github.com/nextcloud/spreed/pull/6896

Once a RTCPeerConnection is established new offers can still be received for that connection. These offers will update/renegotiate the connection (for example, to add a video track to an audio only connection) and need to be handled like the offers to establish the original connection (the offer needs to be set as the remote description and a local answer needs to be created for it, set as the local description and sent to the other peer).

Pending:
- [ ] Trigger renegotiations only if `update` is provided in the offer
- [ ] Reset connections if an offer without `update` is received (as done in the WebUI; this is actually a bug in the Android app)
- [ ] Ensure that everything works as expected also for previous Talk versions both with and without HPB (it should, but... you know :-) )

## How to test

- Setup https://github.com/nextcloud/spreed/pull/6896 (note that a specific pull request for the external signaling server is also needed)
- In the browser, start a call and, in the device checker shown before actually starting the call, select an audio device and no video device
- In the Android app, join the call
- In the browser, open the device settings, select a video device and close the device settings
- Enable video

### Result with this pull request

In the Android app the video is now visible (note that, due to a bug in the WebUI, the video may be visible even before being actually enabled in the browser)

### Result without this pull request

In the Android app the video is not visible
