### PR TITLE
Fix update of guest avatars in call participants

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -2382,22 +2382,11 @@ public class CallActivity extends CallBaseActivity {
             }
         }
 
-        String urlForAvatar;
-        if (!TextUtils.isEmpty(userId4Usage)) {
-            urlForAvatar = ApiUtils.getUrlForAvatar(baseUrl,
-                                                    userId4Usage,
-                                                    true);
-        } else {
-            urlForAvatar = ApiUtils.getUrlForGuestAvatar(baseUrl,
-                                                         nick,
-                                                         true);
-        }
-
-        ParticipantDisplayItem participantDisplayItem = new ParticipantDisplayItem(userId4Usage,
+        ParticipantDisplayItem participantDisplayItem = new ParticipantDisplayItem(baseUrl,
+                                                                                   userId4Usage,
                                                                                    session,
                                                                                    connected,
                                                                                    nick,
-                                                                                   urlForAvatar,
                                                                                    mediaStream,
                                                                                    videoStreamType,
                                                                                    videoStreamEnabled,

--- a/app/src/main/java/com/nextcloud/talk/adapters/ParticipantDisplayItem.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/ParticipantDisplayItem.java
@@ -1,9 +1,14 @@
 package com.nextcloud.talk.adapters;
 
+import android.text.TextUtils;
+
+import com.nextcloud.talk.utils.ApiUtils;
+
 import org.webrtc.EglBase;
 import org.webrtc.MediaStream;
 
 public class ParticipantDisplayItem {
+    private String baseUrl;
     private String userId;
     private String session;
     private boolean connected;
@@ -15,16 +20,18 @@ public class ParticipantDisplayItem {
     private EglBase rootEglBase;
     private boolean isAudioEnabled;
 
-    public ParticipantDisplayItem(String userId, String session, boolean connected, String nick, String urlForAvatar, MediaStream mediaStream, String streamType, boolean streamEnabled, EglBase rootEglBase) {
+    public ParticipantDisplayItem(String baseUrl, String userId, String session, boolean connected, String nick, MediaStream mediaStream, String streamType, boolean streamEnabled, EglBase rootEglBase) {
+        this.baseUrl = baseUrl;
         this.userId = userId;
         this.session = session;
         this.connected = connected;
         this.nick = nick;
-        this.urlForAvatar = urlForAvatar;
         this.mediaStream = mediaStream;
         this.streamType = streamType;
         this.streamEnabled = streamEnabled;
         this.rootEglBase = rootEglBase;
+
+        this.updateUrlForAvatar();
     }
 
     public String getUserId() {
@@ -33,6 +40,8 @@ public class ParticipantDisplayItem {
 
     public void setUserId(String userId) {
         this.userId = userId;
+
+        this.updateUrlForAvatar();
     }
 
     public String getSession() {
@@ -57,14 +66,20 @@ public class ParticipantDisplayItem {
 
     public void setNick(String nick) {
         this.nick = nick;
+
+        this.updateUrlForAvatar();
     }
 
     public String getUrlForAvatar() {
         return urlForAvatar;
     }
 
-    public void setUrlForAvatar(String urlForAvatar) {
-        this.urlForAvatar = urlForAvatar;
+    private void updateUrlForAvatar() {
+        if (!TextUtils.isEmpty(userId)) {
+            urlForAvatar = ApiUtils.getUrlForAvatar(baseUrl, userId, true);
+        } else {
+            urlForAvatar = ApiUtils.getUrlForGuestAvatar(baseUrl, nick, true);
+        }
     }
 
     public MediaStream getMediaStream() {


### PR DESCRIPTION
The URL for the avatar depends on whether the call participant is a user or a guest and, if it is a guest, on its nick. Although the user id of a participant does not change if the participant is a guest the nick may be changed during a call, so the avatar URL needs to be updated as well.

As the avatar URL is fully derived from other properties it is now calculated internally in the ParticipantDisplayItem and calculated when any of the properties it depends on changes (also for the user id for completeness, as technically the item could be reused for a different participant with a different user id, even if it is not currently done).

The issue does not depend on whether the HPB is used or not.

## How to test

- Start a call in the Android app
- In a browser, open the conversation as a guest
- Join the call with video disabled or without camera (so the avatar is shown instead of the video)
- Wait until the connection is established
- Change the guest name

### Result with this pull request

Both the name and the avatar of the guest change in the Android app

### Result without this pull request

The name of the guest changes in the Android app, but the avatar does not