### PR TITLE
Add empty view visuals part to shared items

### DIFF
--- a/app/src/main/res/layout/activity_shared_items.xml
+++ b/app/src/main/res/layout/activity_shared_items.xml
@@ -56,6 +56,11 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
+    <include
+        android:id="+id/emptyContainer"
+        layout="@layout/empty_list"
+        android:visibility="gone" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/image_recycler"
         android:layout_width="match_parent"


### PR DESCRIPTION
Resolves #1984 

@timkrueger maybe you can pick this one up since this would also add the first scenario where the new patetrn has to handle general "state changes" as in 
* loading
* success (display the data)
* error

Before the new pattern in place we i.e. did it like this in here https://github.com/nextcloud/talk-android/blob/master/app/src/main/java/com/nextcloud/talk/controllers/ProfileController.kt#L247-L253

So now I guess we need to emit such events so the UI can be changed to hide&/show certain parts, maybe @AlvaroBrey or you have an idea how that would need to be done. Given the current implementation I would expect the view model to emit the state and the activity to handle the show/hide? Not sure though. Also I believe that at some point in the near future we would also need to move most of the activity to a fragment but to be discussed I guess.

Signed-off-by: Andy Scherzinger <info@andy-scherzinger.de>