### PR TITLE
Added A scroll down button + new icon + some styles for the button

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -685,16 +685,8 @@ class ChatController(args: Bundle) :
 
                 if (newState == AbsListView.OnScrollListener.SCROLL_STATE_IDLE) {
 
-                    val offset = recyclerView.computeVerticalScrollOffset()
-                    val extent = recyclerView.computeVerticalScrollExtent()
-                    val range = recyclerView.computeVerticalScrollRange()
-
-                    // 0.0 is the top of the chat, 100.0 is the bottom of the chat
-                    val scrollPercentage = 100.0f * offset / (range - extent).toFloat()
-
-                    if (scrollPercentage <= 90) {
+                    if (layoutManager!!.findFirstCompletelyVisibleItemPosition() > 0) {
                         binding?.scrollDownButton?.visibility = View.VISIBLE
-
                     } else {
                         binding?.scrollDownButton?.visibility = View.INVISIBLE
                     }

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -673,6 +673,8 @@ class ChatController(args: Bundle) :
             }
         }
 
+        binding?.scrollDownButton?.setOnClickListener { binding?.messagesListView?.smoothScrollToPosition(0) }
+
         binding?.let { viewThemeUtils.material.colorMaterialButtonPrimaryFilled(it.popupBubbleView) }
 
         binding?.messageInputView?.setPadding(0, 0, 0, 0)
@@ -682,6 +684,21 @@ class ChatController(args: Bundle) :
                 super.onScrollStateChanged(recyclerView, newState)
 
                 if (newState == AbsListView.OnScrollListener.SCROLL_STATE_IDLE) {
+
+                    val offset = recyclerView.computeVerticalScrollOffset()
+                    val extent = recyclerView.computeVerticalScrollExtent()
+                    val range = recyclerView.computeVerticalScrollRange()
+
+                    // 0.0 is the top of the chat, 100.0 is the bottom of the chat
+                    val scrollPercentage = 100.0f * offset / (range - extent).toFloat()
+
+                    if (scrollPercentage <= 90) {
+                        binding?.scrollDownButton?.visibility = View.VISIBLE
+
+                    } else {
+                        binding?.scrollDownButton?.visibility = View.INVISIBLE
+                    }
+
                     if (newMessagesCount != 0 && layoutManager != null) {
                         if (layoutManager!!.findFirstCompletelyVisibleItemPosition() < newMessagesCount) {
                             newMessagesCount = 0

--- a/app/src/main/res/drawable/ic_baseline_keyboard_double_arrow_down_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_keyboard_double_arrow_down_24.xml
@@ -1,3 +1,16 @@
+<!--
+    @author Google LLC
+    Copyright (C) 2023 Google LLC
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
 <vector android:height="24dp" android:tint="#000"
     android:viewportHeight="24" android:viewportWidth="24"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">

--- a/app/src/main/res/drawable/ic_baseline_keyboard_double_arrow_down_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_keyboard_double_arrow_down_24.xml
@@ -1,0 +1,8 @@
+<vector android:height="24dp" android:tint="#000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/black"
+        android:pathData="M18,6.41l-1.41,-1.41l-4.59,4.58l-4.59,-4.58l-1.41,1.41l6,6z"/>
+    <path android:fillColor="@android:color/black"
+        android:pathData="M18,13l-1.41,-1.41l-4.59,4.58l-4.59,-4.58l-1.41,1.41l6,6z"/>
+</vector>

--- a/app/src/main/res/layout/controller_chat.xml
+++ b/app/src/main/res/layout/controller_chat.xml
@@ -114,15 +114,16 @@
             android:id="@+id/scrollDownButton"
             android:layout_width="44dp"
             android:layout_height="44dp"
-            android:layout_alignParentRight="true"
+            android:layout_alignParentEnd="true"
             android:layout_alignParentBottom="true"
             android:layout_marginEnd="6dp"
             android:layout_marginBottom="16dp"
             android:background="@drawable/shape_oval"
             android:backgroundTint="@color/scroll_down_chat_button"
+            android:contentDescription="@string/scroll_to_bottom"
             android:src="@drawable/ic_baseline_keyboard_double_arrow_down_24"
-            app:tint="@color/scroll_down_chat_button_icon"
-            android:visibility="invisible" />
+            android:visibility="invisible"
+            app:tint="@color/scroll_down_chat_button_icon" />
 
     </RelativeLayout>
 

--- a/app/src/main/res/layout/controller_chat.xml
+++ b/app/src/main/res/layout/controller_chat.xml
@@ -3,6 +3,8 @@
   ~
   ~ @author Mario Danic
   ~ @author Andy Scherzinger
+  ~ @author Julius Linus
+  ~ Copyright (C) 2023 Julius Linus <juliuslinus1@gmail.com>
   ~ Copyright (C) 2021 Andy Scherzinger <info@andy-scherzinger.de>
   ~ Copyright (C) 2017-2018 Mario Danic <mario@lovelyhq.com>
   ~
@@ -107,6 +109,20 @@
             app:background="@color/colorPrimary"
             app:cornerRadius="@dimen/button_corner_radius"
             app:icon="@drawable/ic_baseline_arrow_downward_24px" />
+
+        <ImageButton
+            android:id="@+id/scrollDownButton"
+            android:layout_width="44dp"
+            android:layout_height="44dp"
+            android:layout_alignParentRight="true"
+            android:layout_alignParentBottom="true"
+            android:layout_marginEnd="6dp"
+            android:layout_marginBottom="16dp"
+            android:background="@drawable/shape_oval"
+            android:backgroundTint="@color/scroll_down_chat_button"
+            android:src="@drawable/ic_baseline_keyboard_double_arrow_down_24"
+            app:tint="@color/scroll_down_chat_button_icon"
+            android:visibility="invisible" />
 
     </RelativeLayout>
 

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -76,4 +76,8 @@
 
     <color name="dialog_background">#353535</color>
 
+    <!-- scroll down chat button  -->
+    <color name="scroll_down_chat_button">#141F25</color>
+    <color name="scroll_down_chat_button_icon">#99C3DA</color>
+
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -102,6 +102,10 @@
     <color name="list_divider_background">#1F121212</color>
     <color name="grey_200">#EEEEEE</color>
 
+    <!-- scroll down chat button  -->
+    <color name="scroll_down_chat_button">#E5F0F5</color>
+    <color name="scroll_down_chat_button_icon">#002A41</color>
+
     <!-- this is just a helper for status icon background because getting the background color of a dialog is not
     possible?! don't use this to set the background of dialogs -->
     <color name="dialog_background">#FFFFFF</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -630,5 +630,6 @@
 
     <string name="nc_not_allowed_to_activate_audio">You are not allowed to activate audio!</string>
     <string name="nc_not_allowed_to_activate_video">You are not allowed to activate video!</string>
+    <string name="scroll_to_bottom">Scroll to bottom</string>
 
 </resources>


### PR DESCRIPTION
fixes #2470 

### Notes
- Scrolls to the bottom using `smoothScrollToPosition(0)` meaning that the scroll animation can be interrupted if wanted
- Scroll is based off percentage of layout scrolled, with 0.0 being at the top of the chat, and 100.0 being at the bottom. I know that's a little weird, so I left a comment there. 
- I just set the `ImageButton` to only appear at anything past 90, and to be invisible by default.

### 🖼️ Screenshots

🌙 Dark | ☀️ Light
---|---
![Screenshot_1675018992](https://user-images.githubusercontent.com/69230048/215349641-4a963877-940f-46ef-a5df-ce137f8be37a.png)| ![Screenshot_1675018976](https://user-images.githubusercontent.com/69230048/215349620-ae5441ed-d473-4c4f-aad8-358481cea39b.png)

[issue-2470-test-webm-smaller.webm](https://user-images.githubusercontent.com/69230048/215351025-5b2249de-1a6e-4a09-a3a3-471a0b8b8ceb.webm)

^^ Sorry about the blurry footage, just to be clear the button isn't animated it just disappears.

### 🚧 TODO

- [x] chats should have a scroll to bottom button in the lower right corner

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)