### PR TITLE
Get branch name from head instead of base

### DIFF
--- a/scripts/analysis/getBranchName.sh
+++ b/scripts/analysis/getBranchName.sh
@@ -7,5 +7,5 @@
 if [ -z "$3" ] ; then
     git branch | grep '\*' | cut -d' ' -f2
 else
-    curl 2>/dev/null -u "$1":"$2" "https://api.github.com/repos/nextcloud/talk-android/pulls/$3" | jq .base.ref
+    curl 2>/dev/null -u "$1":"$2" "https://api.github.com/repos/nextcloud/talk-android/pulls/$3" | jq .head.ref
 fi


### PR DESCRIPTION
Not the name of the branch were the changes should pulled into is
needed. The name of the current branch must be determined.

Resolves error introduced with cc1e1270e1daabb6b9700792debdecb22b072c77


## GitHub response
```json
{
  "url": "https://api.github.com/repos/nextcloud/talk-android/pulls/2393",
  "id": 1059797651,
  ...
  "head": {
    "label": "nextcloud:fix-icon-not-visible-in-call-state-message",
    "ref": "fix-icon-not-visible-in-call-state-message",
    "sha": "7bb84fcf020bbde20f48e89f1542bcded0674453",
    ...
  },
  "base": {
    "label": "nextcloud:master",
    "ref": "master",
    "sha": "61b343c73f3c5833ae0f3e42b6d12f40610a3702",
    ...
  },
  "comments": 3,
  "review_comments": 0,
  "maintainer_can_modify": false,
  "commits": 1,
  "additions": 28,
  "deletions": 22,
  "changed_files": 1
}
```