### PR TITLE
Fix icon not visible in call state message

### DIFF
--- a/app/src/main/res/layout/call_states.xml
+++ b/app/src/main/res/layout/call_states.xml
@@ -25,34 +25,40 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <ImageView
-        android:id="@+id/errorImageView"
-        android:layout_width="48dp"
-        android:layout_height="48dp"
-        android:layout_above="@id/callStateTextView"
-        android:layout_centerHorizontal="true"
-        android:contentDescription="@null"
-        android:src="@drawable/ic_signal_wifi_off_white_24dp"
-        android:visibility="gone" />
+    <FrameLayout
+        android:id="@+id/callStateIconFrameLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:measureAllChildren="@bool/value_true">
 
-    <ProgressBar
-        android:id="@+id/callStateProgressBar"
-        android:layout_width="@dimen/item_height"
-        android:layout_height="@dimen/item_height"
-        android:layout_above="@id/callStateTextView"
-        android:layout_centerHorizontal="true"
-        android:layout_marginStart="@dimen/activity_horizontal_margin"
-        android:layout_marginLeft="@dimen/activity_horizontal_margin"
-        android:layout_marginEnd="@dimen/activity_horizontal_margin"
-        android:layout_marginRight="@dimen/activity_horizontal_margin"
-        android:indeterminate="true"
-        android:indeterminateTint="@color/colorPrimary"
-        android:indeterminateTintMode="src_in" />
+        <ImageView
+            android:id="@+id/errorImageView"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_gravity="center"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_signal_wifi_off_white_24dp"
+            android:visibility="gone" />
+
+        <ProgressBar
+            android:id="@+id/callStateProgressBar"
+            android:layout_width="@dimen/item_height"
+            android:layout_height="@dimen/item_height"
+            android:layout_gravity="center"
+            android:layout_marginStart="@dimen/activity_horizontal_margin"
+            android:layout_marginLeft="@dimen/activity_horizontal_margin"
+            android:layout_marginEnd="@dimen/activity_horizontal_margin"
+            android:layout_marginRight="@dimen/activity_horizontal_margin"
+            android:indeterminate="true"
+            android:indeterminateTint="@color/colorPrimary"
+            android:indeterminateTintMode="src_in" />
+    </FrameLayout>
 
     <TextView
         android:id="@+id/callStateTextView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_below="@id/callStateIconFrameLayout"
         android:layout_centerInParent="true"
         android:layout_margin="16dp"
         android:gravity="center"


### PR DESCRIPTION
The call state uses a RelativeLayout with a wrap content height where the state icons (including the progress bar) position was set as above the message. However, this caused the call state to wrap only the text; the icons were indeed above the message, but out of the view boundaries.

Now the icons are wrapped in a FrameLayout and the text position is set below that frame layout instead, which causes the RelativeLayout height to correctly wrap its content.

The last part (checking the time out icon) of the test below requires the fixes for leaving the call (#2387 and #2388), as otherwise the call activity is closed rather than kept open when timing out.

## How to test

- Start a call (and do not join it from any other device)

### Result with this pull request

The progress bar is shown above the message; after 45 seconds the timer icon is shown above the message

### Result without this pull request

The progress bar is not shown above the message; after 45 seconds the timer icon is not shown above the message
