### PR TITLE
Fix trying to establish a connection before a participant joins the call

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -1825,7 +1825,7 @@ public class CallActivity extends CallBaseActivity {
         peerConnectionWrapperList.remove(peerConnectionWrapper);
     }
 
-    private PeerConnectionWrapper getPeerConnectionWrapperForSessionId(String sessionId, String type) {
+    private PeerConnectionWrapper getPeerConnectionWrapperForSessionIdAndType(String sessionId, String type) {
         for (int i = 0; i < peerConnectionWrapperList.size(); i++) {
             if (peerConnectionWrapperList.get(i).getSessionId().equals(sessionId)
                 && peerConnectionWrapperList.get(i).getVideoStreamType().equals(type)) {
@@ -1840,7 +1840,7 @@ public class CallActivity extends CallBaseActivity {
                                                                                       String type,
                                                                                       boolean publisher) {
         PeerConnectionWrapper peerConnectionWrapper;
-        if ((peerConnectionWrapper = getPeerConnectionWrapperForSessionId(sessionId, type)) != null) {
+        if ((peerConnectionWrapper = getPeerConnectionWrapperForSessionIdAndType(sessionId, type)) != null) {
             return peerConnectionWrapper;
         } else {
             if (hasMCU && publisher) {

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -1544,8 +1544,8 @@ public class CallActivity extends CallBaseActivity {
     private void processMessage(NCSignalingMessage ncSignalingMessage) {
         if (ncSignalingMessage.getRoomType().equals("video") || ncSignalingMessage.getRoomType().equals("screen")) {
             PeerConnectionWrapper peerConnectionWrapper =
-                getPeerConnectionWrapperForSessionIdAndType(ncSignalingMessage.getFrom(),
-                                                            ncSignalingMessage.getRoomType(), false);
+                getOrCreatePeerConnectionWrapperForSessionIdAndType(ncSignalingMessage.getFrom(),
+                                                                    ncSignalingMessage.getRoomType(), false);
 
             String type = null;
             if (ncSignalingMessage.getPayload() != null && ncSignalingMessage.getPayload().getType() != null) {
@@ -1765,12 +1765,12 @@ public class CallActivity extends CallBaseActivity {
 
         if (hasMCU) {
             // Ensure that own publishing peer is set up.
-            getPeerConnectionWrapperForSessionIdAndType(webSocketClient.getSessionId(), VIDEO_STREAM_TYPE_VIDEO, true);
+            getOrCreatePeerConnectionWrapperForSessionIdAndType(webSocketClient.getSessionId(), VIDEO_STREAM_TYPE_VIDEO, true);
         }
 
         for (String sessionId : newSessions) {
             Log.d(TAG, "   newSession joined: " + sessionId);
-            getPeerConnectionWrapperForSessionIdAndType(sessionId, VIDEO_STREAM_TYPE_VIDEO, false);
+            getOrCreatePeerConnectionWrapperForSessionIdAndType(sessionId, VIDEO_STREAM_TYPE_VIDEO, false);
         }
 
         if (newSessions.size() > 0 && !currentCallStatus.equals(CallStatus.IN_CONVERSATION)) {
@@ -1836,9 +1836,9 @@ public class CallActivity extends CallBaseActivity {
         return null;
     }
 
-    private PeerConnectionWrapper getPeerConnectionWrapperForSessionIdAndType(String sessionId,
-                                                                              String type,
-                                                                              boolean publisher) {
+    private PeerConnectionWrapper getOrCreatePeerConnectionWrapperForSessionIdAndType(String sessionId,
+                                                                                      String type,
+                                                                                      boolean publisher) {
         PeerConnectionWrapper peerConnectionWrapper;
         if ((peerConnectionWrapper = getPeerConnectionWrapperForSessionId(sessionId, type)) != null) {
             return peerConnectionWrapper;
@@ -2181,7 +2181,7 @@ public class CallActivity extends CallBaseActivity {
         if (hasExternalSignalingServer) {
             nick = webSocketClient.getDisplayNameForSession(session);
         } else {
-            nick = getPeerConnectionWrapperForSessionIdAndType(session, videoStreamType, false).getNick();
+            nick = getOrCreatePeerConnectionWrapperForSessionIdAndType(session, videoStreamType, false).getNick();
         }
 
         String userId = "";


### PR DESCRIPTION
Fixes #1889

[When a new participant joins a call](https://github.com/nextcloud/talk-android/blob/1b30a6ef62dde17b9eb95a6867d03089a5b3dea9/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java#L1773) the Android app creates a connection with that participant. However, a connection with another participant was also created [when any signaling message was received from that participant and no connection existed yet](https://github.com/nextcloud/talk-android/blob/1b30a6ef62dde17b9eb95a6867d03089a5b3dea9/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java#L1547-L1548). In some cases a signaling message can be received from another participant before that participant has joined the call, so this caused a connection to be tried to be established with that participant.

For example, [the WebUI sends a `mute` or `unmute` signaling message whenever the media state changes](https://github.com/nextcloud/spreed/blob/7e75c34ff5e69029ddfc5c36dface7a28b9a2527/src/utils/webrtc/simplewebrtc/simplewebrtc.js#L186-L198). When a call is joined the audio or video can be automatically enabled, which is a state change and therefore triggers an `unmute` message. However, that message can be sent even before the participant finished joining the call, so this could cause the Android app to try to establish the connection with that participant before that participant is in the call.

To make things more interesting, this scenario would happen only if the WebUI joined another call before. If the call is joined for the first time in that session the objects that handle the media events would not be listening yet, and no message would be sent. However, after leaving a call the WebRTC related objects are kept, so the next time that a call is joined the event handlers will be already active and that will cause the message to be sent.

In any case, if the HPB is used establishing a connection with another participant requires requesting an offer from that participant. Since version 0.4.0 of nextcloud-spreed-signaling [a participant can request an offer from another participant only if both participants are in the same call](https://github.com/strukturag/nextcloud-spreed-signaling/commit/b3985914479db3958a898e25a79132c917bcea3b). Due to this, in the described scenario the Android app would request an offer when it received the `unmute` message from the WebUI, but as the WebUI did not join the call yet the HPB would reject the request and no connection would be established to receive media from the WebUI.

Is that all? Of course not, the fun has not ended yet! :-P

[When a participant leaves the call](https://github.com/nextcloud/talk-android/blob/1b30a6ef62dde17b9eb95a6867d03089a5b3dea9/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java#L1782) the connection with that participant is ended and removed. However, if a signaling message from that participant is received after that a connection will try to be established again. That would not be possible, but the connection object will still be there. If the participant then joins the call again no connection will try to be established, because there is already a connection object; the Android app will do nothing with the new participant, so there will not even be a message about not being able to request the offer.

This could happen, for example, if the participant in the WebUI leaves the call a few seconds after establishing the connection. [When a connection is established with another participant](https://github.com/nextcloud/spreed/blob/b5112441b3f69228a1726df2008fd496dfc94152/src/utils/webrtc/webrtc.js#L709) the WebUI sends a few signaling messages with the current media state, each one with a longer timeout (the last one is sent 30 seconds after joining). If the participant leaves the call roughly at the same time that a signaling message is being sent the signaling message could be received and processed by the Android app once it ended and removed the connection, thus creating a new one.

To solve all that now the Android app only creates a connection [when the participant list changes](https://github.com/nextcloud/talk-android/blob/1b30a6ef62dde17b9eb95a6867d03089a5b3dea9/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java#L1773) or when receiving an offer (as without HPB the other participant could send an offer before this participant _noticed_ that she is in the call), and ignores any other signaling message that does not belong to an already established connection. [This is the same done by the WebUI](https://github.com/nextcloud/spreed/blob/7e75c34ff5e69029ddfc5c36dface7a28b9a2527/src/utils/webrtc/simplewebrtc/simplewebrtc.js#L82-L104). The iOS app also creates the connection [when receiving answers or candidates](https://github.com/nextcloud/talk-ios/blob/c377002cb56b1bb01881eb3c1bf40f0c60168788/NextcloudTalk/NCCallController.m#L766-L782); that should not be necessary, unless I am missing something, of course :-)

As a note the new code in `processMessage` is not exactly the prettiest I have ever written :-P , but I did not find a better way to adjust the changes to the existing code style :shrug:

Finally, note that trying to periodically request the offer again until a connection was established would not be a real fix. It would have been a workaround and, what is worse, it would have masked the real issue. Despite that it should be implemented anyway, as it would make calls more robust. But something for later ;-)

**Reviewers:** I have tested this only with HPB. It should not cause any regression without HPB, but please test it too! :-)

The reproduction steps below only cover the first scenario, as I had not found a reliable way to reproduce the race condition from the second scenario.

## How to test

- Setup the HPB
- Add a log to `processMessage` to know if the issue would have happened without this pull request, something like `if (!type.equals("offer") && peerConnectionWrapper == null) { Log.d(TAG, "A connection would have been created"); }`
- Start a call in the WebUI
- Leave the call
- Start a call in the Android app
- In the WebUI join the call; in the device checker shown before joining the call enable audio and/or video

### Result with this pull request

The connection with the WebUI participant is established from the Android app

### Result without this pull request

The connection with the WebUI participant is not established from the Android app
