### PR TITLE
fix to show reactionsEmojiWrapper

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/Reaction.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/Reaction.kt
@@ -47,6 +47,7 @@ class Reaction {
     ) {
         binding.reactionsEmojiWrapper.removeAllViews()
         if (message.reactions != null && message.reactions!!.isNotEmpty()) {
+            binding.reactionsEmojiWrapper.visibility = View.VISIBLE
 
             var remainingEmojisToDisplay = MAX_EMOJIS_TO_DISPLAY
             val showInfoAboutMoreEmojis = message.reactions!!.size > MAX_EMOJIS_TO_DISPLAY


### PR DESCRIPTION
fix https://github.com/nextcloud/talk-android/issues/2432

with https://github.com/nextcloud/talk-android/pull/2364 it was implemented to hide the reactionsEmojiWrapper when no emojis are set for a message. whenever a emoji was added, it was actually not shown because the wrapper was still hidden.

with the fix, the wrapper is made visible again

Signed-off-by: Marcel Hibbe <dev@mhibbe.de>