### PR TITLE
Fix disposing local stream when the call activity is not being left

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -1166,6 +1166,14 @@ public class CallActivity extends CallBaseActivity {
 
     @Override
     public void onDestroy() {
+        if (localStream != null) {
+            localStream.dispose();
+            localStream = null;
+            Log.d(TAG, "Disposed localStream");
+        } else {
+            Log.d(TAG, "localStream is null");
+        }
+
         if (!currentCallStatus.equals(CallStatus.LEAVING)) {
             setCallState(CallStatus.LEAVING);
             hangup(true);
@@ -1709,14 +1717,6 @@ public class CallActivity extends CallBaseActivity {
 
         for (PeerConnectionWrapper wrapper : peerConnectionWrapperList) {
             endPeerConnection(wrapper.getSessionId(), false);
-        }
-
-        if (localStream != null) {
-            localStream.dispose();
-            localStream = null;
-            Log.d(TAG, "Disposed localStream");
-        } else {
-            Log.d(TAG, "localStream is null");
         }
 
         hangupNetworkCalls(shutDownView);


### PR DESCRIPTION
[The local stream is set](https://github.com/nextcloud/talk-android/blob/f10d74f0ed34a37a9f6f58ec09686068a7dc1d44/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java#L451) only when [the activity is created](https://github.com/nextcloud/talk-android/blob/f10d74f0ed34a37a9f6f58ec09686068a7dc1d44/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java#L338). However, it was disposed when hanging up, which happens not only when closing the activity, but also in cases in which the call activity is kept open and the participant reconnects to the call (for example, when starting the call times out), which caused the local stream to freeze. Now the local stream is disposed only when the call activity is destroyed.

The test below requires the fixes for leaving the call (#2387 and #2388), as otherwise the call activity is closed rather than kept open when timing out.

## How to test

- Start a call with video
- Wait until it times out

### Result with this pull request

The video is still active

### Result without this pull request

The video is frozen
