### PR TITLE
Analysis: Also publish summary to GITHUB_STEP_SUMMARY

### DIFF
--- a/scripts/analysis/analysis-wrapper.sh
+++ b/scripts/analysis/analysis-wrapper.sh
@@ -119,7 +119,9 @@ else
         notNull="org.jetbrains.annotations.NotNull is used. Please use androidx.annotation.NonNull instead.<br><br>"
     fi
 
-    payload="{ \"body\" : \"$codacyResult $lintResult $spotbugsResult $lintMessage $spotbugsMessage $gplayLimitation $notNull\" }"
+    bodyContent="$codacyResult $lintResult $spotbugsResult $lintMessage $spotbugsMessage $gplayLimitation $notNull"
+    echo "$bodyContent" >> "$GITHUB_STEP_SUMMARY"
+    payload="{ \"body\" : \"$bodyContent\" }"
     curl_gh -X POST "https://api.github.com/repos/nextcloud/$repository/issues/${PR_NUMBER}/comments" -d "$payload"
 
     if [ ! -z "$gplayLimitation" ]; then


### PR DESCRIPTION
See https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/

This will still let us see the summary even for third-party PRs where secrets are unavailable.

How it looks:https://github.com/nextcloud/android/actions/runs/3748919814
How to get to it: click "details" next to the analysis check, then click "summary" in the left bar

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)