### PR TITLE
solve issue of low contrast

### DIFF
--- a/app/src/main/res/layout/controller_server_selection.xml
+++ b/app/src/main/res/layout/controller_server_selection.xml
@@ -100,7 +100,7 @@
                 android:paddingBottom="2dp"
                 android:text="@string/nc_server_helper_text"
                 android:textAlignment="viewStart"
-                android:textColor="@color/nc_login_text_color" />
+                android:textColor="#000000" />
 
             <LinearLayout
                 android:id="@+id/serverEntryProgressBar"
@@ -162,7 +162,7 @@
                 android:padding="@dimen/standard_padding"
                 android:text="@string/nc_get_from_provider"
                 android:textAlignment="center"
-                android:textColor="@color/nc_login_text_color" />
+                android:textColor="#000000" />
 
             <TextView
                 android:id="@+id/cert_text_view"
@@ -175,7 +175,7 @@
                 android:padding="@dimen/standard_padding"
                 android:text="@string/nc_configure_cert_auth"
                 android:textAlignment="center"
-                android:textColor="@color/nc_login_text_color" />
+                android:textColor="#000000" />
 
         </LinearLayout>
 


### PR DESCRIPTION
The original text color of the component is '#FFFFFF', and the contrast between the text color ('#B3DAEF') and the background color ('#0082C9') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#000000') are as follows:
![image](https://user-images.githubusercontent.com/101503193/158533337-249c5397-c9d2-497c-90e5-d9f0eac82826.png)
The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.