### PR TITLE
Bump androidxCoreKtx from 1.8.0 to 1.9.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -286,7 +286,7 @@ dependencies {
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
     })
 
-    implementation 'androidx.core:core-ktx:1.8.0'
+    implementation 'androidx.core:core-ktx:1.9.0'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:4.11.0'


### PR DESCRIPTION
### 🚧 TODO

- [ ] bump sdk to v33

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)