### PR TITLE
Fix issues when leaving calls

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -396,7 +396,6 @@ public class CallActivity extends CallBaseActivity {
         binding.cameraButton.setOnClickListener(l -> onCameraClick());
 
         binding.hangupButton.setOnClickListener(l -> {
-            setCallState(CallStatus.LEAVING);
             hangup(true);
         });
 
@@ -1167,7 +1166,6 @@ public class CallActivity extends CallBaseActivity {
     @Override
     public void onDestroy() {
         if (!currentCallStatus.equals(CallStatus.LEAVING)) {
-            setCallState(CallStatus.LEAVING);
             hangup(true);
         }
         powerManagerUtils.updatePhoneState(PowerManagerUtils.PhoneState.IDLE);
@@ -1660,6 +1658,9 @@ public class CallActivity extends CallBaseActivity {
 
     private void hangup(boolean shutDownView) {
         Log.d(TAG, "hangup! shutDownView=" + shutDownView);
+        if (shutDownView) {
+            setCallState(CallStatus.LEAVING);
+        }
         stopCallingSound();
         dispose(null);
 

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -1483,6 +1483,10 @@ public class CallActivity extends CallBaseActivity {
 
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
     public void onMessageEvent(WebSocketCommunicationEvent webSocketCommunicationEvent) {
+        if (CallStatus.LEAVING.equals(currentCallStatus)) {
+            return;
+        }
+
         switch (webSocketCommunicationEvent.getType()) {
             case "hello":
                 Log.d(TAG, "onMessageEvent 'hello'");

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -1798,7 +1798,7 @@ public class CallActivity extends CallBaseActivity {
                 }
             } else {
                 Log.d(TAG, "   inCallFlag of currentSessionId: " + inCallFlag);
-                if (inCallFlag == 0) {
+                if (inCallFlag == 0 && !CallStatus.LEAVING.equals(currentCallStatus) && ApplicationWideCurrentRoomHolder.getInstance().isInCall()) {
                     Log.d(TAG, "Most probably a moderator ended the call for all.");
                     hangup(true);
                 }


### PR DESCRIPTION
Fixes (the part about a duplicated set of join/leave messages) #2060

When a publisher failed or starting the call timed out the call activity was closed instead of kept open. This was caused by handling all disconnected call flags for the current participant as being triggered by a moderator ending the call (a regression introduced in https://github.com/nextcloud/talk-android/commit/f70f94e6be18c07e64bdb1b6491b48407c98bee1). Now the state of the Android app is also taken into account when processing those messages, and only when the local participant left the call due to a remote action the call activity is closed.

Independently of that, when the HPB is used the call is joined and left again when the call activity is closed and the chat controller is opened. When [the chat controller is attached the room is joined](https://github.com/nextcloud/talk-android/blob/0c06c8b2eb953a783841b1c3e31730b3d6b55e7d/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt#L1780-L1781), which in turn causes [the external signaling server to also join the room](https://github.com/nextcloud/talk-android/blob/0c06c8b2eb953a783841b1c3e31730b3d6b55e7d/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt#L1950). All this happens after the call activity is paused but before it is stopped (which is when [it unregisters from the event bus](https://github.com/nextcloud/talk-android/blob/704df25a6dbd95191279fcf92aa2e2e4240fa854/app/src/main/java/com/nextcloud/talk/activities/BaseActivity.kt#L154-L157)), so the call activity [receives the `roomJoined` event from the external signaling server and starts a call again](https://github.com/nextcloud/talk-android/blob/f10d74f0ed34a37a9f6f58ec09686068a7dc1d44/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java#L1499-L1506).

## How to test (scenario 1)

- Setup the HPB
- Start a call
- Leave it

### Result with this pull request

There is only one message about joining the call and leaving it

### Result without this pull request

There are two sets of messages about joining the call and leaving it


## How to test (scenario 2)

- Start a call
- Wait until it times out

### Result with this pull request

The call activity is kept open and the call can be started again

### Result without this pull request

The call activity is closed


## How to test (scenario 3)

- Setup the HPB, but do not enable a TURN server with TCP
- Block UDP connections from the Android device (so the publisher fails to connect to the HPB and triggers a reconnection)
- Start a call
- Wait until the publisher fails

### Result with this pull request

The call activity is kept open and the call is tried to be reconnected

### Result with this pull request

The call activity is closed
