### PR TITLE
Fix joining call when signaling messages overtake the response

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -1879,6 +1879,8 @@ public class CallActivity extends CallBaseActivity {
                 if (inCallFlag == 0 && currentCallStatus != CallStatus.LEAVING && ApplicationWideCurrentRoomHolder.getInstance().isInCall()) {
                     Log.d(TAG, "Most probably a moderator ended the call for all.");
                     hangup(true);
+
+                    return;
                 }
             }
         }

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -1442,7 +1442,9 @@ public class CallActivity extends CallBaseActivity {
                 @Override
                 public void onNext(@io.reactivex.annotations.NonNull GenericOverall genericOverall) {
                     if (currentCallStatus != CallStatus.LEAVING) {
-                        setCallState(CallStatus.JOINED);
+                        if (currentCallStatus != CallStatus.IN_CONVERSATION) {
+                            setCallState(CallStatus.JOINED);
+                        }
 
                         ApplicationWideCurrentRoomHolder.getInstance().setInCall(true);
                         ApplicationWideCurrentRoomHolder.getInstance().setDialing(false);


### PR DESCRIPTION
Fixes? #1316 (it is very similar to scenario 1, although not exactly the same, but that could be because other things changed in the code in the meantime)

When a call is joined the call flags of the local participant change, so this causes a signaling message to be sent by the server. When the HPB is used the signaling message is sent through a WebSocket, which is already connected before joining the call. Therefore, in some cases the signaling message can be received through the WebSocket even before the response to the HTTP `joinCall` request.

The call state was set to `JOINED` when the `joinCall` response was received, but this could override the `IN_CONVERSATION` state already set when processing the participant list sent through the WebSocket. Additionally as the call state may not have been set yet to `JOINED` when the participant list is received it should be also processed for other states, like `RECONNECTING` or `PUBLISHER_FAILED`.

Besides that this also (partially) fixes the PiP mode when the HPB is used. When the chat is shown the conversation is joined again, which triggers a `roomJoined` event by the WebSocket, and as it is shared between the chat and the call this in turn [causes the call to be joined again](https://github.com/nextcloud/talk-android/blob/45224741fd6f11b032004f48faaea46c89e2e075/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java#L1585-L1592), which reset the call state to `JOINED` and then caused the call to be left after 45 seconds (unless another participant joined or left in the meantime).

Note that the PiP mode is fixed only if the call was already active; other states were not taken into account. It should be easier to solve that once the signaling code is moved to its own class, so something for the future.

All the scenarios below should be tested with HPB.

## How to test (scenario 1)

- Delay the HTTP response when joining calls by adding `sleep(5);` to [the end of `CallController::joinCall`](https://github.com/nextcloud/spreed/blob/62f47af2b6143d7c9ff1f24b1ffce2ff6951bc7f/lib/Controller/CallController.php#L131) (it must be after the call flags were updated)
- Start a call in a browser
- Join the call in the Android app

### Result with this pull request

The call is joined and the connection established as expected.

### Result without this pull request

The call is joined and the connection with the other participant is established, but then the call UI in the Android app changes to _Connecting..._ and after 45 seconds the message _No response in 45 seconds, tap to try again_ is shown and the call left


## How to test (scenario 2)

- Delay the HTTP response when joining calls by adding `sleep(5);` to [the end of `CallController::joinCall`](https://github.com/nextcloud/spreed/blob/62f47af2b6143d7c9ff1f24b1ffce2ff6951bc7f/lib/Controller/CallController.php#L131) (it must be after the call flags were updated)
- Start a call in the Android app
- Wait 45 seconds until the message _No response in 45 seconds, tap to try again_ is shown
- In a browser, join the call
- In the Android app, tap to try again

### Result with this pull request

The call is joined and the connection established as expected.

### Result without this pull request (or without the last commit)

The connection is not established, and after 45 seconds the message _No response in 45 seconds, tap to try again_ is shown and the call left



## How to test (scenario 3)

- Delay the HTTP response when joining calls by adding `sleep(5);` to [the end of `CallController::joinCall`](https://github.com/nextcloud/spreed/blob/62f47af2b6143d7c9ff1f24b1ffce2ff6951bc7f/lib/Controller/CallController.php#L131) (it must be after the call flags were updated)
- Start a call in the Android app
- In a browser, join the call
- Once the connection is established, block the publisher connection of the Android app in the firewall* of the machine running the HPB (so the publisher connection fails)

### Result with this pull request

The call is joined again and the connection established as expected.

### Result without this pull request (or without the last commit)

The call is joined again, but the connection is not established, and after 45 seconds the message _No response in 45 seconds, tap to try again_ is shown and the call left

*If you disable both audio and video in the browser (but still have a microphone or a camera selected to ensure that there will be a connection) and enable audio and video in the Android app you can run `tcpdump` in the machine running the HPB to guess the port that the Android app is using to send the media (basically, the port from the IP address of the Android app that appears the most and with the higher data count). Then you can block that port running `iptables --append INPUT --protocol udp --source {THE-IP-OF-THE-ANDROID-APP} --source-port {THE-PORT-OF-THE-PUBLISHER-IN-THE-ANDROID-APP} --jump DROP`; if the HPB is running in a Docker container you should use `--insert DOCKER-USER` rather than `--append INPUT` (but the rule should be applied on the host, not inside the container).

Do not forget to delete the rules once you have finished the test :-) You can do that typing the same command again (with all the parameters), but replacing `--append` or `--insert` with `--delete`.

## How to test (scenario 4)

- Start a call in the Android app
- In a browser, join the call
- Once the connection is established, change to PiP mode

### Result with this pull request

The other participant is visible in the PiP window

### Result without this pull request (or without the last commit)

The other participant is not visible in the PiP window