### PR TITLE
Conversation view shows search bar when opened from notification

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
@@ -349,7 +349,7 @@ class MainActivity : BaseActivity(), ActionBarProvider {
             } else {
                 remapChatController(
                     router!!, intent.getParcelableExtra<UserEntity>(KEY_USER_ENTITY)!!.id,
-                    intent.getStringExtra(KEY_ROOM_TOKEN)!!, intent.extras!!, false
+                    intent.getStringExtra(KEY_ROOM_TOKEN)!!, intent.extras!!, false, true
                 )
             }
         }

--- a/app/src/main/java/com/nextcloud/talk/utils/ConductorRemapping.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/ConductorRemapping.kt
@@ -24,15 +24,28 @@ import android.os.Bundle
 import com.bluelinelabs.conductor.Router
 import com.bluelinelabs.conductor.RouterTransaction
 import com.bluelinelabs.conductor.changehandler.HorizontalChangeHandler
+import com.bluelinelabs.conductor.changehandler.SimpleSwapChangeHandler
 import com.nextcloud.talk.controllers.ChatController
 
 object ConductorRemapping {
+
     fun remapChatController(
         router: Router,
         internalUserId: Long,
         roomTokenOrId: String,
         bundle: Bundle,
         replaceTop: Boolean
+    ) {
+        remapChatController(router, internalUserId, roomTokenOrId, bundle, replaceTop, false)
+    }
+
+    fun remapChatController(
+        router: Router,
+        internalUserId: Long,
+        roomTokenOrId: String,
+        bundle: Bundle,
+        replaceTop: Boolean,
+        pushImmediately: Boolean
     ) {
         val tag = "$internalUserId@$roomTokenOrId"
         if (router.getControllerWithTag(tag) != null) {
@@ -49,16 +62,21 @@ object ConductorRemapping {
             backstack.add(routerTransaction)
             router.setBackstack(backstack, HorizontalChangeHandler())
         } else {
+            var pushChangeHandler = if (pushImmediately) {
+                SimpleSwapChangeHandler()
+            } else {
+                HorizontalChangeHandler()
+            }
             if (!replaceTop) {
                 router.pushController(
                     RouterTransaction.with(ChatController(bundle))
-                        .pushChangeHandler(HorizontalChangeHandler())
+                        .pushChangeHandler(pushChangeHandler)
                         .popChangeHandler(HorizontalChangeHandler()).tag(tag)
                 )
             } else {
                 router.replaceTopController(
                     RouterTransaction.with(ChatController(bundle))
-                        .pushChangeHandler(HorizontalChangeHandler())
+                        .pushChangeHandler(pushChangeHandler)
                         .popChangeHandler(HorizontalChangeHandler()).tag(tag)
                 )
             }

--- a/app/src/main/java/com/nextcloud/talk/utils/ConductorRemapping.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/ConductorRemapping.kt
@@ -62,7 +62,7 @@ object ConductorRemapping {
             backstack.add(routerTransaction)
             router.setBackstack(backstack, HorizontalChangeHandler())
         } else {
-            var pushChangeHandler = if (pushImmediately) {
+            val pushChangeHandler = if (pushImmediately) {
                 SimpleSwapChangeHandler()
             } else {
                 HorizontalChangeHandler()

--- a/detekt.yml
+++ b/detekt.yml
@@ -1,5 +1,5 @@
 build:
-  maxIssues: 149
+  maxIssues: 150
   weights:
     # complexity: 2
     # LongParameterList: 1


### PR DESCRIPTION
Fixes #1861 

When **remapChatController** is called from a notification use a **SimpleSwapChangeHandler** rather than **HorizontalChangeHandler** to avoid animation.

This has the following effects:

- **ConversationsListController.onAttach** is not called in most cases (_occasionally when the **MainActivity** is destroyed and recreated the ConversationsListController.onAttach can still be called, but this seems rare_).
- The toolbar rather than the search bar is shown as expected.
- The **getRooms** API is **not** called.
- Screen flickering is significantly reduced. Sometimes the conversation list still becomes briefly visible, but in many cases the app shows the chat view immediately.