### PR TITLE
handle expiring messages

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/api/NcApi.java
+++ b/app/src/main/java/com/nextcloud/talk/api/NcApi.java
@@ -550,4 +550,10 @@ public interface NcApi {
     @DELETE
     Observable<PollOverall> closePoll(@Header("Authorization") String authorization,
                                       @Url String url);
+
+    @FormUrlEncoded
+    @POST
+    Observable<GenericOverall> setMessageExpiration(@Header("Authorization") String authorization,
+                                     @Url String url,
+                                     @Field("seconds") Integer seconds);
 }

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -2217,7 +2217,7 @@ class ChatController(args: Bundle) :
                             Log.i(TAG, "UI destroyed - view binding already gone")
                         }
 
-                        deleteExpiredMessages()
+                        processExpiredMessages()
                     }
 
                     override fun onError(e: Throwable) {
@@ -2259,7 +2259,7 @@ class ChatController(args: Bundle) :
                             Log.i(TAG, "UI destroyed - view binding already gone", e)
                         }
 
-                        deleteExpiredMessages()
+                        processExpiredMessages()
                     }
 
                     override fun onError(e: Throwable) {
@@ -2274,8 +2274,8 @@ class ChatController(args: Bundle) :
         }
     }
 
-    private fun deleteExpiredMessages() {
-        if (CapabilitiesUtilNew.hasSpreedFeatureCapability(conversationUser, "message-expiration")) {
+    private fun processExpiredMessages() {
+        fun deleteExpiredMessages() {
             val messagesToDelete: ArrayList<ChatMessage> = ArrayList()
             val systemTime = System.currentTimeMillis() / ONE_SECOND_IN_MILLIS
 
@@ -2289,6 +2289,10 @@ class ChatController(args: Bundle) :
             }
             adapter!!.delete(messagesToDelete)
             adapter!!.notifyDataSetChanged()
+        }
+
+        if (CapabilitiesUtilNew.hasSpreedFeatureCapability(conversationUser, "message-expiration")) {
+            deleteExpiredMessages()
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -2216,6 +2216,8 @@ class ChatController(args: Bundle) :
                             // since this is called asynchrously and UI might have been destroyed in the meantime
                             Log.i(TAG, "UI destroyed - view binding already gone")
                         }
+
+                        deleteExpiredMessages()
                     }
 
                     override fun onError(e: Throwable) {
@@ -2256,6 +2258,8 @@ class ChatController(args: Bundle) :
                             // since this is called asynchrously and UI might have been destroyed in the meantime
                             Log.i(TAG, "UI destroyed - view binding already gone", e)
                         }
+
+                        deleteExpiredMessages()
                     }
 
                     override fun onError(e: Throwable) {
@@ -2267,6 +2271,24 @@ class ChatController(args: Bundle) :
                         pullChatMessagesPending = false
                     }
                 })
+        }
+    }
+
+    private fun deleteExpiredMessages() {
+        if (CapabilitiesUtilNew.hasSpreedFeatureCapability(conversationUser, "message-expiration")) {
+            val messagesToDelete: ArrayList<ChatMessage> = ArrayList()
+            val systemTime = System.currentTimeMillis() / ONE_SECOND_IN_MILLIS
+
+            for (itemWrapper in adapter?.items!!) {
+                if (itemWrapper.item is ChatMessage) {
+                    val chatMessage = itemWrapper.item as ChatMessage
+                    if (chatMessage.expirationTimestamp != 0 && chatMessage.expirationTimestamp < systemTime) {
+                        messagesToDelete.add(chatMessage)
+                    }
+                }
+            }
+            adapter!!.delete(messagesToDelete)
+            adapter!!.notifyDataSetChanged()
         }
     }
 
@@ -3252,5 +3274,6 @@ class ChatController(args: Bundle) :
         private const val RETRIES: Long = 3
         private const val LOOKING_INTO_FUTURE_TIMEOUT = 30
         private const val CHUNK_SIZE: Int = 10
+        private const val ONE_SECOND_IN_MILLIS = 1000
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
@@ -677,6 +677,7 @@ class ConversationInfoController(args: Bundle) :
 
                             loadConversationAvatar()
                             adjustNotificationLevelUI()
+                            initExpiringMessageOption()
 
                             binding.notificationSettingsView.notificationSettings.visibility = View.VISIBLE
                         }
@@ -695,6 +696,18 @@ class ConversationInfoController(args: Bundle) :
                     roomDisposable!!.dispose()
                 }
             })
+    }
+
+    private fun initExpiringMessageOption() {
+        if (conversation!!.isParticipantOwnerOrModerator &&
+            CapabilitiesUtilNew.hasSpreedFeatureCapability(conversationUser, "message-expiration")
+        ) {
+            databaseStorageModule?.setMessageExpiration(conversation!!.messageExpiration)
+            binding.conversationInfoExpireMessages.setStorageModule(databaseStorageModule)
+            binding.conversationInfoExpireMessages.visibility = View.VISIBLE
+        } else {
+            binding.categoryConversationSettings.visibility = View.GONE
+        }
     }
 
     private fun adjustNotificationLevelUI() {

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
@@ -204,6 +204,7 @@ class ConversationInfoController(args: Bundle) :
                 participantsListCategory,
                 ownOptions,
                 categorySharedItems,
+                categoryConversationSettings,
                 binding.webinarInfoView.conversationInfoWebinar,
                 binding.notificationSettingsView.notificationSettingsCategory
             ).forEach(viewThemeUtils::colorPreferenceCategory)

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationInfoController.kt
@@ -705,6 +705,7 @@ class ConversationInfoController(args: Bundle) :
             databaseStorageModule?.setMessageExpiration(conversation!!.messageExpiration)
             binding.conversationInfoExpireMessages.setStorageModule(databaseStorageModule)
             binding.conversationInfoExpireMessages.visibility = View.VISIBLE
+            binding.conversationInfoExpireMessagesExplanation.visibility = View.VISIBLE
         } else {
             binding.categoryConversationSettings.visibility = View.GONE
         }

--- a/app/src/main/java/com/nextcloud/talk/models/json/chat/ChatMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/chat/ChatMessage.kt
@@ -112,6 +112,9 @@ data class ChatMessage(
     @JsonField(name = ["reactionsSelf"])
     var reactionsSelf: ArrayList<String>? = null,
 
+    @JsonField(name = ["expirationTimestamp"])
+    var expirationTimestamp: Int = 0,
+
     var isDownloadingVoiceMessage: Boolean = false,
 
     var resetVoiceMessage: Boolean = false,
@@ -141,11 +144,7 @@ data class ChatMessage(
     fun hasFileAttachment(): Boolean {
         if (messageParameters != null && messageParameters!!.size > 0) {
             for ((_, individualHashMap) in messageParameters!!) {
-                if (MessageDigest.isEqual(
-                        individualHashMap["type"]!!.toByteArray(),
-                        "file".toByteArray()
-                    )
-                ) {
+                if (isHashMapEntryEqualTo(individualHashMap, "type", "file")) {
                     return true
                 }
             }
@@ -156,11 +155,7 @@ data class ChatMessage(
     fun hasGeoLocation(): Boolean {
         if (messageParameters != null && messageParameters!!.size > 0) {
             for ((_, individualHashMap) in messageParameters!!) {
-                if (MessageDigest.isEqual(
-                        individualHashMap["type"]!!.toByteArray(),
-                        "geo-location".toByteArray()
-                    )
-                ) {
+                if (isHashMapEntryEqualTo(individualHashMap, "type", "geo-location")) {
                     return true
                 }
             }
@@ -171,11 +166,7 @@ data class ChatMessage(
     fun isPoll(): Boolean {
         if (messageParameters != null && messageParameters!!.size > 0) {
             for ((_, individualHashMap) in messageParameters!!) {
-                if (MessageDigest.isEqual(
-                        individualHashMap["type"]!!.toByteArray(),
-                        "talk-poll".toByteArray()
-                    )
-                ) {
+                if (isHashMapEntryEqualTo(individualHashMap, "type", "talk-poll")) {
                     return true
                 }
             }
@@ -183,14 +174,11 @@ data class ChatMessage(
         return false
     }
 
+    @Suppress("Detekt.NestedBlockDepth")
     override fun getImageUrl(): String? {
         if (messageParameters != null && messageParameters!!.size > 0) {
             for ((_, individualHashMap) in messageParameters!!) {
-                if (MessageDigest.isEqual(
-                        individualHashMap["type"]!!.toByteArray(),
-                        "file".toByteArray()
-                    )
-                ) {
+                if (isHashMapEntryEqualTo(individualHashMap, "type", "file")) {
                     // FIX-ME: this selectedIndividualHashMap stuff needs to be analyzed and most likely be refactored!
                     //  it just feels wrong to fill this here inside getImageUrl()
                     selectedIndividualHashMap = individualHashMap
@@ -418,6 +406,10 @@ data class ChatMessage(
 
     override fun getSystemMessage(): String {
         return EnumSystemMessageTypeConverter().convertToString(systemMessageType)
+    }
+
+    private fun isHashMapEntryEqualTo(map: HashMap<String?, String?>, key: String, searchTerm: String): Boolean {
+        return map != null && MessageDigest.isEqual(map[key]!!.toByteArray(), searchTerm.toByteArray())
     }
 
     val isVoiceMessage: Boolean

--- a/app/src/main/java/com/nextcloud/talk/models/json/chat/ChatMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/chat/ChatMessage.kt
@@ -484,7 +484,9 @@ data class ChatMessage(
         REACTION_DELETED,
         REACTION_REVOKED,
         POLL_VOTED,
-        POLL_CLOSED
+        POLL_CLOSED,
+        MESSAGE_EXPIRATION_ENABLED,
+        MESSAGE_EXPIRATION_DISABLED,
     }
 
     companion object {

--- a/app/src/main/java/com/nextcloud/talk/models/json/chat/ChatUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/chat/ChatUtils.kt
@@ -34,6 +34,7 @@ class ChatUtils {
             return message
         }
 
+        @Suppress("Detekt.ComplexMethod")
         private fun parse(
             messageParameters: HashMap<String?, HashMap<String?, String?>>,
             message: String?
@@ -41,19 +42,22 @@ class ChatUtils {
             var resultMessage = message
             for (key in messageParameters.keys) {
                 val individualHashMap = messageParameters[key]
-                val type = individualHashMap?.get("type")
-                if (type == "user" || type == "guest" || type == "call") {
-                    resultMessage = resultMessage?.replace("{$key}", "@" + individualHashMap["name"])
-                } else if (type == "geo-location") {
-                    resultMessage = individualHashMap.get("name")
-                } else if (individualHashMap?.containsKey("link") == true) {
-                    resultMessage = if (type == "file") {
-                        resultMessage?.replace("{$key}", individualHashMap["name"].toString())
+
+                if (individualHashMap != null) {
+                    val type = individualHashMap["type"]
+                    resultMessage = if (type == "user" || type == "guest" || type == "call") {
+                        resultMessage?.replace("{$key}", "@" + individualHashMap["name"])
+                    } else if (type == "geo-location") {
+                        individualHashMap["name"]
+                    } else if (individualHashMap?.containsKey("link") == true) {
+                        if (type == "file") {
+                            resultMessage?.replace("{$key}", individualHashMap["name"].toString())
+                        } else {
+                            individualHashMap["link"].toString()
+                        }
                     } else {
-                        individualHashMap["link"].toString()
+                        individualHashMap["name"]?.let { resultMessage?.replace("{$key}", it) }
                     }
-                } else {
-                    resultMessage = individualHashMap?.get("name")?.let { resultMessage?.replace("{$key}", it) }
                 }
             }
             return resultMessage

--- a/app/src/main/java/com/nextcloud/talk/models/json/conversations/Conversation.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/conversations/Conversation.kt
@@ -4,6 +4,8 @@
  * @author Mario Danic
  * @author Tim Krüger
  * @author Andy Scherzinger
+ * @author Marcel Hibbe
+ * Copyright (C) 2022 Marcel Hibbe <dev@mhibbe.de>
  * Copyright (C) 2022 Andy Scherzinger <info@andy-scherzinger.de>
  * Copyright (C) 2021 Tim Krüger <t@timkrueger.me>
  * Copyright (C) 2017 Mario Danic (mario@lovelyhq.com)
@@ -122,7 +124,11 @@ data class Conversation(
     var notificationCalls: Int? = null,
 
     @JsonField(name = ["permissions"])
-    var permissions: Int = 0
+    var permissions: Int = 0,
+
+    @JsonField(name = ["messageExpiration"])
+    var messageExpiration: Int = 0
+
 ) : Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
     constructor() : this(null, null)

--- a/app/src/main/java/com/nextcloud/talk/models/json/converters/EnumSystemMessageTypeConverter.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/converters/EnumSystemMessageTypeConverter.kt
@@ -60,6 +60,8 @@ import com.nextcloud.talk.models.json.chat.ChatMessage.SystemMessageType.MATTERB
 import com.nextcloud.talk.models.json.chat.ChatMessage.SystemMessageType.MATTERBRIDGE_CONFIG_ENABLED
 import com.nextcloud.talk.models.json.chat.ChatMessage.SystemMessageType.MATTERBRIDGE_CONFIG_REMOVED
 import com.nextcloud.talk.models.json.chat.ChatMessage.SystemMessageType.MESSAGE_DELETED
+import com.nextcloud.talk.models.json.chat.ChatMessage.SystemMessageType.MESSAGE_EXPIRATION_DISABLED
+import com.nextcloud.talk.models.json.chat.ChatMessage.SystemMessageType.MESSAGE_EXPIRATION_ENABLED
 import com.nextcloud.talk.models.json.chat.ChatMessage.SystemMessageType.MODERATOR_DEMOTED
 import com.nextcloud.talk.models.json.chat.ChatMessage.SystemMessageType.MODERATOR_PROMOTED
 import com.nextcloud.talk.models.json.chat.ChatMessage.SystemMessageType.OBJECT_SHARED
@@ -171,6 +173,8 @@ class EnumSystemMessageTypeConverter : StringBasedTypeConverter<ChatMessage.Syst
             "reaction_revoked" -> REACTION_REVOKED
             "poll_voted" -> POLL_VOTED
             "poll_closed" -> POLL_CLOSED
+            "message_expiration_enabled" -> MESSAGE_EXPIRATION_ENABLED
+            "message_expiration_disabled" -> MESSAGE_EXPIRATION_DISABLED
             else -> DUMMY
         }
     }
@@ -226,6 +230,8 @@ class EnumSystemMessageTypeConverter : StringBasedTypeConverter<ChatMessage.Syst
             REACTION_REVOKED -> "reaction_revoked"
             POLL_VOTED -> "poll_voted"
             POLL_CLOSED -> "poll_closed"
+            MESSAGE_EXPIRATION_ENABLED -> "message_expiration_enabled"
+            MESSAGE_EXPIRATION_DISABLED -> "message_expiration_disabled"
             else -> ""
         }
     }

--- a/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
@@ -147,7 +147,7 @@ public class ApiUtils {
                     return version;
                 }
                 if (version == APIv1 &&
-                    user.hasSpreedFeatureCapability( "mention-flag") &&
+                    user.hasSpreedFeatureCapability("mention-flag") &&
                     !user.hasSpreedFeatureCapability("conversation-v4")) {
                     return version;
                 }
@@ -477,6 +477,10 @@ public class ApiUtils {
     public static String getUrlForPoll(String baseUrl,
                                        String roomToken) {
         return baseUrl + ocsApiVersion + spreedApiVersion + "/poll/" + roomToken;
+    }
+
+    public static String getUrlForMessageExpiration(int version, String baseUrl, String token) {
+        return getUrlForRoom(version, baseUrl, token) + "/message-expiration";
     }
 
 }

--- a/app/src/main/res/layout/controller_conversation_info.xml
+++ b/app/src/main/res/layout/controller_conversation_info.xml
@@ -3,6 +3,8 @@
   ~
   ~ @author Mario Danic
   ~ @author Andy Scherzinger
+  ~ @author Marcel Hibbe
+  ~ Copyright (C) 2022 Marcel Hibbe <dev@mhibbe.de>
   ~ Copyright (C) 2021 Andy Scherzinger <info@andy-scherzinger.de>
   ~ Copyright (C) 2017-2018 Mario Danic <mario@lovelyhq.com>
   ~
@@ -45,9 +47,10 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <RelativeLayout
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
             <com.yarolegovich.mp.MaterialPreferenceCategory
                 android:id="@+id/conversation_info_name"
@@ -87,7 +90,6 @@
                 android:id="@+id/conversation_description"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_below="@id/conversation_info_name"
                 android:animateLayoutChanges="true"
                 android:visibility="gone"
                 apc:cardBackgroundColor="@color/bg_default"
@@ -109,7 +111,6 @@
                 android:id="@+id/otherRoomOptions"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_below="@id/conversation_description"
                 android:visibility="gone"
                 apc:cardBackgroundColor="@color/bg_default"
                 apc:cardElevation="0dp"
@@ -127,11 +128,76 @@
 
             </com.yarolegovich.mp.MaterialPreferenceCategory>
 
+            <LinearLayout
+                android:id="@+id/settings"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <include
+                    android:id="@+id/notification_settings_view"
+                    layout="@layout/notification_settings_item"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
+
+                <include
+                    android:id="@+id/webinar_info_view"
+                    layout="@layout/webinar_info_item"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
+
+            </LinearLayout>
+
+            <com.yarolegovich.mp.MaterialPreferenceCategory
+                android:id="@+id/category_shared_items"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:animateLayoutChanges="true"
+                apc:cardBackgroundColor="@color/bg_default"
+                apc:cardElevation="0dp"
+                apc:mpc_title="@string/nc_shared_items">
+
+                <com.yarolegovich.mp.MaterialStandardPreference
+                    android:id="@+id/show_shared_items_action"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    apc:mp_icon="@drawable/ic_folder_multiple_image"
+                    apc:mp_icon_tint="@color/grey_600"
+                    apc:mp_title="@string/nc_shared_items_description" />
+
+            </com.yarolegovich.mp.MaterialPreferenceCategory>
+
+            <com.yarolegovich.mp.MaterialPreferenceCategory
+                android:id="@+id/category_conversation_settings"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:animateLayoutChanges="true"
+                apc:cardBackgroundColor="@color/bg_default"
+                apc:cardElevation="0dp"
+                apc:mpc_title="@string/nc_conversation_settings">
+
+                <com.yarolegovich.mp.MaterialChoicePreference
+                    android:id="@+id/conversation_info_expire_messages"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:visibility="gone"
+                    apc:mp_entry_descriptions="@array/message_expiring_descriptions"
+                    apc:mp_entry_values="@array/message_expiring_values"
+                    apc:mp_key="message_expire_key"
+                    apc:mp_show_value="onBottom"
+                    apc:mp_title="@string/nc_expire_messages">
+                </com.yarolegovich.mp.MaterialChoicePreference>
+
+            </com.yarolegovich.mp.MaterialPreferenceCategory>
+
             <com.yarolegovich.mp.MaterialPreferenceCategory
                 android:id="@+id/participants_list_category"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_below="@+id/category_shared_items"
                 android:visibility="gone"
                 apc:cardBackgroundColor="@color/bg_default"
                 apc:cardElevation="0dp"
@@ -159,7 +225,6 @@
                 android:id="@+id/ownOptions"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_below="@id/participants_list_category"
                 android:visibility="gone"
                 apc:cardBackgroundColor="@color/bg_default"
                 apc:cardElevation="0dp"
@@ -191,52 +256,6 @@
 
             </com.yarolegovich.mp.MaterialPreferenceCategory>
 
-            <LinearLayout
-                android:id="@+id/settings"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_below="@id/otherRoomOptions"
-                android:orientation="vertical">
-
-                <include
-                    android:id="@+id/notification_settings_view"
-                    layout="@layout/notification_settings_item"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:visibility="gone"
-                    tools:visibility="gone" />
-
-                <include
-                    android:id="@+id/webinar_info_view"
-                    layout="@layout/webinar_info_item"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:visibility="gone"
-                    tools:visibility="visible" />
-
-            </LinearLayout>
-
-
-            <com.yarolegovich.mp.MaterialPreferenceCategory
-                android:id="@+id/category_shared_items"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_below="@id/settings"
-                android:animateLayoutChanges="true"
-                apc:cardBackgroundColor="@color/bg_default"
-                apc:cardElevation="0dp"
-                apc:mpc_title="@string/nc_shared_items">
-
-                <com.yarolegovich.mp.MaterialStandardPreference
-                    android:id="@+id/show_shared_items_action"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    apc:mp_icon="@drawable/ic_folder_multiple_image"
-                    apc:mp_icon_tint="@color/grey_600"
-                    apc:mp_title="@string/nc_shared_items_description" />
-
-            </com.yarolegovich.mp.MaterialPreferenceCategory>
-
-        </RelativeLayout>
+        </LinearLayout>
     </ScrollView>
 </RelativeLayout>

--- a/app/src/main/res/layout/controller_conversation_info.xml
+++ b/app/src/main/res/layout/controller_conversation_info.xml
@@ -192,6 +192,17 @@
                     apc:mp_title="@string/nc_expire_messages">
                 </com.yarolegovich.mp.MaterialChoicePreference>
 
+                <TextView
+                    android:id="@+id/conversation_info_expire_messages_explanation"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:visibility="gone"
+                    android:layout_marginStart="@dimen/standard_margin"
+                    android:layout_marginEnd="@dimen/standard_margin"
+                    android:textColor="@color/disabled_text"
+                    android:text="@string/nc_expire_messages_explanation">
+                </TextView>
+
             </com.yarolegovich.mp.MaterialPreferenceCategory>
 
             <com.yarolegovich.mp.MaterialPreferenceCategory

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -3,6 +3,8 @@
   ~ Nextcloud Talk application
   ~
   ~ @author Mario Danic
+  ~ @author Marcel Hibbe
+  ~ Copyright (C) 2022 Marcel Hibbe <dev@mhibbe.de>
   ~ Copyright (C) 2017 Mario Danic <mario@lovelyhq.com>
   ~
   ~ This program is free software: you can redistribute it and/or modify
@@ -37,6 +39,24 @@
         <item>never</item>
         <item>mention</item>
         <item>always</item>
+    </array>
+
+    <array name="message_expiring_descriptions">
+        <item>@string/nc_expire_message_off</item>
+        <item>@string/nc_expire_message_four_weeks</item>
+        <item>@string/nc_expire_message_one_week</item>
+        <item>@string/nc_expire_message_one_day</item>
+        <item>@string/nc_expire_message_eight_hours</item>
+        <item>@string/nc_expire_message_one_hour</item>
+    </array>
+
+    <array name="message_expiring_values">
+        <item>expire_0</item>
+        <item>expire_2419200</item>
+        <item>expire_604800</item>
+        <item>expire_86400</item>
+        <item>expire_28800</item>
+        <item>expire_3600</item>
     </array>
 
     <array name="screen_lock_timeout_descriptions">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,8 @@
   ~
   ~ @author Mario Danic
   ~ @author Andy Scherzinger
+  ~ @author Marcel Hibbe
+  ~ Copyright (C) 2022 Marcel Hibbe <dev@mhibbe.de>
   ~ Copyright (C) 2021 Andy Scherzinger <info@andy-scherzinger.de>
   ~ Copyright (C) 2017-2018 Mario Danic <mario@lovelyhq.com>
   ~
@@ -563,5 +565,17 @@
     <string name="send_without_notification">Send without notification</string>
     <string name="call_without_notification">Call without notification</string>
     <string name="set_avatar_from_camera">Set avatar from camera</string>
+
+    <string name="nc_conversation_settings">Conversation settings</string>
+
+    <!-- Expiring messages -->
+    <string name="nc_expire_messages">Expire chat messages</string>
+    <string name="nc_expire_message_off">Off</string>
+    <string name="nc_expire_message_four_weeks">4 weeks</string>
+    <string name="nc_expire_message_one_week">1 week</string>
+    <string name="nc_expire_message_one_day">1 day</string>
+    <string name="nc_expire_message_eight_hours">8 hours</string>
+    <string name="nc_expire_message_one_hour">1 hour</string>
+
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -576,6 +576,7 @@
     <string name="nc_expire_message_one_day">1 day</string>
     <string name="nc_expire_message_eight_hours">8 hours</string>
     <string name="nc_expire_message_one_hour">1 hour</string>
+    <string name="nc_expire_messages_explanation">Expire chat messages after a certain time. Files shared into the chat will only be unshared from the conversation but are not deleted for the owner.</string>
 
 
 </resources>


### PR DESCRIPTION
resolve #2281

Conversation settings | Conversation settings dark | Expiring messages dialog 
------- | ------- |-------- 
![grafik](https://user-images.githubusercontent.com/2932790/186391986-97da88f6-ab7e-47e8-85fa-36f16a2a8910.png) | ![grafik](https://user-images.githubusercontent.com/2932790/186393135-e4f909ce-a086-4af8-92db-76e3607ccf9b.png) | ![grafik](https://user-images.githubusercontent.com/2932790/186392792-9eebbfb3-1af2-4416-8a76-65aae22305bc.png) | 



Tasks:
- [x] Make sure items are removed from the view when their message expiration is reached even when the user doesn't leave the conversation
- [x] Make sure when entering a conversation we don't show messages that expired in the meantime
- [x] Handle system message

Follow-up possible:
- [x] Add an option to set the expiration with:
    - Off
    - 4 weeks
    - 1 week
    - 1 day
    - 8 hours
    - 1 hour

# remaining TODOS:
- [x] fix klint/detect
- [x] remove some hardcodings?

# Notes
- Handling of expiring messages must be implemented in a cleaner way once offline support is done with the new architecture. (right now data is modified on the adapter itself which is not a good practice).

- Setting time for expiring messages must be implemented in a cleaner way once dependency `com.yarolegovich:mp` is replaced with plain android solutions.


Signed-off-by: Marcel Hibbe <dev@mhibbe.de>