### PR TITLE
[stable-14.1] Make private broadcast permission depend on applicationId

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -84,7 +84,7 @@ android {
         testInstrumentationRunnerArgument "TEST_SERVER_USERNAME", "${NC_TEST_SERVER_USERNAME}"
         testInstrumentationRunnerArgument "TEST_SERVER_PASSWORD", "${NC_TEST_SERVER_PASSWORD}"
 
-        def localBroadcastPermission = "com.nextcloud.talk.permission.PRIVATE_BROADCAST"
+        def localBroadcastPermission = "PRIVATE_BROADCAST"
         manifestPlaceholders.broadcastPermission = localBroadcastPermission
         buildConfigField "String", "PERMISSION_LOCAL_BROADCAST", "\"${localBroadcastPermission}\""
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -83,9 +83,9 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <permission
-        android:name="${broadcastPermission}"
+        android:name="${applicationId}.${broadcastPermission}"
         android:protectionLevel="signature" />
-    <uses-permission android:name="${broadcastPermission}"/>
+    <uses-permission android:name="${applicationId}.${broadcastPermission}"/>
 
     <application
         android:name=".application.NextcloudTalkApplication"

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -53,7 +53,6 @@ import android.widget.RelativeLayout;
 import android.widget.Toast;
 
 import com.bluelinelabs.logansquare.LoganSquare;
-import com.nextcloud.talk.BuildConfig;
 import com.nextcloud.talk.R;
 import com.nextcloud.talk.adapters.ParticipantDisplayItem;
 import com.nextcloud.talk.adapters.ParticipantsAdapter;
@@ -92,6 +91,7 @@ import com.nextcloud.talk.utils.NotificationUtils;
 import com.nextcloud.talk.utils.animations.PulseAnimation;
 import com.nextcloud.talk.utils.bundle.BundleKeys;
 import com.nextcloud.talk.utils.database.user.UserUtils;
+import com.nextcloud.talk.utils.permissions.PlatformPermissionUtil;
 import com.nextcloud.talk.utils.power.PowerManagerUtils;
 import com.nextcloud.talk.utils.preferences.AppPreferences;
 import com.nextcloud.talk.utils.singletons.ApplicationWideCurrentRoomHolder;
@@ -185,6 +185,8 @@ public class CallActivity extends CallBaseActivity {
     AppPreferences appPreferences;
     @Inject
     Cache cache;
+    @Inject
+    PlatformPermissionUtil permissionUtil;
 
     public static final String TAG = "CallActivity";
 
@@ -2588,7 +2590,7 @@ public class CallActivity extends CallBaseActivity {
                 };
             registerReceiver(mReceiver,
                              new IntentFilter(MICROPHONE_PIP_INTENT_NAME),
-                             BuildConfig.PERMISSION_LOCAL_BROADCAST,
+                             permissionUtil.getPrivateBroadcastPermission(),
                              null);
 
             updateUiForPipMode();

--- a/app/src/main/java/com/nextcloud/talk/utils/permissions/PlatformPermissionUtil.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/permissions/PlatformPermissionUtil.kt
@@ -1,0 +1,27 @@
+/*
+ * Nextcloud Talk application
+ *
+ * @author Álvaro Brey
+ * Copyright (C) 2022 Álvaro Brey
+ * Copyright (C) 2022 Nextcloud GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.nextcloud.talk.utils.permissions
+
+interface PlatformPermissionUtil {
+    val privateBroadcastPermission: String
+    fun isCameraPermissionGranted(): Boolean
+}

--- a/app/src/main/java/com/nextcloud/talk/utils/permissions/PlatformPermissionUtilImpl.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/permissions/PlatformPermissionUtilImpl.kt
@@ -1,0 +1,44 @@
+/*
+ * Nextcloud Talk application
+ *
+ * @author Álvaro Brey
+ * Copyright (C) 2022 Álvaro Brey
+ * Copyright (C) 2022 Nextcloud GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.nextcloud.talk.utils.permissions
+
+import android.Manifest
+import android.content.Context
+import android.os.Build
+import androidx.core.content.PermissionChecker
+import com.nextcloud.talk.BuildConfig
+
+class PlatformPermissionUtilImpl(private val context: Context) : PlatformPermissionUtil {
+    override val privateBroadcastPermission: String =
+        "${BuildConfig.APPLICATION_ID}.${BuildConfig.PERMISSION_LOCAL_BROADCAST}"
+
+    override fun isCameraPermissionGranted(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            return PermissionChecker.checkSelfPermission(
+                context,
+                Manifest.permission.CAMERA
+            ) == PermissionChecker.PERMISSION_GRANTED
+        } else {
+            true
+        }
+    }
+}


### PR DESCRIPTION
Otherwise we can't install QA and normal app side by side

Signed-off-by: Álvaro Brey <alvaro.brey@nextcloud.com>