### PR TITLE
Bump target and compile SDK to 33

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,14 +36,14 @@ apply plugin: "org.jlleitschuh.gradle.ktlint"
 apply plugin: 'kotlinx-serialization'
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
     buildToolsVersion '33.0.2'
 
     namespace 'com.nextcloud.talk'
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 31
+        targetSdkVersion 33
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         // mayor.minor.hotfix.increment (for increment: 01-50=Alpha / 51-89=RC / 90-99=stable)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -71,7 +71,12 @@
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="29"
         tools:ignore="ScopedStorage" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.kt
@@ -87,7 +87,6 @@ import com.nextcloud.talk.jobs.AccountRemovalWorker
 import com.nextcloud.talk.jobs.ContactAddressBookWorker.Companion.run
 import com.nextcloud.talk.jobs.DeleteConversationWorker
 import com.nextcloud.talk.jobs.UploadAndShareFilesWorker
-import com.nextcloud.talk.jobs.UploadAndShareFilesWorker.Companion.isStoragePermissionGranted
 import com.nextcloud.talk.jobs.UploadAndShareFilesWorker.Companion.requestStoragePermission
 import com.nextcloud.talk.messagesearch.MessageSearchHelper
 import com.nextcloud.talk.messagesearch.MessageSearchHelper.MessageSearchResults
@@ -119,6 +118,7 @@ import com.nextcloud.talk.utils.database.user.CapabilitiesUtilNew.hasSpreedFeatu
 import com.nextcloud.talk.utils.database.user.CapabilitiesUtilNew.isServerEOL
 import com.nextcloud.talk.utils.database.user.CapabilitiesUtilNew.isUnifiedSearchAvailable
 import com.nextcloud.talk.utils.database.user.CapabilitiesUtilNew.isUserStatusAvailable
+import com.nextcloud.talk.utils.permissions.PlatformPermissionUtil
 import com.nextcloud.talk.utils.remapchat.ConductorRemapping.remapChatController
 import com.nextcloud.talk.utils.rx.SearchViewObservable.Companion.observeSearchView
 import com.nextcloud.talk.utils.singletons.ApplicationWideCurrentRoomHolder
@@ -158,6 +158,9 @@ class ConversationsListController(bundle: Bundle) :
 
     @Inject
     lateinit var unifiedSearchRepository: UnifiedSearchRepository
+
+    @Inject
+    lateinit var platformPermissionUtil: PlatformPermissionUtil
 
     private val binding: ControllerConversationsRvBinding? by viewBinding(ControllerConversationsRvBinding::bind)
 
@@ -960,7 +963,7 @@ class ConversationsListController(bundle: Bundle) :
     }
 
     private fun showSendFilesConfirmDialog() {
-        if (isStoragePermissionGranted(context)) {
+        if (platformPermissionUtil.isFilesPermissionGranted()) {
             val fileNamesWithLineBreaks = StringBuilder("\n")
             for (file in filesToShare!!) {
                 val filename = FileUtils.getFileName(Uri.parse(file), context)

--- a/app/src/main/java/com/nextcloud/talk/messagesearch/MessageSearchActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/messagesearch/MessageSearchActivity.kt
@@ -220,12 +220,12 @@ class MessageSearchActivity : BaseActivity() {
         searchView = menuItem.actionView as SearchView
         setupSearchView()
         menuItem.setOnActionExpandListener(object : MenuItem.OnActionExpandListener {
-            override fun onMenuItemActionExpand(item: MenuItem?): Boolean {
+            override fun onMenuItemActionExpand(item: MenuItem): Boolean {
                 searchView.requestFocus()
                 return true
             }
 
-            override fun onMenuItemActionCollapse(item: MenuItem?): Boolean {
+            override fun onMenuItemActionCollapse(item: MenuItem): Boolean {
                 onBackPressed()
                 return false
             }

--- a/app/src/main/java/com/nextcloud/talk/utils/permissions/PlatformPermissionUtil.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/permissions/PlatformPermissionUtil.kt
@@ -24,4 +24,6 @@ package com.nextcloud.talk.utils.permissions
 interface PlatformPermissionUtil {
     val privateBroadcastPermission: String
     fun isCameraPermissionGranted(): Boolean
+
+    fun isFilesPermissionGranted(): Boolean
 }

--- a/app/src/main/java/com/nextcloud/talk/utils/permissions/PlatformPermissionUtilImpl.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/permissions/PlatformPermissionUtilImpl.kt
@@ -23,6 +23,8 @@ package com.nextcloud.talk.utils.permissions
 
 import android.Manifest
 import android.content.Context
+import android.os.Build
+import android.util.Log
 import androidx.core.content.PermissionChecker
 import com.nextcloud.talk.BuildConfig
 
@@ -35,5 +37,56 @@ class PlatformPermissionUtilImpl(private val context: Context) : PlatformPermiss
             context,
             Manifest.permission.CAMERA
         ) == PermissionChecker.PERMISSION_GRANTED
+    }
+
+    override fun isFilesPermissionGranted(): Boolean {
+        return when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> {
+                if (
+                    PermissionChecker.checkSelfPermission(context, Manifest.permission.READ_MEDIA_IMAGES)
+                    == PermissionChecker.PERMISSION_GRANTED ||
+                    PermissionChecker.checkSelfPermission(context, Manifest.permission.READ_MEDIA_VIDEO)
+                    == PermissionChecker.PERMISSION_GRANTED ||
+                    PermissionChecker.checkSelfPermission(context, Manifest.permission.READ_MEDIA_AUDIO)
+                    == PermissionChecker.PERMISSION_GRANTED
+                ) {
+                    Log.d(TAG, "Permission is granted (SDK 33 or greater)")
+                    true
+                } else {
+                    Log.d(TAG, "Permission is revoked (SDK 33 or greater)")
+                    false
+                }
+            }
+            Build.VERSION.SDK_INT > Build.VERSION_CODES.Q -> {
+                if (PermissionChecker.checkSelfPermission(
+                        context,
+                        Manifest.permission.READ_EXTERNAL_STORAGE
+                    ) == PermissionChecker.PERMISSION_GRANTED
+                ) {
+                    Log.d(TAG, "Permission is granted (SDK 30 or greater)")
+                    true
+                } else {
+                    Log.d(TAG, "Permission is revoked (SDK 30 or greater)")
+                    false
+                }
+            }
+            else -> {
+                if (PermissionChecker.checkSelfPermission(
+                        context,
+                        Manifest.permission.WRITE_EXTERNAL_STORAGE
+                    ) == PermissionChecker.PERMISSION_GRANTED
+                ) {
+                    Log.d(TAG, "Permission is granted")
+                    true
+                } else {
+                    Log.d(TAG, "Permission is revoked")
+                    false
+                }
+            }
+        }
+    }
+
+    companion object {
+        private val TAG = PlatformPermissionUtilImpl::class.simpleName
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -464,6 +464,7 @@ How to translate with transifex:
     <string name="nc_upload_notification_text">%1$s to %2$s - %3$s\%%</string>
     <string name="nc_upload_failed_notification_title">Failure</string>
     <string name="nc_upload_failed_notification_text">Failed to upload %1$s</string>
+    <string name="nc_file_storage_permission">Permission for file access is required</string>
 
     <!-- Video -->
     <string name="nc_video_filename">Video recording from %1$s</string>


### PR DESCRIPTION
Resolves #2299 

### 🚧 TODO

- [x] Adapt to new permission on Android 13, see https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions when sharing files from device

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)