### PR TITLE
Fix computing new sessions in call

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -1856,8 +1856,8 @@ public class CallActivity extends CallBaseActivity {
                     + " : "
                     + inCallFlag);
 
-                boolean isNewSession = inCallFlag != 0;
-                if (isNewSession) {
+                boolean isInCall = inCallFlag != 0;
+                if (isInCall) {
                     newSessions.add(participant.get("sessionId").toString());
                 } else {
                     oldSessions.add(participant.get("sessionId").toString());

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -1859,8 +1859,6 @@ public class CallActivity extends CallBaseActivity {
                 boolean isInCall = inCallFlag != 0;
                 if (isInCall) {
                     newSessions.add(participant.get("sessionId").toString());
-                } else {
-                    oldSessions.add(participant.get("sessionId").toString());
                 }
 
                 // The property is "userId" when not using the external signaling server and "userid" when using it.

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -1851,13 +1851,12 @@ public class CallActivity extends CallBaseActivity {
         for (HashMap<String, Object> participant : users) {
             long inCallFlag = (long) participant.get("inCall");
             if (!participant.get("sessionId").equals(currentSessionId)) {
-                boolean isNewSession;
                 Log.d(TAG, "   inCallFlag of participant "
                     + participant.get("sessionId").toString().substring(0, 4)
                     + " : "
                     + inCallFlag);
-                isNewSession = inCallFlag != 0;
 
+                boolean isNewSession = inCallFlag != 0;
                 if (isNewSession) {
                     newSessions.add(participant.get("sessionId").toString());
                 } else {

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -1885,7 +1885,8 @@ public class CallActivity extends CallBaseActivity {
         }
 
         // Calculate sessions that left the call
-        oldSessions.removeAll(newSessions);
+        List<String> disconnectedSessions = new ArrayList<>(oldSessions);
+        disconnectedSessions.removeAll(newSessions);
 
         // Calculate sessions that join the call
         newSessions.removeAll(oldSessions);
@@ -1923,7 +1924,7 @@ public class CallActivity extends CallBaseActivity {
             setCallState(CallStatus.IN_CONVERSATION);
         }
 
-        for (String sessionId : oldSessions) {
+        for (String sessionId : disconnectedSessions) {
             Log.d(TAG, "   oldSession that will be removed is: " + sessionId);
             endPeerConnection(sessionId, false);
         }


### PR DESCRIPTION
Follow up to #2390 (technically the regression was introduced by c3f1f6c, but it is caused by a previous existing bug computing the new sessions, #2390 only revealed that bug)

Labelled as `developing` until I can verify some claims regarding the HPB that I have made in a commit message :-P But it could be reviewed in the meantime (and even merged if needed if you can live with a commit description that might not be fully accurate ;-) ).

The new sessions are computed by substracting the old sessions (those for which a `PeerConnectionWrapper` exists) from the sessions currently in the call. However, when `oldSessions` was used for that it no longer contained the old sessions, it only contained the sessions which were no longer in the call. As those sessions are mutually exclusive with the sessions currently in the call nothing was substracted from `newSessions`, and it ended being the sessions currently in the call instead.

When the HPB is not used the list of participants in the conversation is periodically updated every 30 seconds if no other signaling message was received in the meantime. As the layout for a participant overrides any previous layout for that participant this periodically reset the layout of all participants in the call, as they were all treated as new sessions.

When the HPB is used the list of participants in the conversation is  updated only when something changed. However, similarly to the previous case, when that happens the layout of all participants in the call is also reset for the same reason.

To solve that now `oldSessions` is not modified, so it contains the sessions for which a `PeerConnectionWrapper` exists, and substracting it from `newSessions` now gives only the new sessions. Besides that `oldSessions` no longer contains the sessions that are not in the call and for which there was no `PeerConnectionWrapper`, as it made no difference when computing the disconnected and the new sessions.

The other usages of `newSessions` besides creating the connection and setting up the layout, that is, getting the peers in the call and changing the call status to _In conversation_, should be safe if executed only when there are new sessions rather than when there are participants in the call but they did not change.

Having said that... please test thoroughly with and without HPB to ensure that I did not miss anything :-) Thanks!

## How to test (scenario 1)

- Do not setup the HPB
- Start a call in the WebUI with video enabled
- Join the call in the Android app
- Wait until the connection is established and the video from the WebUI is visible in the Android app
- Wait again more than 30 seconds to receive the [periodic](https://github.com/nextcloud/spreed/blob/5f060687c8a0c77f1a61bf9a3462d4bfa4fe055f/lib/Controller/SignalingController.php#L348-L353) signaling message [with the users in the room](https://github.com/nextcloud/spreed/blob/5f060687c8a0c77f1a61bf9a3462d4bfa4fe055f/lib/Controller/SignalingController.php#L364-L366)

### Result with this pull request

The video of the remote participant is still enabled

### Result without this pull request

The video of the remote participant is eventually disabled



## How to test (scenario 2)

- Setup the HPB
- Start a call in the WebUI with video enabled
- Join the call in the Android app
- Wait until the connection is established and the video from the WebUI is visible in the Android app
- In a private browser window, join the call with another participant

### Result with this pull request

The video of the first remote participant is still enabled

### Result without this pull request

The video of the first remote participant is eventually disabled
