### PR TITLE
ChatController: fix scroll to unread messages

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -2314,7 +2314,7 @@ class ChatController(args: Bundle) :
 
                 var chatMessage: ChatMessage
 
-                val shouldAddNewMessagesNotice = timeout == 0 && adapter?.itemCount ?: 0 > 0 && chatMessageList.size > 0
+                val shouldAddNewMessagesNotice = (adapter?.itemCount ?: 0) > 0 && chatMessageList.isNotEmpty()
 
                 if (shouldAddNewMessagesNotice) {
                     val unreadChatMessage = ChatMessage()


### PR DESCRIPTION
While looking at #2122 I found that the logic for scrolling to unread messages was already present,
but was broken because of the condition changed in this PR.

Unfortunately I can't understand the reason for that condition, as the history has been lost and there's no explanation in the code. During testing, I didn't find anything broken

Perhaps one of the reviewers can give input?


Fixes #2122