### PR TITLE
Use unique request code to create PendingIntent

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.java
@@ -292,7 +292,10 @@ public class NotificationWorker extends Worker {
                 }
         }
 
-        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent, 0);
+        // Use unique request code to make sure that a new PendingIntent gets created for each notification
+        // See https://github.com/nextcloud/talk-android/issues/2111
+        int requestCode = (int) System.currentTimeMillis();
+        PendingIntent pendingIntent = PendingIntent.getActivity(context, requestCode, intent, 0);
 
         Uri uri = Uri.parse(signatureVerification.getUserEntity().getBaseUrl());
         String baseUrl = uri.getHost();


### PR DESCRIPTION
Fix #2111 

My bad :disappointed:

This has been broken by my commit: [This setAction call seems strange and redundant](https://github.com/nextcloud/talk-android/pull/1923/commits/4bb4d6870a5f1b79f232f054d138fc3fdcc4a674).

At least I start to understand why this was necessary. :wink:

Here is an explanation regarding [creating a PendingIntent object](https://developer.android.com/reference/android/app/PendingIntent):

> Because of this behavior, it is important to know when two Intents are considered to be the same for purposes of retrieving a PendingIntent. A common mistake people make is to create multiple PendingIntent objects with Intents that only vary in their "extra" contents, expecting to get a different PendingIntent each time. This does not happen. The parts of the Intent that are used for matching are the same ones defined by [Intent.filterEquals](https://developer.android.com/reference/android/content/Intent#filterEquals(android.content.Intent)). If you use two Intent objects that are equivalent as per [Intent.filterEquals](https://developer.android.com/reference/android/content/Intent#filterEquals(android.content.Intent)), then you will get the same PendingIntent for both of them.

The simplest way to fix this would be to revert the commit. But a setAction call with a time stamp seems to be an _unconventional_ way, so I suggest to use the requestCode parameter that apparently has been created exactly for this purpose.