### PR TITLE
Shared items: Add tabs for polls, deck cards, locations and other objects

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -2557,6 +2557,10 @@ class ChatController(args: Bundle) :
         intent.putExtra(KEY_CONVERSATION_NAME, currentConversation?.displayName)
         intent.putExtra(KEY_ROOM_TOKEN, roomToken)
         intent.putExtra(KEY_USER_ENTITY, conversationUser as Parcelable)
+        intent.putExtra(
+            SharedItemsActivity.KEY_USER_IS_OWNER_OR_MODERATOR,
+            currentConversation?.isParticipantOwnerOrModerator
+        )
         activity!!.startActivity(intent)
     }
 

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
@@ -107,12 +107,10 @@ class ConversationInfoController(args: Bundle) :
     private val binding: ControllerConversationInfoBinding by viewBinding(ControllerConversationInfoBinding::bind)
 
     @Inject
-    @JvmField
-    var ncApi: NcApi? = null
+    lateinit var ncApi: NcApi
 
     @Inject
-    @JvmField
-    var eventBus: EventBus? = null
+    lateinit var eventBus: EventBus
 
     private val conversationToken: String?
     private val conversationUser: User?
@@ -162,7 +160,7 @@ class ConversationInfoController(args: Bundle) :
 
     override fun onAttach(view: View) {
         super.onAttach(view)
-        eventBus?.register(this)
+        eventBus.register(this)
 
         if (databaseStorageModule == null) {
             databaseStorageModule = DatabaseStorageModule(conversationUser!!, conversationToken)

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
@@ -192,6 +192,7 @@ class ConversationInfoController(args: Bundle) :
         intent.putExtra(BundleKeys.KEY_CONVERSATION_NAME, conversation?.displayName)
         intent.putExtra(BundleKeys.KEY_ROOM_TOKEN, conversationToken)
         intent.putExtra(BundleKeys.KEY_USER_ENTITY, conversationUser as Parcelable)
+        intent.putExtra(SharedItemsActivity.KEY_USER_IS_OWNER_OR_MODERATOR, conversation?.isParticipantOwnerOrModerator)
         activity!!.startActivity(intent)
     }
 

--- a/app/src/main/java/com/nextcloud/talk/shareditems/activities/SharedItemsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/shareditems/activities/SharedItemsActivity.kt
@@ -63,6 +63,7 @@ class SharedItemsActivity : AppCompatActivity() {
         val roomToken = intent.getStringExtra(KEY_ROOM_TOKEN)!!
         val conversationName = intent.getStringExtra(KEY_CONVERSATION_NAME)
         val user = intent.getParcelableExtra<User>(KEY_USER_ENTITY)!!
+        val isUserConversationOwnerOrModerator = intent.getBooleanExtra(KEY_USER_IS_OWNER_OR_MODERATOR, false)
 
         binding = ActivitySharedItemsBinding.inflate(layoutInflater)
         setSupportActionBar(binding.sharedItemsToolbar)
@@ -104,7 +105,12 @@ class SharedItemsActivity : AppCompatActivity() {
                         LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false)
                     }
 
-                    val adapter = SharedItemsAdapter(showGrid, user).apply {
+                    val adapter = SharedItemsAdapter(
+                        showGrid,
+                        user,
+                        roomToken,
+                        isUserConversationOwnerOrModerator
+                    ).apply {
                         items = sharedMediaItems.items
                     }
                     binding.imageRecycler.adapter = adapter
@@ -176,6 +182,13 @@ class SharedItemsActivity : AppCompatActivity() {
             binding.sharedItemsTabs.addTab(tabVoice)
         }
 
+        if (sharedItemTypes.contains(SharedItemType.POLL)) {
+            val tabVoice: TabLayout.Tab = binding.sharedItemsTabs.newTab()
+            tabVoice.tag = SharedItemType.POLL
+            tabVoice.setText(R.string.shared_items_poll)
+            binding.sharedItemsTabs.addTab(tabVoice)
+        }
+
         // if(sharedItemTypes.contains(SharedItemType.LOCATION)) {
         // val tabLocation: TabLayout.Tab = binding.sharedItemsTabs.newTab()
         // tabLocation.tag = SharedItemType.LOCATION
@@ -220,5 +233,6 @@ class SharedItemsActivity : AppCompatActivity() {
     companion object {
         private val TAG = SharedItemsActivity::class.simpleName
         const val SPAN_COUNT: Int = 4
+        const val KEY_USER_IS_OWNER_OR_MODERATOR = "userIsOwnerOrModerator"
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/shareditems/activities/SharedItemsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/shareditems/activities/SharedItemsActivity.kt
@@ -213,12 +213,12 @@ class SharedItemsActivity : AppCompatActivity() {
         // binding.sharedItemsTabs.addTab(tabDeckCard)
         // }
 
-        // if(sharedItemTypes.contains(SharedItemType.OTHER)) {
-        // val tabOther: TabLayout.Tab = binding.sharedItemsTabs.newTab()
-        // tabOther.tag = SharedItemType.OTHER
-        // tabOther.setText(R.string.shared_items_other)
-        // binding.sharedItemsTabs.addTab(tabOther)
-        // }
+        if (sharedItemTypes.contains(SharedItemType.OTHER)) {
+            val tabOther: TabLayout.Tab = binding.sharedItemsTabs.newTab()
+            tabOther.tag = SharedItemType.OTHER
+            tabOther.setText(R.string.shared_items_other)
+            binding.sharedItemsTabs.addTab(tabOther)
+        }
 
         binding.sharedItemsTabs.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
             override fun onTabSelected(tab: TabLayout.Tab) {

--- a/app/src/main/java/com/nextcloud/talk/shareditems/adapters/SharedItemsAdapter.kt
+++ b/app/src/main/java/com/nextcloud/talk/shareditems/adapters/SharedItemsAdapter.kt
@@ -22,17 +22,24 @@
 
 package com.nextcloud.talk.shareditems.adapters
 
+import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.databinding.SharedItemGridBinding
 import com.nextcloud.talk.databinding.SharedItemListBinding
+import com.nextcloud.talk.polls.ui.PollMainDialogFragment
+import com.nextcloud.talk.shareditems.activities.SharedItemsActivity
+import com.nextcloud.talk.shareditems.model.SharedFileItem
 import com.nextcloud.talk.shareditems.model.SharedItem
+import com.nextcloud.talk.shareditems.model.SharedPollItem
 
 class SharedItemsAdapter(
     private val showGrid: Boolean,
-    private val user: User
+    private val user: User,
+    private val roomToken: String,
+    private val isUserConversationOwnerOrModerator: Boolean
 ) : RecyclerView.Adapter<SharedItemsViewHolder>() {
 
     var items: List<SharedItem> = emptyList()
@@ -61,10 +68,31 @@ class SharedItemsAdapter(
     }
 
     override fun onBindViewHolder(holder: SharedItemsViewHolder, position: Int) {
-        holder.onBind(items[position])
+        when (val item = items[position]) {
+            is SharedPollItem -> holder.onBind(item, ::showPoll)
+            is SharedFileItem -> holder.onBind(item)
+        }
     }
 
     override fun getItemCount(): Int {
         return items.size
+    }
+
+    private fun showPoll(item: SharedItem, context: Context) {
+        val pollVoteDialog = PollMainDialogFragment.newInstance(
+            user,
+            roomToken,
+            isUserConversationOwnerOrModerator,
+            item.id,
+            item.name
+        )
+        pollVoteDialog.show(
+            (context as SharedItemsActivity).supportFragmentManager,
+            TAG
+        )
+    }
+
+    companion object {
+        private val TAG = SharedItemsAdapter::class.simpleName
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/shareditems/adapters/SharedItemsAdapter.kt
+++ b/app/src/main/java/com/nextcloud/talk/shareditems/adapters/SharedItemsAdapter.kt
@@ -34,6 +34,7 @@ import com.nextcloud.talk.shareditems.activities.SharedItemsActivity
 import com.nextcloud.talk.shareditems.model.SharedFileItem
 import com.nextcloud.talk.shareditems.model.SharedItem
 import com.nextcloud.talk.shareditems.model.SharedLocationItem
+import com.nextcloud.talk.shareditems.model.SharedOtherItem
 import com.nextcloud.talk.shareditems.model.SharedPollItem
 
 class SharedItemsAdapter(
@@ -73,6 +74,7 @@ class SharedItemsAdapter(
             is SharedPollItem -> holder.onBind(item, ::showPoll)
             is SharedFileItem -> holder.onBind(item)
             is SharedLocationItem -> holder.onBind(item)
+            is SharedOtherItem -> holder.onBind(item)
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/shareditems/adapters/SharedItemsAdapter.kt
+++ b/app/src/main/java/com/nextcloud/talk/shareditems/adapters/SharedItemsAdapter.kt
@@ -33,6 +33,7 @@ import com.nextcloud.talk.polls.ui.PollMainDialogFragment
 import com.nextcloud.talk.shareditems.activities.SharedItemsActivity
 import com.nextcloud.talk.shareditems.model.SharedFileItem
 import com.nextcloud.talk.shareditems.model.SharedItem
+import com.nextcloud.talk.shareditems.model.SharedLocationItem
 import com.nextcloud.talk.shareditems.model.SharedPollItem
 
 class SharedItemsAdapter(
@@ -71,6 +72,7 @@ class SharedItemsAdapter(
         when (val item = items[position]) {
             is SharedPollItem -> holder.onBind(item, ::showPoll)
             is SharedFileItem -> holder.onBind(item)
+            is SharedLocationItem -> holder.onBind(item)
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/shareditems/adapters/SharedItemsListViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/shareditems/adapters/SharedItemsListViewHolder.kt
@@ -23,6 +23,7 @@
 package com.nextcloud.talk.shareditems.adapters
 
 import android.content.Context
+import android.content.Intent
 import android.text.format.Formatter
 import android.view.View
 import android.widget.ProgressBar
@@ -33,6 +34,7 @@ import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.databinding.SharedItemListBinding
 import com.nextcloud.talk.shareditems.model.SharedFileItem
 import com.nextcloud.talk.shareditems.model.SharedItem
+import com.nextcloud.talk.shareditems.model.SharedLocationItem
 import com.nextcloud.talk.shareditems.model.SharedPollItem
 import com.nextcloud.talk.utils.DateUtils
 
@@ -76,6 +78,25 @@ class SharedItemsListViewHolder(
         )
         clickTarget.setOnClickListener {
             showPoll(item, it.context)
+        }
+    }
+
+    override fun onBind(item: SharedLocationItem) {
+        super.onBind(item)
+
+        binding.fileName.text = item.name
+        binding.fileMetadata.visibility = View.GONE
+        image.hierarchy.setPlaceholderImage(R.drawable.ic_baseline_location_on_24)
+        image.setColorFilter(
+            ContextCompat.getColor(image.context, R.color.high_emphasis_menu_icon),
+            android.graphics.PorterDuff.Mode.SRC_IN
+        )
+
+        clickTarget.setOnClickListener {
+
+            val browserIntent = Intent(Intent.ACTION_VIEW, item.geoUri)
+            browserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            it.context.startActivity(browserIntent)
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/shareditems/adapters/SharedItemsListViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/shareditems/adapters/SharedItemsListViewHolder.kt
@@ -22,13 +22,18 @@
 
 package com.nextcloud.talk.shareditems.adapters
 
+import android.content.Context
 import android.text.format.Formatter
 import android.view.View
 import android.widget.ProgressBar
+import androidx.core.content.ContextCompat
 import com.facebook.drawee.view.SimpleDraweeView
+import com.nextcloud.talk.R
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.databinding.SharedItemListBinding
+import com.nextcloud.talk.shareditems.model.SharedFileItem
 import com.nextcloud.talk.shareditems.model.SharedItem
+import com.nextcloud.talk.shareditems.model.SharedPollItem
 import com.nextcloud.talk.utils.DateUtils
 
 class SharedItemsListViewHolder(
@@ -43,12 +48,12 @@ class SharedItemsListViewHolder(
     override val progressBar: ProgressBar
         get() = binding.progressBar
 
-    override fun onBind(item: SharedItem) {
+    override fun onBind(item: SharedFileItem) {
 
         super.onBind(item)
 
         binding.fileName.text = item.name
-        binding.fileSize.text = item.fileSize?.let {
+        binding.fileSize.text = item.fileSize.let {
             Formatter.formatShortFileSize(
                 binding.fileSize.context,
                 it
@@ -57,6 +62,21 @@ class SharedItemsListViewHolder(
         binding.fileDate.text = DateUtils.getLocalDateTimeStringFromTimestamp(
             item.date * ONE_SECOND_IN_MILLIS
         )
+    }
+
+    override fun onBind(item: SharedPollItem, showPoll: (item: SharedItem, context: Context) -> Unit) {
+        super.onBind(item, showPoll)
+
+        binding.fileName.text = item.name
+        binding.fileMetadata.visibility = View.GONE
+        image.hierarchy.setPlaceholderImage(R.drawable.ic_baseline_bar_chart_24)
+        image.setColorFilter(
+            ContextCompat.getColor(image.context, R.color.high_emphasis_menu_icon),
+            android.graphics.PorterDuff.Mode.SRC_IN
+        )
+        clickTarget.setOnClickListener {
+            showPoll(item, it.context)
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/nextcloud/talk/shareditems/adapters/SharedItemsListViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/shareditems/adapters/SharedItemsListViewHolder.kt
@@ -35,6 +35,7 @@ import com.nextcloud.talk.databinding.SharedItemListBinding
 import com.nextcloud.talk.shareditems.model.SharedFileItem
 import com.nextcloud.talk.shareditems.model.SharedItem
 import com.nextcloud.talk.shareditems.model.SharedLocationItem
+import com.nextcloud.talk.shareditems.model.SharedOtherItem
 import com.nextcloud.talk.shareditems.model.SharedPollItem
 import com.nextcloud.talk.utils.DateUtils
 
@@ -98,6 +99,18 @@ class SharedItemsListViewHolder(
             browserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             it.context.startActivity(browserIntent)
         }
+    }
+
+    override fun onBind(item: SharedOtherItem) {
+        super.onBind(item)
+
+        binding.fileName.text = item.name
+        binding.fileMetadata.visibility = View.GONE
+        image.hierarchy.setPlaceholderImage(R.drawable.ic_mimetype_file)
+        image.setColorFilter(
+            ContextCompat.getColor(image.context, R.color.high_emphasis_menu_icon),
+            android.graphics.PorterDuff.Mode.SRC_IN
+        )
     }
 
     companion object {

--- a/app/src/main/java/com/nextcloud/talk/shareditems/adapters/SharedItemsViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/shareditems/adapters/SharedItemsViewHolder.kt
@@ -43,6 +43,7 @@ import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.shareditems.model.SharedFileItem
 import com.nextcloud.talk.shareditems.model.SharedItem
 import com.nextcloud.talk.shareditems.model.SharedLocationItem
+import com.nextcloud.talk.shareditems.model.SharedOtherItem
 import com.nextcloud.talk.shareditems.model.SharedPollItem
 import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.DrawableUtils
@@ -130,6 +131,8 @@ abstract class SharedItemsViewHolder(
     open fun onBind(item: SharedPollItem, showPoll: (item: SharedItem, context: Context) -> Unit) {}
 
     open fun onBind(item: SharedLocationItem) {}
+
+    open fun onBind(item: SharedOtherItem) {}
 
     private fun staticImage(
         mimeType: String?,

--- a/app/src/main/java/com/nextcloud/talk/shareditems/adapters/SharedItemsViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/shareditems/adapters/SharedItemsViewHolder.kt
@@ -42,6 +42,7 @@ import com.facebook.imagepipeline.request.ImageRequestBuilder
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.shareditems.model.SharedFileItem
 import com.nextcloud.talk.shareditems.model.SharedItem
+import com.nextcloud.talk.shareditems.model.SharedLocationItem
 import com.nextcloud.talk.shareditems.model.SharedPollItem
 import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.DrawableUtils
@@ -127,6 +128,8 @@ abstract class SharedItemsViewHolder(
     }
 
     open fun onBind(item: SharedPollItem, showPoll: (item: SharedItem, context: Context) -> Unit) {}
+
+    open fun onBind(item: SharedLocationItem) {}
 
     private fun staticImage(
         mimeType: String?,

--- a/app/src/main/java/com/nextcloud/talk/shareditems/adapters/SharedItemsViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/shareditems/adapters/SharedItemsViewHolder.kt
@@ -22,6 +22,7 @@
 
 package com.nextcloud.talk.shareditems.adapters
 
+import android.content.Context
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.util.Log
@@ -39,14 +40,16 @@ import com.facebook.imagepipeline.common.RotationOptions
 import com.facebook.imagepipeline.image.ImageInfo
 import com.facebook.imagepipeline.request.ImageRequestBuilder
 import com.nextcloud.talk.data.user.model.User
+import com.nextcloud.talk.shareditems.model.SharedFileItem
 import com.nextcloud.talk.shareditems.model.SharedItem
+import com.nextcloud.talk.shareditems.model.SharedPollItem
 import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.DrawableUtils
 import com.nextcloud.talk.utils.FileViewerUtils
 
 abstract class SharedItemsViewHolder(
     open val binding: ViewBinding,
-    private val user: User
+    internal val user: User
 ) : RecyclerView.ViewHolder(binding.root) {
 
     companion object {
@@ -64,9 +67,9 @@ abstract class SharedItemsViewHolder(
         )
     )
 
-    open fun onBind(item: SharedItem) {
+    open fun onBind(item: SharedFileItem) {
         image.hierarchy.setPlaceholderImage(staticImage(item.mimeType, image))
-        if (item.previewAvailable == true) {
+        if (item.previewAvailable) {
             image.controller = configurePreview(item)
         }
 
@@ -100,7 +103,7 @@ abstract class SharedItemsViewHolder(
         )
     }
 
-    private fun configurePreview(item: SharedItem): DraweeController {
+    private fun configurePreview(item: SharedFileItem): DraweeController {
 
         val imageRequest = ImageRequestBuilder.newBuilderWithSource(Uri.parse(item.previewLink))
             .setProgressiveRenderingEnabled(true)
@@ -122,6 +125,8 @@ abstract class SharedItemsViewHolder(
             .setControllerListener(listener)
             .build()
     }
+
+    open fun onBind(item: SharedPollItem, showPoll: (item: SharedItem, context: Context) -> Unit) {}
 
     private fun staticImage(
         mimeType: String?,

--- a/app/src/main/java/com/nextcloud/talk/shareditems/model/SharedFileItem.kt
+++ b/app/src/main/java/com/nextcloud/talk/shareditems/model/SharedFileItem.kt
@@ -22,8 +22,16 @@
 
 package com.nextcloud.talk.shareditems.model
 
-class SharedMediaItems(
-    val items: List<SharedItem>,
-    var lastSeenId: Int?,
-    var moreItemsExisting: Boolean
-)
+data class SharedFileItem(
+    override val id: String,
+    override val name: String,
+    override val actorId: String,
+    override val actorName: String,
+    val fileSize: Long,
+    val date: Long,
+    val path: String,
+    val link: String,
+    val mimeType: String,
+    val previewAvailable: Boolean = false,
+    val previewLink: String
+) : SharedItem

--- a/app/src/main/java/com/nextcloud/talk/shareditems/model/SharedItem.kt
+++ b/app/src/main/java/com/nextcloud/talk/shareditems/model/SharedItem.kt
@@ -1,35 +1,8 @@
-/*
- * Nextcloud Talk application
- *
- * @author Tim Krüger
- * @author Álvaro Brey
- * Copyright (C) 2022 Álvaro Brey
- * Copyright (C) 2022 Tim Krüger <t@timkrueger.me>
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
-
 package com.nextcloud.talk.shareditems.model
 
-data class SharedItem(
-    val id: String,
-    val name: String,
-    val fileSize: Long?,
-    val date: Long,
-    val path: String,
-    val link: String?,
-    val mimeType: String?,
-    val previewAvailable: Boolean?,
-    val previewLink: String
-)
+interface SharedItem {
+    val id: String
+    val name: String
+    val actorId: String
+    val actorName: String
+}

--- a/app/src/main/java/com/nextcloud/talk/shareditems/model/SharedItems.kt
+++ b/app/src/main/java/com/nextcloud/talk/shareditems/model/SharedItems.kt
@@ -22,20 +22,9 @@
 
 package com.nextcloud.talk.shareditems.model
 
-import java.util.Locale
-
-enum class SharedItemType {
-
-    AUDIO,
-    FILE,
-    MEDIA,
-    VOICE,
-    LOCATION,
-    DECKCARD,
-    OTHER,
-    POLL;
-
-    companion object {
-        fun typeFor(name: String) = valueOf(name.uppercase(Locale.ROOT))
-    }
-}
+class SharedItems(
+    val items: List<SharedItem>,
+    val type: SharedItemType,
+    var lastSeenId: Int?,
+    var moreItemsExisting: Boolean
+)

--- a/app/src/main/java/com/nextcloud/talk/shareditems/model/SharedLocationItem.kt
+++ b/app/src/main/java/com/nextcloud/talk/shareditems/model/SharedLocationItem.kt
@@ -1,0 +1,30 @@
+/*
+ * Nextcloud Talk application
+ *
+ * @author Tim Krüger
+ * Copyright (C) 2022 Tim Krüger <t@timkrueger.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.nextcloud.talk.shareditems.model
+
+import android.net.Uri
+
+data class SharedLocationItem(
+    override val id: String,
+    override val name: String,
+    override val actorId: String,
+    override val actorName: String,
+    val geoUri: Uri
+) : SharedItem

--- a/app/src/main/java/com/nextcloud/talk/shareditems/model/SharedOtherItem.kt
+++ b/app/src/main/java/com/nextcloud/talk/shareditems/model/SharedOtherItem.kt
@@ -1,0 +1,27 @@
+/*
+ * Nextcloud Talk application
+ *
+ * @author Tim Krüger
+ * Copyright (C) 2022 Tim Krüger <t@timkrueger.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.nextcloud.talk.shareditems.model
+
+data class SharedOtherItem(
+    override val id: String,
+    override val name: String,
+    override val actorId: String,
+    override val actorName: String,
+) : SharedItem

--- a/app/src/main/java/com/nextcloud/talk/shareditems/model/SharedPollItem.kt
+++ b/app/src/main/java/com/nextcloud/talk/shareditems/model/SharedPollItem.kt
@@ -2,8 +2,6 @@
  * Nextcloud Talk application
  *
  * @author Tim Krüger
- * @author Álvaro Brey
- * Copyright (C) 2022 Álvaro Brey
  * Copyright (C) 2022 Tim Krüger <t@timkrueger.me>
  *
  * This program is free software: you can redistribute it and/or modify
@@ -19,23 +17,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 package com.nextcloud.talk.shareditems.model
 
-import java.util.Locale
-
-enum class SharedItemType {
-
-    AUDIO,
-    FILE,
-    MEDIA,
-    VOICE,
-    LOCATION,
-    DECKCARD,
-    OTHER,
-    POLL;
-
-    companion object {
-        fun typeFor(name: String) = valueOf(name.uppercase(Locale.ROOT))
-    }
-}
+data class SharedPollItem(
+    override val id: String,
+    override val name: String,
+    override val actorId: String,
+    override val actorName: String,
+) : SharedItem

--- a/app/src/main/java/com/nextcloud/talk/shareditems/repositories/SharedItemsRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/shareditems/repositories/SharedItemsRepository.kt
@@ -23,7 +23,7 @@
 package com.nextcloud.talk.shareditems.repositories
 
 import com.nextcloud.talk.shareditems.model.SharedItemType
-import com.nextcloud.talk.shareditems.model.SharedMediaItems
+import com.nextcloud.talk.shareditems.model.SharedItems
 import io.reactivex.Observable
 
 interface SharedItemsRepository {
@@ -31,13 +31,13 @@ interface SharedItemsRepository {
     fun media(
         parameters: Parameters,
         type: SharedItemType
-    ): Observable<SharedMediaItems>?
+    ): Observable<SharedItems>?
 
     fun media(
         parameters: Parameters,
         type: SharedItemType,
         lastKnownMessageId: Int?
-    ): Observable<SharedMediaItems>?
+    ): Observable<SharedItems>?
 
     fun availableTypes(parameters: Parameters): Observable<Set<SharedItemType>>
 

--- a/app/src/main/java/com/nextcloud/talk/shareditems/repositories/SharedItemsRepositoryImpl.kt
+++ b/app/src/main/java/com/nextcloud/talk/shareditems/repositories/SharedItemsRepositoryImpl.kt
@@ -22,6 +22,7 @@
 
 package com.nextcloud.talk.shareditems.repositories
 
+import android.net.Uri
 import android.util.Log
 import com.nextcloud.talk.R
 import com.nextcloud.talk.api.NcApi
@@ -31,6 +32,7 @@ import com.nextcloud.talk.shareditems.model.SharedFileItem
 import com.nextcloud.talk.shareditems.model.SharedItem
 import com.nextcloud.talk.shareditems.model.SharedItemType
 import com.nextcloud.talk.shareditems.model.SharedItems
+import com.nextcloud.talk.shareditems.model.SharedLocationItem
 import com.nextcloud.talk.shareditems.model.SharedPollItem
 import com.nextcloud.talk.utils.ApiUtils
 import io.reactivex.Observable
@@ -101,16 +103,27 @@ class SharedItemsRepositoryImpl @Inject constructor(private val ncApi: NcApi) : 
                     )
                 } else if (it.value.messageParameters?.containsKey("object") == true) {
                     val objectParameters = it.value.messageParameters!!["object"]!!
-                    if ("talk-poll" == objectParameters["type"]) {
-                        items[it.value.id] = SharedPollItem(
-                            objectParameters["id"]!!,
-                            objectParameters["name"]!!,
-                            actorParameters["id"]!!,
-                            actorParameters["name"]!!
-                        )
+                    when (objectParameters["type"]) {
+                        "talk-poll" -> {
+                            items[it.value.id] = SharedPollItem(
+                                objectParameters["id"]!!,
+                                objectParameters["name"]!!,
+                                actorParameters["id"]!!,
+                                actorParameters["name"]!!
+                            )
+                        }
+                        "geo-location" -> {
+                            items[it.value.id] = SharedLocationItem(
+                                objectParameters["id"]!!,
+                                objectParameters["name"]!!,
+                                actorParameters["id"]!!,
+                                actorParameters["name"]!!,
+                                Uri.parse(objectParameters["id"]!!.replace("geo:", "geo:0,0?z=11&q="))
+                            )
+                        }
                     }
                 } else {
-                    Log.w(TAG, "location and deckcard are not yet supported")
+                    Log.w(TAG, "Item contains neither 'file' or 'object'.")
                 }
             }
         }

--- a/app/src/main/java/com/nextcloud/talk/shareditems/repositories/SharedItemsRepositoryImpl.kt
+++ b/app/src/main/java/com/nextcloud/talk/shareditems/repositories/SharedItemsRepositoryImpl.kt
@@ -33,6 +33,7 @@ import com.nextcloud.talk.shareditems.model.SharedItem
 import com.nextcloud.talk.shareditems.model.SharedItemType
 import com.nextcloud.talk.shareditems.model.SharedItems
 import com.nextcloud.talk.shareditems.model.SharedLocationItem
+import com.nextcloud.talk.shareditems.model.SharedOtherItem
 import com.nextcloud.talk.shareditems.model.SharedPollItem
 import com.nextcloud.talk.utils.ApiUtils
 import io.reactivex.Observable
@@ -119,6 +120,14 @@ class SharedItemsRepositoryImpl @Inject constructor(private val ncApi: NcApi) : 
                                 actorParameters["id"]!!,
                                 actorParameters["name"]!!,
                                 Uri.parse(objectParameters["id"]!!.replace("geo:", "geo:0,0?z=11&q="))
+                            )
+                        }
+                        else -> {
+                            items[it.value.id] = SharedOtherItem(
+                                objectParameters["id"]!!,
+                                objectParameters["name"]!!,
+                                actorParameters["id"]!!,
+                                actorParameters["name"]!!
                             )
                         }
                     }

--- a/app/src/main/java/com/nextcloud/talk/shareditems/viewmodels/SharedItemsViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/shareditems/viewmodels/SharedItemsViewModel.kt
@@ -28,7 +28,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.shareditems.model.SharedItemType
-import com.nextcloud.talk.shareditems.model.SharedMediaItems
+import com.nextcloud.talk.shareditems.model.SharedItems
 import com.nextcloud.talk.shareditems.repositories.SharedItemsRepository
 import io.reactivex.Observer
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -50,7 +50,7 @@ class SharedItemsViewModel @Inject constructor(
     class LoadingItemsState(types: Set<SharedItemType>, selectedType: SharedItemType) :
         TypesLoadedState(types, selectedType)
 
-    class LoadedState(types: Set<SharedItemType>, selectedType: SharedItemType, val items: SharedMediaItems) :
+    class LoadedState(types: Set<SharedItemType>, selectedType: SharedItemType, val items: SharedItems) :
         TypesLoadedState(types, selectedType)
 
     private val _viewState: MutableLiveData<ViewState> = MutableLiveData(InitialState)
@@ -128,13 +128,13 @@ class SharedItemsViewModel @Inject constructor(
         }
     }
 
-    inner class SharedMediaItemsObserver : Observer<SharedMediaItems> {
+    inner class SharedMediaItemsObserver : Observer<SharedItems> {
 
-        var newSharedItems: SharedMediaItems? = null
+        var newSharedItems: SharedItems? = null
 
         override fun onSubscribe(d: Disposable) = Unit
 
-        override fun onNext(response: SharedMediaItems) {
+        override fun onNext(response: SharedItems) {
             newSharedItems = response
         }
 
@@ -148,8 +148,9 @@ class SharedItemsViewModel @Inject constructor(
             if (state is LoadedState) {
                 val oldItems = state.items.items
                 val newItems =
-                    SharedMediaItems(
+                    SharedItems(
                         oldItems + newSharedItems!!.items,
+                        state.items.type,
                         newSharedItems!!.lastSeenId,
                         newSharedItems!!.moreItemsExisting
                     )
@@ -159,7 +160,7 @@ class SharedItemsViewModel @Inject constructor(
             }
         }
 
-        private fun setCurrentState(items: SharedMediaItems) {
+        private fun setCurrentState(items: SharedItems) {
             when (val state = this@SharedItemsViewModel._viewState.value) {
                 is TypesLoadedState -> {
                     this@SharedItemsViewModel._viewState.value = LoadedState(

--- a/app/src/main/res/layout/shared_item_list.xml
+++ b/app/src/main/res/layout/shared_item_list.xml
@@ -78,6 +78,7 @@
             tools:text="Filename.md" />
 
         <LinearLayout
+            android:id="@+id/file_metadata"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal">
@@ -91,12 +92,13 @@
                 tools:text="11 KB" />
 
             <TextView
+                android:id="@+id/separator"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/standard_quarter_margin"
+                android:text="|"
                 android:textColor="@color/textColorMaxContrast"
                 android:textSize="14sp"
-                android:text="|"
                 tools:ignore="HardcodedText" />
 
             <TextView
@@ -106,7 +108,7 @@
                 android:layout_marginStart="@dimen/standard_quarter_margin"
                 android:textColor="@color/textColorMaxContrast"
                 android:textSize="14sp"
-                tools:text="04-05-2022 21:16"/>
+                tools:text="04-05-2022 21:16" />
 
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -523,6 +523,7 @@
     <string name="shared_items_audio">Audio</string>
     <string name="shared_items_voice">Voice</string>
     <string name="shared_items_other">Other</string>
+    <string name="shared_items_poll">Poll</string>
 
     <!-- Message search -->
     <string name="messages">Messages</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -430,6 +430,7 @@
     <string name="nc_shared_items">Shared items</string>
     <string name="nc_shared_items_description">Images, files, voice messages …</string>
     <string name="nc_shared_items_empty">No shared items</string>
+    <string name="nc_shared_items_location">Location</string>
 
     <!-- voice messages -->
     <string name="nc_voice_message_filename">Talk recording from %1$s (%2$s)</string>


### PR DESCRIPTION
Add missing types in the shared items view
- [x] polls
- [ ] deck cards
- [x] localtions
- [ ] other objects

<table>
<tr>
<th>
<img src="https://user-images.githubusercontent.com/606665/181591232-72b6a266-7e04-4c2e-96f0-bc8c67138bb7.png" width="300" />
</th>
<th>
<img src="https://user-images.githubusercontent.com/606665/183471516-5c2503cc-ad4e-4dd2-8a43-39b4b2efe3e6.png" width="300" />
</th>
</tr>
</table>

Resolves #2029