### PR TITLE
Fix crash after hangup due to modifying a list while iterating over it

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -1707,8 +1707,12 @@ public class CallActivity extends CallBaseActivity {
             }
         }
 
+        List<String> sessionIdsToEnd = new ArrayList<String>(peerConnectionWrapperList.size());
         for (PeerConnectionWrapper wrapper : peerConnectionWrapperList) {
-            endPeerConnection(wrapper.getSessionId(), false);
+            sessionIdsToEnd.add(wrapper.getSessionId());
+        }
+        for (String sessionId : sessionIdsToEnd) {
+            endPeerConnection(sessionId, false);
         }
 
         if (localStream != null) {


### PR DESCRIPTION
Fixes #2347, which is a regression introduced in https://github.com/nextcloud/talk-android/pull/2326/commits/f10d74f0ed34a37a9f6f58ec09686068a7dc1d44

`endPeerConnection()` removes the item from the list, so neither a for-each loop nor an iterator can be used to traverse the list; otherwise a `ConcurrentModificationException` is thrown due to modifying the collection while iterating over it.

In the past this was done using a good old for loop, but that could potentially skip some items too, as removing an item could move the rest of the items towards the head, while the iterator count was advanced towards the tail.

To solve that now the list of connections is first traversed to get all the sessions, and then the list of sessions is traversed to end the connections.
