### PR TITLE
Add decision to use MADR

### DIFF
--- a/docs/decisions/0000-use-markdown-any-decision-records.md
+++ b/docs/decisions/0000-use-markdown-any-decision-records.md
@@ -1,0 +1,32 @@
+---
+status: accepted
+date: 2022-10-24
+---
+
+# Use Markdown Any Decision Records
+
+## Context and Problem Statement
+
+We want to record any decisions made in this project independent whether decisions concern the architecture ("architectural decision record"), the code, or other fields.
+Which format and structure should these records follow?
+
+## Considered Options
+
+* [MADR](https://adr.github.io/madr/) 3.0.0 – The Markdown Any Decision Records
+* [Michael Nygard's template](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) – The first incarnation of the term "ADR"
+* [Sustainable Architectural Decisions](https://www.infoq.com/articles/sustainable-architectural-design-decisions) – The Y-Statements
+* Other templates listed at <https://github.com/joelparkerhenderson/architecture_decision_record>
+* Formless – No conventions for file format and structure
+
+## Decision Outcome
+
+Chosen option: "MADR 3.0.0", because
+
+* Implicit assumptions should be made explicit.
+  Design documentation is important to enable people understanding the decisions later on.
+  See also [A rational design process: How and why to fake it](https://doi.org/10.1109/TSE.1986.6312940).
+* MADR allows for structured capturing of any decision.
+* The MADR format is lean and fits our development style.
+* The MADR structure is comprehensible and facilitates usage & maintenance.
+* The MADR project is vivid.
+

--- a/docs/decisions/0000-use-markdown-any-decision-records.md
+++ b/docs/decisions/0000-use-markdown-any-decision-records.md
@@ -1,5 +1,5 @@
 ---
-status: accepted
+status: proposed
 date: 2022-10-24
 ---
 

--- a/docs/decisions/0000-use-markdown-any-decision-records.md
+++ b/docs/decisions/0000-use-markdown-any-decision-records.md
@@ -1,6 +1,6 @@
 ---
-status: proposed
-date: 2022-10-24
+status: accepted
+date: 2022-11-29
 ---
 
 # Use Markdown Any Decision Records

--- a/docs/decisions/template.md
+++ b/docs/decisions/template.md
@@ -1,10 +1,8 @@
 ---
-# These are optional elements. Feel free to remove any of them.
-status: {proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)}
+status: { rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)}
 date: {YYYY-MM-DD when the decision was last updated}
+# These are optional elements. Feel free to remove any of them.
 deciders: {list everyone involved in the decision}
-consulted: {list everyone whose opinions are sought (typically subject-matter experts); and with whom there is a two-way communication}
-informed: {list everyone who is kept up-to-date on progress; and with whom there is a one-way communication}
 ---
 # {short title of solved problem and solution}
 

--- a/docs/decisions/template.md
+++ b/docs/decisions/template.md
@@ -1,0 +1,80 @@
+---
+# These are optional elements. Feel free to remove any of them.
+status: {proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)}
+date: {YYYY-MM-DD when the decision was last updated}
+deciders: {list everyone involved in the decision}
+consulted: {list everyone whose opinions are sought (typically subject-matter experts); and with whom there is a two-way communication}
+informed: {list everyone who is kept up-to-date on progress; and with whom there is a one-way communication}
+---
+# {short title of solved problem and solution}
+
+## Context and Problem Statement
+
+{Describe the context and problem statement, e.g., in free form using two to three sentences or in the form of an illustrative story.
+ You may want to articulate the problem in form of a question and add links to collaboration boards or issue management systems.}
+
+<!-- This is an optional element. Feel free to remove. -->
+## Decision Drivers
+
+* {decision driver 1, e.g., a force, facing concern, …}
+* {decision driver 2, e.g., a force, facing concern, …}
+* … <!-- numbers of drivers can vary -->
+
+## Considered Options
+
+* {title of option 1}
+* {title of option 2}
+* {title of option 3}
+* … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: "{title of option 1}", because
+{justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force {force} | … | comes out best (see below)}.
+
+<!-- This is an optional element. Feel free to remove. -->
+### Consequences
+
+* Good, because {positive consequence, e.g., improvement of one or more desired qualities, …}
+* Bad, because {negative consequence, e.g., compromising one or more desired qualities, …}
+* … <!-- numbers of consequences can vary -->
+
+<!-- This is an optional element. Feel free to remove. -->
+## Validation
+
+{describe how the implementation of/compliance with the ADR is validated. E.g., by a review or an ArchUnit test}
+
+<!-- This is an optional element. Feel free to remove. -->
+## Pros and Cons of the Options
+
+### {title of option 1}
+
+<!-- This is an optional element. Feel free to remove. -->
+{example | description | pointer to more information | …}
+
+* Good, because {argument a}
+* Good, because {argument b}
+<!-- use "neutral" if the given argument weights neither for good nor bad -->
+* Neutral, because {argument c}
+* Bad, because {argument d}
+* … <!-- numbers of pros and cons can vary -->
+
+### {title of other option}
+
+{example | description | pointer to more information | …}
+
+* Good, because {argument a}
+* Good, because {argument b}
+* Neutral, because {argument c}
+* Bad, because {argument d}
+* …
+
+<!-- This is an optional element. Feel free to remove. -->
+## More Information
+
+{You might want to provide additional evidence/confidence for the decision outcome here and/or
+ document the team agreement on the decision and/or
+ define when this decision when and how the decision should be realized and if/when it should be re-visited and/or
+ how the decision is validated.
+ Links to other decisions and resources might here appear as well.}
+


### PR DESCRIPTION
Add first decision to use Markdown Any Decision Records. The current
status is 'proposed' and will be discussed in the regarding pull
request.

Also an template for decisions is added. It is a copy of the current
MADR 3.0 template.

It should be discussed:

- The decision 0000 - Use Markdown Any Decision Records.
- The scope of the template.

See: https://adr.github.io/madr/

----
This idea came up in our last Android meeting. We decided to make a pull request and discuss if we want to use decision records to improve our technical documentation. And be more kind to our future self's.
If we will, this will be added also to the android, android-common, android-config and android-library. 



