### PR TITLE
Show error when loading chats fails

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.kt
@@ -616,6 +616,7 @@ class ConversationsListController(bundle: Bundle) :
                 handleHttpExceptions(throwable)
                 withNullableControllerViewBinding {
                     binding.swipeRefreshLayoutView.isRefreshing = false
+                    showErrorDialog()
                 }
                 dispose(roomsQueryDisposable)
             }) {
@@ -625,6 +626,24 @@ class ConversationsListController(bundle: Bundle) :
                 }
                 isRefreshing = false
             }
+    }
+
+    private fun showErrorDialog() {
+        val dialogBuilder = MaterialAlertDialogBuilder(binding.floatingActionButton.context)
+            .setIcon(
+                viewThemeUtils.dialog.colorMaterialAlertDialogIcon(
+                    context,
+                    R.drawable.ic_baseline_error_outline_24dp,
+                )
+            )
+            .setTitle(R.string.error_loading_chats)
+            .setCancelable(false)
+            .setNegativeButton(R.string.close, null)
+        viewThemeUtils.dialog.colorMaterialAlertDialogBackground(binding.floatingActionButton.context, dialogBuilder)
+        val dialog = dialogBuilder.show()
+        viewThemeUtils.platform.colorTextButtons(
+            dialog.getButton(AlertDialog.BUTTON_NEGATIVE)
+        )
     }
 
     private fun sortConversations(conversationItems: MutableList<AbstractFlexibleItem<*>>) {
@@ -1344,6 +1363,7 @@ class ConversationsListController(bundle: Bundle) :
         handleHttpExceptions(throwable)
         withNullableControllerViewBinding {
             binding.swipeRefreshLayoutView.isRefreshing = false
+            showErrorDialog()
         }
     }
 

--- a/app/src/main/res/drawable/ic_baseline_error_outline_24dp.xml
+++ b/app/src/main/res/drawable/ic_baseline_error_outline_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FF0000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M11,15h2v2h-2zM11,7h2v6h-2zM11.99,2C6.47,2 2,6.48 2,12s4.47,10 9.99,10C17.52,22 22,17.52 22,12S17.52,2 11.99,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -292,6 +292,8 @@
     <string name="nc_new_mention">Unread mentions</string>
     <string name="conversations">Conversations</string>
     <string name="openConversations">Open conversations</string>
+    <string name="error_loading_chats">There was a problem loading your chats</string>
+    <string name="close">Close</string>
 
     <!-- Chat -->
     <string name="nc_hint_enter_a_message">Enter a message …</string>


### PR DESCRIPTION
Partially addresses https://github.com/nextcloud/talk-android/issues/2346, but only shows that an error happened and doesn't offer any options.
![Screenshot_1664552840](https://user-images.githubusercontent.com/26026535/193308555-c459789a-2a8d-42cf-bfc9-684a7301ede3.png)