### PR TITLE
Implemented automatic scrolling to quoted messages on tap

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingTextMessageViewHolder.kt
@@ -40,6 +40,7 @@ import coil.load
 import com.nextcloud.talk.R
 import com.nextcloud.talk.application.NextcloudTalkApplication
 import com.nextcloud.talk.application.NextcloudTalkApplication.Companion.sharedApplication
+import com.nextcloud.talk.controllers.ChatController
 import com.nextcloud.talk.databinding.ItemCustomIncomingTextMessageBinding
 import com.nextcloud.talk.extensions.loadBotsAvatar
 import com.nextcloud.talk.extensions.loadChangelogBotAvatar
@@ -73,7 +74,6 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) : MessageHolde
     lateinit var dateUtils: DateUtils
 
     lateinit var commonMessageInterface: CommonMessageInterface
-
     override fun onBind(message: ChatMessage) {
         super.onBind(message)
         sharedApplication!!.componentApplication.inject(this)
@@ -197,6 +197,11 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) : MessageHolde
             binding.messageQuote.quoteColoredView.setBackgroundColor(
                 ContextCompat.getColor(binding.messageQuote.quoteColoredView.context, R.color.high_emphasis_text)
             )
+        }
+
+        binding.messageQuote.quotedChatMessageView.setOnClickListener() {
+            val chatController = commonMessageInterface as ChatController
+            chatController.jumpToQuotedMessage(parentChatMessage)
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingTextMessageViewHolder.kt
@@ -74,6 +74,7 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) : MessageHolde
     lateinit var dateUtils: DateUtils
 
     lateinit var commonMessageInterface: CommonMessageInterface
+
     override fun onBind(message: ChatMessage) {
         super.onBind(message)
         sharedApplication!!.componentApplication.inject(this)

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -3487,6 +3487,16 @@ class ChatController(args: Bundle) :
         )
     }
 
+    fun jumpToQuotedMessage(parentMessage: ChatMessage) {
+        for(position in 0 until(adapter!!.items.size)) {
+            val currentItem = adapter?.items?.get(position)?.item
+            if( currentItem is ChatMessage && currentItem.id == parentMessage.id) {
+                layoutManager!!.scrollToPosition(position)
+                break
+            }
+        }
+    }
+
     private fun logConversationInfos(methodName: String) {
         Log.d(TAG, " |-----------------------------------------------")
         Log.d(TAG, " | method: $methodName")

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -3488,9 +3488,9 @@ class ChatController(args: Bundle) :
     }
 
     fun jumpToQuotedMessage(parentMessage: ChatMessage) {
-        for(position in 0 until(adapter!!.items.size)) {
+        for (position in 0 until (adapter!!.items.size)) {
             val currentItem = adapter?.items?.get(position)?.item
-            if( currentItem is ChatMessage && currentItem.id == parentMessage.id) {
+            if (currentItem is ChatMessage && currentItem.id == parentMessage.id) {
                 layoutManager!!.scrollToPosition(position)
                 break
             }


### PR DESCRIPTION
fixes #1090 

Implemented automatic scrolling to a quoted message on tap. 

### 🖼️ Video
[issue-1090-test-webm.webm](https://user-images.githubusercontent.com/69230048/221612508-f54713d0-262c-40cf-b092-cc4281248b44.webm)



### 🚧 TODO

- [x] basic functionality

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)