### PR TITLE
Split call participants and peer connections

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -1999,7 +1999,7 @@ public class CallActivity extends CallBaseActivity {
                 final CallParticipantModel callParticipantModel = callParticipant.getCallParticipantModel();
 
                 runOnUiThread(() -> {
-                    setupVideoStreamForLayout(callParticipantModel, type);
+                    addParticipantDisplayItem(callParticipantModel, type);
                 });
             }
 
@@ -2032,7 +2032,7 @@ public class CallActivity extends CallBaseActivity {
                         PeerConnectionWrapper.PeerConnectionObserver peerConnectionObserver = peerConnectionObservers.remove(sessionId + "-" + videoStreamType);
                         peerConnectionWrapper.removeObserver(peerConnectionObserver);
 
-                        runOnUiThread(() -> removeMediaStream(sessionId, videoStreamType));
+                        runOnUiThread(() -> removeParticipantDisplayItem(sessionId, videoStreamType));
 
                         CallParticipant callParticipant = callParticipants.get(sessionId);
                         if (callParticipant != null) {
@@ -2066,8 +2066,8 @@ public class CallActivity extends CallBaseActivity {
         }
     }
 
-    private void removeMediaStream(String sessionId, String videoStreamType) {
-        Log.d(TAG, "removeMediaStream");
+    private void removeParticipantDisplayItem(String sessionId, String videoStreamType) {
+        Log.d(TAG, "removeParticipantDisplayItem");
         ParticipantDisplayItem participantDisplayItem = participantDisplayItems.remove(sessionId + "-" + videoStreamType);
         if (participantDisplayItem == null) {
             return;
@@ -2200,7 +2200,7 @@ public class CallActivity extends CallBaseActivity {
                                                          this);
     }
 
-    private void setupVideoStreamForLayout(CallParticipantModel callParticipantModel, String videoStreamType) {
+    private void addParticipantDisplayItem(CallParticipantModel callParticipantModel, String videoStreamType) {
         String defaultGuestNick = getResources().getString(R.string.nc_nick_guest);
 
         ParticipantDisplayItem participantDisplayItem = new ParticipantDisplayItem(baseUrl,

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -1971,7 +1971,7 @@ public class CallActivity extends CallBaseActivity {
             peerConnectionWrapperList.add(peerConnectionWrapper);
 
             PeerConnectionWrapper.PeerConnectionObserver peerConnectionObserver =
-                new CallActivityPeerConnectionObserver(sessionId, type);
+                new CallActivityPeerConnectionObserver(sessionId);
             peerConnectionObservers.put(sessionId + "-" + type, peerConnectionObserver);
             peerConnectionWrapper.addObserver(peerConnectionObserver);
 
@@ -2566,11 +2566,9 @@ public class CallActivity extends CallBaseActivity {
     private class CallActivityPeerConnectionObserver implements PeerConnectionWrapper.PeerConnectionObserver {
 
         private final String sessionId;
-        private final String videoStreamType;
 
-        private CallActivityPeerConnectionObserver(String sessionId, String videoStreamType) {
+        private CallActivityPeerConnectionObserver(String sessionId) {
             this.sessionId = sessionId;
-            this.videoStreamType = videoStreamType;
         }
 
         @Override
@@ -2586,12 +2584,6 @@ public class CallActivity extends CallBaseActivity {
             runOnUiThread(() -> {
                 if (webSocketClient != null && webSocketClient.getSessionId() != null && webSocketClient.getSessionId().equals(sessionId)) {
                     updateSelfVideoViewIceConnectionState(iceConnectionState);
-                }
-
-                if (iceConnectionState == PeerConnection.IceConnectionState.CLOSED) {
-                    endPeerConnection(sessionId, VIDEO_STREAM_TYPE_SCREEN.equals(videoStreamType));
-
-                    return;
                 }
 
                 if (iceConnectionState == PeerConnection.IceConnectionState.FAILED) {

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -740,6 +740,10 @@ public class CallActivity extends CallBaseActivity {
                 }
             });
 
+        if (participantsAdapter != null) {
+            participantsAdapter.destroy();
+        }
+
         participantsAdapter = new ParticipantsAdapter(
             this,
             participantDisplayItems,
@@ -1853,17 +1857,11 @@ public class CallActivity extends CallBaseActivity {
             String userId = userIdsBySessionId.get(sessionId);
             if (userId != null) {
                 runOnUiThread(() -> {
-                    boolean notifyDataSetChanged = false;
                     if (participantDisplayItems.get(sessionId + "-video") != null) {
                         participantDisplayItems.get(sessionId + "-video").setUserId(userId);
-                        notifyDataSetChanged = true;
                     }
                     if (participantDisplayItems.get(sessionId + "-screen") != null) {
                         participantDisplayItems.get(sessionId + "-screen").setUserId(userId);
-                        notifyDataSetChanged = true;
-                    }
-                    if (notifyDataSetChanged) {
-                        participantsAdapter.notifyDataSetChanged();
                     }
                 });
             }
@@ -2527,17 +2525,11 @@ public class CallActivity extends CallBaseActivity {
         private void onOfferOrAnswer(String nick) {
             this.nick = nick;
 
-            boolean notifyDataSetChanged = false;
             if (participantDisplayItems.get(sessionId + "-video") != null) {
                 participantDisplayItems.get(sessionId + "-video").setNick(nick);
-                notifyDataSetChanged = true;
             }
             if (participantDisplayItems.get(sessionId + "-screen") != null) {
                 participantDisplayItems.get(sessionId + "-screen").setNick(nick);
-                notifyDataSetChanged = true;
-            }
-            if (notifyDataSetChanged) {
-                participantsAdapter.notifyDataSetChanged();
             }
         }
 
@@ -2582,7 +2574,6 @@ public class CallActivity extends CallBaseActivity {
             runOnUiThread(() -> {
                 if (participantDisplayItems.get(participantDisplayItemId) != null) {
                     participantDisplayItems.get(participantDisplayItemId).setAudioEnabled(true);
-                    participantsAdapter.notifyDataSetChanged();
                 }
             });
         }
@@ -2592,7 +2583,6 @@ public class CallActivity extends CallBaseActivity {
             runOnUiThread(() -> {
                 if (participantDisplayItems.get(participantDisplayItemId) != null) {
                     participantDisplayItems.get(participantDisplayItemId).setAudioEnabled(false);
-                    participantsAdapter.notifyDataSetChanged();
                 }
             });
         }
@@ -2602,7 +2592,6 @@ public class CallActivity extends CallBaseActivity {
             runOnUiThread(() -> {
                 if (participantDisplayItems.get(participantDisplayItemId) != null) {
                     participantDisplayItems.get(participantDisplayItemId).setStreamEnabled(true);
-                    participantsAdapter.notifyDataSetChanged();
                 }
             });
         }
@@ -2612,7 +2601,6 @@ public class CallActivity extends CallBaseActivity {
             runOnUiThread(() -> {
                 if (participantDisplayItems.get(participantDisplayItemId) != null) {
                     participantDisplayItems.get(participantDisplayItemId).setStreamEnabled(false);
-                    participantsAdapter.notifyDataSetChanged();
                 }
             });
         }
@@ -2622,7 +2610,6 @@ public class CallActivity extends CallBaseActivity {
             runOnUiThread(() -> {
                 if (participantDisplayItems.get(participantDisplayItemId) != null) {
                     participantDisplayItems.get(participantDisplayItemId).setNick(nick);
-                    participantsAdapter.notifyDataSetChanged();
                 }
             });
         }
@@ -2664,7 +2651,6 @@ public class CallActivity extends CallBaseActivity {
                 ParticipantDisplayItem participantDisplayItem = participantDisplayItems.get(participantDisplayItemId);
                 participantDisplayItem.setMediaStream(mediaStream);
                 participantDisplayItem.setStreamEnabled(hasAtLeastOneVideoStream);
-                participantsAdapter.notifyDataSetChanged();
             });
         }
 
@@ -2675,7 +2661,6 @@ public class CallActivity extends CallBaseActivity {
                     updateSelfVideoViewIceConnectionState(iceConnectionState);
                 } else if (participantDisplayItems.get(participantDisplayItemId) != null) {
                     participantDisplayItems.get(participantDisplayItemId).setIceConnectionState(iceConnectionState);
-                    participantsAdapter.notifyDataSetChanged();
                 }
 
                 if (iceConnectionState == PeerConnection.IceConnectionState.CLOSED) {

--- a/app/src/main/java/com/nextcloud/talk/adapters/ParticipantDisplayItem.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/ParticipantDisplayItem.java
@@ -37,22 +37,10 @@ public class ParticipantDisplayItem {
         this.updateUrlForAvatar();
     }
 
-    public String getUserId() {
-        return userId;
-    }
-
     public void setUserId(String userId) {
         this.userId = userId;
 
         this.updateUrlForAvatar();
-    }
-
-    public String getSession() {
-        return session;
-    }
-
-    public void setSession(String session) {
-        this.session = session;
     }
 
     public boolean isConnected() {
@@ -98,14 +86,6 @@ public class ParticipantDisplayItem {
         this.mediaStream = mediaStream;
     }
 
-    public String getStreamType() {
-        return streamType;
-    }
-
-    public void setStreamType(String streamType) {
-        this.streamType = streamType;
-    }
-
     public boolean isStreamEnabled() {
         return streamEnabled;
     }
@@ -116,10 +96,6 @@ public class ParticipantDisplayItem {
 
     public EglBase getRootEglBase() {
         return rootEglBase;
-    }
-
-    public void setRootEglBase(EglBase rootEglBase) {
-        this.rootEglBase = rootEglBase;
     }
 
     public boolean isAudioEnabled() {

--- a/app/src/main/java/com/nextcloud/talk/adapters/ParticipantDisplayItem.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/ParticipantDisplayItem.java
@@ -9,17 +9,17 @@ import org.webrtc.MediaStream;
 import org.webrtc.PeerConnection;
 
 public class ParticipantDisplayItem {
-    private String baseUrl;
+    private final String baseUrl;
     private String userId;
-    private String session;
+    private final String session;
     private PeerConnection.IceConnectionState iceConnectionState;
     private String nick;
     private final String defaultGuestNick;
     private String urlForAvatar;
     private MediaStream mediaStream;
-    private String streamType;
+    private final String streamType;
     private boolean streamEnabled;
-    private EglBase rootEglBase;
+    private final EglBase rootEglBase;
     private boolean isAudioEnabled;
 
     public ParticipantDisplayItem(String baseUrl, String userId, String session, PeerConnection.IceConnectionState iceConnectionState, String nick, String defaultGuestNick, MediaStream mediaStream, String streamType, boolean streamEnabled, EglBase rootEglBase) {

--- a/app/src/main/java/com/nextcloud/talk/adapters/ParticipantDisplayItem.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/ParticipantDisplayItem.java
@@ -10,16 +10,18 @@ import org.webrtc.PeerConnection;
 
 public class ParticipantDisplayItem {
     private final String baseUrl;
-    private String userId;
+    private final String defaultGuestNick;
+    private final EglBase rootEglBase;
+
     private final String session;
+    private final String streamType;
+
+    private String userId;
     private PeerConnection.IceConnectionState iceConnectionState;
     private String nick;
-    private final String defaultGuestNick;
     private String urlForAvatar;
     private MediaStream mediaStream;
-    private final String streamType;
     private boolean streamEnabled;
-    private final EglBase rootEglBase;
     private boolean isAudioEnabled;
 
     public ParticipantDisplayItem(String baseUrl, String userId, String session, PeerConnection.IceConnectionState iceConnectionState, String nick, String defaultGuestNick, MediaStream mediaStream, String streamType, boolean streamEnabled, EglBase rootEglBase) {

--- a/app/src/main/java/com/nextcloud/talk/adapters/ParticipantDisplayItem.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/ParticipantDisplayItem.java
@@ -9,6 +9,13 @@ import org.webrtc.MediaStream;
 import org.webrtc.PeerConnection;
 
 public class ParticipantDisplayItem {
+
+    public interface Observer {
+        void onChange();
+    }
+
+    private final ParticipantDisplayItemNotifier participantDisplayItemNotifier = new ParticipantDisplayItemNotifier();
+
     private final String baseUrl;
     private final String defaultGuestNick;
     private final EglBase rootEglBase;
@@ -43,6 +50,8 @@ public class ParticipantDisplayItem {
         this.userId = userId;
 
         this.updateUrlForAvatar();
+
+        participantDisplayItemNotifier.notifyChange();
     }
 
     public boolean isConnected() {
@@ -52,6 +61,8 @@ public class ParticipantDisplayItem {
 
     public void setIceConnectionState(PeerConnection.IceConnectionState iceConnectionState) {
         this.iceConnectionState = iceConnectionState;
+
+        participantDisplayItemNotifier.notifyChange();
     }
 
     public String getNick() {
@@ -66,6 +77,8 @@ public class ParticipantDisplayItem {
         this.nick = nick;
 
         this.updateUrlForAvatar();
+
+        participantDisplayItemNotifier.notifyChange();
     }
 
     public String getUrlForAvatar() {
@@ -86,6 +99,8 @@ public class ParticipantDisplayItem {
 
     public void setMediaStream(MediaStream mediaStream) {
         this.mediaStream = mediaStream;
+
+        participantDisplayItemNotifier.notifyChange();
     }
 
     public boolean isStreamEnabled() {
@@ -94,6 +109,8 @@ public class ParticipantDisplayItem {
 
     public void setStreamEnabled(boolean streamEnabled) {
         this.streamEnabled = streamEnabled;
+
+        participantDisplayItemNotifier.notifyChange();
     }
 
     public EglBase getRootEglBase() {
@@ -106,6 +123,16 @@ public class ParticipantDisplayItem {
 
     public void setAudioEnabled(boolean audioEnabled) {
         isAudioEnabled = audioEnabled;
+
+        participantDisplayItemNotifier.notifyChange();
+    }
+
+    public void addObserver(Observer observer) {
+        participantDisplayItemNotifier.addObserver(observer);
+    }
+
+    public void removeObserver(Observer observer) {
+        participantDisplayItemNotifier.removeObserver(observer);
     }
 
     @Override

--- a/app/src/main/java/com/nextcloud/talk/adapters/ParticipantDisplayItem.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/ParticipantDisplayItem.java
@@ -6,12 +6,13 @@ import com.nextcloud.talk.utils.ApiUtils;
 
 import org.webrtc.EglBase;
 import org.webrtc.MediaStream;
+import org.webrtc.PeerConnection;
 
 public class ParticipantDisplayItem {
     private String baseUrl;
     private String userId;
     private String session;
-    private boolean connected;
+    private PeerConnection.IceConnectionState iceConnectionState;
     private String nick;
     private final String defaultGuestNick;
     private String urlForAvatar;
@@ -21,11 +22,11 @@ public class ParticipantDisplayItem {
     private EglBase rootEglBase;
     private boolean isAudioEnabled;
 
-    public ParticipantDisplayItem(String baseUrl, String userId, String session, boolean connected, String nick, String defaultGuestNick, MediaStream mediaStream, String streamType, boolean streamEnabled, EglBase rootEglBase) {
+    public ParticipantDisplayItem(String baseUrl, String userId, String session, PeerConnection.IceConnectionState iceConnectionState, String nick, String defaultGuestNick, MediaStream mediaStream, String streamType, boolean streamEnabled, EglBase rootEglBase) {
         this.baseUrl = baseUrl;
         this.userId = userId;
         this.session = session;
-        this.connected = connected;
+        this.iceConnectionState = iceConnectionState;
         this.nick = nick;
         this.defaultGuestNick = defaultGuestNick;
         this.mediaStream = mediaStream;
@@ -55,11 +56,12 @@ public class ParticipantDisplayItem {
     }
 
     public boolean isConnected() {
-        return connected;
+        return iceConnectionState == PeerConnection.IceConnectionState.CONNECTED ||
+            iceConnectionState == PeerConnection.IceConnectionState.COMPLETED;
     }
 
-    public void setConnected(boolean connected) {
-        this.connected = connected;
+    public void setIceConnectionState(PeerConnection.IceConnectionState iceConnectionState) {
+        this.iceConnectionState = iceConnectionState;
     }
 
     public String getNick() {

--- a/app/src/main/java/com/nextcloud/talk/adapters/ParticipantDisplayItem.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/ParticipantDisplayItem.java
@@ -95,7 +95,10 @@ public class ParticipantDisplayItem {
 
     public boolean isConnected() {
         return iceConnectionState == PeerConnection.IceConnectionState.CONNECTED ||
-            iceConnectionState == PeerConnection.IceConnectionState.COMPLETED;
+            iceConnectionState == PeerConnection.IceConnectionState.COMPLETED ||
+            // If there is no connection state that means that no connection is needed, so it is a special case that is
+            // also seen as "connected".
+            iceConnectionState == null;
     }
 
     public String getNick() {

--- a/app/src/main/java/com/nextcloud/talk/adapters/ParticipantDisplayItemNotifier.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/ParticipantDisplayItemNotifier.java
@@ -1,0 +1,55 @@
+/*
+ * Nextcloud Talk application
+ *
+ * @author Daniel Calviño Sánchez
+ * Copyright (C) 2022 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.nextcloud.talk.adapters;
+
+import com.nextcloud.talk.signaling.SignalingMessageReceiver;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Helper class to register and notify ParticipantDisplayItem.Observers.
+ *
+ * This class is only meant for internal use by ParticipantDisplayItem; observers must register themselves against a
+ * ParticipantDisplayItem rather than against a ParticipantDisplayItemNotifier.
+ */
+class ParticipantDisplayItemNotifier {
+
+    private final Set<ParticipantDisplayItem.Observer> participantDisplayItemObservers = new LinkedHashSet<>();
+
+    public synchronized void addObserver(ParticipantDisplayItem.Observer observer) {
+        if (observer == null) {
+            throw new IllegalArgumentException("ParticipantDisplayItem.Observer can not be null");
+        }
+
+        participantDisplayItemObservers.add(observer);
+    }
+
+    public synchronized void removeObserver(ParticipantDisplayItem.Observer observer) {
+        participantDisplayItemObservers.remove(observer);
+    }
+
+    public synchronized void notifyChange() {
+        for (ParticipantDisplayItem.Observer observer : new ArrayList<>(participantDisplayItemObservers)) {
+            observer.onChange();
+        }
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/adapters/ParticipantsAdapter.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/ParticipantsAdapter.java
@@ -29,6 +29,8 @@ public class ParticipantsAdapter extends BaseAdapter {
 
     private static final String TAG = "ParticipantsAdapter";
 
+    private final ParticipantDisplayItem.Observer participantDisplayItemObserver = this::notifyDataSetChanged;
+
     private final Context mContext;
     private final ArrayList<ParticipantDisplayItem> participantDisplayItems;
     private final RelativeLayout gridViewWrapper;
@@ -50,8 +52,17 @@ public class ParticipantsAdapter extends BaseAdapter {
 
         this.participantDisplayItems = new ArrayList<>();
         this.participantDisplayItems.addAll(participantDisplayItems.values());
+
+        for (ParticipantDisplayItem participantDisplayItem : this.participantDisplayItems) {
+            participantDisplayItem.addObserver(participantDisplayItemObserver);
+        }
     }
 
+    public void destroy() {
+        for (ParticipantDisplayItem participantDisplayItem : participantDisplayItems) {
+            participantDisplayItem.removeObserver(participantDisplayItemObserver);
+        }
+    }
 
     @Override
     public int getCount() {

--- a/app/src/main/java/com/nextcloud/talk/call/CallParticipant.java
+++ b/app/src/main/java/com/nextcloud/talk/call/CallParticipant.java
@@ -1,0 +1,198 @@
+/*
+ * Nextcloud Talk application
+ *
+ * @author Daniel Calviño Sánchez
+ * Copyright (C) 2022 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.nextcloud.talk.call;
+
+import com.nextcloud.talk.webrtc.PeerConnectionWrapper;
+
+import org.webrtc.MediaStream;
+import org.webrtc.PeerConnection;
+
+/**
+ * Model for (remote) call participants.
+ *
+ * This class keeps track of the state changes in a call participant and updates its data model as needed. View classes
+ * are expected to directly use the read-only data model.
+ */
+public class CallParticipant {
+
+    private final PeerConnectionWrapper.PeerConnectionObserver peerConnectionObserver =
+            new PeerConnectionWrapper.PeerConnectionObserver() {
+        @Override
+        public void onStreamAdded(MediaStream mediaStream) {
+            handleStreamChange(mediaStream);
+        }
+
+        @Override
+        public void onStreamRemoved(MediaStream mediaStream) {
+            handleStreamChange(mediaStream);
+        }
+
+        @Override
+        public void onIceConnectionStateChanged(PeerConnection.IceConnectionState iceConnectionState) {
+            handleIceConnectionStateChange(iceConnectionState);
+        }
+    };
+
+    private final PeerConnectionWrapper.PeerConnectionObserver screenPeerConnectionObserver =
+            new PeerConnectionWrapper.PeerConnectionObserver() {
+        @Override
+        public void onStreamAdded(MediaStream mediaStream) {
+            callParticipantModel.setScreenMediaStream(mediaStream);
+        }
+
+        @Override
+        public void onStreamRemoved(MediaStream mediaStream) {
+            callParticipantModel.setScreenMediaStream(null);
+        }
+
+        @Override
+        public void onIceConnectionStateChanged(PeerConnection.IceConnectionState iceConnectionState) {
+            callParticipantModel.setScreenIceConnectionState(iceConnectionState);
+        }
+    };
+
+    // DataChannel messages are sent only in video peers; (sender) screen peers do not even open them.
+    private final PeerConnectionWrapper.DataChannelMessageListener dataChannelMessageListener =
+            new PeerConnectionWrapper.DataChannelMessageListener() {
+        @Override
+        public void onAudioOn() {
+            callParticipantModel.setAudioAvailable(Boolean.TRUE);
+        }
+
+        @Override
+        public void onAudioOff() {
+            callParticipantModel.setAudioAvailable(Boolean.FALSE);
+        }
+
+        @Override
+        public void onVideoOn() {
+            callParticipantModel.setVideoAvailable(Boolean.TRUE);
+        }
+
+        @Override
+        public void onVideoOff() {
+            callParticipantModel.setVideoAvailable(Boolean.FALSE);
+        }
+
+        @Override
+        public void onNickChanged(String nick) {
+            callParticipantModel.setNick(nick);
+        }
+    };
+
+    private final MutableCallParticipantModel callParticipantModel;
+
+    private PeerConnectionWrapper peerConnectionWrapper;
+    private PeerConnectionWrapper screenPeerConnectionWrapper;
+
+    public CallParticipant(String sessionId) {
+        callParticipantModel = new MutableCallParticipantModel(sessionId);
+    }
+
+    public void destroy() {
+        if (peerConnectionWrapper != null) {
+            peerConnectionWrapper.removeObserver(peerConnectionObserver);
+            peerConnectionWrapper.removeListener(dataChannelMessageListener);
+        }
+        if (screenPeerConnectionWrapper != null) {
+            screenPeerConnectionWrapper.removeObserver(screenPeerConnectionObserver);
+        }
+    }
+
+    public CallParticipantModel getCallParticipantModel() {
+        return callParticipantModel;
+    }
+
+    public void setUserId(String userId) {
+        callParticipantModel.setUserId(userId);
+    }
+
+    public void setNick(String nick) {
+        callParticipantModel.setNick(nick);
+    }
+
+    public void setPeerConnectionWrapper(PeerConnectionWrapper peerConnectionWrapper) {
+        if (this.peerConnectionWrapper != null) {
+            this.peerConnectionWrapper.removeObserver(peerConnectionObserver);
+            this.peerConnectionWrapper.removeListener(dataChannelMessageListener);
+        }
+
+        this.peerConnectionWrapper = peerConnectionWrapper;
+
+        if (this.peerConnectionWrapper == null) {
+            callParticipantModel.setIceConnectionState(null);
+            callParticipantModel.setMediaStream(null);
+            callParticipantModel.setAudioAvailable(null);
+            callParticipantModel.setVideoAvailable(null);
+
+            return;
+        }
+
+        handleIceConnectionStateChange(this.peerConnectionWrapper.getPeerConnection().iceConnectionState());
+        handleStreamChange(this.peerConnectionWrapper.getStream());
+
+        this.peerConnectionWrapper.addObserver(peerConnectionObserver);
+        this.peerConnectionWrapper.addListener(dataChannelMessageListener);
+    }
+
+    private void handleIceConnectionStateChange(PeerConnection.IceConnectionState iceConnectionState) {
+        callParticipantModel.setIceConnectionState(iceConnectionState);
+
+        if (iceConnectionState == PeerConnection.IceConnectionState.NEW ||
+                iceConnectionState == PeerConnection.IceConnectionState.CHECKING) {
+            callParticipantModel.setAudioAvailable(null);
+            callParticipantModel.setVideoAvailable(null);
+        }
+    }
+
+    private void handleStreamChange(MediaStream mediaStream) {
+        if (mediaStream == null) {
+            callParticipantModel.setMediaStream(null);
+            callParticipantModel.setVideoAvailable(Boolean.FALSE);
+
+            return;
+        }
+
+        boolean hasAtLeastOneVideoStream = mediaStream.videoTracks != null && !mediaStream.videoTracks.isEmpty();
+
+        callParticipantModel.setMediaStream(mediaStream);
+        callParticipantModel.setVideoAvailable(hasAtLeastOneVideoStream);
+    }
+
+    public void setScreenPeerConnectionWrapper(PeerConnectionWrapper screenPeerConnectionWrapper) {
+        if (this.screenPeerConnectionWrapper != null) {
+            this.screenPeerConnectionWrapper.removeObserver(screenPeerConnectionObserver);
+        }
+
+        this.screenPeerConnectionWrapper = screenPeerConnectionWrapper;
+
+        if (this.screenPeerConnectionWrapper == null) {
+            callParticipantModel.setScreenIceConnectionState(null);
+            callParticipantModel.setScreenMediaStream(null);
+
+            return;
+        }
+
+        callParticipantModel.setScreenIceConnectionState(this.screenPeerConnectionWrapper.getPeerConnection().iceConnectionState());
+        callParticipantModel.setScreenMediaStream(this.screenPeerConnectionWrapper.getStream());
+
+        this.screenPeerConnectionWrapper.addObserver(screenPeerConnectionObserver);
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/call/CallParticipantList.java
+++ b/app/src/main/java/com/nextcloud/talk/call/CallParticipantList.java
@@ -1,0 +1,164 @@
+/*
+ * Nextcloud Talk application
+ *
+ * @author Daniel Calviño Sánchez
+ * Copyright (C) 2022 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.nextcloud.talk.call;
+
+import com.nextcloud.talk.models.json.participants.Participant;
+import com.nextcloud.talk.signaling.SignalingMessageReceiver;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Helper class to keep track of the participants in a call based on the signaling messages.
+ *
+ * The CallParticipantList adds a listener for participant list messages as soon as it is created and starts tracking
+ * the call participants until destroyed. Notifications about the changes can be received by adding an observer to the
+ * CallParticipantList; note that no sorting is guaranteed on the participants.
+ */
+public class CallParticipantList {
+
+    public interface Observer {
+        void onCallParticipantsChanged(Collection<Participant> joined, Collection<Participant> updated,
+                                       Collection<Participant> left, Collection<Participant> unchanged);
+        void onCallEndedForAll();
+    }
+
+    private final SignalingMessageReceiver.ParticipantListMessageListener participantListMessageListener =
+            new SignalingMessageReceiver.ParticipantListMessageListener() {
+
+        private final Map<String, Participant> callParticipants = new HashMap<>();
+
+        @Override
+        public void onUsersInRoom(List<Participant> participants) {
+            processParticipantList(participants);
+        }
+
+        @Override
+        public void onParticipantsUpdate(List<Participant> participants) {
+            processParticipantList(participants);
+        }
+
+        private void processParticipantList(List<Participant> participants) {
+            Collection<Participant> joined = new ArrayList<>();
+            Collection<Participant> updated = new ArrayList<>();
+            Collection<Participant> left = new ArrayList<>();
+            Collection<Participant> unchanged = new ArrayList<>();
+
+            Collection<Participant> knownCallParticipantsNotFound = new ArrayList<>(callParticipants.values());
+
+            for (Participant participant : participants) {
+                String sessionId = participant.getSessionId();
+                Participant callParticipant = callParticipants.get(sessionId);
+
+                boolean knownCallParticipant = callParticipant != null;
+                if (!knownCallParticipant && participant.getInCall() != Participant.InCallFlags.DISCONNECTED) {
+                    callParticipants.put(sessionId, copyParticipant(participant));
+                    joined.add(copyParticipant(participant));
+                } else if (knownCallParticipant && participant.getInCall() == Participant.InCallFlags.DISCONNECTED) {
+                    callParticipants.remove(sessionId);
+                    // No need to copy it, as it will be no longer used.
+                    callParticipant.setInCall(Participant.InCallFlags.DISCONNECTED);
+                    left.add(callParticipant);
+                } else if (knownCallParticipant && callParticipant.getInCall() != participant.getInCall()) {
+                    callParticipant.setInCall(participant.getInCall());
+                    updated.add(copyParticipant(participant));
+                } else if (knownCallParticipant) {
+                    unchanged.add(copyParticipant(participant));
+                }
+
+                if (knownCallParticipant) {
+                    knownCallParticipantsNotFound.remove(callParticipant);
+                }
+            }
+
+            for (Participant callParticipant : knownCallParticipantsNotFound) {
+                callParticipants.remove(callParticipant.getSessionId());
+                // No need to copy it, as it will be no longer used.
+                callParticipant.setInCall(Participant.InCallFlags.DISCONNECTED);
+                left.add(callParticipant);
+            }
+
+            if (!joined.isEmpty() || !updated.isEmpty() || !left.isEmpty()) {
+                callParticipantListNotifier.notifyChanged(joined, updated, left, unchanged);
+            }
+        }
+
+        @Override
+        public void onAllParticipantsUpdate(long inCall) {
+            if (inCall != Participant.InCallFlags.DISCONNECTED) {
+                // Updating all participants is expected to happen only to disconnect them.
+                return;
+            }
+
+            callParticipantListNotifier.notifyCallEndedForAll();
+
+            Collection<Participant> joined = new ArrayList<>();
+            Collection<Participant> updated = new ArrayList<>();
+            Collection<Participant> left = new ArrayList<>(callParticipants.size());
+            Collection<Participant> unchanged = new ArrayList<>();
+
+            for (Participant callParticipant : callParticipants.values()) {
+                // No need to copy it, as it will be no longer used.
+                callParticipant.setInCall(Participant.InCallFlags.DISCONNECTED);
+                left.add(callParticipant);
+            }
+            callParticipants.clear();
+
+            if (!left.isEmpty()) {
+                callParticipantListNotifier.notifyChanged(joined, updated, left, unchanged);
+            }
+        }
+
+        private Participant copyParticipant(Participant participant) {
+            Participant copiedParticipant = new Participant();
+            copiedParticipant.setInCall(participant.getInCall());
+            copiedParticipant.setLastPing(participant.getLastPing());
+            copiedParticipant.setSessionId(participant.getSessionId());
+            copiedParticipant.setType(participant.getType());
+            copiedParticipant.setUserId(participant.getUserId());
+
+            return copiedParticipant;
+        }
+    };
+
+    private final CallParticipantListNotifier callParticipantListNotifier = new CallParticipantListNotifier();
+
+    private final SignalingMessageReceiver signalingMessageReceiver;
+
+    public CallParticipantList(SignalingMessageReceiver signalingMessageReceiver) {
+        this.signalingMessageReceiver = signalingMessageReceiver;
+        this.signalingMessageReceiver.addListener(participantListMessageListener);
+    }
+
+    public void destroy() {
+        signalingMessageReceiver.removeListener(participantListMessageListener);
+    }
+
+    public void addObserver(Observer observer) {
+        callParticipantListNotifier.addObserver(observer);
+    }
+
+    public void removeObserver(Observer observer) {
+        callParticipantListNotifier.removeObserver(observer);
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/call/CallParticipantListNotifier.java
+++ b/app/src/main/java/com/nextcloud/talk/call/CallParticipantListNotifier.java
@@ -1,0 +1,63 @@
+/*
+ * Nextcloud Talk application
+ *
+ * @author Daniel Calviño Sánchez
+ * Copyright (C) 2022 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.nextcloud.talk.call;
+
+import com.nextcloud.talk.models.json.participants.Participant;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Helper class to register and notify CallParticipantList.Observers.
+ *
+ * This class is only meant for internal use by CallParticipantList; listeners must register themselves against
+ * a CallParticipantList rather than against a CallParticipantListNotifier.
+ */
+class CallParticipantListNotifier {
+
+    private final Set<CallParticipantList.Observer> callParticipantListObservers = new LinkedHashSet<>();
+
+    public synchronized void addObserver(CallParticipantList.Observer observer) {
+        if (observer == null) {
+            throw new IllegalArgumentException("CallParticipantList.Observer can not be null");
+        }
+
+        callParticipantListObservers.add(observer);
+    }
+
+    public synchronized void removeObserver(CallParticipantList.Observer observer) {
+        callParticipantListObservers.remove(observer);
+    }
+
+    public synchronized void notifyChanged(Collection<Participant> joined, Collection<Participant> updated,
+                                           Collection<Participant> left, Collection<Participant> unchanged) {
+        for (CallParticipantList.Observer observer : new ArrayList<>(callParticipantListObservers)) {
+            observer.onCallParticipantsChanged(joined, updated, left, unchanged);
+        }
+    }
+
+    public synchronized void notifyCallEndedForAll() {
+        for (CallParticipantList.Observer observer : new ArrayList<>(callParticipantListObservers)) {
+            observer.onCallEndedForAll();
+        }
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/call/CallParticipantModel.java
+++ b/app/src/main/java/com/nextcloud/talk/call/CallParticipantModel.java
@@ -1,0 +1,164 @@
+/*
+ * Nextcloud Talk application
+ *
+ * @author Daniel Calviño Sánchez
+ * Copyright (C) 2022 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.nextcloud.talk.call;
+
+import android.os.Handler;
+
+import org.webrtc.MediaStream;
+import org.webrtc.PeerConnection;
+
+import java.util.Objects;
+
+/**
+ * Read-only data model for (remote) call participants.
+ *
+ * The received audio and video are available only if the participant is sending them and also has them enabled.
+ * Before a connection is established it is not known whether audio and video are available or not, so null is returned
+ * in that case (therefore it should not be autoboxed to a plain boolean without checking that).
+ *
+ * Audio and video in screen shares, on the other hand, are always seen as available.
+ *
+ * Clients of the model can observe it with CallParticipantModel.Observer to be notified when any value changes.
+ * Getters called after receiving a notification are guaranteed to provide at least the value that triggered the
+ * notification, but it may return even a more up to date one (so getting the value again on the following
+ * notification may return the same value as before).
+ */
+public class CallParticipantModel {
+
+    public interface Observer {
+        void onChange();
+    }
+
+    protected class Data<T> {
+
+        private T value;
+
+        public T getValue() {
+            return value;
+        }
+
+        public void setValue(T value) {
+            if (Objects.equals(this.value, value)) {
+                return;
+            }
+
+            this.value = value;
+
+            callParticipantModelNotifier.notifyChange();
+        }
+    }
+
+    private final CallParticipantModelNotifier callParticipantModelNotifier = new CallParticipantModelNotifier();
+
+    protected final String sessionId;
+
+    protected Data<String> userId;
+    protected Data<String> nick;
+
+    protected Data<PeerConnection.IceConnectionState> iceConnectionState;
+    protected Data<MediaStream> mediaStream;
+    protected Data<Boolean> audioAvailable;
+    protected Data<Boolean> videoAvailable;
+
+    protected Data<PeerConnection.IceConnectionState> screenIceConnectionState;
+    protected Data<MediaStream> screenMediaStream;
+
+    public CallParticipantModel(String sessionId) {
+        this.sessionId = sessionId;
+
+        this.userId = new Data<>();
+        this.nick = new Data<>();
+
+        this.iceConnectionState = new Data<>();
+        this.mediaStream = new Data<>();
+        this.audioAvailable = new Data<>();
+        this.videoAvailable = new Data<>();
+
+        this.screenIceConnectionState = new Data<>();
+        this.screenMediaStream = new Data<>();
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public String getUserId() {
+        return userId.getValue();
+    }
+
+    public String getNick() {
+        return nick.getValue();
+    }
+
+    public PeerConnection.IceConnectionState getIceConnectionState() {
+        return iceConnectionState.getValue();
+    }
+
+    public MediaStream getMediaStream() {
+        return mediaStream.getValue();
+    }
+
+    public Boolean isAudioAvailable() {
+        return audioAvailable.getValue();
+    }
+
+    public Boolean isVideoAvailable() {
+        return videoAvailable.getValue();
+    }
+
+    public PeerConnection.IceConnectionState getScreenIceConnectionState() {
+        return screenIceConnectionState.getValue();
+    }
+
+    public MediaStream getScreenMediaStream() {
+        return screenMediaStream.getValue();
+    }
+
+    /**
+     * Adds an Observer to be notified when any value changes.
+     *
+     * @param observer the Observer
+     * @see CallParticipantModel#addObserver(Observer, Handler)
+     */
+    public void addObserver(Observer observer) {
+        addObserver(observer, null);
+    }
+
+    /**
+     * Adds an observer to be notified when any value changes.
+     *
+     * The observer will be notified on the thread associated to the given handler. If no handler is given the
+     * observer will be immediately notified on the same thread that changed the value; the observer will be
+     * immediately notified too if the thread of the handler is the same thread that changed the value.
+     *
+     * An observer is expected to be added only once. If the same observer is added again it will be notified just
+     * once on the thread of the last handler.
+     *
+     * @param observer the Observer
+     * @param handler a Handler for the thread to be notified on
+     */
+    public void addObserver(Observer observer, Handler handler) {
+        callParticipantModelNotifier.addObserver(observer, handler);
+    }
+
+    public void removeObserver(Observer observer) {
+        callParticipantModelNotifier.removeObserver(observer);
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/call/CallParticipantModelNotifier.java
+++ b/app/src/main/java/com/nextcloud/talk/call/CallParticipantModelNotifier.java
@@ -1,0 +1,86 @@
+/*
+ * Nextcloud Talk application
+ *
+ * @author Daniel Calviño Sánchez
+ * Copyright (C) 2022 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.nextcloud.talk.call;
+
+import android.os.Handler;
+import android.os.Looper;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Helper class to register and notify CallParticipantModel.Observers.
+ *
+ * This class is only meant for internal use by CallParticipantModel; observers must register themselves against a
+ * CallParticipantModel rather than against a CallParticipantModelNotifier.
+ */
+class CallParticipantModelNotifier {
+
+    /**
+     * Helper class to associate a CallParticipantModel.Observer with a Handler.
+     */
+    private static class CallParticipantModelObserverOn {
+        public final CallParticipantModel.Observer observer;
+        public final Handler handler;
+
+        private CallParticipantModelObserverOn(CallParticipantModel.Observer observer, Handler handler) {
+            this.observer = observer;
+            this.handler = handler;
+        }
+    }
+
+    private final List<CallParticipantModelObserverOn> callParticipantModelObserversOn = new ArrayList<>();
+
+    public synchronized void addObserver(CallParticipantModel.Observer observer, Handler handler) {
+        if (observer == null) {
+            throw new IllegalArgumentException("CallParticipantModel.Observer can not be null");
+        }
+
+        removeObserver(observer);
+
+        callParticipantModelObserversOn.add(new CallParticipantModelObserverOn(observer, handler));
+    }
+
+    public synchronized void removeObserver(CallParticipantModel.Observer observer) {
+        Iterator<CallParticipantModelObserverOn> it = callParticipantModelObserversOn.iterator();
+        while (it.hasNext()) {
+            CallParticipantModelObserverOn observerOn = it.next();
+
+            if (observerOn.observer == observer) {
+                it.remove();
+
+                return;
+            }
+        }
+    }
+
+    public synchronized void notifyChange() {
+        for (CallParticipantModelObserverOn observerOn : new ArrayList<>(callParticipantModelObserversOn)) {
+            if (observerOn.handler == null || observerOn.handler.getLooper() == Looper.myLooper()) {
+                observerOn.observer.onChange();
+            } else {
+                observerOn.handler.post(() -> {
+                    observerOn.observer.onChange();
+                });
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/call/MutableCallParticipantModel.java
+++ b/app/src/main/java/com/nextcloud/talk/call/MutableCallParticipantModel.java
@@ -1,0 +1,67 @@
+/*
+ * Nextcloud Talk application
+ *
+ * @author Daniel Calviño Sánchez
+ * Copyright (C) 2022 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.nextcloud.talk.call;
+
+import org.webrtc.MediaStream;
+import org.webrtc.PeerConnection;
+
+/**
+ * Mutable data model for (remote) call participants.
+ *
+ * There is no synchronization when setting the values; if needed, it should be handled by the clients of the model.
+ */
+public class MutableCallParticipantModel extends CallParticipantModel {
+
+    public MutableCallParticipantModel(String sessionId) {
+        super(sessionId);
+    }
+
+    public void setUserId(String userId) {
+        this.userId.setValue(userId);
+    }
+
+    public void setNick(String nick) {
+        this.nick.setValue(nick);
+    }
+
+    public void setIceConnectionState(PeerConnection.IceConnectionState iceConnectionState) {
+        this.iceConnectionState.setValue(iceConnectionState);
+    }
+
+    public void setMediaStream(MediaStream mediaStream) {
+        this.mediaStream.setValue(mediaStream);
+    }
+
+    public void setAudioAvailable(Boolean audioAvailable) {
+        this.audioAvailable.setValue(audioAvailable);
+    }
+
+    public void setVideoAvailable(Boolean videoAvailable) {
+        this.videoAvailable.setValue(videoAvailable);
+    }
+
+    public void setScreenIceConnectionState(PeerConnection.IceConnectionState screenIceConnectionState) {
+        this.screenIceConnectionState.setValue(screenIceConnectionState);
+    }
+
+    public void setScreenMediaStream(MediaStream screenMediaStream) {
+        this.screenMediaStream.setValue(screenMediaStream);
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
@@ -121,6 +121,9 @@ public class PeerConnectionWrapper {
     private final boolean isMCUPublisher;
     private final String videoStreamType;
 
+    // It is assumed that there will be at most one remote stream at each time.
+    private MediaStream stream;
+
     @Inject
     Context context;
 
@@ -217,6 +220,10 @@ public class PeerConnectionWrapper {
 
     public String getVideoStreamType() {
         return videoStreamType;
+    }
+
+    public MediaStream getStream() {
+        return stream;
     }
 
     public void removePeerConnection() {
@@ -484,11 +491,15 @@ public class PeerConnectionWrapper {
 
         @Override
         public void onAddStream(MediaStream mediaStream) {
+            stream = mediaStream;
+
             peerConnectionNotifier.notifyStreamAdded(mediaStream);
         }
 
         @Override
         public void onRemoveStream(MediaStream mediaStream) {
+            stream = null;
+
             peerConnectionNotifier.notifyStreamRemoved(mediaStream);
         }
 

--- a/app/src/test/java/com/nextcloud/talk/call/CallParticipantListExternalSignalingTest.java
+++ b/app/src/test/java/com/nextcloud/talk/call/CallParticipantListExternalSignalingTest.java
@@ -1,0 +1,663 @@
+/*
+ * Nextcloud Talk application
+ *
+ * @author Daniel Calviño Sánchez
+ * Copyright (C) 2022 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.nextcloud.talk.call;
+
+import com.nextcloud.talk.models.json.participants.Participant;
+import com.nextcloud.talk.signaling.SignalingMessageReceiver;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
+import org.mockito.InOrder;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import static com.nextcloud.talk.models.json.participants.Participant.InCallFlags.DISCONNECTED;
+import static com.nextcloud.talk.models.json.participants.Participant.InCallFlags.IN_CALL;
+import static com.nextcloud.talk.models.json.participants.Participant.InCallFlags.WITH_AUDIO;
+import static com.nextcloud.talk.models.json.participants.Participant.InCallFlags.WITH_VIDEO;
+import static com.nextcloud.talk.models.json.participants.Participant.ParticipantType.GUEST;
+import static com.nextcloud.talk.models.json.participants.Participant.ParticipantType.GUEST_MODERATOR;
+import static com.nextcloud.talk.models.json.participants.Participant.ParticipantType.MODERATOR;
+import static com.nextcloud.talk.models.json.participants.Participant.ParticipantType.OWNER;
+import static com.nextcloud.talk.models.json.participants.Participant.ParticipantType.USER;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class CallParticipantListExternalSignalingTest {
+
+    private static class ParticipantsUpdateParticipantBuilder {
+        private Participant newUser(long inCall, long lastPing, String sessionId, Participant.ParticipantType type,
+                                    String userId) {
+            Participant participant = new Participant();
+            participant.setInCall(inCall);
+            participant.setLastPing(lastPing);
+            participant.setSessionId(sessionId);
+            participant.setType(type);
+            participant.setUserId(userId);
+
+            return participant;
+        }
+
+        private Participant newGuest(long inCall, long lastPing, String sessionId, Participant.ParticipantType type) {
+            Participant participant = new Participant();
+            participant.setInCall(inCall);
+            participant.setLastPing(lastPing);
+            participant.setSessionId(sessionId);
+            participant.setType(type);
+
+            return participant;
+        }
+    }
+
+    private final ParticipantsUpdateParticipantBuilder builder = new ParticipantsUpdateParticipantBuilder();
+
+    private CallParticipantList callParticipantList;
+    private SignalingMessageReceiver.ParticipantListMessageListener participantListMessageListener;
+
+    private CallParticipantList.Observer mockedCallParticipantListObserver;
+
+    private Collection<Participant> expectedJoined;
+    private Collection<Participant> expectedUpdated;
+    private Collection<Participant> expectedLeft;
+    private Collection<Participant> expectedUnchanged;
+
+    // The order of the left participants in some tests depends on how they are internally sorted by the map, so the
+    // list of left participants needs to be checked ignoring the sorting (or, rather, sorting by session ID as in
+    // expectedLeft).
+    // Other tests can just relay on the not guaranteed, but known internal sorting of the elements.
+    private final ArgumentMatcher<List<Participant>> matchesExpectedLeftIgnoringOrder = left -> {
+        Collections.sort(left, Comparator.comparing(Participant::getSessionId));
+        return expectedLeft.equals(left);
+    };
+
+    @Before
+    public void setUp() {
+        SignalingMessageReceiver mockedSignalingMessageReceiver = mock(SignalingMessageReceiver.class);
+
+        callParticipantList = new CallParticipantList(mockedSignalingMessageReceiver);
+
+        mockedCallParticipantListObserver = mock(CallParticipantList.Observer.class);
+
+        // Get internal ParticipantListMessageListener from callParticipantList set in the
+        // mockedSignalingMessageReceiver.
+        ArgumentCaptor<SignalingMessageReceiver.ParticipantListMessageListener> participantListMessageListenerArgumentCaptor =
+            ArgumentCaptor.forClass(SignalingMessageReceiver.ParticipantListMessageListener.class);
+
+        verify(mockedSignalingMessageReceiver).addListener(participantListMessageListenerArgumentCaptor.capture());
+
+        participantListMessageListener = participantListMessageListenerArgumentCaptor.getValue();
+
+        expectedJoined = new ArrayList<>();
+        expectedUpdated = new ArrayList<>();
+        expectedLeft = new ArrayList<>();
+        expectedUnchanged = new ArrayList<>();
+    }
+
+    @Test
+    public void testParticipantsUpdateJoinRoom() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", MODERATOR, "theUserId1"));
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        verifyNoInteractions(mockedCallParticipantListObserver);
+    }
+
+    @Test
+    public void testParticipantsUpdateJoinRoomSeveralParticipants() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", MODERATOR, "theUserId1"));
+        participants.add(builder.newGuest(DISCONNECTED, 2, "theSessionId2", GUEST));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", USER, "theUserId3"));
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", MODERATOR, "theUserId1"));
+        participants.add(builder.newGuest(DISCONNECTED, 2, "theSessionId2", GUEST));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", USER, "theUserId3"));
+        participants.add(builder.newUser(DISCONNECTED, 4, "theSessionId4", USER, "theUserId4"));
+        participants.add(builder.newUser(DISCONNECTED, 5, "theSessionId5", OWNER, "theUserId5"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        verifyNoInteractions(mockedCallParticipantListObserver);
+    }
+
+    @Test
+    public void testParticipantsUpdateJoinRoomThenJoinCall() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", MODERATOR, "theUserId1"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", MODERATOR, "theUserId1"));
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        expectedJoined.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", MODERATOR, "theUserId1"));
+
+        verify(mockedCallParticipantListObserver, only()).onCallParticipantsChanged(expectedJoined, expectedUpdated,
+                                                                                    expectedLeft, expectedUnchanged);
+    }
+
+    @Test
+    public void testParticipantsUpdateJoinRoomThenJoinCallSeveralParticipants() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", MODERATOR, "theUserId1"));
+        participants.add(builder.newGuest(DISCONNECTED, 2, "theSessionId2", GUEST));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", USER, "theUserId3"));
+        participants.add(builder.newUser(DISCONNECTED, 4, "theSessionId4", USER, "theUserId4"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", MODERATOR, "theUserId1"));
+        participants.add(builder.newGuest(DISCONNECTED, 2, "theSessionId2", GUEST));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", USER, "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", USER, "theUserId4"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", MODERATOR, "theUserId1"));
+        participants.add(builder.newGuest(IN_CALL, 2, "theSessionId2", GUEST));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", USER, "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", USER, "theUserId4"));
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        expectedJoined.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", MODERATOR, "theUserId1"));
+        expectedJoined.add(builder.newGuest(IN_CALL, 2, "theSessionId2", GUEST));
+        expectedUnchanged.add(builder.newUser(IN_CALL, 4, "theSessionId4", USER, "theUserId4"));
+
+        verify(mockedCallParticipantListObserver, only()).onCallParticipantsChanged(expectedJoined, expectedUpdated,
+                                                                                    expectedLeft, expectedUnchanged);
+    }
+
+    @Test
+    public void testParticipantsUpdateJoinRoomAndCall() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", MODERATOR, "theUserId1"));
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        expectedJoined.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", MODERATOR, "theUserId1"));
+
+        verify(mockedCallParticipantListObserver, only()).onCallParticipantsChanged(expectedJoined, expectedUpdated,
+                                                                                    expectedLeft, expectedUnchanged);
+    }
+
+    @Test
+    public void testParticipantsUpdateJoinRoomAndCallSeveralParticipants() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", USER, "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", USER, "theUserId4"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", MODERATOR, "theUserId1"));
+        participants.add(builder.newGuest(IN_CALL, 2, "theSessionId2", GUEST));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", USER, "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", USER, "theUserId4"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        expectedJoined.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", MODERATOR, "theUserId1"));
+        expectedJoined.add(builder.newGuest(IN_CALL, 2, "theSessionId2", GUEST));
+        expectedUnchanged.add(builder.newUser(IN_CALL, 4, "theSessionId4", USER, "theUserId4"));
+
+        verify(mockedCallParticipantListObserver, only()).onCallParticipantsChanged(expectedJoined, expectedUpdated,
+                                                                                    expectedLeft, expectedUnchanged);
+    }
+
+    @Test
+    public void testParticipantsUpdateJoinRoomAndCallRepeated() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", MODERATOR, "theUserId1"));
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+        participantListMessageListener.onParticipantsUpdate(participants);
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        expectedJoined.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", MODERATOR, "theUserId1"));
+
+        verify(mockedCallParticipantListObserver, only()).onCallParticipantsChanged(expectedJoined, expectedUpdated,
+                                                                                    expectedLeft, expectedUnchanged);
+    }
+
+    @Test
+    public void testParticipantsUpdateChangeCallFlags() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", MODERATOR, "theUserId1"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO | WITH_VIDEO, 1, "theSessionId1", MODERATOR, "theUserId1"));
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        expectedUpdated.add(builder.newUser(IN_CALL | WITH_AUDIO | WITH_VIDEO, 1, "theSessionId1", MODERATOR, "theUserId1"));
+
+        verify(mockedCallParticipantListObserver, only()).onCallParticipantsChanged(expectedJoined, expectedUpdated,
+                                                                                    expectedLeft, expectedUnchanged);
+    }
+
+    @Test
+    public void testParticipantsUpdateChangeCallFlagsSeveralParticipants() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", MODERATOR, "theUserId1"));
+        participants.add(builder.newGuest(IN_CALL | WITH_AUDIO | WITH_VIDEO, 2, "theSessionId2", GUEST));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", USER, "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", USER, "theUserId4"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL, 1, "theSessionId1", MODERATOR, "theUserId1"));
+        participants.add(builder.newGuest(IN_CALL | WITH_AUDIO | WITH_VIDEO, 2, "theSessionId2", GUEST));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", USER, "theUserId3"));
+        participants.add(builder.newUser(IN_CALL | WITH_VIDEO, 4, "theSessionId4", USER, "theUserId4"));
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        expectedUpdated.add(builder.newUser(IN_CALL, 1, "theSessionId1", MODERATOR, "theUserId1"));
+        expectedUpdated.add(builder.newUser(IN_CALL | WITH_VIDEO, 4, "theSessionId4", USER, "theUserId4"));
+        expectedUnchanged.add(builder.newGuest(IN_CALL | WITH_AUDIO | WITH_VIDEO, 2, "theSessionId2", GUEST));
+
+        verify(mockedCallParticipantListObserver, only()).onCallParticipantsChanged(expectedJoined, expectedUpdated,
+                                                                                    expectedLeft, expectedUnchanged);
+    }
+
+    @Test
+    public void testParticipantsUpdateChangeLastPing() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", MODERATOR, "theUserId1"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 42, "theSessionId1", MODERATOR, "theUserId1"));
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        verifyNoInteractions(mockedCallParticipantListObserver);
+    }
+
+    @Test
+    public void testParticipantsUpdateChangeLastPingSeveralParticipants() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", MODERATOR, "theUserId1"));
+        participants.add(builder.newGuest(IN_CALL | WITH_AUDIO, 2, "theSessionId2", GUEST));
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 3, "theSessionId3", USER, "theUserId3"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 42, "theSessionId1", MODERATOR, "theUserId1"));
+        participants.add(builder.newGuest(IN_CALL | WITH_AUDIO, 108, "theSessionId2", GUEST));
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 815, "theSessionId3", USER, "theUserId3"));
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        verifyNoInteractions(mockedCallParticipantListObserver);
+    }
+
+    @Test
+    public void testParticipantsUpdateChangeParticipantType() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", MODERATOR, "theUserId1"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", USER, "theUserId1"));
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        verifyNoInteractions(mockedCallParticipantListObserver);
+    }
+
+    @Test
+    public void testParticipantsUpdateChangeParticipantTypeeSeveralParticipants() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", MODERATOR, "theUserId1"));
+        participants.add(builder.newGuest(IN_CALL | WITH_AUDIO, 2, "theSessionId2", GUEST));
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 3, "theSessionId3", USER, "theUserId3"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", USER, "theUserId1"));
+        participants.add(builder.newGuest(IN_CALL | WITH_AUDIO, 2, "theSessionId2", GUEST_MODERATOR));
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 3, "theSessionId3", MODERATOR, "theUserId3"));
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        verifyNoInteractions(mockedCallParticipantListObserver);
+    }
+
+    @Test
+    public void testParticipantsUpdateLeaveCall() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", MODERATOR, "theUserId1"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", MODERATOR, "theUserId1"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        expectedLeft.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", MODERATOR, "theUserId1"));
+
+        verify(mockedCallParticipantListObserver, only()).onCallParticipantsChanged(expectedJoined, expectedUpdated,
+                                                                                    expectedLeft, expectedUnchanged);
+    }
+
+    @Test
+    public void testParticipantsUpdateLeaveCallSeveralParticipants() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", MODERATOR, "theUserId1"));
+        participants.add(builder.newGuest(IN_CALL, 2, "theSessionId2", GUEST));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", USER, "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", USER, "theUserId4"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", MODERATOR, "theUserId1"));
+        participants.add(builder.newGuest(DISCONNECTED, 2, "theSessionId2", GUEST));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", USER, "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", USER, "theUserId4"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        expectedLeft.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", MODERATOR, "theUserId1"));
+        expectedLeft.add(builder.newGuest(DISCONNECTED, 2, "theSessionId2", GUEST));
+        expectedUnchanged.add(builder.newUser(IN_CALL, 4, "theSessionId4", USER, "theUserId4"));
+
+        verify(mockedCallParticipantListObserver, only()).onCallParticipantsChanged(expectedJoined, expectedUpdated,
+                                                                                    expectedLeft, expectedUnchanged);
+    }
+
+    @Test
+    public void testParticipantsUpdateLeaveCallThenLeaveRoom() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", MODERATOR, "theUserId1"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", MODERATOR, "theUserId1"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participants = new ArrayList<>();
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        verifyNoInteractions(mockedCallParticipantListObserver);
+    }
+
+    @Test
+    public void testParticipantsUpdateLeaveCallThenLeaveRoomSeveralParticipants() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", MODERATOR, "theUserId1"));
+        participants.add(builder.newGuest(IN_CALL, 2, "theSessionId2", GUEST));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", USER, "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", USER, "theUserId4"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", MODERATOR, "theUserId1"));
+        participants.add(builder.newGuest(DISCONNECTED, 2, "theSessionId2", GUEST));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", USER, "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", USER, "theUserId4"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", USER, "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", USER, "theUserId4"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        verifyNoInteractions(mockedCallParticipantListObserver);
+    }
+
+    @Test
+    public void testParticipantsUpdateLeaveCallAndRoom() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", MODERATOR, "theUserId1"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participants = new ArrayList<>();
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        expectedLeft.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", MODERATOR, "theUserId1"));
+
+        verify(mockedCallParticipantListObserver, only()).onCallParticipantsChanged(expectedJoined, expectedUpdated,
+                                                                                    expectedLeft, expectedUnchanged);
+    }
+
+    @Test
+    public void testParticipantsUpdateLeaveCallAndRoomSeveralParticipants() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", MODERATOR, "theUserId1"));
+        participants.add(builder.newGuest(IN_CALL, 2, "theSessionId2", GUEST));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", USER, "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", USER, "theUserId4"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", USER, "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", USER, "theUserId4"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        expectedLeft.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", MODERATOR, "theUserId1"));
+        expectedLeft.add(builder.newGuest(DISCONNECTED, 2, "theSessionId2", GUEST));
+        expectedUnchanged.add(builder.newUser(IN_CALL, 4, "theSessionId4", USER, "theUserId4"));
+
+        verify(mockedCallParticipantListObserver).onCallParticipantsChanged(eq(expectedJoined), eq(expectedUpdated),
+                                                                            argThat(matchesExpectedLeftIgnoringOrder), eq(expectedUnchanged));
+    }
+
+    @Test
+    public void testParticipantsUpdateSeveralEventsSeveralParticipants() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", MODERATOR, "theUserId1"));
+        participants.add(builder.newGuest(IN_CALL, 2, "theSessionId2", GUEST));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", USER, "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", USER, "theUserId4"));
+        participants.add(builder.newUser(IN_CALL, 5, "theSessionId5", OWNER, "theUserId5"));
+        // theSessionId6 has not joined yet.
+        participants.add(builder.newGuest(IN_CALL | WITH_VIDEO, 7, "theSessionId7", GUEST));
+        participants.add(builder.newUser(DISCONNECTED, 8, "theSessionId8", USER, "theUserId8"));
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 9, "theSessionId9", MODERATOR, "theUserId9"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participants = new ArrayList<>();
+        // theSessionId1 is gone.
+        participants.add(builder.newGuest(DISCONNECTED, 2, "theSessionId2", GUEST));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", USER, "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", USER, "theUserId4"));
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO | WITH_VIDEO, 5, "theSessionId5", OWNER, "theUserId5"));
+        participants.add(builder.newGuest(IN_CALL | WITH_AUDIO, 6, "theSessionId6", GUEST));
+        participants.add(builder.newGuest(IN_CALL, 7, "theSessionId7", GUEST));
+        participants.add(builder.newUser(IN_CALL, 8, "theSessionId8", USER, "theUserId8"));
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 42, "theSessionId9", USER, "theUserId9"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        expectedJoined.add(builder.newGuest(IN_CALL | WITH_AUDIO, 6, "theSessionId6", GUEST));
+        expectedJoined.add(builder.newUser(IN_CALL, 8, "theSessionId8", USER, "theUserId8"));
+        expectedUpdated.add(builder.newUser(IN_CALL | WITH_AUDIO | WITH_VIDEO, 5, "theSessionId5", OWNER, "theUserId5"));
+        expectedUpdated.add(builder.newGuest(IN_CALL, 7, "theSessionId7", GUEST));
+        expectedLeft.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", MODERATOR, "theUserId1"));
+        expectedLeft.add(builder.newGuest(DISCONNECTED, 2, "theSessionId2", GUEST));
+        expectedUnchanged.add(builder.newUser(IN_CALL, 4, "theSessionId4", USER, "theUserId4"));
+        // Last ping and participant type are not seen as changed, even if they did.
+        expectedUnchanged.add(builder.newUser(IN_CALL | WITH_AUDIO, 42, "theSessionId9", USER, "theUserId9"));
+
+        verify(mockedCallParticipantListObserver).onCallParticipantsChanged(eq(expectedJoined), eq(expectedUpdated),
+                                                                            argThat(matchesExpectedLeftIgnoringOrder), eq(expectedUnchanged));
+    }
+
+    @Test
+    public void testAllParticipantsUpdateDisconnected() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL, 1, "theSessionId1", MODERATOR, "theUserId1"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participantListMessageListener.onAllParticipantsUpdate(DISCONNECTED);
+
+        expectedLeft.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", MODERATOR, "theUserId1"));
+
+        InOrder inOrder = inOrder(mockedCallParticipantListObserver);
+
+        inOrder.verify(mockedCallParticipantListObserver).onCallEndedForAll();
+        inOrder.verify(mockedCallParticipantListObserver).onCallParticipantsChanged(expectedJoined, expectedUpdated,
+                                                                                    expectedLeft, expectedUnchanged);
+    }
+
+    @Test
+    public void testAllParticipantsUpdateDisconnectedWithSeveralParticipants() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL, 1, "theSessionId1", MODERATOR, "theUserId1"));
+        participants.add(builder.newUser(DISCONNECTED, 2, "theSessionId2", USER, "theUserId2"));
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 3, "theSessionId3", USER, "theUserId3"));
+        participants.add(builder.newGuest(IN_CALL | WITH_AUDIO | WITH_VIDEO, 4, "theSessionId4", GUEST));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participantListMessageListener.onAllParticipantsUpdate(DISCONNECTED);
+
+        expectedLeft.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", MODERATOR, "theUserId1"));
+        expectedLeft.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", USER, "theUserId3"));
+        expectedLeft.add(builder.newGuest(DISCONNECTED, 4, "theSessionId4", GUEST));
+
+        InOrder inOrder = inOrder(mockedCallParticipantListObserver);
+
+        inOrder.verify(mockedCallParticipantListObserver).onCallEndedForAll();
+        inOrder.verify(mockedCallParticipantListObserver).onCallParticipantsChanged(eq(expectedJoined), eq(expectedUpdated),
+            argThat(matchesExpectedLeftIgnoringOrder), eq(expectedUnchanged));
+    }
+
+    @Test
+    public void testAllParticipantsUpdateDisconnectedNoOneInCall() {
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participantListMessageListener.onAllParticipantsUpdate(DISCONNECTED);
+
+        InOrder inOrder = inOrder(mockedCallParticipantListObserver);
+
+        inOrder.verify(mockedCallParticipantListObserver).onCallEndedForAll();
+        verifyNoMoreInteractions(mockedCallParticipantListObserver);
+    }
+
+    @Test
+    public void testAllParticipantsUpdateDisconnectedThenJoinCallAgain() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL, 1, "theSessionId1", MODERATOR, "theUserId1"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        participantListMessageListener.onAllParticipantsUpdate(DISCONNECTED);
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL, 1, "theSessionId1", MODERATOR, "theUserId1"));
+
+        participantListMessageListener.onParticipantsUpdate(participants);
+
+        expectedJoined.add(builder.newUser(IN_CALL, 1, "theSessionId1", MODERATOR, "theUserId1"));
+
+        verify(mockedCallParticipantListObserver, only()).onCallParticipantsChanged(expectedJoined, expectedUpdated,
+                                                                                    expectedLeft, expectedUnchanged);
+    }
+}

--- a/app/src/test/java/com/nextcloud/talk/call/CallParticipantListInternalSignalingTest.java
+++ b/app/src/test/java/com/nextcloud/talk/call/CallParticipantListInternalSignalingTest.java
@@ -1,0 +1,535 @@
+/*
+ * Nextcloud Talk application
+ *
+ * @author Daniel Calviño Sánchez
+ * Copyright (C) 2022 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.nextcloud.talk.call;
+
+import com.nextcloud.talk.models.json.participants.Participant;
+import com.nextcloud.talk.signaling.SignalingMessageReceiver;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import static com.nextcloud.talk.models.json.participants.Participant.InCallFlags.DISCONNECTED;
+import static com.nextcloud.talk.models.json.participants.Participant.InCallFlags.IN_CALL;
+import static com.nextcloud.talk.models.json.participants.Participant.InCallFlags.WITH_AUDIO;
+import static com.nextcloud.talk.models.json.participants.Participant.InCallFlags.WITH_VIDEO;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+public class CallParticipantListInternalSignalingTest {
+
+    private static class UsersInRoomParticipantBuilder {
+        private Participant newUser(long inCall, long lastPing, String sessionId, String userId) {
+            Participant participant = new Participant();
+            participant.setInCall(inCall);
+            participant.setLastPing(lastPing);
+            participant.setSessionId(sessionId);
+            participant.setUserId(userId);
+
+            return participant;
+        }
+
+        private Participant newGuest(long inCall, long lastPing, String sessionId) {
+            Participant participant = new Participant();
+            participant.setInCall(inCall);
+            participant.setLastPing(lastPing);
+            participant.setSessionId(sessionId);
+
+            return participant;
+        }
+    }
+
+    private final UsersInRoomParticipantBuilder builder = new UsersInRoomParticipantBuilder();
+
+    private CallParticipantList callParticipantList;
+    private SignalingMessageReceiver.ParticipantListMessageListener participantListMessageListener;
+
+    private CallParticipantList.Observer mockedCallParticipantListObserver;
+
+    private Collection<Participant> expectedJoined;
+    private Collection<Participant> expectedUpdated;
+    private Collection<Participant> expectedLeft;
+    private Collection<Participant> expectedUnchanged;
+
+    // The order of the left participants in some tests depends on how they are internally sorted by the map, so the
+    // list of left participants needs to be checked ignoring the sorting (or, rather, sorting by session ID as in
+    // expectedLeft).
+    // Other tests can just relay on the not guaranteed, but known internal sorting of the elements.
+    private final ArgumentMatcher<List<Participant>> matchesExpectedLeftIgnoringOrder = left -> {
+        Collections.sort(left, Comparator.comparing(Participant::getSessionId));
+        return expectedLeft.equals(left);
+    };
+
+    @Before
+    public void setUp() {
+        SignalingMessageReceiver mockedSignalingMessageReceiver = mock(SignalingMessageReceiver.class);
+
+        callParticipantList = new CallParticipantList(mockedSignalingMessageReceiver);
+
+        mockedCallParticipantListObserver = mock(CallParticipantList.Observer.class);
+
+        // Get internal ParticipantListMessageListener from callParticipantList set in the
+        // mockedSignalingMessageReceiver.
+        ArgumentCaptor<SignalingMessageReceiver.ParticipantListMessageListener> participantListMessageListenerArgumentCaptor =
+            ArgumentCaptor.forClass(SignalingMessageReceiver.ParticipantListMessageListener.class);
+
+        verify(mockedSignalingMessageReceiver).addListener(participantListMessageListenerArgumentCaptor.capture());
+
+        participantListMessageListener = participantListMessageListenerArgumentCaptor.getValue();
+
+        expectedJoined = new ArrayList<>();
+        expectedUpdated = new ArrayList<>();
+        expectedLeft = new ArrayList<>();
+        expectedUnchanged = new ArrayList<>();
+    }
+
+    @Test
+    public void testUsersInRoomJoinRoom() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", "theUserId1"));
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        verifyNoInteractions(mockedCallParticipantListObserver);
+    }
+
+    @Test
+    public void testUsersInRoomJoinRoomSeveralParticipants() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", "theUserId1"));
+        participants.add(builder.newGuest(DISCONNECTED, 2, "theSessionId2"));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", "theUserId3"));
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", "theUserId1"));
+        participants.add(builder.newGuest(DISCONNECTED, 2, "theSessionId2"));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", "theUserId3"));
+        participants.add(builder.newUser(DISCONNECTED, 4, "theSessionId4", "theUserId4"));
+        participants.add(builder.newUser(DISCONNECTED, 5, "theSessionId5", "theUserId5"));
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        verifyNoInteractions(mockedCallParticipantListObserver);
+    }
+
+    @Test
+    public void testUsersInRoomJoinRoomThenJoinCall() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", "theUserId1"));
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", "theUserId1"));
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        expectedJoined.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", "theUserId1"));
+
+        verify(mockedCallParticipantListObserver, only()).onCallParticipantsChanged(expectedJoined, expectedUpdated,
+                                                                                    expectedLeft, expectedUnchanged);
+    }
+
+    @Test
+    public void testUsersInRoomJoinRoomThenJoinCallSeveralParticipants() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", "theUserId1"));
+        participants.add(builder.newGuest(DISCONNECTED, 2, "theSessionId2"));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", "theUserId3"));
+        participants.add(builder.newUser(DISCONNECTED, 4, "theSessionId4", "theUserId4"));
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", "theUserId1"));
+        participants.add(builder.newGuest(DISCONNECTED, 2, "theSessionId2"));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", "theUserId4"));
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", "theUserId1"));
+        participants.add(builder.newGuest(IN_CALL, 2, "theSessionId2"));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", "theUserId4"));
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        expectedJoined.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", "theUserId1"));
+        expectedJoined.add(builder.newGuest(IN_CALL, 2, "theSessionId2"));
+        expectedUnchanged.add(builder.newUser(IN_CALL, 4, "theSessionId4", "theUserId4"));
+
+        verify(mockedCallParticipantListObserver, only()).onCallParticipantsChanged(expectedJoined, expectedUpdated,
+                                                                                    expectedLeft, expectedUnchanged);
+    }
+
+    @Test
+    public void testUsersInRoomJoinRoomAndCall() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", "theUserId1"));
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        expectedJoined.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", "theUserId1"));
+
+        verify(mockedCallParticipantListObserver, only()).onCallParticipantsChanged(expectedJoined, expectedUpdated,
+                                                                                    expectedLeft, expectedUnchanged);
+    }
+
+    @Test
+    public void testUsersInRoomJoinRoomAndCallSeveralParticipants() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", "theUserId4"));
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", "theUserId1"));
+        participants.add(builder.newGuest(IN_CALL, 2, "theSessionId2"));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", "theUserId4"));
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        expectedJoined.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", "theUserId1"));
+        expectedJoined.add(builder.newGuest(IN_CALL, 2, "theSessionId2"));
+        expectedUnchanged.add(builder.newUser(IN_CALL, 4, "theSessionId4", "theUserId4"));
+
+        verify(mockedCallParticipantListObserver, only()).onCallParticipantsChanged(expectedJoined, expectedUpdated,
+                                                                                    expectedLeft, expectedUnchanged);
+    }
+
+    @Test
+    public void testUsersInRoomJoinRoomAndCallRepeated() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", "theUserId1"));
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participantListMessageListener.onUsersInRoom(participants);
+        participantListMessageListener.onUsersInRoom(participants);
+        participantListMessageListener.onUsersInRoom(participants);
+
+        expectedJoined.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", "theUserId1"));
+
+        verify(mockedCallParticipantListObserver, only()).onCallParticipantsChanged(expectedJoined, expectedUpdated,
+                                                                                    expectedLeft, expectedUnchanged);
+    }
+
+    @Test
+    public void testUsersInRoomChangeCallFlags() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", "theUserId1"));
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO | WITH_VIDEO, 1, "theSessionId1", "theUserId1"));
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        expectedUpdated.add(builder.newUser(IN_CALL | WITH_AUDIO | WITH_VIDEO, 1, "theSessionId1", "theUserId1"));
+
+        verify(mockedCallParticipantListObserver, only()).onCallParticipantsChanged(expectedJoined, expectedUpdated,
+                                                                                    expectedLeft, expectedUnchanged);
+    }
+
+    @Test
+    public void testUsersInRoomChangeCallFlagsSeveralParticipants() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", "theUserId1"));
+        participants.add(builder.newGuest(IN_CALL | WITH_AUDIO | WITH_VIDEO, 2, "theSessionId2"));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", "theUserId4"));
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL, 1, "theSessionId1", "theUserId1"));
+        participants.add(builder.newGuest(IN_CALL | WITH_AUDIO | WITH_VIDEO, 2, "theSessionId2"));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", "theUserId3"));
+        participants.add(builder.newUser(IN_CALL | WITH_VIDEO, 4, "theSessionId4", "theUserId4"));
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        expectedUpdated.add(builder.newUser(IN_CALL, 1, "theSessionId1", "theUserId1"));
+        expectedUpdated.add(builder.newUser(IN_CALL | WITH_VIDEO, 4, "theSessionId4", "theUserId4"));
+        expectedUnchanged.add(builder.newGuest(IN_CALL | WITH_AUDIO | WITH_VIDEO, 2, "theSessionId2"));
+
+        verify(mockedCallParticipantListObserver, only()).onCallParticipantsChanged(expectedJoined, expectedUpdated,
+                                                                                    expectedLeft, expectedUnchanged);
+    }
+
+    @Test
+    public void testUsersInRoomChangeLastPing() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", "theUserId1"));
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 42, "theSessionId1", "theUserId1"));
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        verifyNoInteractions(mockedCallParticipantListObserver);
+    }
+
+    @Test
+    public void testUsersInRoomChangeLastPingSeveralParticipants() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", "theUserId1"));
+        participants.add(builder.newGuest(IN_CALL | WITH_AUDIO, 2, "theSessionId2"));
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 3, "theSessionId3", "theUserId3"));
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 42, "theSessionId1", "theUserId1"));
+        participants.add(builder.newGuest(IN_CALL | WITH_AUDIO, 108, "theSessionId2"));
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 815, "theSessionId3", "theUserId3"));
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        verifyNoInteractions(mockedCallParticipantListObserver);
+    }
+
+    @Test
+    public void testUsersInRoomLeaveCall() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", "theUserId1"));
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", "theUserId1"));
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        expectedLeft.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", "theUserId1"));
+
+        verify(mockedCallParticipantListObserver, only()).onCallParticipantsChanged(expectedJoined, expectedUpdated,
+                                                                                    expectedLeft, expectedUnchanged);
+    }
+
+    @Test
+    public void testUsersInRoomLeaveCallSeveralParticipants() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", "theUserId1"));
+        participants.add(builder.newGuest(IN_CALL, 2, "theSessionId2"));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", "theUserId4"));
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", "theUserId1"));
+        participants.add(builder.newGuest(DISCONNECTED, 2, "theSessionId2"));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", "theUserId4"));
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        expectedLeft.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", "theUserId1"));
+        expectedLeft.add(builder.newGuest(DISCONNECTED, 2, "theSessionId2"));
+        expectedUnchanged.add(builder.newUser(IN_CALL, 4, "theSessionId4", "theUserId4"));
+
+        verify(mockedCallParticipantListObserver, only()).onCallParticipantsChanged(expectedJoined, expectedUpdated,
+                                                                                    expectedLeft, expectedUnchanged);
+    }
+
+    @Test
+    public void testUsersInRoomLeaveCallThenLeaveRoom() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", "theUserId1"));
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", "theUserId1"));
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participants = new ArrayList<>();
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        verifyNoInteractions(mockedCallParticipantListObserver);
+    }
+
+    @Test
+    public void testUsersInRoomLeaveCallThenLeaveRoomSeveralParticipants() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", "theUserId1"));
+        participants.add(builder.newGuest(IN_CALL, 2, "theSessionId2"));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", "theUserId4"));
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", "theUserId1"));
+        participants.add(builder.newGuest(DISCONNECTED, 2, "theSessionId2"));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", "theUserId4"));
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", "theUserId4"));
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        verifyNoInteractions(mockedCallParticipantListObserver);
+    }
+
+    @Test
+    public void testUsersInRoomLeaveCallAndRoom() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", "theUserId1"));
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participants = new ArrayList<>();
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        expectedLeft.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", "theUserId1"));
+
+        verify(mockedCallParticipantListObserver, only()).onCallParticipantsChanged(expectedJoined, expectedUpdated,
+                                                                                    expectedLeft, expectedUnchanged);
+    }
+
+    @Test
+    public void testUsersInRoomLeaveCallAndRoomSeveralParticipants() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", "theUserId1"));
+        participants.add(builder.newGuest(IN_CALL, 2, "theSessionId2"));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", "theUserId4"));
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participants = new ArrayList<>();
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", "theUserId4"));
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        expectedLeft.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", "theUserId1"));
+        expectedLeft.add(builder.newGuest(DISCONNECTED, 2, "theSessionId2"));
+        expectedUnchanged.add(builder.newUser(IN_CALL, 4, "theSessionId4", "theUserId4"));
+
+        verify(mockedCallParticipantListObserver).onCallParticipantsChanged(eq(expectedJoined), eq(expectedUpdated),
+                                                                            argThat(matchesExpectedLeftIgnoringOrder), eq(expectedUnchanged));
+    }
+
+    @Test
+    public void testUsersInRoomSeveralEventsSeveralParticipants() {
+        List<Participant> participants = new ArrayList<>();
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 1, "theSessionId1", "theUserId1"));
+        participants.add(builder.newGuest(IN_CALL, 2, "theSessionId2"));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", "theUserId4"));
+        participants.add(builder.newUser(IN_CALL, 5, "theSessionId5", "theUserId5"));
+        // theSessionId6 has not joined yet.
+        participants.add(builder.newGuest(IN_CALL | WITH_VIDEO, 7, "theSessionId7"));
+        participants.add(builder.newUser(DISCONNECTED, 8, "theSessionId8", "theUserId8"));
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 9, "theSessionId9", "theUserId9"));
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        callParticipantList.addObserver(mockedCallParticipantListObserver);
+
+        participants = new ArrayList<>();
+        // theSessionId1 is gone.
+        participants.add(builder.newGuest(DISCONNECTED, 2, "theSessionId2"));
+        participants.add(builder.newUser(DISCONNECTED, 3, "theSessionId3", "theUserId3"));
+        participants.add(builder.newUser(IN_CALL, 4, "theSessionId4", "theUserId4"));
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO | WITH_VIDEO, 5, "theSessionId5", "theUserId5"));
+        participants.add(builder.newGuest(IN_CALL | WITH_AUDIO, 6, "theSessionId6"));
+        participants.add(builder.newGuest(IN_CALL, 7, "theSessionId7"));
+        participants.add(builder.newUser(IN_CALL, 8, "theSessionId8", "theUserId8"));
+        participants.add(builder.newUser(IN_CALL | WITH_AUDIO, 42, "theSessionId9", "theUserId9"));
+
+        participantListMessageListener.onUsersInRoom(participants);
+
+        expectedJoined.add(builder.newGuest(IN_CALL | WITH_AUDIO, 6, "theSessionId6"));
+        expectedJoined.add(builder.newUser(IN_CALL, 8, "theSessionId8", "theUserId8"));
+        expectedUpdated.add(builder.newUser(IN_CALL | WITH_AUDIO | WITH_VIDEO, 5, "theSessionId5", "theUserId5"));
+        expectedUpdated.add(builder.newGuest(IN_CALL, 7, "theSessionId7"));
+        expectedLeft.add(builder.newUser(DISCONNECTED, 1, "theSessionId1", "theUserId1"));
+        expectedLeft.add(builder.newGuest(DISCONNECTED, 2, "theSessionId2"));
+        expectedUnchanged.add(builder.newUser(IN_CALL, 4, "theSessionId4", "theUserId4"));
+        // Last ping is not seen as changed, even if it did.
+        expectedUnchanged.add(builder.newUser(IN_CALL | WITH_AUDIO, 42, "theSessionId9", "theUserId9"));
+
+        verify(mockedCallParticipantListObserver).onCallParticipantsChanged(eq(expectedJoined), eq(expectedUpdated),
+                                                                            argThat(matchesExpectedLeftIgnoringOrder), eq(expectedUnchanged));
+    }
+}

--- a/app/src/test/java/com/nextcloud/talk/call/CallParticipantListTest.java
+++ b/app/src/test/java/com/nextcloud/talk/call/CallParticipantListTest.java
@@ -1,0 +1,61 @@
+/*
+ * Nextcloud Talk application
+ *
+ * @author Daniel Calviño Sánchez
+ * Copyright (C) 2022 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.nextcloud.talk.call;
+
+import com.nextcloud.talk.signaling.SignalingMessageReceiver;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class CallParticipantListTest {
+
+    private SignalingMessageReceiver mockedSignalingMessageReceiver;
+
+    private CallParticipantList callParticipantList;
+    private SignalingMessageReceiver.ParticipantListMessageListener participantListMessageListener;
+
+    @Before
+    public void setUp() {
+        mockedSignalingMessageReceiver = mock(SignalingMessageReceiver.class);
+
+        callParticipantList = new CallParticipantList(mockedSignalingMessageReceiver);
+
+        // Get internal ParticipantListMessageListener from callParticipantList set in the
+        // mockedSignalingMessageReceiver.
+        ArgumentCaptor<SignalingMessageReceiver.ParticipantListMessageListener> participantListMessageListenerArgumentCaptor =
+            ArgumentCaptor.forClass(SignalingMessageReceiver.ParticipantListMessageListener.class);
+
+        verify(mockedSignalingMessageReceiver).addListener(participantListMessageListenerArgumentCaptor.capture());
+
+        participantListMessageListener = participantListMessageListenerArgumentCaptor.getValue();
+    }
+
+    @Test
+    public void testDestroy() {
+        callParticipantList.destroy();
+
+        verify(mockedSignalingMessageReceiver).removeListener(participantListMessageListener);
+        verifyNoMoreInteractions(mockedSignalingMessageReceiver);
+    }
+}


### PR DESCRIPTION
Fixes #2544
~~Requires #2590 (so the first commit of this pull request is _Handle the raw ICE connection state in the views_)~~

It is highly recommended to review this commit by commit rather than all at once ;-) Commit messages may also provide additional context.

Model classes for call participants were added. `CallParticipant` is the main model class, which observes the changes in its peer connections and data channels and updates a data object that keeps track of the state*. This data object is the one exposed to the view classes through a read-only object (`CallParticipantModel`) that can be also observed for changes on specific threads. Thanks to that the `ParticipantDisplayItems` are now automatically updated in the main thread when the model changes, and they also propagate the changes to the adapter (so `notifiyDataSetChanged` is automatically called when any item changed).

*In the future it should also listen to signaling messages, for example for raised hands, but also for audio/video enabled/disabled events, as they are also sent through signaling messages besides the data channels just in case the data channel connection could not be established.

Besides that, a helper class is now used to keep track of the participants in the call based on the signaling messages, instead of based on the peer connections. For now it just uses the same signaling messages as before, but in the future this could be used to also handle the message sent by the external signaling server when a participant leaves the room, which implicitly means that the participant left the call (if a participant abruptly leaves the call and the room at the same time no message for leaving the call is sent, only about leaving the room).

With all this now call participants are added and removed when they join and leave the call, and peer connections are only started when the joined participant is publishing media (according to the call flags of the participant for audio/video, and based on the offers received for screen shares). Updating the peer connections of an existing call participant when the flags change during the call is still needed for proper renegotiation support, and it will be done in a follow up.

The steps below should be tested with HPB; without HPB, as the Android app is publishing media, a peer connection is anyway needed to send it to the other participant even if that participant is not publishing.

## How to test

- Start a call without a microphone or camera selected in the browser (that is, not just disabled, but not selected), or without audio and video permissions
- Join the call in the Android app

### Result with this pull request

The Android app does not try to establish a peer connection with the other participant, and no progess bar is shown on that other participant

### Result without this pull request

The Andoid app tries to establish a peer connection with the other participant to receive media (and the external signaling server logs eventually shows that an offer could not be requested), and a progress bar is always shown on that other participant
