### PR TITLE
fix to keep notification channels

### DIFF
--- a/app/src/gplay/java/com/nextcloud/talk/services/firebase/ChatAndCallMessagingService.kt
+++ b/app/src/gplay/java/com/nextcloud/talk/services/firebase/ChatAndCallMessagingService.kt
@@ -217,7 +217,7 @@ class ChatAndCallMessagingService : FirebaseMessagingService() {
                 )
 
                 val soundUri = getCallRingtoneUri(applicationContext!!, appPreferences)
-                val notificationChannelId = NotificationUtils.NOTIFICATION_CHANNEL_CALLS_V4
+                val notificationChannelId = NotificationUtils.NotificationChannels.NOTIFICATION_CHANNEL_CALLS_V4.name
                 val uri = Uri.parse(signatureVerification!!.user!!.baseUrl)
                 val baseUrl = uri.host
 

--- a/app/src/main/java/com/nextcloud/talk/controllers/SettingsController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/SettingsController.kt
@@ -196,7 +196,7 @@ class SettingsController : BaseController(R.layout.controller_settings) {
                 intent.putExtra(Settings.EXTRA_APP_PACKAGE, BuildConfig.APPLICATION_ID)
                 intent.putExtra(
                     Settings.EXTRA_CHANNEL_ID,
-                    NotificationUtils.NOTIFICATION_CHANNEL_CALLS_V4
+                    NotificationUtils.NotificationChannels.NOTIFICATION_CHANNEL_CALLS_V4.name
                 )
 
                 startActivity(intent)
@@ -206,7 +206,7 @@ class SettingsController : BaseController(R.layout.controller_settings) {
                 intent.putExtra(Settings.EXTRA_APP_PACKAGE, BuildConfig.APPLICATION_ID)
                 intent.putExtra(
                     Settings.EXTRA_CHANNEL_ID,
-                    NotificationUtils.NOTIFICATION_CHANNEL_MESSAGES_V4
+                    NotificationUtils.NotificationChannels.NOTIFICATION_CHANNEL_MESSAGES_V4.name
                 )
                 startActivity(intent)
             }

--- a/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.java
@@ -362,7 +362,7 @@ public class NotificationWorker extends Worker {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             if (CHAT.equals(decryptedPushMessage.getType()) || ROOM.equals(decryptedPushMessage.getType())) {
-                notificationBuilder.setChannelId(NotificationUtils.NOTIFICATION_CHANNEL_MESSAGES_V4);
+                notificationBuilder.setChannelId(NotificationUtils.NotificationChannels.NOTIFICATION_CHANNEL_MESSAGES_V4.name());
             }
         } else {
             // red color for the lights

--- a/app/src/main/java/com/nextcloud/talk/jobs/UploadAndShareFilesWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/UploadAndShareFilesWorker.kt
@@ -192,7 +192,11 @@ class UploadAndShareFilesWorker(val context: Context, workerParameters: WorkerPa
 
     private fun initNotification() {
         mNotifyManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        mBuilder = NotificationCompat.Builder(context, NotificationUtils.NOTIFICATION_CHANNEL_UPLOADS)
+        mBuilder = NotificationCompat.Builder(
+            context,
+            NotificationUtils.NotificationChannels
+                .NOTIFICATION_CHANNEL_UPLOADS.name
+        )
 
         notification = mBuilder!!
             .setContentTitle(context.resources.getString(R.string.nc_upload_in_progess))

--- a/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
@@ -49,19 +49,11 @@ import java.io.IOException
 
 object NotificationUtils {
 
-    // Notification channel IDs commented below are no longer used.
-    // All old notification channels get deleted when the app is upgraded to the current version.
-    //
-    // val NOTIFICATION_CHANNEL_MESSAGES = "NOTIFICATION_CHANNEL_MESSAGES"
-    // val NOTIFICATION_CHANNEL_MESSAGES_V2 = "NOTIFICATION_CHANNEL_MESSAGES_V2"
-    // val NOTIFICATION_CHANNEL_MESSAGES_V3 = "NOTIFICATION_CHANNEL_MESSAGES_V3"
-    // val NOTIFICATION_CHANNEL_CALLS = "NOTIFICATION_CHANNEL_CALLS"
-    // val NOTIFICATION_CHANNEL_CALLS_V2 = "NOTIFICATION_CHANNEL_CALLS_V2"
-    // val NOTIFICATION_CHANNEL_CALLS_V3 = "NOTIFICATION_CHANNEL_CALLS_V3"
-
-    const val NOTIFICATION_CHANNEL_MESSAGES_V4 = "NOTIFICATION_CHANNEL_MESSAGES_V4"
-    const val NOTIFICATION_CHANNEL_CALLS_V4 = "NOTIFICATION_CHANNEL_CALLS_V4"
-    const val NOTIFICATION_CHANNEL_UPLOADS = "NOTIFICATION_CHANNEL_UPLOADS"
+    enum class NotificationChannels {
+        NOTIFICATION_CHANNEL_MESSAGES_V4,
+        NOTIFICATION_CHANNEL_CALLS_V4,
+        NOTIFICATION_CHANNEL_UPLOADS
+    }
 
     const val DEFAULT_CALL_RINGTONE_URI =
         "android.resource://" + BuildConfig.APPLICATION_ID + "/raw/librem_by_feandesign_call"
@@ -121,7 +113,7 @@ object NotificationUtils {
         createNotificationChannel(
             context,
             Channel(
-                NOTIFICATION_CHANNEL_CALLS_V4,
+                NotificationChannels.NOTIFICATION_CHANNEL_CALLS_V4.name,
                 context.resources.getString(R.string.nc_notification_channel_calls),
                 context.resources.getString(R.string.nc_notification_channel_calls_description),
                 true
@@ -145,7 +137,7 @@ object NotificationUtils {
         createNotificationChannel(
             context,
             Channel(
-                NOTIFICATION_CHANNEL_MESSAGES_V4,
+                NotificationChannels.NOTIFICATION_CHANNEL_MESSAGES_V4.name,
                 context.resources.getString(R.string.nc_notification_channel_messages),
                 context.resources.getString(R.string.nc_notification_channel_messages_description),
                 true
@@ -161,7 +153,7 @@ object NotificationUtils {
         createNotificationChannel(
             context,
             Channel(
-                NOTIFICATION_CHANNEL_UPLOADS,
+                NotificationChannels.NOTIFICATION_CHANNEL_UPLOADS.name,
                 context.resources.getString(R.string.nc_notification_channel_uploads),
                 context.resources.getString(R.string.nc_notification_channel_uploads_description),
                 false
@@ -190,12 +182,11 @@ object NotificationUtils {
                 notificationManager.deleteNotificationChannelGroup(channelGroup.id)
             }
 
+            val channelsToKeep = NotificationChannels.values().map { it.name }
+
             // Delete all notification channels created by previous versions
             for (channel in notificationManager.notificationChannels) {
-                if (
-                    channel.id != NOTIFICATION_CHANNEL_CALLS_V4 &&
-                    channel.id != NOTIFICATION_CHANNEL_MESSAGES_V4
-                ) {
+                if (!channelsToKeep.contains(channel.id)) {
                     notificationManager.deleteNotificationChannel(channel.id)
                 }
             }
@@ -312,7 +303,8 @@ object NotificationUtils {
     ): Uri? {
         return getRingtoneUri(
             context,
-            appPreferences.callRingtoneUri, DEFAULT_CALL_RINGTONE_URI, NOTIFICATION_CHANNEL_CALLS_V4
+            appPreferences.callRingtoneUri,
+            DEFAULT_CALL_RINGTONE_URI, NotificationChannels.NOTIFICATION_CHANNEL_CALLS_V4.name
         )
     }
 
@@ -322,7 +314,8 @@ object NotificationUtils {
     ): Uri? {
         return getRingtoneUri(
             context,
-            appPreferences.messageRingtoneUri, DEFAULT_MESSAGE_RINGTONE_URI, NOTIFICATION_CHANNEL_MESSAGES_V4
+            appPreferences.messageRingtoneUri,
+            DEFAULT_MESSAGE_RINGTONE_URI, NotificationChannels.NOTIFICATION_CHANNEL_MESSAGES_V4.name
         )
     }
 


### PR DESCRIPTION
new notification channels must not be deleted. for this an enum was created, so that in removeOldNotificationChannels there is no manual work to do

Signed-off-by: Marcel Hibbe <dev@mhibbe.de>