### PR TITLE
Bugfix/2181/fix conversation title

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
@@ -50,13 +50,13 @@ import com.nextcloud.talk.databinding.ActivityMainBinding
 import com.nextcloud.talk.models.json.conversations.RoomOverall
 import com.nextcloud.talk.users.UserManager
 import com.nextcloud.talk.utils.ApiUtils
-import com.nextcloud.talk.utils.ConductorRemapping.remapChatController
 import com.nextcloud.talk.utils.SecurityUtils
 import com.nextcloud.talk.utils.bundle.BundleKeys
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_ACTIVE_CONVERSATION
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_ROOM_ID
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_ROOM_TOKEN
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_USER_ENTITY
+import com.nextcloud.talk.utils.remapchat.ConductorRemapping.remapChatController
 import io.reactivex.Observer
 import io.reactivex.SingleObserver
 import io.reactivex.android.schedulers.AndroidSchedulers

--- a/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
@@ -363,13 +363,10 @@ class MainActivity : BaseActivity(), ActionBarProvider {
     }
 
     override fun onBackPressed() {
-        Log.d(TAG, "onBackPressed")
         if (router!!.getControllerWithTag(LockedController.TAG) != null) {
             return
         }
-
         if (!router!!.handleBack()) {
-            Log.d(TAG, "back press was not handled by top controller. call onBackPressed...")
             super.onBackPressed()
         }
     }

--- a/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
@@ -363,11 +363,13 @@ class MainActivity : BaseActivity(), ActionBarProvider {
     }
 
     override fun onBackPressed() {
+        Log.d(TAG, "onBackPressed")
         if (router!!.getControllerWithTag(LockedController.TAG) != null) {
             return
         }
 
         if (!router!!.handleBack()) {
+            Log.d(TAG, "back press was not handled by top controller. call onBackPressed...")
             super.onBackPressed()
         }
     }

--- a/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
@@ -354,7 +354,7 @@ class MainActivity : BaseActivity(), ActionBarProvider {
                     intent.getParcelableExtra<User>(KEY_USER_ENTITY)!!.id!!,
                     intent.getStringExtra(KEY_ROOM_TOKEN)!!,
                     intent.extras!!,
-                    false,
+                    true,
                     true
                 )
                 logRouterBackStack(router!!)

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -1803,8 +1803,6 @@ class ChatController(args: Bundle) :
         if (inConversation) {
             Log.d(TAG, "execute joinRoomWithPassword in onAttach")
             joinRoomWithPassword()
-            // replace with getRoomInfo() ? otherwise getRoomInfo is not called periodically after coming
-            //  back to app when it was in background
         }
     }
 
@@ -1905,8 +1903,6 @@ class ChatController(args: Bundle) :
     }
 
     private fun joinRoomWithPassword() {
-        Log.d(TAG, "joinRoomWithPassword. currentConversation==null ?:" + (currentConversation == null).toString())
-
         if (!validSessionId()) {
             Log.d(TAG, "sessionID was not valid -> joinRoom")
             var apiVersion = 1

--- a/app/src/main/java/com/nextcloud/talk/controllers/ContactsController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ContactsController.kt
@@ -66,9 +66,9 @@ import com.nextcloud.talk.models.json.participants.Participant
 import com.nextcloud.talk.ui.dialog.ContactsBottomDialog
 import com.nextcloud.talk.users.UserManager
 import com.nextcloud.talk.utils.ApiUtils
-import com.nextcloud.talk.utils.ConductorRemapping
 import com.nextcloud.talk.utils.bundle.BundleKeys
 import com.nextcloud.talk.utils.database.user.CapabilitiesUtilNew
+import com.nextcloud.talk.utils.remapchat.ConductorRemapping
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.SelectableAdapter
 import eu.davidea.flexibleadapter.common.SmoothScrollLinearLayoutManager
@@ -285,8 +285,11 @@ class ContactsController(args: Bundle) :
                                     Parcels.wrap(roomOverall.ocs!!.data!!)
                                 )
                                 ConductorRemapping.remapChatController(
-                                    router, currentUser!!.id!!,
-                                    roomOverall.ocs!!.data!!.token!!, bundle, true
+                                    router,
+                                    currentUser!!.id!!,
+                                    roomOverall.ocs!!.data!!.token!!,
+                                    bundle,
+                                    true
                                 )
                             }
 
@@ -738,9 +741,11 @@ class ContactsController(args: Bundle) :
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onMessageEvent(openConversationEvent: OpenConversationEvent) {
         ConductorRemapping.remapChatController(
-            router, currentUser!!.id!!,
+            router,
+            currentUser!!.id!!,
             openConversationEvent.conversation!!.token!!,
-            openConversationEvent.bundle!!, true
+            openConversationEvent.bundle!!,
+            true
         )
         contactsBottomDialog?.dismiss()
     }

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.kt
@@ -99,7 +99,6 @@ import com.nextcloud.talk.ui.dialog.ConversationsListBottomDialog
 import com.nextcloud.talk.users.UserManager
 import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.ClosedInterfaceImpl
-import com.nextcloud.talk.utils.ConductorRemapping.remapChatController
 import com.nextcloud.talk.utils.FileUtils
 import com.nextcloud.talk.utils.Mimetype
 import com.nextcloud.talk.utils.ParticipantPermissions
@@ -119,6 +118,7 @@ import com.nextcloud.talk.utils.database.user.CapabilitiesUtilNew.hasSpreedFeatu
 import com.nextcloud.talk.utils.database.user.CapabilitiesUtilNew.isServerEOL
 import com.nextcloud.talk.utils.database.user.CapabilitiesUtilNew.isUnifiedSearchAvailable
 import com.nextcloud.talk.utils.database.user.CapabilitiesUtilNew.isUserStatusAvailable
+import com.nextcloud.talk.utils.remapchat.ConductorRemapping.remapChatController
 import com.nextcloud.talk.utils.rx.SearchViewObservable.Companion.observeSearchView
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.common.SmoothScrollLinearLayoutManager

--- a/app/src/main/java/com/nextcloud/talk/controllers/base/BaseController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/base/BaseController.kt
@@ -245,6 +245,9 @@ abstract class BaseController(@LayoutRes var layoutRes: Int, args: Bundle? = nul
                 calculateValidParentController()
             }
             actionBar!!.title = title
+            Log.d(TAG, "setTitle: $title")
+        } else {
+            Log.d(TAG, "title was not set!!!!")
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/controllers/base/BaseController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/base/BaseController.kt
@@ -245,9 +245,6 @@ abstract class BaseController(@LayoutRes var layoutRes: Int, args: Bundle? = nul
                 calculateValidParentController()
             }
             actionBar!!.title = title
-            Log.d(TAG, "setTitle: $title")
-        } else {
-            Log.d(TAG, "title was not set!!!!")
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/ui/bottom/sheet/ProfileBottomSheet.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/bottom/sheet/ProfileBottomSheet.kt
@@ -41,8 +41,8 @@ import com.nextcloud.talk.ui.bottom.sheet.ProfileBottomSheet.AllowedAppIds.EMAIL
 import com.nextcloud.talk.ui.bottom.sheet.ProfileBottomSheet.AllowedAppIds.PROFILE
 import com.nextcloud.talk.ui.bottom.sheet.ProfileBottomSheet.AllowedAppIds.SPREED
 import com.nextcloud.talk.utils.ApiUtils
-import com.nextcloud.talk.utils.ConductorRemapping
 import com.nextcloud.talk.utils.bundle.BundleKeys
+import com.nextcloud.talk.utils.remapchat.ConductorRemapping
 import io.reactivex.Observer
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable

--- a/app/src/main/java/com/nextcloud/talk/utils/remapchat/RemapChatModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/remapchat/RemapChatModel.kt
@@ -1,0 +1,12 @@
+package com.nextcloud.talk.utils.remapchat
+
+import android.os.Bundle
+import com.bluelinelabs.conductor.ControllerChangeHandler
+import com.bluelinelabs.conductor.Router
+
+data class RemapChatModel(
+    val router: Router,
+    val controllerChangeHandler: ControllerChangeHandler,
+    val chatControllerTag: String,
+    val bundle: Bundle
+)


### PR DESCRIPTION
fix #2181

# Steps to reproduce
## how to reproduce:
- https://github.com/nextcloud/talk-android/issues/2181#issuecomment-1172224102

## Actual behaviour
#2181 (sometimes avatar/title are wrong + most likely other weird bugs)

## Expected behaviour
avatar and title always match to the opened conversation

# Problem

issue #218 is caused by the sessionId being "0" when switching between chats. This happens only sometimes.

sessionId being "0" has the following effect which explains the issue:

when going back to another chat from the chat that had the sessionId "0":
-> validSessionId() will be false in onDetach
	-> leaveRoom is not executed
		-> disposable is not disposed
			-> getRoomInfo() continues to execute for controller which had the sessionId "0"
				-> e.g appbar infos can be periodically overwritten (wrong avatar/title)

The api calls to leave roomA and enter roomB will be mixed and maybe this is a problem...?
so after leaveRoom is executed for roomA, then sessionId "0" is retrieved for roomB in getRoomInfo#onNext.
(although roomB already retrieved a valid sessionId just before leaveRoom was execcuted for roomA)

this might be caused by https://github.com/nextcloud/spreed/issues/4670#issuecomment-1300461242 or https://github.com/nextcloud/spreed/issues/8416


# Solution

this PR makes sure that a room is left BEFORE a new conductor controller [is added](https://github.com/nextcloud/talk-android/pull/2620/files#diff-2a0db874d7779de90a1a29521d56db79fbc0d78ae76f0497885e86a277bf31ebR81) or [replaced](https://github.com/nextcloud/talk-android/pull/2620/files#diff-2a0db874d7779de90a1a29521d56db79fbc0d78ae76f0497885e86a277bf31ebR79) by using a callback. This will avoid sessionId to become "0".
This might not be the BEST solution, but it should do the job until conductor is replaced (#1551).
However in theory there might still be rare scenarios to trigger this bug by using the 'back' buttons (Although i was not able to reproduce such a scenario). But these scenarios should at latest be fixed by https://github.com/nextcloud/spreed/issues/4670#issuecomment-1300461242

also done in this PR:
- add logging in ChatController (should be worth it to keep it for other debugging)
- refactor ConductorRemapping.kt

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)