### PR TITLE
Like Android Files we should rely on generic camera feature, but not required.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-feature
-        android:name="android.hardware.camera.any"
+        android:name="android.hardware.camera"
         android:required="false" />
     <uses-feature
         android:name="android.hardware.camera.autofocus"


### PR DESCRIPTION


This then should allow us to install Talk on Chromebooks

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>