### PR TITLE
build: Fix/optimize gradle repo configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ buildscript {
 
     repositories {
         google()
-        maven { url 'https://plugins.gradle.org/m2/' }
+        gradlePluginPortal()
         mavenCentral()
         maven { url 'https://jitpack.io' }
     }
@@ -55,7 +55,6 @@ allprojects {
     repositories {
         google()
         maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
-        maven { url 'https://maven.google.com' }
         mavenCentral()
         maven { url 'https://jitpack.io' }
         gradlePluginPortal() // for jcenter mirroring, remove ASAP

--- a/build.gradle
+++ b/build.gradle
@@ -29,10 +29,10 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
-        maven { url 'https://jitpack.io' }
         maven { url 'https://plugins.gradle.org/m2/' }
         mavenCentral()
+        maven { url 'https://jitpack.io' }
+        jcenter()
     }
 
     dependencies {
@@ -55,11 +55,11 @@ configurations.all {
 allprojects {
     repositories {
         google()
-        jcenter()
         maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
-        maven { url 'https://jitpack.io' }
         maven { url 'https://maven.google.com' }
         mavenCentral()
+        maven { url 'https://jitpack.io' }
+        jcenter()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,6 @@ configurations.all {
 allprojects {
     repositories {
         google()
-        maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
         mavenCentral()
         maven { url 'https://jitpack.io' }
         gradlePluginPortal() // for jcenter mirroring, remove ASAP

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,6 @@ buildscript {
         maven { url 'https://plugins.gradle.org/m2/' }
         mavenCentral()
         maven { url 'https://jitpack.io' }
-        jcenter()
     }
 
     dependencies {
@@ -59,7 +58,7 @@ allprojects {
         maven { url 'https://maven.google.com' }
         mavenCentral()
         maven { url 'https://jitpack.io' }
-        jcenter()
+        gradlePluginPortal() // for jcenter mirroring, remove ASAP
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ buildscript {
         google()
         gradlePluginPortal()
         mavenCentral()
-        maven { url 'https://jitpack.io' }
     }
 
     dependencies {


### PR DESCRIPTION
- Put jitpack and jcenter at the end of the repos list
   - This should make it so dependencies are fetched from google and maven central first, which are faster and more stable
- remove jcenter, use gradle plugin portal as mirror where needed
   - At the moment when this PR is opened, jcenter is not resolving properly, but gradle plugin portal is.
   - This is NOT a permanent solution. We should upgrade or remove jcenter dependencies, see #2064 
- Some additional cleanup
