### PR TITLE
avoid crash when answering call

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallNotificationActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallNotificationActivity.kt
@@ -153,25 +153,29 @@ class CallNotificationActivity : CallBaseActivity() {
     }
 
     private fun proceedToCall() {
-        originalBundle!!.putString(KEY_ROOM_TOKEN, currentConversation!!.token)
-        originalBundle!!.putString(KEY_CONVERSATION_NAME, currentConversation!!.displayName)
+        if (currentConversation != null) {
+            originalBundle!!.putString(KEY_ROOM_TOKEN, currentConversation!!.token)
+            originalBundle!!.putString(KEY_CONVERSATION_NAME, currentConversation!!.displayName)
 
-        val participantPermission = ParticipantPermissions(
-            userBeingCalled!!,
-            currentConversation!!
-        )
-        originalBundle!!.putBoolean(
-            BundleKeys.KEY_PARTICIPANT_PERMISSION_CAN_PUBLISH_AUDIO,
-            participantPermission.canPublishAudio()
-        )
-        originalBundle!!.putBoolean(
-            BundleKeys.KEY_PARTICIPANT_PERMISSION_CAN_PUBLISH_VIDEO,
-            participantPermission.canPublishVideo()
-        )
+            val participantPermission = ParticipantPermissions(
+                userBeingCalled!!,
+                currentConversation!!
+            )
+            originalBundle!!.putBoolean(
+                BundleKeys.KEY_PARTICIPANT_PERMISSION_CAN_PUBLISH_AUDIO,
+                participantPermission.canPublishAudio()
+            )
+            originalBundle!!.putBoolean(
+                BundleKeys.KEY_PARTICIPANT_PERMISSION_CAN_PUBLISH_VIDEO,
+                participantPermission.canPublishVideo()
+            )
 
-        val intent = Intent(this, CallActivity::class.java)
-        intent.putExtras(originalBundle!!)
-        startActivity(intent)
+            val intent = Intent(this, CallActivity::class.java)
+            intent.putExtras(originalBundle!!)
+            startActivity(intent)
+        } else {
+            Log.w(TAG, "conversation was still null when clicked to answer call. User has to click another time.")
+        }
     }
 
     @Suppress("MagicNumber")


### PR DESCRIPTION
this could happen very rarely when clicking very fast to accept the call before the conversation was set.


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)