### PR TITLE
avoid to set link preview content from wrong message/ make link preview messages able to be swiped left

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingLinkPreviewMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingLinkPreviewMessageViewHolder.kt
@@ -37,6 +37,7 @@ import com.nextcloud.talk.databinding.ItemCustomIncomingLinkPreviewMessageBindin
 import com.nextcloud.talk.extensions.loadBotsAvatar
 import com.nextcloud.talk.extensions.loadChangelogBotAvatar
 import com.nextcloud.talk.models.json.chat.ChatMessage
+import com.nextcloud.talk.ui.recyclerview.MessageSwipeCallback
 import com.nextcloud.talk.ui.theme.ViewThemeUtils
 import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.preferences.AppPreferences
@@ -91,6 +92,8 @@ class IncomingLinkPreviewMessageViewHolder(incomingView: View, payload: Any) : M
             commonMessageInterface.onOpenMessageActionsDialog(message)
             true
         }
+
+        itemView.setTag(MessageSwipeCallback.REPLYABLE_VIEW_TAG, message.replyable)
 
         Reaction().showReactions(
             message,

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/LinkPreview.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/LinkPreview.kt
@@ -44,6 +44,11 @@ class LinkPreview {
         binding: ReferenceInsideMessageBinding,
         context: Context
     ) {
+        binding.referenceName.text = ""
+        binding.referenceDescription.text = ""
+        binding.referenceLink.text = ""
+        binding.referenceThumbImage.controller = null
+
         if (!message.extractedUrlToPreview.isNullOrEmpty()) {
             val credentials: String = ApiUtils.getCredentials(message.activeUser?.username, message.activeUser?.token)
             val openGraphLink = ApiUtils.getUrlForOpenGraph(message.activeUser?.baseUrl)

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/LinkPreview.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/LinkPreview.kt
@@ -47,7 +47,7 @@ class LinkPreview {
         binding.referenceName.text = ""
         binding.referenceDescription.text = ""
         binding.referenceLink.text = ""
-        binding.referenceThumbImage.controller = null
+        binding.referenceThumbImage.setImageDrawable(null)
 
         if (!message.extractedUrlToPreview.isNullOrEmpty()) {
             val credentials: String = ApiUtils.getCredentials(message.activeUser?.username, message.activeUser?.token)

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingLinkPreviewMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingLinkPreviewMessageViewHolder.kt
@@ -36,6 +36,7 @@ import com.nextcloud.talk.application.NextcloudTalkApplication.Companion.sharedA
 import com.nextcloud.talk.databinding.ItemCustomOutcomingLinkPreviewMessageBinding
 import com.nextcloud.talk.models.json.chat.ChatMessage
 import com.nextcloud.talk.models.json.chat.ReadStatus
+import com.nextcloud.talk.ui.recyclerview.MessageSwipeCallback
 import com.nextcloud.talk.ui.theme.ViewThemeUtils
 import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.preferences.AppPreferences
@@ -113,6 +114,8 @@ class OutcomingLinkPreviewMessageViewHolder(outcomingView: View, payload: Any) :
             commonMessageInterface.onOpenMessageActionsDialog(message)
             true
         }
+
+        itemView.setTag(MessageSwipeCallback.REPLYABLE_VIEW_TAG, message.replyable)
 
         Reaction().showReactions(
             message,


### PR DESCRIPTION
### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)