### PR TITLE
Avoid duplicated messages / Fix messages not being displayed

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -1591,7 +1591,7 @@ public class CallActivity extends CallBaseActivity {
                         Log.d(TAG, " new callSession by joinRoom= " + callSession);
 
                         ApplicationWideCurrentRoomHolder.getInstance().setSession(callSession);
-                        ApplicationWideCurrentRoomHolder.getInstance().setCurrentRoomId(roomId);
+                        ApplicationWideCurrentRoomHolder.getInstance().setCurrentRoomId(conversation.getRoomId());
                         ApplicationWideCurrentRoomHolder.getInstance().setCurrentRoomToken(roomToken);
                         ApplicationWideCurrentRoomHolder.getInstance().setUserInRoom(conversationUser);
                         callOrJoinRoomViaWebSocket();


### PR DESCRIPTION
fix #2060
fix  #2171
might fix #2372 (can't reproduce right now, also not without this PR)

Please test/review carefully

# How to test

## Scenario 1)
1. Join chat on android
2. Rotate device with screen being allowed to rotate
3. Send message to android

### Result without this PR
message shown twice

### Result with this PR
message shown once


## Scenario 2)
1. Join chat on android
2. Join call for this room on android
3. Leave call on android
4. Send message to android

### Result without this PR
message shown twice

### Result with this PR
message shown once

### 🚧 TODO

- [ ] getRoomInfo is called every 5 sec (also when not being in the lobby, and also without this PR). Should be checked if this should be changed?! -->followUp 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)