### PR TITLE
Fix checking lobby state from chat controller while in a call

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -1818,6 +1818,12 @@ class ChatController(args: Bundle) :
             activity?.findViewById<View>(R.id.toolbar)?.setOnClickListener(null)
         }
 
+        checkingLobbyStatus = false
+
+        if (lobbyTimerHandler != null) {
+            lobbyTimerHandler?.removeCallbacksAndMessages(null)
+        }
+
         if (conversationUser != null && isActivityNotChangingConfigurations() && isNotInCall()) {
             ApplicationWideCurrentRoomHolder.getInstance().clear()
             if (inConversation && validSessionId()) {
@@ -1952,6 +1958,7 @@ class ChatController(args: Bundle) :
                     currentConversation?.sessionId
                 )
             }
+            checkLobbyState()
             if (isFirstMessagesProcessing) {
                 pullChatMessages(0)
             } else {


### PR DESCRIPTION
The chat controller [gets the room information again and again to check whether the lobby is enabled](https://github.com/nextcloud/talk-android/blob/5a2b04740b0123e42670defb85535a5843630b7e/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt#L383-L392) and update the UI as needed. This [loop is stopped](https://github.com/nextcloud/talk-android/blob/5a2b04740b0123e42670defb85535a5843630b7e/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt#L1994-L1998) when the chat controller is detached, but only [if no call is active](https://github.com/nextcloud/talk-android/blob/5a2b04740b0123e42670defb85535a5843630b7e/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt#L1825); if a call is active the room information will still be got again and again, even if the chat controller is detached.

Technically the call should be left if the lobby is activated, but the room information from the chat controller is not used at all in the call activity. Moreover, the call activity should fetch that information on its own (either directly or, probably better, through a shared service), as the chat controller is not guaranteed to be active in the background (for example, when handling a call notification).

Besides that other changes would be needed too, as fetching the room information every 5 seconds is overkill, and when the external signaling server is used it should be possible to do it only when something changed (as [the external signaling server is notified when the lobby state has changed](https://github.com/nextcloud/spreed/commit/8524f184f1a56cb249427e285ede12f5422561ff) and it forwards that event to the clients).

Due to all that for now getting the room information is simply stopped when the chat controller is detached, no matter if there is an active call or not, and started again when joining the room, which is done when the chat controller is attached.

However, this is just a quick fix that does not solve the issue in all cases; the loop can still continue during calls, for example if the request to get the information is sent before detaching the controller and the response is received once the controller was detached, as that would start the timer again.

Also note that a similar problem happens when pulling chat messages, although in this case it is less spammy (it happens every 30 seconds rather than 5 seconds), so I did not address it (but the room information messages in logcat were too distracting, hence this pull request :-) ).

## How to test

- Open a conversation
- Start a call
- Check logcat or the webserver access logs

### Result with this pull request

No further requests to get the room information are done while the call activity is maximized

### Result without this pull request

Requests to get the room information are still done every 5 seconds while the call activity is maximized
