### PR TITLE
Fix call flags in video calls

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -1349,7 +1349,8 @@ public class CallActivity extends CallBaseActivity {
         if (isVoiceOnlyCall) {
             inCallFlag = Participant.InCallFlags.IN_CALL + Participant.InCallFlags.WITH_AUDIO;
         } else {
-            inCallFlag = Participant.InCallFlags.IN_CALL + Participant.InCallFlags.WITH_VIDEO;
+            inCallFlag =
+                Participant.InCallFlags.IN_CALL + Participant.InCallFlags.WITH_AUDIO + Participant.InCallFlags.WITH_VIDEO;
         }
 
         int apiVersion = ApiUtils.getCallApiVersion(conversationUser, new int[]{ApiUtils.APIv4, 1});


### PR DESCRIPTION
[The call flags describe the streams provided by the client](https://github.com/nextcloud/spreed/blob/5278e716c7e45c0751257cc0b14db1fbe344f40b/docs/constants.md#participant-in-call-flag), so in a video call both audio and video are provided, not just video.

Note that as publishing permissions are currently not implemented in the Android app the provided flags do not take into account the available permissions. Nevertheless, [the server restricts the flags based on the permissions](https://github.com/nextcloud/spreed/blob/c07251f0c67d3c02debe1f6dbe0e12ee3fe9f99a/lib/Service/ParticipantService.php#L1003-L1009), so the other participants would see the appropriate flags. In the future it would be better to send the right flags directly from the Android app.

Similarly, for now, it is just assumed that both audio and video tracks will be provided by the Android app, but the flags should reflect the actually available tracks (for example, if it was not possible to get a video track for some reason the call flags should not include `WITH_VIDEO`).

Independently of all that I would suggest to refactor `IN_CALL + WITH_AUDIO`/`IN_CALL + WITH_AUDIO + WITH_VIDEO` to `IN_CALL | WITH_AUDIO`/`IN_CALL | WITH_AUDIO | WITH_VIDEO`, as in my opinion that would reflect better the bitwise nature of the flags. But as it is just a matter of personal preference I have not done that ;-)

The test described below is only meant to show that the flags are now properly adjusted. Nevertheless, please note that it also shows other unrelated issues caused by not respecting the publishing permissions; please ignore that :-) (but you can use the scenario for future testing once permissions are supported ;-) )
- If the HPB is not used the video from the Android app will be visible by other participants (if they join, that is not included in the steps :-P ), as the clients currently do not filter the received tracks based on the permissions, it is assumed that the other clients will send the right ones.
- If the HPB is used the Android app will not be able to establish a connection with the HPB, because the HPB does not make that assumption and rejects the offers if they do not match the available permissions ;-)

## How to test

- In a browser, open a conversation as a moderator
- Revoke video permissions from a participant, but leave audio permissions
- Open the network tab in the developer tools
- In the Android app, join the conversation as that participant
- Start a video call
- In the browser, in the network tab, check the last response of getting the participants list

### Result with this pull request

According to the call flags, the participant of the Android app is in the call with an audio stream.

### Result without this pull request

According to the call flags, the participant of the Android app is in the call but has no audio nor video stream.
