### PR TITLE
Reply from notification - initial error handling

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/receivers/DirectReplyReceiver.kt
+++ b/app/src/main/java/com/nextcloud/talk/receivers/DirectReplyReceiver.kt
@@ -128,9 +128,7 @@ class DirectReplyReceiver : BroadcastReceiver() {
     private fun informReplyFailed() {
         val errorColor = ForegroundColorSpan(context.resources.getColor(R.color.medium_emphasis_text, context.theme))
         val errorMessageHeader = context.resources.getString(R.string.nc_message_failed_to_send)
-        val errorMessage = SpannableStringBuilder()
-            .append("$errorMessageHeader\n$replyMessage", errorColor, 0)
-            // .append("\n$replyMessage")
+        val errorMessage = SpannableStringBuilder().append("$errorMessageHeader\n$replyMessage", errorColor, 0)
         appendMessageToNotification(errorMessage)
     }
 

--- a/app/src/main/java/com/nextcloud/talk/receivers/DirectReplyReceiver.kt
+++ b/app/src/main/java/com/nextcloud/talk/receivers/DirectReplyReceiver.kt
@@ -26,12 +26,15 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.text.Html
+import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.Person
 import androidx.core.app.RemoteInput
 import autodagger.AutoInjector
+import com.nextcloud.talk.R
 import com.nextcloud.talk.api.NcApi
 import com.nextcloud.talk.application.NextcloudTalkApplication
 import com.nextcloud.talk.models.database.UserEntity
@@ -103,9 +106,10 @@ class DirectReplyReceiver : BroadcastReceiver() {
                     confirmReplySent()
                 }
 
+                @RequiresApi(Build.VERSION_CODES.N)
                 override fun onError(e: Throwable) {
-                    // TODO - inform the user that sending of the reply failed
-                    // unused atm
+                    Log.e(TAG, "Failed to send reply", e)
+                    informReplyFailed()
                 }
 
                 override fun onComplete() {
@@ -115,13 +119,30 @@ class DirectReplyReceiver : BroadcastReceiver() {
     }
 
     @RequiresApi(Build.VERSION_CODES.N)
+    private fun confirmReplySent() {
+        appendMessageToNotification(replyMessage!!)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.N)
+    private fun informReplyFailed() {
+        val errorMessage =
+            Html.fromHtml(
+                "<font color='red'><em>" +
+                    context.resources.getString(R.string.nc_message_failed_to_send) +
+                    "</em></font>",
+                Html.FROM_HTML_MODE_COMPACT
+            )
+        appendMessageToNotification(errorMessage)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.N)
     private fun findActiveNotification(notificationId: Int): Notification? {
         val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         return notificationManager.activeNotifications.find { it.id == notificationId }?.notification
     }
 
     @RequiresApi(Build.VERSION_CODES.N)
-    private fun confirmReplySent() {
+    private fun appendMessageToNotification(reply: CharSequence) {
         // Implementation inspired by the SO question and article below:
         // https://stackoverflow.com/questions/51549456/android-o-notification-for-direct-reply-message
         // https://medium.com/@sidorovroman3/android-how-to-use-messagingstyle-for-notifications-without-caching-messages-c414ef2b816c
@@ -145,7 +166,7 @@ class DirectReplyReceiver : BroadcastReceiver() {
             .setName(currentUser.displayName)
             .setIcon(NotificationUtils.loadAvatarSync(avatarUrl))
             .build()
-        val message = NotificationCompat.MessagingStyle.Message(replyMessage, System.currentTimeMillis(), me)
+        val message = NotificationCompat.MessagingStyle.Message(reply, System.currentTimeMillis(), me)
         previousStyle?.addMessage(message)
 
         // Set the updated style
@@ -153,5 +174,9 @@ class DirectReplyReceiver : BroadcastReceiver() {
 
         // Update the active notification.
         NotificationManagerCompat.from(context).notify(systemNotificationId!!, previousBuilder.build())
+    }
+
+    companion object {
+        const val TAG = "DirectReplyReceiver"
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/receivers/DirectReplyReceiver.kt
+++ b/app/src/main/java/com/nextcloud/talk/receivers/DirectReplyReceiver.kt
@@ -26,7 +26,8 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.os.Build
-import android.text.Html
+import android.text.SpannableStringBuilder
+import android.text.style.ForegroundColorSpan
 import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
@@ -125,13 +126,11 @@ class DirectReplyReceiver : BroadcastReceiver() {
 
     @RequiresApi(Build.VERSION_CODES.N)
     private fun informReplyFailed() {
-        val errorMessage =
-            Html.fromHtml(
-                "<font color='red'><em>" +
-                    context.resources.getString(R.string.nc_message_failed_to_send) +
-                    "</em></font>",
-                Html.FROM_HTML_MODE_COMPACT
-            )
+        val errorColor = ForegroundColorSpan(context.resources.getColor(R.color.medium_emphasis_text, context.theme))
+        val errorMessageHeader = context.resources.getString(R.string.nc_message_failed_to_send)
+        val errorMessage = SpannableStringBuilder()
+            .append("$errorMessageHeader\n$replyMessage", errorColor, 0)
+            // .append("\n$replyMessage")
         appendMessageToNotification(errorMessage)
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -325,7 +325,7 @@
     <string name="nc_formatted_message_you">You: %1$s</string>
     <string name="nc_message_read">Message read</string>
     <string name="nc_message_sent">Message sent</string>
-    <string name="nc_message_failed_to_send">Failed to send message</string>
+    <string name="nc_message_failed_to_send">Failed to send message:</string>
     <string name="nc_remote_audio_off">Remote audio off</string>
     <string name="nc_add_attachment">Add attachment</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -325,6 +325,7 @@
     <string name="nc_formatted_message_you">You: %1$s</string>
     <string name="nc_message_read">Message read</string>
     <string name="nc_message_sent">Message sent</string>
+    <string name="nc_message_failed_to_send">Failed to send message</string>
     <string name="nc_remote_audio_off">Remote audio off</string>
     <string name="nc_add_attachment">Add attachment</string>
 


### PR DESCRIPTION
Follow-up to #1923.

I have implemented a very basic notification when the reply cannot be sent. This is how it looks like at the moment.
![obraz](https://user-images.githubusercontent.com/8277636/168449087-36fd4e8d-b785-423b-9306-784cdd14abc8.png)

The way this works and looks should probably be aligned with #1259.

Any suggestions?