### PR TITLE
Remove kotlin option jvmTarget = "1.8"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -338,9 +338,3 @@ detekt {
     config = files("../detekt.yml")
     input = files("src/")
 }
-
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-}


### PR DESCRIPTION
Not longer needed since we're on Java 11.

