### PR TITLE
Workaround for crash when loading avatar

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -424,12 +424,17 @@ class ChatController(args: Bundle) :
                         if (actionBar != null && bitmap != null && resources != null) {
 
                             val avatarSize = (actionBar?.height!! / 1.5).roundToInt()
-                            val bitmapResized = Bitmap.createScaledBitmap(bitmap, avatarSize, avatarSize, false)
+                            if (avatarSize > 0) {
+                                val bitmapResized = Bitmap.createScaledBitmap(bitmap, avatarSize, avatarSize, false)
 
-                            val roundedBitmapDrawable = RoundedBitmapDrawableFactory.create(resources!!, bitmapResized)
-                            roundedBitmapDrawable.isCircular = true
-                            roundedBitmapDrawable.setAntiAlias(true)
-                            actionBar?.setIcon(roundedBitmapDrawable)
+                                val roundedBitmapDrawable =
+                                    RoundedBitmapDrawableFactory.create(resources!!, bitmapResized)
+                                roundedBitmapDrawable.isCircular = true
+                                roundedBitmapDrawable.setAntiAlias(true)
+                                actionBar?.setIcon(roundedBitmapDrawable)
+                            } else {
+                                Log.d(TAG, "loadAvatarForStatusBar avatarSize <= 0")
+                            }
                         }
                     }
 


### PR DESCRIPTION
Workaround for #1869

I have not figured out why avatarSize becomes <= 0 in this case. With this workaround the app seems to behave OK - I have not even been able to notice that the avatar is incorrect.