### PR TITLE
Make equals null-safe in case no status is set

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.java
@@ -51,6 +51,7 @@ import com.nextcloud.talk.utils.DisplayUtils;
 import com.nextcloud.talk.utils.database.user.CapabilitiesUtilNew;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import androidx.core.content.ContextCompat;
@@ -97,7 +98,7 @@ public class ConversationItem extends AbstractFlexibleItem<ConversationItem.Conv
     public boolean equals(Object o) {
         if (o instanceof ConversationItem) {
             ConversationItem inItem = (ConversationItem) o;
-            return conversation.equals(inItem.getModel()) && status.equals(inItem.status);
+            return conversation.equals(inItem.getModel()) && Objects.equals(status, inItem.status);
         }
         return false;
     }


### PR DESCRIPTION
follow-up for #2267 since status can be null hence running into a NPE which kills the "unread notification" popup bubble.

Signed-off-by: Andy Scherzinger <info@andy-scherzinger.de>