### PR TITLE
add more precise text when spreed is not available

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,7 +58,7 @@
     <string name="nc_capabilities_failed">Failed to fetch capabilities, aborting</string>
     <string name="nc_external_server_failed">Failed to fetch signaling settings</string>
     <string name="nc_display_name_not_fetched">Display name couldn\'t be fetched, aborting</string>
-    <string name="nc_nextcloud_talk_app_not_installed">%1$s app not installed on the server, aborting</string>
+    <string name="nc_nextcloud_talk_app_not_installed">%1$s not available (not installed or restricted by admin)</string>
     <string name="nc_display_name_not_stored">Could not store display name, aborting</string>
 
     <string name="nc_never">Never joined</string>


### PR DESCRIPTION
see https://github.com/nextcloud/talk-android/issues/2418#issuecomment-1316570085

spreed usage can be restricted by admins to groups. For this case users should get a error message which also takes this into account. Else it could be frustrating for users to find out why talk  is not working.

Signed-off-by: Marcel Hibbe <dev@mhibbe.de>