### PR TITLE
Fix self video size after coming back from pip mode

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -2028,14 +2028,14 @@ public class CallActivity extends CallBaseActivity {
             }
 
             if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE) {
-                layoutParams.height = (int) getResources().getDimension(R.dimen.large_preview_dimension);
+                layoutParams.height = (int) getResources().getDimension(R.dimen.call_self_video_short_side_length);
                 layoutParams.width = FrameLayout.LayoutParams.WRAP_CONTENT;
-                newXafterRotate = (float) (screenWidthDp - getResources().getDimension(R.dimen.large_preview_dimension) * 0.8);
+                newXafterRotate = (float) (screenWidthDp - getResources().getDimension(R.dimen.call_self_video_short_side_length) * 0.8);
 
             } else if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT) {
                 layoutParams.height = FrameLayout.LayoutParams.WRAP_CONTENT;
-                layoutParams.width = (int) getResources().getDimension(R.dimen.large_preview_dimension);
-                newXafterRotate = (float) (screenWidthDp - getResources().getDimension(R.dimen.large_preview_dimension) * 0.5);
+                layoutParams.width = (int) getResources().getDimension(R.dimen.call_self_video_short_side_length);
+                newXafterRotate = (float) (screenWidthDp - getResources().getDimension(R.dimen.call_self_video_short_side_length) * 0.5);
             }
             binding.selfVideoRenderer.setLayoutParams(layoutParams);
 

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -2029,11 +2029,11 @@ public class CallActivity extends CallBaseActivity {
 
             if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE) {
                 layoutParams.height = (int) getResources().getDimension(R.dimen.call_self_video_short_side_length);
-                layoutParams.width = FrameLayout.LayoutParams.WRAP_CONTENT;
+                layoutParams.width = (int) getResources().getDimension(R.dimen.call_self_video_long_side_length);
                 newXafterRotate = (float) (screenWidthDp - getResources().getDimension(R.dimen.call_self_video_short_side_length) * 0.8);
 
             } else if (getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT) {
-                layoutParams.height = FrameLayout.LayoutParams.WRAP_CONTENT;
+                layoutParams.height = (int) getResources().getDimension(R.dimen.call_self_video_long_side_length);
                 layoutParams.width = (int) getResources().getDimension(R.dimen.call_self_video_short_side_length);
                 newXafterRotate = (float) (screenWidthDp - getResources().getDimension(R.dimen.call_self_video_short_side_length) * 0.5);
             }

--- a/app/src/main/res/layout/call_activity.xml
+++ b/app/src/main/res/layout/call_activity.xml
@@ -61,7 +61,7 @@
 
                 <org.webrtc.SurfaceViewRenderer
                     android:id="@+id/selfVideoRenderer"
-                    android:layout_width="@dimen/large_preview_dimension"
+                    android:layout_width="@dimen/call_self_video_short_side_length"
                     android:layout_height="150dp"
                     android:layout_gravity="center"
                     android:layout_margin="16dp"

--- a/app/src/main/res/layout/call_activity.xml
+++ b/app/src/main/res/layout/call_activity.xml
@@ -62,7 +62,7 @@
                 <org.webrtc.SurfaceViewRenderer
                     android:id="@+id/selfVideoRenderer"
                     android:layout_width="@dimen/call_self_video_short_side_length"
-                    android:layout_height="150dp"
+                    android:layout_height="@dimen/call_self_video_long_side_length"
                     android:layout_gravity="center"
                     android:layout_margin="16dp"
                     android:clickable="false"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -63,6 +63,7 @@
     <dimen name="dialog_padding">24dp</dimen>
     <dimen name="dialog_padding_top_bottom">18dp</dimen>
 
+    <dimen name="call_self_video_long_side_length">150dp</dimen>
     <dimen name="call_self_video_short_side_length">80dp</dimen>
     <dimen name="call_grid_item_min_height">180dp</dimen>
     <dimen name="call_controls_height">110dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -46,7 +46,6 @@
 
     <dimen name="maximum_file_preview_size">192dp</dimen>
 
-    <dimen name="large_preview_dimension">80dp</dimen>
     <dimen name="corner_radius">16dp</dimen>
     <dimen name="button_corner_radius">24dp</dimen>
     <dimen name="standard_margin">16dp</dimen>
@@ -64,6 +63,7 @@
     <dimen name="dialog_padding">24dp</dimen>
     <dimen name="dialog_padding_top_bottom">18dp</dimen>
 
+    <dimen name="call_self_video_short_side_length">80dp</dimen>
     <dimen name="call_grid_item_min_height">180dp</dimen>
     <dimen name="call_controls_height">110dp</dimen>
     <dimen name="zero">0dp</dimen>


### PR DESCRIPTION
The self video had a _wrap_content_ height when coming back from PiP mode, which caused it to expand and occupy the full window height. Now the height is set to the same value used when starting the call activity.

As this is just a quick fix no fancy things like basing the self video size on the screen size and ratio were added :-)

## How to test

- Start a video call
- Go back to the chat without leaving the call (for example, pressing the back button)
- Tap on the PiP window to maximize the call activity again

### Result with this pull request

The self video view has the same size as when the activity was first launched

### Result without this pull request

The self video view occupies the full window height (it can be noticed by the position of the button to switch the camera, as it is aligned to the bottom)
