### PR TITLE
Determine base branch with 'jq'

### DIFF
--- a/scripts/analysis/getBranchName.sh
+++ b/scripts/analysis/getBranchName.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-# $1: username, $2: password/token, $3: pull request number
+# $1: username
+# $2: password/token
+# $3: pull request number
 
-if [ -z $3 ] ; then
-    git branch | grep '*' | cut -d' ' -f2
+if [ -z "$3" ] ; then
+    git branch | grep '\*' | cut -d' ' -f2
 else
-    curl 2>/dev/null -u $1:$2 https://api.github.com/repos/nextcloud/talk-android/pulls/$3 | grep \"ref\": | grep -v master | cut -d"\"" -f4
+    curl 2>/dev/null -u "$1":"$2" "https://api.github.com/repos/nextcloud/talk-android/pulls/$3" | jq .base.ref
 fi


### PR DESCRIPTION
The GitHub API response contains the base branch in which the changes should
pulled into. This is now extracted with 'jq' from the response.

Also some Shellcheck issues were fixed.
