### PR TITLE
Disable lint check 'PrivateResource'

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -138,7 +138,7 @@ android {
 
     lint {
         abortOnError false
-        disable 'MissingTranslation'
+        disable 'MissingTranslation','PrivateResource'
         htmlOutput file("$project.buildDir/reports/lint/lint.html")
         htmlReport true
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,7 +20,7 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
     <!-- Common -->
     <string name="nc_yes">Yes</string>
     <string name="nc_no">No</string>
@@ -328,9 +328,9 @@
     <string name="nc_message_failed_to_send">Failed to send message:</string>
     <string name="nc_remote_audio_off">Remote audio off</string>
     <string name="nc_add_attachment">Add attachment</string>
-    <string name="emoji_category_recent" tools:ignore="PrivateResource">Recent</string>
-    <string name="emoji_backspace" tools:ignore="PrivateResource">Backspace</string>
-    <string name="emoji_search" tools:ignore="PrivateResource">Search emoji</string>
+    <string name="emoji_category_recent">Recent</string>
+    <string name="emoji_backspace">Backspace</string>
+    <string name="emoji_search">Search emoji</string>
 
     <!-- Content descriptions -->
     <string name="nc_description_send_message_button">Send message</string>


### PR DESCRIPTION
Removes the in commit cedd929f10 added string attribute 'tools:ignore'. These
would require an adjustment to our CI which we want to avoid.

So instead the lint check 'PrivateResousce' is globally deactivated.

See: commit cedd929f10, #2110

