### PR TITLE
Avoid NPE (replace scrollToPositionWithOffset(..) with scrollToPositi…

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -2495,10 +2495,7 @@ class ChatController(args: Bundle) :
         addMessagesToAdapter(shouldAddNewMessagesNotice, chatMessageList)
 
         if (shouldAddNewMessagesNotice && adapter != null) {
-            layoutManager?.scrollToPositionWithOffset(
-                adapter!!.getMessagePositionByIdInReverse("-1"),
-                binding?.messagesListView?.height!! / 2
-            )
+            layoutManager?.scrollToPosition(0)
         }
     }
 


### PR DESCRIPTION
fix #2834

i don't understand why scrollToPositionWithOffset was used at all.
So using scrollToPosition(0) which also avoids the NPE.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)