### PR TITLE
Fix remote participants display with both video and screen share

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -2087,8 +2087,9 @@ public class CallActivity extends CallBaseActivity {
         if (!(peerConnectionWrappers = getPeerConnectionWrapperListForSessionId(sessionId)).isEmpty()) {
             for (PeerConnectionWrapper peerConnectionWrapper : peerConnectionWrappers) {
                 if (peerConnectionWrapper.getSessionId().equals(sessionId)) {
-                    if (VIDEO_STREAM_TYPE_SCREEN.equals(peerConnectionWrapper.getVideoStreamType()) || !justScreen) {
-                        runOnUiThread(() -> removeMediaStream(sessionId));
+                    String videoStreamType = peerConnectionWrapper.getVideoStreamType();
+                    if (VIDEO_STREAM_TYPE_SCREEN.equals(videoStreamType) || !justScreen) {
+                        runOnUiThread(() -> removeMediaStream(sessionId, videoStreamType));
                         deletePeerConnection(peerConnectionWrapper);
                     }
                 }
@@ -2096,9 +2097,9 @@ public class CallActivity extends CallBaseActivity {
         }
     }
 
-    private void removeMediaStream(String sessionId) {
+    private void removeMediaStream(String sessionId, String videoStreamType) {
         Log.d(TAG, "removeMediaStream");
-        participantDisplayItems.remove(sessionId);
+        participantDisplayItems.remove(sessionId + "-" + videoStreamType);
 
         if (!isDestroyed()) {
             initGridAdapter();
@@ -2409,7 +2410,7 @@ public class CallActivity extends CallBaseActivity {
                                                                                    videoStreamType,
                                                                                    videoStreamEnabled,
                                                                                    rootEglBase);
-        participantDisplayItems.put(session, participantDisplayItem);
+        participantDisplayItems.put(session + "-" + videoStreamType, participantDisplayItem);
 
         initGridAdapter();
     }


### PR DESCRIPTION
ParticipantDisplayItems are not associated to a full participant but to each of the single connections that the participant may have (video and screen). However, when they are added to the map only the session ID is used as key. Due to this when a participant starts a screen share the ParticipantDisplayItem for the screen share overwrites the item for the video, and once the screen share is stopped the old item is not restored. Moreover, if a participant is already sharing a screen when the local participant joins whether the video or the screen share is shown is undefined and depends on which connection is established first.

To solve that the ParticipantDisplayItems are now associated with both the session ID and the video stream type ("video" or "screen"). Due to this both the video and the screen share of the remote participant are shown in the grid view; in the future it might be better to only show the screen share, or allow switching between screen share and video, or show the screen share in full screen and hide the grid... but for now, as a quick fix, this is good enough :-)

Note that this issue should not be related to the recent changes in the CallActivity, and it is very likely that it happened already in the previous app version.

The issue happens both with and without HPB (so the scenarios below should be tested in both cases).

## How to test (scenario 1)

- Start a call with video in the browser
- Join the call with the Android app
- Wait until the video is shown in the Android app
- In the browser, share the screen
- Wait until the screen is shown in the Android app
- Stop sharing the screen

### Result with this pull request

The video of the remote participant is shown

### Result without this pull request

No remote participant is shown (neither video nor avatar)



## How to test (scenario 2)

- Start a call with video in the browser
- Share the screen
- Join the call with the Android app

### Result with this pull request

Both the video and the screen share are shown

### Result without this pull request

Sometimes only the video is shown, but not the screen share
