### PR TITLE
Fix call not joined again if reconnecting while in PiP mode

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -700,7 +700,9 @@ public class CallActivity extends CallBaseActivity {
         if (isVoiceOnlyCall) {
             onMicrophoneClick();
         } else {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            if (EffortlessPermissions.hasPermissions(this, PERMISSIONS_CALL)) {
+                onPermissionsGranted();
+            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 requestPermissions(PERMISSIONS_CALL, 100);
             } else {
                 onRequestPermissionsResult(100, PERMISSIONS_CALL, new int[]{1, 1});


### PR DESCRIPTION
When a publisher fails during a call a [reconnection is triggered](https://github.com/nextcloud/talk-android/blob/f10d74f0ed34a37a9f6f58ec09686068a7dc1d44/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java#L2090-L2095), which [first leaves the call](https://github.com/nextcloud/talk-android/blob/f10d74f0ed34a37a9f6f58ec09686068a7dc1d44/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java#L1730) and then [initiates it again](https://github.com/nextcloud/talk-android/blob/f10d74f0ed34a37a9f6f58ec09686068a7dc1d44/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java#L1743-L1746). Initiating a video call first [request the permissions](https://github.com/nextcloud/talk-android/blob/f10d74f0ed34a37a9f6f58ec09686068a7dc1d44/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java#L704), but it seems that the request hangs when done while in PiP mode (I have not checked if the problem comes from PiP mode itself, the activity being paused or what; I just found that it hangs there :-) ). Due to this if the publisher fails while in PiP mode and the call is initiated again the call will be simply left, without reconnecting to it.

The problem is specific to video calls, as [in voice only calls `onMicrophoneClick` is used instead](https://github.com/nextcloud/talk-android/blob/f10d74f0ed34a37a9f6f58ec09686068a7dc1d44/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java#L699-L701), and it explicitly checks [if the permissions are already granted](https://github.com/nextcloud/talk-android/blob/f10d74f0ed34a37a9f6f58ec09686068a7dc1d44/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java#L879-L880). Checking if the permissions are already granted before requesting them is also [recommended in the Android developer guide](https://developer.android.com/training/permissions/requesting#already-granted)), and as the permissions are requested during the original call initialization it is expected that they will be already granted if the call is changed to PiP mode, so the problem is work arounded that way.

If the permissions are not granted when the publisher fails in PiP mode the problem would still happen, although that should be quite uncommon. Nevertheless, the permission request flow will be probably changed when the support for Talk media publishing permissions is added, so I think that for now this is fine.

In any case, I am not sure if directly calling `onPermissionsGranted()` is fine or if the code should be something like this instead (although I do not know what that `1` means, as [PERMISSION_GRANTED is 0](https://developer.android.com/reference/android/content/pm/PackageManager#PERMISSION_GRANTED) and [PERMISSION_DENIED is -1](https://developer.android.com/reference/android/content/pm/PackageManager#PERMISSION_DENIED) :thinking:):
```
if (EffortlessPermissions.hasPermissions(this, PERMISSIONS_CALL) || Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
    onRequestPermissionsResult(100, PERMISSIONS_CALL, new int[]{1, 1});
} else {
    requestPermissions(PERMISSIONS_CALL, 100);
}
```

Independently of all that, note that when the publisher fails while in PiP mode the call state appears in the PiP mode. However, [the call state is explicitly hidden when switching to PiP mode](https://github.com/nextcloud/talk-android/blob/f10d74f0ed34a37a9f6f58ec09686068a7dc1d44/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java#L2627), even if the call was not established yet. That seems inconsistent, but I do not know if it is the expected behaviour, so I have not changed anything in that regard. Additionally, the call state is kept hidden when coming back from PiP mode (you can test this by starting a call, switching to PiP mode and coming back; the _Calling_ state will not be shown), but as it is also related to that mentioned inconsistency I did not change anything there either.

The test below requires the fixes for leaving the call (#2387 and #2388), as otherwise the call activity is closed rather than reconnecting when the publisher fails.

## How to test

- Setup the HPB, but do not enable a TURN server with TCP
- Block UDP connections from the Android device (so the publisher fails to connect to the HPB and triggers a reconnection)
- Start a call
- Change to PiP mode

### Result with this pull request

After some seconds the publisher fails and the call is tried to be joined again

### Result without this pull request

After some seconds the publisher fails, but then the call is not tried to be joined again
