### PR TITLE
Bugfix/2446/fix disappearing accounts

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -1661,7 +1661,7 @@ public class CallActivity extends CallBaseActivity {
     }
 
     private void processMessage(NCSignalingMessage ncSignalingMessage) {
-        if (ncSignalingMessage.getRoomType().equals("video") || ncSignalingMessage.getRoomType().equals("screen")) {
+        if ("video".equals(ncSignalingMessage.getRoomType()) || "screen".equals(ncSignalingMessage.getRoomType())) {
             String type = null;
             if (ncSignalingMessage.getPayload() != null && ncSignalingMessage.getPayload().getType() != null) {
                 type = ncSignalingMessage.getPayload().getType();

--- a/app/src/main/java/com/nextcloud/talk/controllers/AccountVerificationController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/AccountVerificationController.kt
@@ -28,6 +28,7 @@ import android.os.Handler
 import android.text.TextUtils
 import android.util.Log
 import android.view.View
+import android.widget.Toast
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
@@ -443,25 +444,33 @@ class AccountVerificationController(args: Bundle? = null) :
     }
 
     private fun proceedWithLogin() {
+        Log.d(TAG, "proceedWithLogin...")
         cookieManager.cookieStore.removeAll()
-        val userDisabledCount = userManager.disableAllUsersWithoutId(internalAccountId).blockingGet()
-        Log.d(TAG, "Disabled $userDisabledCount users that had no id")
-        if (activity != null) {
-            activity!!.runOnUiThread {
-                if (userManager.users.blockingGet().size == 1) {
-                    router.setRoot(
-                        RouterTransaction.with(ConversationsListController(Bundle()))
-                            .pushChangeHandler(HorizontalChangeHandler())
-                            .popChangeHandler(HorizontalChangeHandler())
-                    )
-                } else {
-                    if (isAccountImport) {
-                        ApplicationWideMessageHolder.getInstance().messageType =
-                            ApplicationWideMessageHolder.MessageType.ACCOUNT_WAS_IMPORTED
+
+        val userToSetAsActive = userManager.getUserWithId(internalAccountId).blockingGet()
+        Log.d(TAG, "userToSetAsActive: " + userToSetAsActive.username)
+
+        if (userManager.setUserAsActive(userToSetAsActive).blockingGet()) {
+            if (activity != null) {
+                activity!!.runOnUiThread {
+                    if (userManager.users.blockingGet().size == 1) {
+                        router.setRoot(
+                            RouterTransaction.with(ConversationsListController(Bundle()))
+                                .pushChangeHandler(HorizontalChangeHandler())
+                                .popChangeHandler(HorizontalChangeHandler())
+                        )
+                    } else {
+                        if (isAccountImport) {
+                            ApplicationWideMessageHolder.getInstance().messageType =
+                                ApplicationWideMessageHolder.MessageType.ACCOUNT_WAS_IMPORTED
+                        }
+                        router.popToRoot()
                     }
-                    router.popToRoot()
                 }
             }
+        } else {
+            Log.e(TAG, "failed to set active user")
+            Toast.makeText(context, R.string.nc_common_error_sorry, Toast.LENGTH_LONG).show()
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/controllers/AccountVerificationController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/AccountVerificationController.kt
@@ -324,9 +324,9 @@ class AccountVerificationController(args: Bundle? = null) :
                     }
                     if (!TextUtils.isEmpty(displayName)) {
                         storeProfile(
-                            displayName, userProfileOverall.ocs!!.data!!.userId!!,
-                            capabilities.ocs!!.data!!
-                                .capabilities!!
+                            displayName,
+                            userProfileOverall.ocs!!.data!!.userId!!,
+                            capabilities.ocs!!.data!!.capabilities!!
                         )
                     } else {
                         if (activity != null) {

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.kt
@@ -295,7 +295,7 @@ class ConversationsListController(bundle: Bundle) :
             }
             fetchRooms()
         } else {
-            Log.e(TAG, "currentUser was null in ConversationsListController.onAttach")
+            Log.e(TAG, "userManager.currentUser.blockingGet() returned null")
             Toast.makeText(context, R.string.nc_common_error_sorry, Toast.LENGTH_LONG).show()
         }
     }

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.kt
@@ -209,26 +209,30 @@ class ConversationsListController(bundle: Bundle) :
     private fun loadUserAvatar(
         target: Target
     ) {
-
         if (activity != null) {
-            val url = ApiUtils.getUrlForAvatar(
-                currentUser!!.baseUrl,
-                currentUser!!.userId,
-                true
-            )
+            if (currentUser != null) {
+                val url = ApiUtils.getUrlForAvatar(
+                    currentUser!!.baseUrl,
+                    currentUser!!.userId,
+                    true
+                )
 
-            val credentials = ApiUtils.getCredentials(currentUser!!.username, currentUser!!.token)
+                val credentials = ApiUtils.getCredentials(currentUser!!.username, currentUser!!.token)
 
-            context.imageLoader.enqueue(
-                ImageRequest.Builder(context)
-                    .data(url)
-                    .addHeader("Authorization", credentials)
-                    .placeholder(R.drawable.ic_user)
-                    .transformations(CircleCropTransformation())
-                    .crossfade(true)
-                    .target(target)
-                    .build()
-            )
+                context.imageLoader.enqueue(
+                    ImageRequest.Builder(context)
+                        .data(url)
+                        .addHeader("Authorization", credentials)
+                        .placeholder(R.drawable.ic_user)
+                        .transformations(CircleCropTransformation())
+                        .crossfade(true)
+                        .target(target)
+                        .build()
+                )
+            } else {
+                Log.e(TAG, "currentUser was null in loadUserAvatar")
+                Toast.makeText(context, R.string.nc_common_error_sorry, Toast.LENGTH_LONG).show()
+            }
         }
     }
 
@@ -238,6 +242,7 @@ class ConversationsListController(bundle: Bundle) :
             override fun onStart(placeholder: Drawable?) {
                 button.icon = placeholder
             }
+
             override fun onSuccess(result: Drawable) {
                 button.icon = result
             }
@@ -251,6 +256,7 @@ class ConversationsListController(bundle: Bundle) :
             override fun onStart(placeholder: Drawable?) {
                 menuItem.icon = placeholder
             }
+
             override fun onSuccess(result: Drawable) {
                 menuItem.icon = result
             }
@@ -288,6 +294,9 @@ class ConversationsListController(bundle: Bundle) :
                     .colorMaterialTextButton((activity as MainActivity?)!!.binding.switchAccountButton)
             }
             fetchRooms()
+        } else {
+            Log.e(TAG, "currentUser was null in ConversationsListController.onAttach")
+            Toast.makeText(context, R.string.nc_common_error_sorry, Toast.LENGTH_LONG).show()
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/data/user/UsersDao.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/user/UsersDao.kt
@@ -74,9 +74,6 @@ abstract class UsersDao {
     @Query("SELECT * FROM User where userId = :userId")
     abstract fun getUserWithUserId(userId: String): Maybe<UserEntity>
 
-    @Query("SELECT * FROM User where id != :id")
-    abstract fun getUsersWithoutId(id: Long): Single<List<UserEntity>>
-
     @Query("SELECT * FROM User where scheduledForDeletion = 1")
     abstract fun getUsersScheduledForDeletion(): Single<List<UserEntity>>
 
@@ -92,6 +89,13 @@ abstract class UsersDao {
         return try {
             getUsers().blockingGet().forEach { user ->
                 user.current = user.id == id
+
+                Log.d(TAG, "xxxxxxxxxxxx")
+                Log.d(TAG, "setUserAsActiveWithId. user.username: " + user.username)
+                Log.d(TAG, "setUserAsActiveWithId. user.id: " + user.id)
+                Log.d(TAG, "setUserAsActiveWithId. user.current: " + user.current)
+                Log.d(TAG, "xxxxxxxxxxxx")
+
                 updateUser(user)
             }
             true

--- a/app/src/main/java/com/nextcloud/talk/data/user/UsersDao.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/user/UsersDao.kt
@@ -82,10 +82,9 @@ abstract class UsersDao {
     abstract fun getUserWithUsernameAndServer(username: String, server: String): Maybe<UserEntity>
 
     @Query(
-        "UPDATE User " +
-            "SET current = CASE " +
+        "UPDATE User SET current = CASE " +
             "WHEN id == :id THEN 1 " +
-            "WHEN userId != :id THEN 0 " +
+            "WHEN id != :id THEN 0 " +
             "END"
     )
     abstract fun setUserAsActiveWithId(id: Long): Int

--- a/app/src/main/java/com/nextcloud/talk/data/user/UsersDao.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/user/UsersDao.kt
@@ -29,6 +29,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
 import com.nextcloud.talk.data.user.model.UserEntity
+import com.nextcloud.talk.models.json.push.PushConfigurationState
 import io.reactivex.Maybe
 import io.reactivex.Observable
 import io.reactivex.Single
@@ -88,6 +89,9 @@ abstract class UsersDao {
             "END"
     )
     abstract fun setUserAsActiveWithId(id: Long): Int
+
+    @Query("Update User SET pushConfigurationState = :state WHERE id == :id")
+    abstract fun updatePushState(id: Long, state: PushConfigurationState): Single<Int>
 
     companion object {
         const val TAG = "UsersDao"

--- a/app/src/main/java/com/nextcloud/talk/data/user/UsersRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/user/UsersRepository.kt
@@ -35,7 +35,6 @@ interface UsersRepository {
     fun getUserWithId(id: Long): Maybe<User>
     fun getUserWithIdNotScheduledForDeletion(id: Long): Maybe<User>
     fun getUserWithUserId(userId: String): Maybe<User>
-    fun getUsersWithoutUserId(id: Long): Single<List<User>>
     fun getUsersScheduledForDeletion(): Single<List<User>>
     fun getUsersNotScheduledForDeletion(): Single<List<User>>
     fun getUserWithUsernameAndServer(username: String, server: String): Maybe<User>

--- a/app/src/main/java/com/nextcloud/talk/data/user/UsersRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/user/UsersRepository.kt
@@ -23,6 +23,7 @@
 package com.nextcloud.talk.data.user
 
 import com.nextcloud.talk.data.user.model.User
+import com.nextcloud.talk.models.json.push.PushConfigurationState
 import io.reactivex.Maybe
 import io.reactivex.Observable
 import io.reactivex.Single
@@ -42,4 +43,5 @@ interface UsersRepository {
     fun insertUser(user: User): Long
     fun setUserAsActiveWithId(id: Long): Single<Boolean>
     fun deleteUser(user: User): Int
+    fun updatePushState(id: Long, state: PushConfigurationState): Single<Int>
 }

--- a/app/src/main/java/com/nextcloud/talk/data/user/UsersRepositoryImpl.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/user/UsersRepositoryImpl.kt
@@ -54,10 +54,6 @@ class UsersRepositoryImpl(private val usersDao: UsersDao) : UsersRepository {
         return usersDao.getUserWithUserId(userId).map { UserMapper.toModel(it) }
     }
 
-    override fun getUsersWithoutUserId(id: Long): Single<List<User>> {
-        return usersDao.getUsersWithoutId(id).map { UserMapper.toModel(it) }
-    }
-
     override fun getUsersScheduledForDeletion(): Single<List<User>> {
         return usersDao.getUsersScheduledForDeletion().map { UserMapper.toModel(it) }
     }

--- a/app/src/main/java/com/nextcloud/talk/data/user/UsersRepositoryImpl.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/user/UsersRepositoryImpl.kt
@@ -23,6 +23,7 @@
 package com.nextcloud.talk.data.user
 
 import com.nextcloud.talk.data.user.model.User
+import com.nextcloud.talk.models.json.push.PushConfigurationState
 import io.reactivex.Maybe
 import io.reactivex.Observable
 import io.reactivex.Single
@@ -85,5 +86,9 @@ class UsersRepositoryImpl(private val usersDao: UsersDao) : UsersRepository {
 
     override fun deleteUser(user: User): Int {
         return usersDao.deleteUser(UserMapper.toEntity(user))
+    }
+
+    override fun updatePushState(id: Long, state: PushConfigurationState): Single<Int> {
+        return usersDao.updatePushState(id, state)
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/data/user/UsersRepositoryImpl.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/user/UsersRepositoryImpl.kt
@@ -75,7 +75,12 @@ class UsersRepositoryImpl(private val usersDao: UsersDao) : UsersRepository {
     }
 
     override fun setUserAsActiveWithId(id: Long): Single<Boolean> {
-        return Single.just(usersDao.setUserAsActiveWithId(id))
+        val amountUpdated = usersDao.setUserAsActiveWithId(id)
+        return if (amountUpdated > 0) {
+            Single.just(true)
+        } else {
+            Single.just(false)
+        }
     }
 
     override fun deleteUser(user: User): Int {

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/ChooseAccountDialogFragment.java
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/ChooseAccountDialogFragment.java
@@ -146,8 +146,8 @@ public class ChooseAccountDialogFragment extends DialogFragment {
             User userEntity;
             Participant participant;
 
-            for (Object userItem : userManager.getUsers().blockingGet()) {
-                userEntity = (User) userItem;
+            for (User userItem : userManager.getUsers().blockingGet()) {
+                userEntity = userItem;
                 Log.d(TAG, "---------------------");
                 Log.d(TAG, "userEntity.getUserId() " + userEntity.getUserId());
                 Log.d(TAG, "userEntity.getCurrent() " + userEntity.getCurrent());

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/ChooseAccountDialogFragment.java
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/ChooseAccountDialogFragment.java
@@ -148,6 +148,11 @@ public class ChooseAccountDialogFragment extends DialogFragment {
 
             for (Object userItem : userManager.getUsers().blockingGet()) {
                 userEntity = (User) userItem;
+                Log.d(TAG, "---------------------");
+                Log.d(TAG, "userEntity.getUserId() " + userEntity.getUserId());
+                Log.d(TAG, "userEntity.getCurrent() " + userEntity.getCurrent());
+                Log.d(TAG, "---------------------");
+
                 if (!userEntity.getCurrent()) {
                     String userId;
                     if (userEntity.getUserId() != null) {

--- a/app/src/main/java/com/nextcloud/talk/users/UserManager.kt
+++ b/app/src/main/java/com/nextcloud/talk/users/UserManager.kt
@@ -230,6 +230,10 @@ class UserManager internal constructor(private val userRepository: UsersReposito
         return user
     }
 
+    fun updatePushState(id: Long, state: PushConfigurationState): Single<Int> {
+        return userRepository.updatePushState(id, state)
+    }
+
     companion object {
         const val TAG = "UserManager"
     }

--- a/app/src/main/java/com/nextcloud/talk/users/UserManager.kt
+++ b/app/src/main/java/com/nextcloud/talk/users/UserManager.kt
@@ -58,22 +58,6 @@ class UserManager internal constructor(private val userRepository: UsersReposito
         return userRepository.getUserWithId(id)
     }
 
-    fun disableAllUsersWithoutId(id: Long): Single<Int> {
-        val results = userRepository.getUsersWithoutUserId(id)
-
-        return results.map { users ->
-            var count = 0
-            if (users.isNotEmpty()) {
-                for (entity in users) {
-                    entity.current = false
-                    userRepository.updateUser(entity)
-                    count++
-                }
-            }
-            count
-        }
-    }
-
     fun checkIfUserIsScheduledForDeletion(username: String, server: String): Single<Boolean> {
         return userRepository
             .getUserWithUsernameAndServer(username, server)

--- a/app/src/main/java/com/nextcloud/talk/users/UserManager.kt
+++ b/app/src/main/java/com/nextcloud/talk/users/UserManager.kt
@@ -43,6 +43,7 @@ class UserManager internal constructor(private val userRepository: UsersReposito
     val currentUser: Maybe<User>
         get() {
             return userRepository.getActiveUser()
+                .switchIfEmpty(getAnyUserAndSetAsActive())
         }
 
     val currentUserObservable: Observable<User>

--- a/app/src/main/java/com/nextcloud/talk/users/UserManager.kt
+++ b/app/src/main/java/com/nextcloud/talk/users/UserManager.kt
@@ -149,7 +149,7 @@ class UserManager internal constructor(private val userRepository: UsersReposito
                     else -> {
                         user.token = userAttributes.token
                         user.baseUrl = userAttributes.serverUrl
-                        user.current = true
+                        user.current = userAttributes.currentUser
                         user.userId = userAttributes.userId
                         user.token = userAttributes.token
                         user.displayName = userAttributes.displayName
@@ -237,7 +237,7 @@ class UserManager internal constructor(private val userRepository: UsersReposito
     data class UserAttributes(
         val id: Long?,
         val serverUrl: String?,
-        val currentUser: Boolean?,
+        val currentUser: Boolean,
         val userId: String?,
         val token: String?,
         val displayName: String?,

--- a/app/src/main/java/com/nextcloud/talk/utils/PushUtils.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/PushUtils.java
@@ -235,17 +235,17 @@ public class PushUtils {
 
                 List<User> users = userManager.getUsers().blockingGet();
 
-                    for (User user : users) {
-                        if (!user.getScheduledForDeletion()) {
-                            Map<String, String> nextcloudRegisterPushMap = new HashMap<>();
-                            nextcloudRegisterPushMap.put("format", "json");
-                            nextcloudRegisterPushMap.put("pushTokenHash", pushTokenHash);
-                            nextcloudRegisterPushMap.put("devicePublicKey", devicePublicKeyBase64);
-                            nextcloudRegisterPushMap.put("proxyServer", proxyServer);
+                for (User user : users) {
+                    if (!user.getScheduledForDeletion()) {
+                        Map<String, String> nextcloudRegisterPushMap = new HashMap<>();
+                        nextcloudRegisterPushMap.put("format", "json");
+                        nextcloudRegisterPushMap.put("pushTokenHash", pushTokenHash);
+                        nextcloudRegisterPushMap.put("devicePublicKey", devicePublicKeyBase64);
+                        nextcloudRegisterPushMap.put("proxyServer", proxyServer);
 
-                            registerDeviceWithNextcloud(ncApi, nextcloudRegisterPushMap, token, user);
-                        }
+                        registerDeviceWithNextcloud(ncApi, nextcloudRegisterPushMap, token, user);
                     }
+                }
 
             }
         } else {
@@ -260,9 +260,9 @@ public class PushUtils {
         String credentials = ApiUtils.getCredentials(user.getUsername(), user.getToken());
 
         ncApi.registerDeviceForNotificationsWithNextcloud(
-            credentials,
-            ApiUtils.getUrlNextcloudPush(user.getBaseUrl()),
-            nextcloudRegisterPushMap)
+                credentials,
+                ApiUtils.getUrlNextcloudPush(user.getBaseUrl()),
+                nextcloudRegisterPushMap)
             .subscribe(new Observer<PushRegistrationOverall>() {
                 @Override
                 public void onSubscribe(@NonNull Disposable d) {
@@ -338,26 +338,31 @@ public class PushUtils {
         pushConfigurationState.setUserPublicKey(proxyMap.get("userPublicKey"));
         pushConfigurationState.setUsesRegularPass(Boolean.FALSE);
 
-        userManager.updatePushState(user.getId(), pushConfigurationState).subscribe(new SingleObserver<Integer>() {
-            @Override
-            public void onSubscribe(Disposable d) {
-                // unused atm
-            }
+        if (user.getId() != null) {
+            userManager.updatePushState(user.getId(), pushConfigurationState).subscribe(new SingleObserver<Integer>() {
+                @Override
+                public void onSubscribe(Disposable d) {
+                    // unused atm
+                }
 
-            @Override
-            public void onSuccess(Integer integer) {
-                eventBus.post(new EventStatus(UserIdUtils.INSTANCE.getIdForUser(user),
-                                              EventStatus.EventType.PUSH_REGISTRATION,
-                                              true));
-            }
+                @Override
+                public void onSuccess(Integer integer) {
+                    eventBus.post(new EventStatus(UserIdUtils.INSTANCE.getIdForUser(user),
+                                                  EventStatus.EventType.PUSH_REGISTRATION,
+                                                  true));
+                }
 
-            @Override
-            public void onError(Throwable e) {
-                eventBus.post(new EventStatus(UserIdUtils.INSTANCE.getIdForUser(user),
-                                              EventStatus.EventType.PUSH_REGISTRATION,
-                                              false));
-            }
-        });
+                @Override
+                public void onError(Throwable e) {
+                    eventBus.post(new EventStatus(UserIdUtils.INSTANCE.getIdForUser(user),
+                                                  EventStatus.EventType.PUSH_REGISTRATION,
+                                                  false));
+                }
+            });
+        } else {
+            Log.e(TAG, "failed to update updatePushStateForUser. user.getId() was null");
+        }
+
     }
 
     private Key readKeyFromString(boolean readPublicKey, String keyString) {

--- a/app/src/main/java/com/nextcloud/talk/utils/PushUtils.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/PushUtils.java
@@ -311,7 +311,7 @@ public class PushUtils {
                 public void onNext(@NonNull Void aVoid) {
                     try {
                         Log.d(TAG, "pushToken successfully registered at pushproxy.");
-                        createOrUpdateUser(proxyMap, user);
+                        updatePushStateForUser(proxyMap, user);
                     } catch (IOException e) {
                         Log.e(TAG, "IOException while updating user", e);
                     }
@@ -330,7 +330,7 @@ public class PushUtils {
             });
     }
 
-    private void createOrUpdateUser(Map<String, String> proxyMap, User user) throws IOException {
+    private void updatePushStateForUser(Map<String, String> proxyMap, User user) throws IOException {
         PushConfigurationState pushConfigurationState = new PushConfigurationState();
         pushConfigurationState.setPushToken(proxyMap.get("pushToken"));
         pushConfigurationState.setDeviceIdentifier(proxyMap.get("deviceIdentifier"));

--- a/app/src/main/java/com/nextcloud/talk/utils/PushUtils.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/PushUtils.java
@@ -338,8 +338,7 @@ public class PushUtils {
         pushConfigurationState.setUserPublicKey(proxyMap.get("userPublicKey"));
         pushConfigurationState.setUsesRegularPass(Boolean.FALSE);
 
-        user.setPushConfigurationState(pushConfigurationState);
-        userManager.saveUser(user).subscribe(new SingleObserver<Integer>() {
+        userManager.updatePushState(user.getId(), pushConfigurationState).subscribe(new SingleObserver<Integer>() {
             @Override
             public void onSubscribe(Disposable d) {
                 // unused atm

--- a/app/src/main/java/com/nextcloud/talk/utils/ssl/MagicKeyManager.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/ssl/MagicKeyManager.java
@@ -64,8 +64,9 @@ public class MagicKeyManager implements X509KeyManager {
     @Override
     public String chooseClientAlias(String[] strings, Principal[] principals, Socket socket) {
         String alias;
-        if ((userManager.getCurrentUser().blockingGet() != null &&
-            !TextUtils.isEmpty(alias = userManager.getCurrentUser().blockingGet().getClientCertificate())) ||
+        User currentUser = userManager.getCurrentUser().blockingGet();
+        if ((currentUser != null &&
+            !TextUtils.isEmpty(alias = currentUser.getClientCertificate())) ||
             !TextUtils.isEmpty(alias = appPreferences.getTemporaryClientCertAlias())
                 && new ArrayList<>(Arrays.asList(getClientAliases())).contains(alias)) {
             return alias;


### PR DESCRIPTION
fix #2446
fix #2531

# Problem
There was a race condition for "updateUser" between 

`userManager.saveUser(user).subscribe(new SingleObserver<Integer>() {`
in PushUtils#updatePushStateForUser

and

`if (userManager.setUserAsActive(user).blockingGet()) {`
in ChooseAccountDialogFragment > onSwitchItemClickListener


So while switching accounts via the Account switcher, also the PushUtil method is executed and sometimes asynchronously overwrote other user attributes with old values:

## Scenario1: no users are marked as "current" -> could lead to **app crash on startup**
As a result of this, there could be no users marked as "current". 
Because of this, 

```
@Query("SELECT * FROM User where current = 1")
abstract fun getActiveUser(): Maybe<UserEntity>
```

would return null, which in turn led to a NullPointerException in ConversationsListController for currentUser and the app crashed.
Because it's not a valid state to have no users marked as current, the app always crashed on startup until the app data was deleted, see issue https://github.com/nextcloud/talk-android/issues/2531

remarks: it cannot be 100% ruled out that there are other async scenarios that lead to this state. Anyway the NPE is now avoided so that the app does not crash but shows an error in UI.

## Scenario2: multiple users are marked as "current" -> **accounts are suddenly hidden**
There could be more than one user marked with "current". This caused to only show one of the current accounts in the account switcher while the other one was hidden. So it seemed that an account was lost (although it was still there, that's why push notifications still could have been received), see issue https://github.com/nextcloud/talk-android/issues/2446


# Solution
update only pushState when updating users (instead updating of whole user)
see commit https://github.com/nextcloud/talk-android/pull/2581/commits/b8e3ce457e882fb0fe4d4de02178c316ea025bf5

# How to test
set up multiple accounts and switch very fast and often between them via the account switch dialog (the avatar in the upper right corner)

## without this PR
sometimes scenario 1 or 2 could happen.

## with this PR
neither scenario 1 or 2 occur