### PR TITLE
Fix to show back button when message opened by notification

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/base/BaseController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/base/BaseController.kt
@@ -139,7 +139,7 @@ abstract class BaseController(@LayoutRes var layoutRes: Int, args: Bundle? = nul
         showSearchOrToolbar()
         setTitle()
         if (actionBar != null) {
-            actionBar!!.setDisplayHomeAsUpEnabled(parentController != null || router.backstackSize > 1)
+            actionBar!!.setDisplayHomeAsUpEnabled(parentController != null || router.backstackSize >= 1)
         }
         super.onAttach(view)
     }


### PR DESCRIPTION
Before this fix, it was not possible to go to conversation list when a message was opened by notification

Signed-off-by: Marcel Hibbe <dev@mhibbe.de>


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)