### PR TITLE
Fix ParticipantDisplayItems not updated on events

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -2164,21 +2164,22 @@ public class CallActivity extends CallBaseActivity {
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onMessageEvent(PeerConnectionEvent peerConnectionEvent) {
         String sessionId = peerConnectionEvent.getSessionId();
+        String participantDisplayItemId = sessionId + "-" + peerConnectionEvent.getVideoStreamType();
 
         if (peerConnectionEvent.getPeerConnectionEventType() ==
             PeerConnectionEvent.PeerConnectionEventType.PEER_CONNECTED) {
             if (webSocketClient != null && webSocketClient.getSessionId() != null && webSocketClient.getSessionId().equals(sessionId)) {
                 updateSelfVideoViewConnected(true);
-            } else if (participantDisplayItems.get(sessionId) != null) {
-                participantDisplayItems.get(sessionId).setConnected(true);
+            } else if (participantDisplayItems.get(participantDisplayItemId) != null) {
+                participantDisplayItems.get(participantDisplayItemId).setConnected(true);
                 participantsAdapter.notifyDataSetChanged();
             }
         } else if (peerConnectionEvent.getPeerConnectionEventType() ==
             PeerConnectionEvent.PeerConnectionEventType.PEER_DISCONNECTED) {
             if (webSocketClient != null && webSocketClient.getSessionId() != null && webSocketClient.getSessionId().equals(sessionId)) {
                 updateSelfVideoViewConnected(false);
-            } else if (participantDisplayItems.get(sessionId) != null) {
-                participantDisplayItems.get(sessionId).setConnected(false);
+            } else if (participantDisplayItems.get(participantDisplayItemId) != null) {
+                participantDisplayItems.get(participantDisplayItemId).setConnected(false);
                 participantsAdapter.notifyDataSetChanged();
             }
         } else if (peerConnectionEvent.getPeerConnectionEventType() ==
@@ -2200,20 +2201,20 @@ public class CallActivity extends CallBaseActivity {
             }
         } else if (peerConnectionEvent.getPeerConnectionEventType() ==
             PeerConnectionEvent.PeerConnectionEventType.NICK_CHANGE) {
-            if (participantDisplayItems.get(sessionId) != null) {
-                participantDisplayItems.get(sessionId).setNick(peerConnectionEvent.getNick());
+            if (participantDisplayItems.get(participantDisplayItemId) != null) {
+                participantDisplayItems.get(participantDisplayItemId).setNick(peerConnectionEvent.getNick());
                 participantsAdapter.notifyDataSetChanged();
             }
         } else if (peerConnectionEvent.getPeerConnectionEventType() ==
             PeerConnectionEvent.PeerConnectionEventType.VIDEO_CHANGE && !isVoiceOnlyCall) {
-            if (participantDisplayItems.get(sessionId) != null) {
-                participantDisplayItems.get(sessionId).setStreamEnabled(peerConnectionEvent.getChangeValue());
+            if (participantDisplayItems.get(participantDisplayItemId) != null) {
+                participantDisplayItems.get(participantDisplayItemId).setStreamEnabled(peerConnectionEvent.getChangeValue());
                 participantsAdapter.notifyDataSetChanged();
             }
         } else if (peerConnectionEvent.getPeerConnectionEventType() ==
             PeerConnectionEvent.PeerConnectionEventType.AUDIO_CHANGE) {
-            if (participantDisplayItems.get(sessionId) != null) {
-                participantDisplayItems.get(sessionId).setAudioEnabled(peerConnectionEvent.getChangeValue());
+            if (participantDisplayItems.get(participantDisplayItemId) != null) {
+                participantDisplayItems.get(participantDisplayItemId).setAudioEnabled(peerConnectionEvent.getChangeValue());
                 participantsAdapter.notifyDataSetChanged();
             }
         } else if (peerConnectionEvent.getPeerConnectionEventType() ==

--- a/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
@@ -345,7 +345,7 @@ public class PeerConnectionWrapper {
             Log.d("iceConnectionChangeTo: ", iceConnectionState.name() + " over " + peerConnection.hashCode() + " " + sessionId);
             if (iceConnectionState == PeerConnection.IceConnectionState.CONNECTED) {
                 EventBus.getDefault().post(new PeerConnectionEvent(PeerConnectionEvent.PeerConnectionEventType.PEER_CONNECTED,
-                                                                   sessionId, null, null, null));
+                                                                   sessionId, null, null, videoStreamType));
 
                 if (!isMCUPublisher) {
                     EventBus.getDefault().post(new MediaStreamEvent(remoteStream, sessionId, videoStreamType));
@@ -356,7 +356,7 @@ public class PeerConnectionWrapper {
                 }
             } else if (iceConnectionState == PeerConnection.IceConnectionState.COMPLETED) {
                 EventBus.getDefault().post(new PeerConnectionEvent(PeerConnectionEvent.PeerConnectionEventType.PEER_CONNECTED,
-                                                                   sessionId, null, null, null));
+                                                                   sessionId, null, null, videoStreamType));
             } else if (iceConnectionState == PeerConnection.IceConnectionState.CLOSED) {
                 EventBus.getDefault().post(new PeerConnectionEvent(PeerConnectionEvent.PeerConnectionEventType
                         .PEER_CLOSED, sessionId, null, null, videoStreamType));
@@ -364,12 +364,12 @@ public class PeerConnectionWrapper {
                     iceConnectionState == PeerConnection.IceConnectionState.NEW ||
                     iceConnectionState == PeerConnection.IceConnectionState.CHECKING) {
                 EventBus.getDefault().post(new PeerConnectionEvent(PeerConnectionEvent.PeerConnectionEventType.PEER_DISCONNECTED,
-                                                                   sessionId, null, null, null));
+                                                                   sessionId, null, null, videoStreamType));
             } else if (iceConnectionState == PeerConnection.IceConnectionState.FAILED) {
                 EventBus.getDefault().post(new PeerConnectionEvent(PeerConnectionEvent.PeerConnectionEventType.PEER_DISCONNECTED,
-                                                                   sessionId, null, null, null));
+                                                                   sessionId, null, null, videoStreamType));
                 if (isMCUPublisher) {
-                    EventBus.getDefault().post(new PeerConnectionEvent(PeerConnectionEvent.PeerConnectionEventType.PUBLISHER_FAILED, sessionId, null, null, null));
+                    EventBus.getDefault().post(new PeerConnectionEvent(PeerConnectionEvent.PeerConnectionEventType.PUBLISHER_FAILED, sessionId, null, null, videoStreamType));
                 }
             }
         }


### PR DESCRIPTION
Follow up to #2503

What was I thinking on...? :facepalm: Sorry for the mistake :-(

The `ParticipantDisplayItems` were associated to both the session ID and the video stream type ("video" or "screen"), but the code that gets them was not updated to include the video stream type in the key.

I have pushed the commits in this pull request also to the backport for #2503, that is, #2564

Besides the steps below there are several other ways to test it (changing the nick, enabling or disabling the audio, or having a temporary disconnection by the remote participant)

## How to test

- Start a call with video in the WebUI
- Join the call from the Android app
- In the WebUI, disable the video

### Result with this pull request

In the Android app the avatar is shown for the remote participant

### Result with this pull request

In the Android app the video turns black (because the WebUI sends a black video, not because something was updated in the Android app), but the avatar of the remote participant is not shown
