### PR TITLE
Fix horizontal (=landscape) call design

### DIFF
--- a/app/src/main/res/layout/call_activity.xml
+++ b/app/src/main/res/layout/call_activity.xml
@@ -181,8 +181,9 @@
 
     <LinearLayout
         android:id="@+id/callControls"
-        android:layout_width="match_parent"
         android:layout_height="@dimen/call_controls_height"
+        android:layout_width="450dp"
+        android:layout_centerHorizontal="true"
         android:paddingHorizontal="@dimen/call_controls_padding_horizontal"
         android:layout_alignBottom="@id/linearWrapperLayout"
         android:animateLayoutChanges="true"


### PR DESCRIPTION
Without this fix, the call buttons became huge in landscape mode.

The LinearLayout of the callControls now has a fixed width which comes in handy in landscape mode.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://user-images.githubusercontent.com/2932790/224069864-b29cedef-a0bf-46cb-aea6-0186391c0d0c.png) | ![grafik](https://user-images.githubusercontent.com/2932790/224069913-b4f6c0bd-71fa-4d2d-8318-59dd6a1a0131.png)



### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)