### PR TITLE
Feature/1948/respect chat permission

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -2492,6 +2492,7 @@ class ChatController(args: Bundle) :
                 currentConversation,
                 chatMessage,
                 conversationUser,
+                hasChatPermission,
                 ncApi!!
             ).show()
         }
@@ -2519,6 +2520,7 @@ class ChatController(args: Bundle) :
                     conversationUser,
                     currentConversation,
                     isShowMessageDeletionButton(message),
+                    hasChatPermission,
                     ncApi!!
                 ).show()
             }

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -346,7 +346,9 @@ class ChatController(args: Bundle) :
                         setTitle()
 
                         hasChatPermission =
-                            AttendeePermissionsUtil(currentConversation!!.permissions).hasChatPermission(conversationUser)
+                            AttendeePermissionsUtil(currentConversation!!.permissions).hasChatPermission(
+                                conversationUser
+                            )
 
                         try {
                             setupMentionAutocomplete()
@@ -1458,6 +1460,12 @@ class ChatController(args: Bundle) :
 
     private fun uploadFiles(files: MutableList<String>, isVoiceMessage: Boolean) {
         var metaData = ""
+
+        if (!hasChatPermission) {
+            Log.e(TAG, "uploading file(s) is forbidden because of missing attendee permissions")
+            return
+        }
+
         if (isVoiceMessage) {
             metaData = VOICE_MESSAGE_META_DATA
         }

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -147,6 +147,7 @@ import com.nextcloud.talk.ui.dialog.ShowReactionsDialog
 import com.nextcloud.talk.ui.recyclerview.MessageSwipeActions
 import com.nextcloud.talk.ui.recyclerview.MessageSwipeCallback
 import com.nextcloud.talk.utils.ApiUtils
+import com.nextcloud.talk.utils.AttendeePermissionsUtil
 import com.nextcloud.talk.utils.ConductorRemapping
 import com.nextcloud.talk.utils.ConductorRemapping.remapChatController
 import com.nextcloud.talk.utils.ContactUtils
@@ -2830,6 +2831,8 @@ class ChatController(args: Bundle) :
         if (!isUserAllowedByPrivileges) return false
 
         if (!CapabilitiesUtil.hasSpreedFeatureCapability(conversationUser, "delete-messages")) return false
+
+        if (AttendeePermissionsUtil(currentConversation!!.permissions).canPostChatShareItemsDoReaction(conversationUser)) return true
 
         return true
     }

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -1462,7 +1462,7 @@ class ChatController(args: Bundle) :
         var metaData = ""
 
         if (!hasChatPermission) {
-            Log.e(TAG, "uploading file(s) is forbidden because of missing attendee permissions")
+            Log.w(TAG, "uploading file(s) is forbidden because of missing attendee permissions")
             return
         }
 
@@ -2544,7 +2544,7 @@ class ChatController(args: Bundle) :
 
     fun deleteMessage(message: IMessage?) {
         if (!hasChatPermission) {
-            Log.e(
+            Log.w(
                 TAG,
                 "Deletion of message is skipped because of restrictions by permissions. " +
                     "This method should not have been called!"

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -587,7 +587,7 @@ class ChatController(args: Bundle) :
             }
         }
 
-        if (context != null) {
+        if (context != null && hasChatPermission && !isReadOnlyConversation()) {
             val messageSwipeController = MessageSwipeCallback(
                 activity!!,
                 object : MessageSwipeActions {

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -1177,9 +1177,9 @@ class ChatController(args: Bundle) :
 
     private fun checkShowMessageInputView() {
         if (isAlive()) {
-            if (isReadOnlyConversation()
-                || shouldShowLobby()
-                || !hasChatPermission
+            if (isReadOnlyConversation() ||
+                shouldShowLobby() ||
+                !hasChatPermission
             ) {
                 binding.messageInputView.visibility = View.GONE
             } else {
@@ -2534,7 +2534,8 @@ class ChatController(args: Bundle) :
     fun deleteMessage(message: IMessage?) {
         if (!hasChatPermission) {
             Log.e(
-                TAG, "Deletion of message is skipped because of restrictions by permissions. " +
+                TAG,
+                "Deletion of message is skipped because of restrictions by permissions. " +
                     "This method should not have been called!"
             )
             Toast.makeText(context, R.string.nc_common_error_sorry, Toast.LENGTH_LONG).show()

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -343,8 +343,11 @@ class ChatController(args: Bundle) :
                                 " sessionId: " + currentConversation?.sessionId
                         )
                         loadAvatarForStatusBar()
-
                         setTitle()
+
+                        hasChatPermission =
+                            AttendeePermissionsUtil(currentConversation!!.permissions).hasChatPermission(conversationUser)
+
                         try {
                             setupMentionAutocomplete()
                             checkShowCallButtons()

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
@@ -930,7 +930,8 @@ public class ConversationsListController extends BaseController implements Searc
                 .setNegativeButton(R.string.nc_no, new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        Log.d(TAG, "sharing files aborted");
+                        Log.d(TAG, "sharing files aborted, going back to share-to screen");
+                        showShareToScreen = true;
                     }
                 })
                 .show();

--- a/app/src/main/java/com/nextcloud/talk/models/json/conversations/Conversation.java
+++ b/app/src/main/java/com/nextcloud/talk/models/json/conversations/Conversation.java
@@ -111,6 +111,19 @@ public class Conversation {
     @JsonField(name = "notificationCalls")
     public Integer notificationCalls;
 
+    @JsonField(name = "permissions")
+    public int permissions;
+
+    @JsonField(name = "attendeePermissions")
+    public int attendeePermissions;
+
+    @JsonField(name = "callPermissions")
+    public int callPermissions;
+
+    @JsonField(name = "defaultPermissions")
+    public int defaultPermissions;
+
+
     public boolean isPublic() {
         return (ConversationType.ROOM_PUBLIC_CALL.equals(type));
     }

--- a/app/src/main/java/com/nextcloud/talk/models/json/conversations/Conversation.java
+++ b/app/src/main/java/com/nextcloud/talk/models/json/conversations/Conversation.java
@@ -114,16 +114,6 @@ public class Conversation {
     @JsonField(name = "permissions")
     public int permissions;
 
-    @JsonField(name = "attendeePermissions")
-    public int attendeePermissions;
-
-    @JsonField(name = "callPermissions")
-    public int callPermissions;
-
-    @JsonField(name = "defaultPermissions")
-    public int defaultPermissions;
-
-
     public boolean isPublic() {
         return (ConversationType.ROOM_PUBLIC_CALL.equals(type));
     }
@@ -294,6 +284,10 @@ public class Conversation {
 
     public Integer getNotificationCalls() { return notificationCalls; }
 
+    public int getPermissions() {
+        return permissions;
+    }
+
     public void setRoomId(String roomId) {
         this.roomId = roomId;
     }
@@ -411,6 +405,9 @@ public class Conversation {
         this.unreadMentionDirect = unreadMentionDirect;
     }
 
+    public void setPermissions(int permissions) {
+        this.permissions = permissions;
+    }
 
     @Override
     public boolean equals(Object o) {
@@ -513,6 +510,9 @@ public class Conversation {
         if (!Objects.equals(notificationCalls, that.notificationCalls)) {
             return false;
         }
+        if (permissions != that.permissions) {
+            return false;
+        }
         return Objects.equals(canDeleteConversation, that.canDeleteConversation);
     }
 
@@ -553,6 +553,7 @@ public class Conversation {
         result = 31 * result + (canLeaveConversation != null ? canLeaveConversation.hashCode() : 0);
         result = 31 * result + (canDeleteConversation != null ? canDeleteConversation.hashCode() : 0);
         result = 31 * result + (notificationCalls != null ? notificationCalls.hashCode() : 0);
+        result = 31 * result + permissions;
         return result;
     }
 
@@ -590,6 +591,7 @@ public class Conversation {
                 ", canLeaveConversation=" + canLeaveConversation +
                 ", canDeleteConversation=" + canDeleteConversation +
                 ", notificationCalls=" + notificationCalls +
+                ", permissions=" + permissions +
                 '}';
     }
 

--- a/app/src/main/java/com/nextcloud/talk/models/json/participants/Participant.java
+++ b/app/src/main/java/com/nextcloud/talk/models/json/participants/Participant.java
@@ -87,6 +87,12 @@ public class Participant {
     @JsonField(name = "statusMessage")
     public String statusMessage;
 
+    @JsonField(name = "permissions")
+    public int permissions;
+
+    @JsonField(name = "attendeePermissions")
+    public int attendeePermissions;
+
     public String source;
 
     public boolean selected;

--- a/app/src/main/java/com/nextcloud/talk/models/json/participants/Participant.java
+++ b/app/src/main/java/com/nextcloud/talk/models/json/participants/Participant.java
@@ -87,12 +87,6 @@ public class Participant {
     @JsonField(name = "statusMessage")
     public String statusMessage;
 
-    @JsonField(name = "permissions")
-    public int permissions;
-
-    @JsonField(name = "attendeePermissions")
-    public int attendeePermissions;
-
     public String source;
 
     public boolean selected;

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
@@ -83,8 +83,7 @@ class MessageActionsDialog(
         )
         initMenuDeleteMessage(showMessageDeletionButton)
         initMenuForwardMessage(
-            hasChatPermission &&
-                ChatMessage.MessageType.REGULAR_TEXT_MESSAGE == message.getMessageType() &&
+            ChatMessage.MessageType.REGULAR_TEXT_MESSAGE == message.getMessageType() &&
                 !(message.isDeletedCommentMessage || message.isDeleted)
         )
         initMenuMarkAsUnread(

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
@@ -74,7 +74,7 @@ class MessageActionsDialog(
 
         initEmojiBar(hasChatPermission)
         initMenuItemCopy(!message.isDeleted)
-        initMenuReplyToMessage(message.replyable)
+        initMenuReplyToMessage(message.replyable && hasChatPermission)
         initMenuReplyPrivately(
             message.replyable &&
                 hasUserId(user) &&
@@ -83,7 +83,8 @@ class MessageActionsDialog(
         )
         initMenuDeleteMessage(showMessageDeletionButton)
         initMenuForwardMessage(
-            ChatMessage.MessageType.REGULAR_TEXT_MESSAGE == message.getMessageType() &&
+            hasChatPermission &&
+                ChatMessage.MessageType.REGULAR_TEXT_MESSAGE == message.getMessageType() &&
                 !(message.isDeletedCommentMessage || message.isDeleted)
         )
         initMenuMarkAsUnread(

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
@@ -58,6 +58,7 @@ class MessageActionsDialog(
     private val user: UserEntity?,
     private val currentConversation: Conversation?,
     private val showMessageDeletionButton: Boolean,
+    private val hasChatPermission: Boolean,
     private val ncApi: NcApi
 ) : BottomSheetDialog(chatController.activity!!, R.style.BottomSheetDialogThemeNoFloating) {
 
@@ -71,7 +72,7 @@ class MessageActionsDialog(
         setContentView(dialogMessageActionsBinding.root)
         window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
 
-        initEmojiBar()
+        initEmojiBar(hasChatPermission)
         initMenuItemCopy(!message.isDeleted)
         initMenuReplyToMessage(message.replyable)
         initMenuReplyPrivately(
@@ -160,8 +161,9 @@ class MessageActionsDialog(
         }
     }
 
-    private fun initEmojiBar() {
-        if (CapabilitiesUtil.hasSpreedFeatureCapability(user, "reactions") &&
+    private fun initEmojiBar(hasChatPermission: Boolean) {
+        if (hasChatPermission &&
+            CapabilitiesUtil.hasSpreedFeatureCapability(user, "reactions") &&
             Conversation.ConversationReadOnlyState.CONVERSATION_READ_ONLY !=
             currentConversation?.conversationReadOnlyState &&
             isReactableMessageType(message)

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/ShowReactionsDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/ShowReactionsDialog.kt
@@ -63,6 +63,7 @@ class ShowReactionsDialog(
     private val currentConversation: Conversation?,
     private val chatMessage: ChatMessage,
     private val userEntity: UserEntity?,
+    private val hasChatPermission: Boolean,
     private val ncApi: NcApi
 ) : BottomSheetDialog(activity), ReactionItemClickListener {
 
@@ -183,7 +184,7 @@ class ShowReactionsDialog(
     }
 
     override fun onClick(reactionItem: ReactionItem) {
-        if (reactionItem.reactionVoter.actorId?.equals(userEntity?.userId) == true) {
+        if (hasChatPermission && reactionItem.reactionVoter.actorId?.equals(userEntity?.userId) == true) {
             deleteReaction(chatMessage, reactionItem.reaction!!)
             dismiss()
         }

--- a/app/src/main/java/com/nextcloud/talk/utils/AttendeePermissionsUtil.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/AttendeePermissionsUtil.kt
@@ -1,3 +1,23 @@
+/*
+ * Nextcloud Talk application
+ *
+ * @author Marcel Hibbe
+ * Copyright (C) 2022 Marcel Hibbe <dev@mhibbe.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.nextcloud.talk.utils
 
 import com.nextcloud.talk.models.database.CapabilitiesUtil

--- a/app/src/main/java/com/nextcloud/talk/utils/AttendeePermissionsUtil.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/AttendeePermissionsUtil.kt
@@ -34,7 +34,7 @@ class AttendeePermissionsUtil(flag: Int) {
         if (CapabilitiesUtil.hasSpreedFeatureCapability(user, "chat-permission")) {
             return canPostChatShareItemsDoReaction
         }
-        // if capability is not available the spreed version doesn't support to restrict this
+        // if capability is not available then the spreed version doesn't support to restrict this
         return true
     }
 

--- a/app/src/main/java/com/nextcloud/talk/utils/AttendeePermissionsUtil.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/AttendeePermissionsUtil.kt
@@ -1,0 +1,42 @@
+package com.nextcloud.talk.utils
+
+/**
+ * see https://nextcloud-talk.readthedocs.io/en/latest/constants/#attendee-permissions
+ */
+class AttendeePermissionsUtil(flag: Int) {
+
+    var isDefault: Boolean = false
+    var isCustom: Boolean = false
+    var canStartCall: Boolean = false
+    var canJoinCall: Boolean = false
+    var canIgnoreLobby: Boolean = false
+    var canPublishAudio: Boolean = false
+    var canPublishVideo: Boolean = false
+    var canPublishScreen: Boolean = false
+    var canPostChatShareItemsDoReaction: Boolean = false
+
+    init {
+        isDefault = (flag and DEFAULT) == DEFAULT
+        isCustom = (flag and CUSTOM) == CUSTOM
+        canStartCall = (flag and START_CALL) == START_CALL
+        canJoinCall = (flag and JOIN_CALL) == JOIN_CALL
+        canIgnoreLobby = (flag and CAN_IGNORE_LOBBY) == CAN_IGNORE_LOBBY
+        canPublishAudio = (flag and PUBLISH_AUDIO) == PUBLISH_AUDIO
+        canPublishVideo = (flag and PUBLISH_VIDEO) == PUBLISH_VIDEO
+        canPublishScreen = (flag and PUBLISH_SCREEN) == PUBLISH_SCREEN
+        canPostChatShareItemsDoReaction =
+            (flag and POST_CHAT_SHARE_ITEMS_DO_REACTIONS) == POST_CHAT_SHARE_ITEMS_DO_REACTIONS
+    }
+
+    companion object {
+        const val DEFAULT = 0
+        const val CUSTOM = 1
+        const val START_CALL = 2
+        const val JOIN_CALL = 4
+        const val CAN_IGNORE_LOBBY = 8
+        const val PUBLISH_AUDIO = 16
+        const val PUBLISH_VIDEO = 32
+        const val PUBLISH_SCREEN = 64
+        const val POST_CHAT_SHARE_ITEMS_DO_REACTIONS = 128
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/utils/AttendeePermissionsUtil.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/AttendeePermissionsUtil.kt
@@ -15,7 +15,7 @@ class AttendeePermissionsUtil(flag: Int) {
     var canPublishAudio: Boolean = false
     var canPublishVideo: Boolean = false
     var canPublishScreen: Boolean = false
-    private var canPostChatShareItemsDoReaction: Boolean = false
+    private var hasChatPermission: Boolean = false
 
     init {
         isDefault = (flag and DEFAULT) == DEFAULT
@@ -26,13 +26,12 @@ class AttendeePermissionsUtil(flag: Int) {
         canPublishAudio = (flag and PUBLISH_AUDIO) == PUBLISH_AUDIO
         canPublishVideo = (flag and PUBLISH_VIDEO) == PUBLISH_VIDEO
         canPublishScreen = (flag and PUBLISH_SCREEN) == PUBLISH_SCREEN
-        canPostChatShareItemsDoReaction =
-            (flag and POST_CHAT_SHARE_ITEMS_DO_REACTIONS) == POST_CHAT_SHARE_ITEMS_DO_REACTIONS
+        hasChatPermission = (flag and CHAT) == CHAT
     }
 
-    fun canPostChatShareItemsDoReaction(user: UserEntity): Boolean {
+    fun hasChatPermission(user: UserEntity): Boolean {
         if (CapabilitiesUtil.hasSpreedFeatureCapability(user, "chat-permission")) {
-            return canPostChatShareItemsDoReaction
+            return hasChatPermission
         }
         // if capability is not available then the spreed version doesn't support to restrict this
         return true
@@ -48,6 +47,6 @@ class AttendeePermissionsUtil(flag: Int) {
         const val PUBLISH_AUDIO = 16
         const val PUBLISH_VIDEO = 32
         const val PUBLISH_SCREEN = 64
-        const val POST_CHAT_SHARE_ITEMS_DO_REACTIONS = 128
+        const val CHAT = 128
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/utils/AttendeePermissionsUtil.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/AttendeePermissionsUtil.kt
@@ -1,10 +1,12 @@
 package com.nextcloud.talk.utils
 
+import com.nextcloud.talk.models.database.CapabilitiesUtil
+import com.nextcloud.talk.models.database.UserEntity
+
 /**
  * see https://nextcloud-talk.readthedocs.io/en/latest/constants/#attendee-permissions
  */
 class AttendeePermissionsUtil(flag: Int) {
-
     var isDefault: Boolean = false
     var isCustom: Boolean = false
     var canStartCall: Boolean = false
@@ -13,7 +15,7 @@ class AttendeePermissionsUtil(flag: Int) {
     var canPublishAudio: Boolean = false
     var canPublishVideo: Boolean = false
     var canPublishScreen: Boolean = false
-    var canPostChatShareItemsDoReaction: Boolean = false
+    private var canPostChatShareItemsDoReaction: Boolean = false
 
     init {
         isDefault = (flag and DEFAULT) == DEFAULT
@@ -28,7 +30,16 @@ class AttendeePermissionsUtil(flag: Int) {
             (flag and POST_CHAT_SHARE_ITEMS_DO_REACTIONS) == POST_CHAT_SHARE_ITEMS_DO_REACTIONS
     }
 
+    fun canPostChatShareItemsDoReaction(user: UserEntity): Boolean {
+        if (CapabilitiesUtil.hasSpreedFeatureCapability(user, "chat-permission")) {
+            return canPostChatShareItemsDoReaction
+        }
+        // if capability is not available the spreed version doesn't support to restrict this
+        return true
+    }
+
     companion object {
+        val TAG = AttendeePermissionsUtil::class.simpleName
         const val DEFAULT = 0
         const val CUSTOM = 1
         const val START_CALL = 2

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -392,6 +392,8 @@
     <string name="send_to_three_dots">Send to …</string>
     <string name="read_storage_no_permission">Sharing files from storage is not possible without permissions</string>
     <string name="open_in_files_app">Open in Files app</string>
+    <string name="send_to_forbidden">You are not allowed to share content to this chat</string>
+
 
     <!-- Upload -->
     <string name="nc_add_file">Add to conversation</string>

--- a/app/src/test/java/com/nextcloud/talk/utils/AttendeePermissionsUtilTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/utils/AttendeePermissionsUtilTest.kt
@@ -22,6 +22,7 @@ class AttendeePermissionsUtilTest : TestCase() {
         assertFalse(attendeePermissionsUtil.canIgnoreLobby)
         assertFalse(attendeePermissionsUtil.canPublishAudio)
         assertFalse(attendeePermissionsUtil.canPublishVideo)
-        assertFalse(attendeePermissionsUtil.canPostChatShareItemsDoReaction)
+
+        // canPostChatShareItemsDoReaction() is not possible to test because userEntity is necessary
     }
 }

--- a/app/src/test/java/com/nextcloud/talk/utils/AttendeePermissionsUtilTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/utils/AttendeePermissionsUtilTest.kt
@@ -1,0 +1,27 @@
+package com.nextcloud.talk.utils
+
+import junit.framework.TestCase
+import org.junit.Test
+
+class AttendeePermissionsUtilTest : TestCase() {
+
+    @Test
+    fun test_areFlagsSet() {
+        val attendeePermissionsUtil = AttendeePermissionsUtil(
+            AttendeePermissionsUtil.PUBLISH_SCREEN
+            or AttendeePermissionsUtil.JOIN_CALL
+            or AttendeePermissionsUtil.DEFAULT)
+
+        assert(attendeePermissionsUtil.canPublishScreen)
+        assert(attendeePermissionsUtil.canJoinCall)
+        assert(attendeePermissionsUtil.isDefault) // if AttendeePermissionsUtil.DEFAULT is not set with setFlags and
+        // checked with assertFalse, the logic fails somehow?!
+
+        assertFalse(attendeePermissionsUtil.isCustom)
+        assertFalse(attendeePermissionsUtil.canStartCall)
+        assertFalse(attendeePermissionsUtil.canIgnoreLobby)
+        assertFalse(attendeePermissionsUtil.canPublishAudio)
+        assertFalse(attendeePermissionsUtil.canPublishVideo)
+        assertFalse(attendeePermissionsUtil.canPostChatShareItemsDoReaction)
+    }
+}

--- a/app/src/test/java/com/nextcloud/talk/utils/AttendeePermissionsUtilTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/utils/AttendeePermissionsUtilTest.kt
@@ -1,3 +1,23 @@
+/*
+ * Nextcloud Talk application
+ *
+ * @author Marcel Hibbe
+ * Copyright (C) 2022 Marcel Hibbe <dev@mhibbe.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.nextcloud.talk.utils
 
 import junit.framework.TestCase
@@ -7,22 +27,21 @@ class AttendeePermissionsUtilTest : TestCase() {
 
     @Test
     fun test_areFlagsSet() {
-        val attendeePermissionsUtil = AttendeePermissionsUtil(
-            AttendeePermissionsUtil.PUBLISH_SCREEN
-            or AttendeePermissionsUtil.JOIN_CALL
-            or AttendeePermissionsUtil.DEFAULT)
+        val attendeePermissionsUtil =
+            AttendeePermissionsUtil(
+                AttendeePermissionsUtil.PUBLISH_SCREEN or
+                    AttendeePermissionsUtil.JOIN_CALL or
+                    AttendeePermissionsUtil.DEFAULT
+            )
 
         assert(attendeePermissionsUtil.canPublishScreen)
         assert(attendeePermissionsUtil.canJoinCall)
-        assert(attendeePermissionsUtil.isDefault) // if AttendeePermissionsUtil.DEFAULT is not set with setFlags and
-        // checked with assertFalse, the logic fails somehow?!
+        assert(attendeePermissionsUtil.isDefault)
 
         assertFalse(attendeePermissionsUtil.isCustom)
         assertFalse(attendeePermissionsUtil.canStartCall)
         assertFalse(attendeePermissionsUtil.canIgnoreLobby)
         assertFalse(attendeePermissionsUtil.canPublishAudio)
         assertFalse(attendeePermissionsUtil.canPublishVideo)
-
-        // hasChatPermission() is not possible to test because userEntity is necessary
     }
 }

--- a/app/src/test/java/com/nextcloud/talk/utils/AttendeePermissionsUtilTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/utils/AttendeePermissionsUtilTest.kt
@@ -23,6 +23,6 @@ class AttendeePermissionsUtilTest : TestCase() {
         assertFalse(attendeePermissionsUtil.canPublishAudio)
         assertFalse(attendeePermissionsUtil.canPublishVideo)
 
-        // canPostChatShareItemsDoReaction() is not possible to test because userEntity is necessary
+        // hasChatPermission() is not possible to test because userEntity is necessary
     }
 }


### PR DESCRIPTION
resolve #1948

new permission 128:
https://nextcloud-talk.readthedocs.io/en/latest/constants/#attendee-permissions

# how to test
post content to chat (post chat message, share items, do reactions). If permission is missing, the views/buttons in the android app to trigger these actions should be hidden.

- older server without chat-permission capability: posting of content should just be allowed
- server with chat-permission capability: in the participants list on the right, select to edit the permissions and enable/disable "can send messages/reactions"
![grafik](https://user-images.githubusercontent.com/2932790/168041490-e5dd7087-ce3b-43a0-8f39-e31454d68f99.png)
- enable/disable permission for all participants
![grafik](https://user-images.githubusercontent.com/2932790/168044500-9e2a776b-b9d5-4994-b602-0a97b66724ff.png)


# remaining todos:
- [x] restrict "sendTo"
   - [x] double check just before sending file
- [x] move permission check from initialisation of ChatController back to the places where it's needed? -> on the fly check when permissions were changed while being in chat
   - done by updating this in getRoomInfo 
- [x] forwarding messages to this chat must be forbidden