### PR TITLE
bump webrtc version to 108.5359.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -155,7 +155,7 @@ ext {
     espressoVersion = "3.5.1"
 }
 
-def webRtcVersion = "106.5249.0"
+def webRtcVersion = "108.5359.0"
 tasks.register('downloadWebRtc', DownloadWebRtcTask){
     version = webRtcVersion
 }


### PR DESCRIPTION
Signed-off-by: Marcel Hibbe <dev@mhibbe.de>

### 🚧 TODO

- [ ] manual testing together with @timkrueger 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)