### PR TITLE
Crash when opening personal info - null email

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/ProfileController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ProfileController.kt
@@ -286,7 +286,7 @@ class ProfileController : NewBaseController(R.layout.controller_profile) {
                 arrayOf(
                         userInfo!!.displayName!!,
                         userInfo!!.phone!!,
-                        userInfo!!.email!!,
+                        userInfo!!.email.orEmpty(),
                         userInfo!!.address!!,
                         userInfo!!.twitter!!,
                         userInfo!!.website!!
@@ -373,7 +373,7 @@ class ProfileController : NewBaseController(R.layout.controller_profile) {
         result.add(
             UserInfoDetailsItem(
                 R.drawable.ic_email,
-                userInfo.email!!,
+                userInfo.email.orEmpty(),
                 resources!!.getString(R.string.user_info_email),
                 Field.EMAIL,
                 userInfo.emailScope


### PR DESCRIPTION
Trying to fix #1908. This seems to be related to the recent PR #1884.

On my server I have not defined e-mail addresses for the accounts. The call to **ncApi.getUserProfile()** receives the following JSON data:

```
{
    "ocs": {
        "meta": {
            "status": "ok",
            "statuscode": 200,
            "message": "OK"
        },
        "data": {
            "storageLocation": "\/media\/hd\/www\/owncloud_data\/test12",
            "id": "test12",
            "lastLogin": 1641683516000,
            "backend": "Database",
            "subadmin": [],
            "quota": {
                "free": 712282329088,
                "used": 18177344,
                "total": 712300506432,
                "relative": 0,
                "quota": -3
            },
            "avatarScope": "v2-federated",
            "email": null,
            "emailScope": "v2-federated",
            "additional_mail": [],
            "additional_mailScope": [],
            "displaynameScope": "v2-federated",
            "phone": "",
            "phoneScope": "v2-local",
            "address": "",
            "addressScope": "v2-local",
            "website": "",
            "websiteScope": "v2-local",
            "twitter": "",
            "twitterScope": "v2-local",
            "organisation": "",
            "organisationScope": "v2-local",
            "role": "",
            "roleScope": "v2-local",
            "headline": "",
            "headlineScope": "v2-local",
            "biography": "",
            "biographyScope": "v2-local",
            "profile_enabled": "1",
            "profile_enabledScope": "v2-local",
            "groups": [],
            "language": "en",
            "locale": "",
            "notify_email": null,
            "backendCapabilities": {
                "setDisplayName": true,
                "setPassword": true
            },
            "display-name": "Test 12"
        }
    }
}
```

The **email** field is set explicitly to **null** rather than to an empty string.

Proposed change fixes the issue - however I am not sure if this is the correct place for the fix. Also, I do not know if there are other fields that might be **null** and would require similar changes.