### PR TITLE
Update WebRTC to 106.5249.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -154,7 +154,7 @@ ext {
     espressoVersion = "3.4.0"
 }
 
-def webRtcVersion = "96.4664.0"
+def webRtcVersion = "106.5249.0"
 tasks.register('downloadWebRtc', DownloadWebRtcTask){
     version = webRtcVersion
 }

--- a/buildSrc/src/main/groovy/com/nextcloud/talk/gradle/DownloadWebRtcTask.groovy
+++ b/buildSrc/src/main/groovy/com/nextcloud/talk/gradle/DownloadWebRtcTask.groovy
@@ -45,7 +45,7 @@ abstract class DownloadWebRtcTask extends DefaultTask {
 
     private String getDownloadUrl() {
         def webRtcVersion = version.get()
-        return "https://github.com/nextcloud-releases/talk-clients-webrtc/releases/download/${webRtcVersion}-RC1/${getFileName()}"
+        return "https://github.com/nextcloud-releases/talk-clients-webrtc/releases/download/${webRtcVersion}/${getFileName()}"
     }
 
     private String getOutputPath() {


### PR DESCRIPTION
- Remove 'RC1' for WebRTC versions
- Bump version of WebRTC to 106.5249.0

### TODOs
- [ ] Testing calls with multiple participants

