### PR TITLE
Fix reconnection when the web socket was abruptly closed

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -1578,7 +1578,8 @@ public class CallActivity extends CallBaseActivity {
                     if (currentCallStatus == CallStatus.RECONNECTING) {
                         hangup(false);
                     } else {
-                        initiateCall();
+                        setCallState(CallStatus.RECONNECTING);
+                        runOnUiThread(this::initiateCall);
                     }
                 }
                 break;


### PR DESCRIPTION
When the web socket is abruptly closed it is connected again and the call is rejoined. However, the call was rejoined in a background thread, so an exception was thrown when trying to modify the views, which prevented the call from being joined again.

Besides that the call state needs to be explicitly changed, as if the web socket was connected again while in a call the state would be already "JOINED" or "IN_CONVERSATION", which prevents the signaling settings from being fetched again after the permissions check, and therefore also prevented the call from being joined again.

## How to test

- Setup the HPB
- Start a call in the WebUI
- Join the call in the Android app
- Kill the external signaling server and start it again (note that only the external signaling server should be killed; Janus should not, as that would trigger a "publisher failed" reconnection, which is a different one)

### Result with this pull request

The Android app joins the call again

### Result without this pull request

The Android app tries to join the call, but the log shows an _Only the original thread that created a view hierarchy can touch its views._ exception
