### PR TITLE
Keep retrying with exponential backoff if pulling signaling messages fails

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -1480,7 +1480,15 @@ public class CallActivity extends CallBaseActivity {
                                 .observeOn(AndroidSchedulers.mainThread())
                                 .repeatWhen(observable -> observable)
                                 .takeWhile(observable -> isConnectionEstablished())
-                                .retry(observable -> isConnectionEstablished())
+                                .retryWhen(errors -> errors
+                                    .flatMap(error -> {
+                                        if (!isConnectionEstablished()) {
+                                            return Observable.error(error);
+                                        }
+
+                                        return Observable.just(0l);
+                                    })
+                                )
                                 .subscribe(new Observer<SignalingOverall>() {
                                     @Override
                                     public void onSubscribe(@io.reactivex.annotations.NonNull Disposable d) {

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -1480,7 +1480,7 @@ public class CallActivity extends CallBaseActivity {
                                 .observeOn(AndroidSchedulers.mainThread())
                                 .repeatWhen(observable -> observable)
                                 .takeWhile(observable -> isConnectionEstablished())
-                                .retry(3, observable -> isConnectionEstablished())
+                                .retry(observable -> isConnectionEstablished())
                                 .subscribe(new Observer<SignalingOverall>() {
                                     @Override
                                     public void onSubscribe(@io.reactivex.annotations.NonNull Disposable d) {


### PR DESCRIPTION
When the internal signaling server is used the observable to pull signaling messages is subscribed again after each completion, but in case of an error it was retried only 3 times. Those 3 times are not in a row, though, but in total for the whole observable, no matter how many times it was subscribed again.

Due to the limitation on retries in a long call with a flaky connection pulling the signaling messages could fail more than 3 times, which caused the observable to finish with an error and therefore stop further pullings. In this situation the Android app would not notice if other participants joined or left the call, and thus it would not establish a connection with them or stop it.

Now the number of retries is unlimited, but each new request is increasingly delayed (up to 16 seconds) until a request succeeds again (which resets the delay). In any case the requests are not retried if the local participant is no longer in the call (just like before).

To implement the exponential backoff I had to use an external variable. Unfortunately my RxJava-fu is too weak and I did not find a way to do it fully inside the Observable chain; please feel free to improve it :-)

Note that pulling signaling messages acts as a ping for the participants, and if the messages are not pulled for too long other participants will see the participant as no longer in the call and stop the WebRTC connections. The exponential backoff could cause that if more than 5 requests fail in a row, but if more than 5 requests spaced ~30 seconds fail in a row... then it is likely that the issue would have happened as well without exponential backoff :-)

In any case, once the messages are pulled again the participant will be seen again as in the call, so the connections will try to be reestablished. That might not work as expected for other reasons (like not handling stale peer connections and things like that), but it is unrelated to this pull request.

To sum up failing more than 5 requests in a row should not be a common case, and retrying without limits and with an exponential backoff is anyway an improvement over only retrying 3 times overall.

## How to test
- Tweak the Nextcloud server to randomly return an error when pulling signaling messages with a user by adding the following to the beginning of [`SignalingController::pullMessages`](https://github.com/nextcloud/spreed/blob/5f060687c8a0c77f1a61bf9a3462d4bfa4fe055f/lib/Controller/SignalingController.php#L309):
```
if ($this->userId && rand(0, 9) < 6) {
  return new DataResponse([], 500);
}
```
- Tweak the Android app to log when pulling signaling messages succeeds or fails to see it more clearly by adding the following to the [Observable chain (before the `retry`)](https://github.com/nextcloud/talk-android/blob/4658292602f07fab7c2d33ae58e7070709d9517f/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java#L1483):
```
.doOnNext(value -> Log.d(TAG, "Pull signaling messages: success"))
.doOnError(error -> Log.d(TAG, "Pull signaling messages: error: " + error.getMessage()))
```
- Tweak the Android app to log when it tries to pull signaling messages after a failure:
``` 
                                        return Observable.timer(delayOnError.get(), TimeUnit.SECONDS);
                                    }).doOnNext(value -> Log.d(TAG, "Pull signaling messages: retrying")
                                )
```
- Start a call with the Android app
- In a browser, join the call as a guest
- Once (if) the connection is established, enable and disable audio in the browser (this causes signaling messages to be sent)

### Result with this pull request

The Android app keeps trying to get signaling messages in case of failure, but with an increased delay if several requests fail in a row

### Result without this pull request

Eventually no more signaling messages are received (note that audio is still enabled and disabled because the message is also sent through data channels)