### PR TITLE
Show message in call state when the publisher failed

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -2089,7 +2089,7 @@ public class CallActivity extends CallBaseActivity {
 
         } else if (peerConnectionEvent.getPeerConnectionEventType() ==
             PeerConnectionEvent.PeerConnectionEventType.PUBLISHER_FAILED) {
-            currentCallStatus = CallStatus.PUBLISHER_FAILED;
+            setCallState(CallStatus.PUBLISHER_FAILED);
             webSocketClient.clearResumeId();
             hangup(false);
         }
@@ -2342,6 +2342,25 @@ public class CallActivity extends CallBaseActivity {
 
                         if (binding.callStates.errorImageView.getVisibility() != View.VISIBLE) {
                             binding.callStates.errorImageView.setVisibility(View.VISIBLE);
+                        }
+                    });
+                    break;
+                case PUBLISHER_FAILED:
+                    handler.post(() -> {
+                        // No calling sound when the publisher failed
+                        binding.callStates.callStateTextView.setText(R.string.nc_call_reconnecting);
+                        binding.callModeTextView.setText(getDescriptionForCallType());
+                        if (binding.callStates.callStateRelativeLayout.getVisibility() != View.VISIBLE) {
+                            binding.callStates.callStateRelativeLayout.setVisibility(View.VISIBLE);
+                        }
+                        if (binding.gridview.getVisibility() != View.INVISIBLE) {
+                            binding.gridview.setVisibility(View.INVISIBLE);
+                        }
+                        if (binding.callStates.callStateProgressBar.getVisibility() != View.VISIBLE) {
+                            binding.callStates.callStateProgressBar.setVisibility(View.VISIBLE);
+                        }
+                        if (binding.callStates.errorImageView.getVisibility() != View.GONE) {
+                            binding.callStates.errorImageView.setVisibility(View.GONE);
                         }
                     });
                     break;


### PR DESCRIPTION
When the HPB is used and the publisher fails (which is a disconnection that can not be automatically solved by itself) a forced reconnection is
triggered. This restarts the call, so some feedback should be provided in the UI about it.

The test below requires the fixes for leaving the call (#2387 and #2388), as otherwise the call activity is closed rather than reconnecting when the publisher fails.

## How to test

- Setup the HPB, but do not enable a TURN server with TCP
- Block UDP connections from the Android device (so the publisher fails to connect to the HPB and triggers a reconnection)
- Start a call
- Wait until the publisher fails

### Result with this pull request

The call is tried to be joined again and a _Reconnecting_ message is shown in the call state

### Result without this pull request

The call is tried to be joined again, but no specific message about that is shown in the call state
