### PR TITLE
Fix status visibility in conversation list

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.java
@@ -108,7 +108,9 @@ public class ConversationItem extends AbstractFlexibleItem<ConversationItem.Conv
 
     @Override
     public int hashCode() {
-        return conversation.hashCode() * (status == null ? 1 : status.hashCode());
+        int result = conversation.hashCode();
+        result = 31 * result + (status != null ? status.hashCode() : 0);
+        return result;
     }
 
     @Override

--- a/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.java
@@ -97,7 +97,7 @@ public class ConversationItem extends AbstractFlexibleItem<ConversationItem.Conv
     public boolean equals(Object o) {
         if (o instanceof ConversationItem) {
             ConversationItem inItem = (ConversationItem) o;
-            return conversation.equals(inItem.getModel());
+            return conversation.equals(inItem.getModel()) && status.equals(inItem.status);
         }
         return false;
     }
@@ -108,7 +108,7 @@ public class ConversationItem extends AbstractFlexibleItem<ConversationItem.Conv
 
     @Override
     public int hashCode() {
-        return conversation.hashCode();
+        return conversation.hashCode() * (status == null ? 1 : status.hashCode());
     }
 
     @Override
@@ -211,12 +211,16 @@ public class ConversationItem extends AbstractFlexibleItem<ConversationItem.Conv
 
         if (status != null && Conversation.ConversationType.ROOM_SYSTEM != conversation.getType()) {
             float size = DisplayUtils.convertDpToPixel(STATUS_SIZE_IN_DP, appContext);
+
+            holder.binding.userStatusImage.setVisibility(View.VISIBLE);
             holder.binding.userStatusImage.setImageDrawable(new StatusDrawable(
                 status.getStatus(),
                 status.getIcon(),
                 size,
                 context.getResources().getColor(R.color.bg_default),
                 appContext));
+        } else {
+            holder.binding.userStatusImage.setVisibility(View.GONE);
         }
 
         if (conversation.getLastMessage() != null) {


### PR DESCRIPTION
Status was not hidden on group/chats without status, thus old status was shown.
(I am unsure if changed hashCode is needed, but FlexibleAdapter checks in some way if item has changed and thus to be sure that a changed status will result in an updated view, I added it.)

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>