### PR TITLE
Fix to get websocketInstance

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/application/NextcloudTalkApplication.kt
+++ b/app/src/main/java/com/nextcloud/talk/application/NextcloudTalkApplication.kt
@@ -177,6 +177,18 @@ class NextcloudTalkApplication : MultiDexApplication(), LifecycleObserver {
         ClosedInterfaceImpl().providerInstallerInstallIfNeededAsync()
         DeviceUtils.ignoreSpecialBatteryFeatures()
 
+        initWorkers()
+
+        val config = BundledEmojiCompatConfig(this)
+        config.setReplaceAll(true)
+        val emojiCompat = EmojiCompat.init(config)
+
+        EmojiManager.install(GoogleEmojiProvider())
+
+        NotificationUtils.registerNotificationChannels(applicationContext, appPreferences)
+    }
+
+    private fun initWorkers() {
         val accountRemovalWork = OneTimeWorkRequest.Builder(AccountRemovalWorker::class.java).build()
         val capabilitiesUpdateWork = OneTimeWorkRequest.Builder(CapabilitiesWorker::class.java).build()
         val signalingSettingsWork = OneTimeWorkRequest.Builder(SignalingSettingsWorker::class.java).build()
@@ -199,14 +211,6 @@ class NextcloudTalkApplication : MultiDexApplication(), LifecycleObserver {
             ExistingPeriodicWorkPolicy.REPLACE,
             periodicCapabilitiesUpdateWork
         )
-
-        val config = BundledEmojiCompatConfig(this)
-        config.setReplaceAll(true)
-        val emojiCompat = EmojiCompat.init(config)
-
-        EmojiManager.install(GoogleEmojiProvider())
-
-        NotificationUtils.registerNotificationChannels(applicationContext, appPreferences)
     }
 
     override fun onTerminate() {

--- a/app/src/main/java/com/nextcloud/talk/application/NextcloudTalkApplication.kt
+++ b/app/src/main/java/com/nextcloud/talk/application/NextcloudTalkApplication.kt
@@ -182,6 +182,7 @@ class NextcloudTalkApplication : MultiDexApplication(), LifecycleObserver {
             HALF_DAY,
             TimeUnit.HOURS
         ).build()
+
         val capabilitiesUpdateWork = OneTimeWorkRequest.Builder(CapabilitiesWorker::class.java).build()
         val signalingSettingsWork = OneTimeWorkRequest.Builder(SignalingSettingsWorker::class.java).build()
 

--- a/app/src/main/java/com/nextcloud/talk/controllers/AccountVerificationController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/AccountVerificationController.kt
@@ -48,6 +48,7 @@ import com.nextcloud.talk.events.EventStatus
 import com.nextcloud.talk.jobs.CapabilitiesWorker
 import com.nextcloud.talk.jobs.PushRegistrationWorker
 import com.nextcloud.talk.jobs.SignalingSettingsWorker
+import com.nextcloud.talk.jobs.WebsocketConnectionsWorker
 import com.nextcloud.talk.models.json.capabilities.Capabilities
 import com.nextcloud.talk.models.json.capabilities.CapabilitiesOverall
 import com.nextcloud.talk.models.json.generic.Status
@@ -434,11 +435,15 @@ class AccountVerificationController(args: Bundle? = null) :
             Data.Builder()
                 .putLong(KEY_INTERNAL_USER_ID, internalAccountId)
                 .build()
-        val signalingSettings =
-            OneTimeWorkRequest.Builder(SignalingSettingsWorker::class.java)
-                .setInputData(userData)
-                .build()
-        WorkManager.getInstance().enqueue(signalingSettings)
+        val signalingSettings = OneTimeWorkRequest.Builder(SignalingSettingsWorker::class.java)
+            .setInputData(userData)
+            .build()
+        val websocketConnectionsWorker = OneTimeWorkRequest.Builder(WebsocketConnectionsWorker::class.java).build()
+
+        WorkManager.getInstance(applicationContext!!)
+            .beginWith(signalingSettings)
+            .then(websocketConnectionsWorker)
+            .enqueue()
     }
 
     private fun proceedWithLogin() {

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -1783,6 +1783,7 @@ class ChatController(args: Bundle) :
 
         eventBus.register(this)
 
+        setupWebsocket()
         webSocketInstance?.getSignalingMessageReceiver()?.addListener(localParticipantMessageListener)
 
         if (conversationUser?.userId != "?" &&
@@ -2002,11 +2003,6 @@ class ChatController(args: Bundle) :
 
                         logConversationInfos("joinRoomWithPassword#onNext")
 
-                        // FIXME The web socket should be set up in onAttach(). It is currently setup after joining the
-                        // room to "ensure" (rather, increase the chances) that the WebsocketConnectionsWorker job
-                        // was able to finish and, therefore, that the web socket instance can be got.
-                        setupWebsocket()
-
                         // Ensure that the listener is added if the web socket instance was not set up yet when
                         // onAttach() was called.
                         webSocketInstance?.getSignalingMessageReceiver()?.addListener(localParticipantMessageListener)
@@ -2225,10 +2221,13 @@ class ChatController(args: Bundle) :
             return
         }
 
-        webSocketInstance = WebSocketConnectionHelper.getMagicWebSocketInstanceForUserId(conversationUser.id!!)
+        webSocketInstance = WebSocketConnectionHelper.getWebSocketInstanceForUserId(conversationUser.id!!)
 
         if (webSocketInstance == null) {
-            Log.d(TAG, "magicWebSocketInstance became null")
+            Log.e(TAG, "failed to setup webSocketInstance")
+            if (BuildConfig.DEBUG) {
+                Toast.makeText(context, "failed to setup webSocketInstance", Toast.LENGTH_LONG).show()
+            }
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -2003,10 +2003,6 @@ class ChatController(args: Bundle) :
 
                         logConversationInfos("joinRoomWithPassword#onNext")
 
-                        // Ensure that the listener is added if the web socket instance was not set up yet when
-                        // onAttach() was called.
-                        webSocketInstance?.getSignalingMessageReceiver()?.addListener(localParticipantMessageListener)
-
                         if (isFirstMessagesProcessing) {
                             pullChatMessages(false)
                         } else {

--- a/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ChatController.kt
@@ -2095,15 +2095,6 @@ class ChatController(args: Bundle) :
                             "",
                             sessionIdAfterRoomJoined
                         )
-                    } else {
-                        Log.e(TAG, "magicWebSocketInstance or currentConversation were null! Failed to leave the room!")
-                        if (BuildConfig.DEBUG) {
-                            Toast.makeText(
-                                context,
-                                "magicWebSocketInstance or currentConversation were null! Failed to leave the room!",
-                                Toast.LENGTH_LONG
-                            ).show()
-                        }
                     }
 
                     sessionIdAfterRoomJoined = "0"
@@ -2216,14 +2207,10 @@ class ChatController(args: Bundle) :
         if (conversationUser == null) {
             return
         }
-
         webSocketInstance = WebSocketConnectionHelper.getWebSocketInstanceForUserId(conversationUser.id!!)
 
         if (webSocketInstance == null) {
-            Log.e(TAG, "failed to setup webSocketInstance")
-            if (BuildConfig.DEBUG) {
-                Toast.makeText(context, "failed to setup webSocketInstance", Toast.LENGTH_LONG).show()
-            }
+            Log.d(TAG, "webSocketInstance not set up. This should only happen when not using the HPB")
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/jobs/CapabilitiesWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/CapabilitiesWorker.java
@@ -112,9 +112,9 @@ public class CapabilitiesWorker extends Worker {
         long internalUserId = data.getLong(BundleKeys.KEY_INTERNAL_USER_ID, -1);
 
         List<User> userEntityObjectList = new ArrayList<>();
-        boolean userExists = userManager.getUserWithInternalId(internalUserId).isEmpty().blockingGet();
+        boolean userNotFound = userManager.getUserWithInternalId(internalUserId).isEmpty().blockingGet();
 
-        if (internalUserId == -1 || !userExists) {
+        if (internalUserId == -1 || userNotFound) {
             userEntityObjectList = userManager.getUsers().blockingGet();
         } else {
             userEntityObjectList.add(userManager.getUserWithInternalId(internalUserId).blockingGet());

--- a/app/src/main/java/com/nextcloud/talk/jobs/SignalingSettingsWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/SignalingSettingsWorker.java
@@ -77,9 +77,9 @@ public class SignalingSettingsWorker extends Worker {
         long internalUserId = data.getLong(BundleKeys.KEY_INTERNAL_USER_ID, -1);
 
         List<User> userEntityObjectList = new ArrayList<>();
-        boolean userExists = userManager.getUserWithInternalId(internalUserId).isEmpty().blockingGet();
+        boolean userNotFound = userManager.getUserWithInternalId(internalUserId).isEmpty().blockingGet();
 
-        if (internalUserId == -1 || !userExists) {
+        if (internalUserId == -1 || userNotFound) {
             userEntityObjectList = userManager.getUsers().blockingGet();
         } else {
             userEntityObjectList.add(userManager.getUserWithInternalId(internalUserId).blockingGet());

--- a/app/src/main/java/com/nextcloud/talk/jobs/SignalingSettingsWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/SignalingSettingsWorker.java
@@ -42,8 +42,6 @@ import javax.inject.Inject;
 
 import androidx.annotation.NonNull;
 import androidx.work.Data;
-import androidx.work.OneTimeWorkRequest;
-import androidx.work.WorkManager;
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
 import autodagger.AutoInjector;
@@ -158,11 +156,6 @@ public class SignalingSettingsWorker extends Worker {
                     }
                 });
         }
-
-        OneTimeWorkRequest websocketConnectionsWorker = new OneTimeWorkRequest
-            .Builder(WebsocketConnectionsWorker.class)
-            .build();
-        WorkManager.getInstance().enqueue(websocketConnectionsWorker);
 
         return Result.success();
     }

--- a/app/src/main/java/com/nextcloud/talk/jobs/SignalingSettingsWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/SignalingSettingsWorker.java
@@ -115,6 +115,8 @@ public class SignalingSettingsWorker extends Worker {
                                                                                    .getExternalSignalingTicket());
                         }
 
+                        user.setExternalSignalingServer(externalSignalingServer);
+
                         userManager.saveUser(user).subscribe(new SingleObserver<Integer>() {
                             @Override
                             public void onSubscribe(Disposable d) {

--- a/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketConnectionHelper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketConnectionHelper.java
@@ -48,7 +48,7 @@ import okhttp3.OkHttpClient;
 @AutoInjector(NextcloudTalkApplication.class)
 public class WebSocketConnectionHelper {
     public static final String TAG = "WebSocketConnectionHelper";
-    private static Map<Long, WebSocketInstance> magicWebSocketInstanceMap = new HashMap<>();
+    private static Map<Long, WebSocketInstance> webSocketInstanceMap = new HashMap<>();
 
     @Inject
     OkHttpClient okHttpClient;
@@ -59,11 +59,11 @@ public class WebSocketConnectionHelper {
     }
 
     @SuppressLint("LongLogTag")
-    public static synchronized WebSocketInstance getMagicWebSocketInstanceForUserId(long userId) {
-        WebSocketInstance webSocketInstance = magicWebSocketInstanceMap.get(userId);
+    public static synchronized WebSocketInstance getWebSocketInstanceForUserId(long userId) {
+        WebSocketInstance webSocketInstance = webSocketInstanceMap.get(userId);
 
         if (webSocketInstance == null) {
-            Log.d(TAG, "No magicWebSocketInstance found for user " + userId);
+            Log.e(TAG, "No webSocketInstance found for user " + userId);
         }
 
         return webSocketInstance;
@@ -83,24 +83,24 @@ public class WebSocketConnectionHelper {
         long userId = isGuest ? -1 : user.getId();
 
         WebSocketInstance webSocketInstance;
-        if (userId != -1 && magicWebSocketInstanceMap.containsKey(user.getId()) && (webSocketInstance = magicWebSocketInstanceMap.get(user.getId())) != null) {
+        if (userId != -1 && webSocketInstanceMap.containsKey(user.getId()) && (webSocketInstance = webSocketInstanceMap.get(user.getId())) != null) {
             return webSocketInstance;
         } else {
             if (userId == -1) {
                 deleteExternalSignalingInstanceForUserEntity(userId);
             }
             webSocketInstance = new WebSocketInstance(user, generatedURL, webSocketTicket);
-            magicWebSocketInstanceMap.put(user.getId(), webSocketInstance);
+            webSocketInstanceMap.put(user.getId(), webSocketInstance);
             return webSocketInstance;
         }
     }
 
     public static synchronized void deleteExternalSignalingInstanceForUserEntity(long id) {
         WebSocketInstance webSocketInstance;
-        if ((webSocketInstance = magicWebSocketInstanceMap.get(id)) != null) {
+        if ((webSocketInstance = webSocketInstanceMap.get(id)) != null) {
             if (webSocketInstance.isConnected()) {
                 webSocketInstance.sendBye();
-                magicWebSocketInstanceMap.remove(id);
+                webSocketInstanceMap.remove(id);
             }
         }
     }


### PR DESCRIPTION
This PR fixes to set the externalSignalingServer to the user, see 8c991c697fcbdef8e075cefa8c8026b6dbee2a8a
Furthermore, race conditions of Workers are now avoided by using WorkManager chains, see 609e5a2c7113cb7847104122d35dbd7eaca26f7e



### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)