### PR TITLE
Fix String comparison using operator rather than "equals()"

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -2167,7 +2167,7 @@ public class CallActivity extends CallBaseActivity {
 
         if (peerConnectionEvent.getPeerConnectionEventType() ==
             PeerConnectionEvent.PeerConnectionEventType.PEER_CONNECTED) {
-            if (webSocketClient != null && webSocketClient.getSessionId() == sessionId) {
+            if (webSocketClient != null && webSocketClient.getSessionId() != null && webSocketClient.getSessionId().equals(sessionId)) {
                 updateSelfVideoViewConnected(true);
             } else if (participantDisplayItems.get(sessionId) != null) {
                 participantDisplayItems.get(sessionId).setConnected(true);
@@ -2175,7 +2175,7 @@ public class CallActivity extends CallBaseActivity {
             }
         } else if (peerConnectionEvent.getPeerConnectionEventType() ==
             PeerConnectionEvent.PeerConnectionEventType.PEER_DISCONNECTED) {
-            if (webSocketClient != null && webSocketClient.getSessionId() == sessionId) {
+            if (webSocketClient != null && webSocketClient.getSessionId() != null && webSocketClient.getSessionId().equals(sessionId)) {
                 updateSelfVideoViewConnected(false);
             } else if (participantDisplayItems.get(sessionId) != null) {
                 participantDisplayItems.get(sessionId).setConnected(false);


### PR DESCRIPTION
Follow up to #2390

It seemed to work (that is, the progress bar was shown or hidden on the local participant with HPB depending on whether the connection was working or not), but that was probably thanks to a String pool or other similar optimization done by the JVM :shrug:
