### PR TITLE
buildToolsVersion does not need to be specified

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,6 @@ apply plugin: 'kotlinx-serialization'
 
 android {
     compileSdkVersion 33
-    buildToolsVersion '33.0.2'
 
     namespace 'com.nextcloud.talk'
 


### PR DESCRIPTION
See https://github.com/nextcloud/notes-android/pull/1720

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)