### PR TITLE
fix copyright headers

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/LinkPreview.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/LinkPreview.kt
@@ -16,9 +16,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Parts related to account import were either copied from or inspired by the great work done by David Luhmer at:
- * https://github.com/nextcloud/ownCloud-Account-Importer
  */
 
 package com.nextcloud.talk.adapters.messages

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/Reaction.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/Reaction.kt
@@ -16,9 +16,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Parts related to account import were either copied from or inspired by the great work done by David Luhmer at:
- * https://github.com/nextcloud/ownCloud-Account-Importer
  */
 
 package com.nextcloud.talk.adapters.messages

--- a/app/src/main/java/com/nextcloud/talk/models/json/participants/ParticipantsOCS.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/participants/ParticipantsOCS.kt
@@ -18,9 +18,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Parts related to account import were either copied from or inspired by the great work done by David Luhmer at:
- * https://github.com/nextcloud/ownCloud-Account-Importer
  */
 package com.nextcloud.talk.models.json.participants
 

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/ChooseAccountDialogFragment.java
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/ChooseAccountDialogFragment.java
@@ -20,9 +20,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Parts related to account import were either copied from or inspired by the great work done by David Luhmer at:
- * https://github.com/nextcloud/ownCloud-Account-Importer
  */
 
 package com.nextcloud.talk.ui.dialog;

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/ChooseAccountShareToDialogFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/ChooseAccountShareToDialogFragment.kt
@@ -20,9 +20,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Parts related to account import were either copied from or inspired by the great work done by David Luhmer at:
- * https://github.com/nextcloud/ownCloud-Account-Importer
  */
 package com.nextcloud.talk.ui.dialog
 

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/ShowReactionsDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/ShowReactionsDialog.kt
@@ -20,9 +20,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Parts related to account import were either copied from or inspired by the great work done by David Luhmer at:
- * https://github.com/nextcloud/ownCloud-Account-Importer
  */
 package com.nextcloud.talk.ui.dialog
 


### PR DESCRIPTION
headers contained a wrong sentence that was duplicated via c&p

Signed-off-by: Marcel Hibbe <dev@mhibbe.de>