### PR TITLE
Do not create offer for received screen share

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
@@ -181,7 +181,9 @@ public class PeerConnectionWrapper {
                     // set the recipient session ID in the assembled call message.
                     NCSignalingMessage ncSignalingMessage = createBaseSignalingMessage("requestoffer");
                     signalingMessageSender.send(ncSignalingMessage);
-                } else if (!hasMCU && hasInitiated) {
+                } else if (!hasMCU && hasInitiated && "video".equals(this.videoStreamType)) {
+                    // If the connection type is "screen" the client sharing the screen will send an
+                    // offer; offers should be created only for videos.
                     peerConnection.createOffer(magicSdpObserver, mediaConstraints);
                 }
             }


### PR DESCRIPTION
When the HPB is not used and a `PeerConnectionWrapper` is created it always sent an offer if the local session ID is higher than the remote session ID. However, in the case of screen shares the participant sharing the screen always sends an offer, no matter the session ID. Therefore, when that offer was received the new `PeerConnectionWrapper` object sent a new offer, which in turn created an extra connection in the browser.

Although the screen share connection happens to work the underlying behaviour was wrong, so now no offer is sent for received screen share connections and it is always waited until the offer is sent by the other participant.

## How to test
- Do not setup the HPB
- Open a conversation in the Android app
- Open the same conversation in the browser
- Check if the session ID of the Android participant is higher than the session ID of the browser participant; if not, reload the page until it is (or open the conversation again in the Android app, as preferred)
  - You can check the sessions in the browser console with `store.getters.participantsList('THE_CONVERSATION_TOKEN').forEach(participant => console.log(participant.actorId + " " + participant.sessionIds))`
  - For the comparison purposes note that "0" < "9" < "A" < "Z" < "a" < "z"
- Start a call in the browser
- Join the call in the Android app (via videocall)
- Wait until the connection is established (there are no loading spinners)
- In the browser, share the screen
- Wait until the connection is established (there are no loading spinners)
- Check the peers in the browser console with `OCA.Talk.SimpleWebRTC.webrtc.peers`

### Expected result

There are only two peers

### Actual result

There are three peers; the first and the third are `connected`, but the second one is just `new` (`OCA.Talk.SimpleWebRTC.webrtc.peers[1].pc.iceConnectionState`)
