### PR TITLE
Fix "isInCallWithVideo()" check

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallNotificationActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallNotificationActivity.kt
@@ -350,7 +350,7 @@ class CallNotificationActivity : CallBaseActivity() {
     }
 
     private fun isInCallWithVideo(callFlag: Int): Boolean {
-        return callFlag >= Participant.InCallFlags.IN_CALL + Participant.InCallFlags.WITH_VIDEO
+        return (callFlag and Participant.InCallFlags.WITH_VIDEO) > 0
     }
 
     private fun setUpAfterConversationIsKnown() {


### PR DESCRIPTION
The call flags should be checked using bitwise operators; otherwise a call with phone (`in call | with phone` / `in call + with phone` , that is, `0001 | 1000 = 1001` or `1 + 8 = 9`) would be seen as a call with video (`in call | with video` / `in call + with video`, `0001 | 0100 = 0101` or `1 + 4 = 5`), as `9 >= 5`. On the other hand, using bitwise operators (and only checking against "with video") succeeds only when the call flags contain `with video` (in the previous example, `1001 and 0100 = 0000`, so it does not succeed).

The `IN_CALL` flag is no longer checked, as `WITH_VIDEO` will be set only during calls, and therefore checking for `IN_CALL` is not needed.

As far as I could see other checks in the code against the call flags are fine; I hope not to have missed any :-)

By the way, unfortunately **I did not test it!**. I just changed the code and, as far as I can tell, it should work... but I was not able to test it with a real notification, so please double check and test if possible :-)