### PR TITLE
Fix theming of set status dialog buttons

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/SetStatusDialogFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/SetStatusDialogFragment.kt
@@ -211,6 +211,11 @@ class SetStatusDialogFragment :
         binding.awayStatus.setOnClickListener { setStatus(StatusType.AWAY) }
         binding.invisibleStatus.setOnClickListener { setStatus(StatusType.INVISIBLE) }
 
+        viewThemeUtils.talk.themeStatusCardView(binding.onlineStatus)
+        viewThemeUtils.talk.themeStatusCardView(binding.dndStatus)
+        viewThemeUtils.talk.themeStatusCardView(binding.awayStatus)
+        viewThemeUtils.talk.themeStatusCardView(binding.invisibleStatus)
+
         binding.clearStatus.setOnClickListener { clearStatus() }
         binding.setStatus.setOnClickListener { setStatusMessage() }
         binding.emoji.setOnClickListener { openEmojiPopup() }
@@ -244,8 +249,8 @@ class SetStatusDialogFragment :
 
         viewThemeUtils.platform.themeDialog(binding.root)
 
-        viewThemeUtils.material.colorMaterialButtonText(binding.clearStatus)
-        viewThemeUtils.material.colorMaterialButtonPrimaryFilled(binding.setStatus)
+        viewThemeUtils.material.colorMaterialButtonPrimaryBorderless(binding.clearStatus)
+        viewThemeUtils.material.colorMaterialButtonPrimaryTonal(binding.setStatus)
 
         viewThemeUtils.material.colorTextInputLayout(binding.customStatusInputContainer)
 
@@ -418,18 +423,12 @@ class SetStatusDialogFragment :
                 return
             }
         }
-        viewThemeUtils.material.colorCardViewBackground(views.first)
-        viewThemeUtils.platform.colorPrimaryTextViewElement(views.second)
+        views.first.isChecked = true
+        viewThemeUtils.platform.colorOnSecondaryContainerTextViewElement(views.second)
     }
 
     private fun clearTopStatus() {
         context?.let {
-            val grey = it.resources.getColor(R.color.grey_200)
-            binding.onlineStatus.setCardBackgroundColor(grey)
-            binding.awayStatus.setCardBackgroundColor(grey)
-            binding.dndStatus.setCardBackgroundColor(grey)
-            binding.invisibleStatus.setCardBackgroundColor(grey)
-
             binding.onlineHeadline.setTextColor(resources.getColor(R.color.high_emphasis_text))
             binding.awayHeadline.setTextColor(resources.getColor(R.color.high_emphasis_text))
             binding.dndHeadline.setTextColor(resources.getColor(R.color.high_emphasis_text))
@@ -439,6 +438,11 @@ class SetStatusDialogFragment :
             binding.awayIcon.imageTintList = null
             binding.dndIcon.imageTintList = null
             binding.invisibleIcon.imageTintList = null
+
+            binding.onlineStatus.isChecked = false
+            binding.awayStatus.isChecked = false
+            binding.dndStatus.isChecked = false
+            binding.invisibleStatus.isChecked = false
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/ui/theme/TalkSpecificViewThemeUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/theme/TalkSpecificViewThemeUtils.kt
@@ -227,6 +227,35 @@ class TalkSpecificViewThemeUtils @Inject constructor(
         }
     }
 
+    fun themeStatusCardView(cardView: MaterialCardView) {
+        withScheme(cardView) { scheme ->
+            val background = cardView.context.getColor(R.color.grey_200)
+            cardView.backgroundTintList =
+                ColorStateList(
+                    arrayOf(
+                        intArrayOf(android.R.attr.state_checked),
+                        intArrayOf(-android.R.attr.state_checked)
+                    ),
+                    intArrayOf(
+                        scheme.secondaryContainer,
+                        background
+                    )
+                )
+            cardView.setStrokeColor(
+                ColorStateList(
+                    arrayOf(
+                        intArrayOf(android.R.attr.state_checked),
+                        intArrayOf(-android.R.attr.state_checked)
+                    ),
+                    intArrayOf(
+                        scheme.onSecondaryContainer,
+                        scheme.surface
+                    )
+                )
+            )
+        }
+    }
+
     companion object {
         private val THEMEABLE_PLACEHOLDER_IDS = listOf(
             R.drawable.ic_mimetype_package_x_generic,

--- a/app/src/main/res/layout/dialog_set_status.xml
+++ b/app/src/main/res/layout/dialog_set_status.xml
@@ -60,10 +60,12 @@
                 android:layout_gravity="center_vertical"
                 android:layout_marginEnd="@dimen/standard_half_margin"
                 android:layout_weight="1"
+                android:checkable="true"
                 android:orientation="horizontal"
                 app:cardBackgroundColor="@color/grey_200"
+                app:cardCornerRadius="@dimen/button_corner_radius"
                 app:cardElevation="0dp"
-                app:cardCornerRadius="@dimen/button_corner_radius">
+                app:checkedIcon="@null">
 
                 <RelativeLayout
                     android:layout_width="match_parent"
@@ -128,10 +130,12 @@
                 android:layout_gravity="center_vertical"
                 android:layout_marginStart="@dimen/standard_half_margin"
                 android:layout_weight="1"
+                android:checkable="true"
                 android:orientation="horizontal"
                 app:cardBackgroundColor="@color/grey_200"
+                app:cardCornerRadius="@dimen/button_corner_radius"
                 app:cardElevation="0dp"
-                app:cardCornerRadius="@dimen/button_corner_radius">
+                app:checkedIcon="@null">
 
                 <RelativeLayout
                     android:layout_width="match_parent"
@@ -205,10 +209,12 @@
                 android:layout_gravity="center_vertical"
                 android:layout_marginEnd="@dimen/standard_half_margin"
                 android:layout_weight="1"
+                android:checkable="true"
                 android:orientation="horizontal"
                 app:cardBackgroundColor="@color/grey_200"
+                app:cardCornerRadius="@dimen/button_corner_radius"
                 app:cardElevation="0dp"
-                app:cardCornerRadius="@dimen/button_corner_radius">
+                app:checkedIcon="@null">
 
                 <RelativeLayout
                     android:layout_width="match_parent"
@@ -259,12 +265,13 @@
                 android:layout_height="@dimen/online_status_item_height"
                 android:layout_gravity="center_vertical"
                 android:layout_marginStart="@dimen/standard_half_margin"
-
                 android:layout_weight="1"
+                android:checkable="true"
                 android:orientation="horizontal"
                 app:cardBackgroundColor="@color/grey_200"
+                app:cardCornerRadius="@dimen/button_corner_radius"
                 app:cardElevation="0dp"
-                app:cardCornerRadius="@dimen/button_corner_radius">
+                app:checkedIcon="@null">
 
                 <RelativeLayout
                     android:layout_width="match_parent"
@@ -436,9 +443,9 @@
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/clearStatus"
-            style="@style/OutlinedButton"
+            style="@style/Button.Borderless"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:layout_marginEnd="@dimen/standard_half_margin"
             android:layout_weight="1"
             android:text="@string/clear_status_message"
@@ -447,7 +454,7 @@
         <com.google.android.material.button.MaterialButton
             android:id="@+id/setStatus"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="1"
             android:text="@string/set_status_message"
             android:theme="@style/Button.Primary"


### PR DESCRIPTION
fix #2817

### 🖼️ Screenshots

🏚️ Before | 🏡 After (themed)
---|---
![grafik](https://user-images.githubusercontent.com/2932790/222797670-fad239ea-f0aa-49db-a30b-25f60ec5b3fd.png) | ![grafik](https://user-images.githubusercontent.com/2932790/222797899-3c03d9be-6ef7-4f8d-93dd-d81b81d34ee9.png)



### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)