### PR TITLE
avoid NPE when initializing chat permission

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -312,9 +312,6 @@ class ChatController(args: Bundle) :
         }
 
         this.voiceOnly = args.getBoolean(BundleKeys.KEY_CALL_VOICE_ONLY, false)
-
-        hasChatPermission =
-            AttendeePermissionsUtil(currentConversation!!.permissions).hasChatPermission(conversationUser)
     }
 
     private fun getRoomInfo() {


### PR DESCRIPTION
currentConversation could have been null when opening the ChatController from notification.

hasChatPermission is now only set in
getRoomInfo

Signed-off-by: Marcel Hibbe <dev@mhibbe.de>