### PR TITLE
Load higher resoliton avatars in conversation list

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.java
@@ -287,7 +287,7 @@ public class ConversationsListController extends BaseController implements Flexi
                 ApiUtils.getUrlForAvatar(
                     currentUser.getBaseUrl(),
                     currentUser.getUserId(),
-                    false),
+                    true),
                 currentUser);
 
             ImagePipeline imagePipeline = Fresco.getImagePipeline();


### PR DESCRIPTION
Instead of a 64px avatar now the 512px version is loaded for
conversation lists. For avatars in a single conversation that was
already the case.

Resolves: #2302
