### PR TITLE
fix to load conversation list (restricted user status)

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
@@ -543,13 +543,13 @@ public class ConversationsListController extends BaseController implements Flexi
                 @Override
                 public void onError(@io.reactivex.annotations.NonNull Throwable e) {
                     Log.e(TAG, "failed to fetch user statuses", e);
+                    fetchRooms();
                 }
 
                 @Override
                 public void onComplete() {
                 }
             });
-
     }
 
     private void fetchRooms() {

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/ChooseAccountDialogFragment.java
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/ChooseAccountDialogFragment.java
@@ -233,6 +233,7 @@ public class ChooseAccountDialogFragment extends DialogFragment {
                     @Override
                     public void onError(@NonNull Throwable e) {
                         Log.e(TAG, "Can't receive user status from server. ", e);
+                        binding.statusView.setVisibility(View.GONE);
                     }
 
                     @Override


### PR DESCRIPTION
fix #2123

when the user status app on server is restricted to only some groups, the capabilities for users that are excluded still contains the "user_status" capability.
For the android talk app, this caused that the conversations were not shown.
With this fix, the conversations will be loaded also if the "user_status" is mistakenly set. Additionally, the option to set the status will be hidden.


to test, restrict the user status to some group and test with some user who is not included in this group
![grafik](https://user-images.githubusercontent.com/2932790/173070947-be501622-ad78-4984-892f-d51204638b8e.png)



Signed-off-by: Marcel Hibbe <dev@mhibbe.de>