### PR TITLE
Activate mark-as-unread on message level for everyone

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
@@ -35,7 +35,6 @@ import android.view.inputmethod.InputMethodManager
 import autodagger.AutoInjector
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
-import com.nextcloud.talk.BuildConfig
 import com.nextcloud.talk.R
 import com.nextcloud.talk.application.NextcloudTalkApplication
 import com.nextcloud.talk.controllers.ChatController
@@ -103,8 +102,7 @@ class MessageActionsDialog(
         )
         initMenuMarkAsUnread(
             message.previousMessageId > NO_PREVIOUS_MESSAGE_ID &&
-                ChatMessage.MessageType.SYSTEM_MESSAGE != message.getCalculateMessageType() &&
-                BuildConfig.DEBUG
+                ChatMessage.MessageType.SYSTEM_MESSAGE != message.getCalculateMessageType()
         )
     }
 


### PR DESCRIPTION
Signed-off-by: Andy Scherzinger <info@andy-scherzinger.de>

@mahibi discussed with @nickvergessen - we shall activate the feature for everybody even though it won't always work (hidden in case the code couldn't determin the `id` of the previous message (needed for the unread marker)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)