### PR TITLE
catch NPE for binding (loadCurrentStatus#onError)

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/ChooseAccountDialogFragment.java
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/ChooseAccountDialogFragment.java
@@ -233,7 +233,11 @@ public class ChooseAccountDialogFragment extends DialogFragment {
                     @Override
                     public void onError(@NonNull Throwable e) {
                         Log.e(TAG, "Can't receive user status from server. ", e);
-                        binding.statusView.setVisibility(View.GONE);
+                        try {
+                            binding.statusView.setVisibility(View.GONE);
+                        } catch (NullPointerException npe) {
+                            Log.i(TAG, "UI already teared down", npe);
+                        }
                     }
 
                     @Override


### PR DESCRIPTION
fix https://github.com/nextcloud/talk-android/issues/2197

Signed-off-by: Marcel Hibbe <dev@mhibbe.de>