### PR TITLE
fix switching conversation titles

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -1831,7 +1831,6 @@ class ChatController(args: Bundle) :
 
         adapter = null
         inConversation = false
-        disposables.dispose()
     }
 
     private fun joinRoomWithPassword() {


### PR DESCRIPTION
This fixes a bug which is described in #2181
Be aware that #2181 is not completely fixed with this because there are still scenarios that can cause the bug. The issue will remain open..

This reverts a change from a24f49c7

Before a24f49c7 in onDestroy() the disposables were not disposed. Instead this was "only" done in onComplete() of leaveRoom().
See a24f49c#diff-6b47d0e9875a7f7d5c1e6b80feab998e92d29b0cda8ac9bbf427aab99e56d209R1827
Because with a24f49c7 was now executed in onDestroy() , the leaveRoom() method is not executed successfully because it's destroyed too early. This results in multiple calls of getRoomInfo() with different roomTokens.

Signed-off-by: Marcel Hibbe <dev@mhibbe.de>