### PR TITLE
Replace Controller with Activity for settings

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -206,6 +206,10 @@
             android:name=".profile.ProfileActivity"
             android:theme="@style/AppTheme" />
 
+        <activity
+            android:name=".settings.SettingsActivity"
+            android:theme="@style/AppTheme" />
+
         <receiver android:name=".receivers.PackageReplacedReceiver"
             android:exported="false">
             <intent-filter>

--- a/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
@@ -42,12 +42,12 @@ import com.nextcloud.talk.application.NextcloudTalkApplication
 import com.nextcloud.talk.controllers.ConversationsListController
 import com.nextcloud.talk.controllers.LockedController
 import com.nextcloud.talk.controllers.ServerSelectionController
-import com.nextcloud.talk.controllers.SettingsController
 import com.nextcloud.talk.controllers.WebViewLoginController
 import com.nextcloud.talk.controllers.base.providers.ActionBarProvider
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.databinding.ActivityMainBinding
 import com.nextcloud.talk.models.json.conversations.RoomOverall
+import com.nextcloud.talk.settings.SettingsActivity
 import com.nextcloud.talk.users.UserManager
 import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.SecurityUtils
@@ -193,11 +193,8 @@ class MainActivity : BaseActivity(), ActionBarProvider {
     }
 
     fun openSettings() {
-        router!!.pushController(
-            RouterTransaction.with(SettingsController())
-                .pushChangeHandler(HorizontalChangeHandler())
-                .popChangeHandler(HorizontalChangeHandler())
-        )
+        val intent = Intent(this, SettingsActivity::class.java)
+        startActivity(intent)
     }
 
     fun addAccount() {

--- a/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/ConversationsListController.kt
@@ -93,6 +93,7 @@ import com.nextcloud.talk.messagesearch.MessageSearchHelper.MessageSearchResults
 import com.nextcloud.talk.models.json.conversations.Conversation
 import com.nextcloud.talk.models.json.conversations.RoomsOverall
 import com.nextcloud.talk.repositories.unifiedsearch.UnifiedSearchRepository
+import com.nextcloud.talk.settings.SettingsActivity
 import com.nextcloud.talk.ui.dialog.ChooseAccountDialogFragment
 import com.nextcloud.talk.ui.dialog.ChooseAccountShareToDialogFragment
 import com.nextcloud.talk.ui.dialog.ConversationsListBottomDialog
@@ -719,11 +720,8 @@ class ConversationsListController(bundle: Bundle) :
                         ChooseAccountDialogFragment.TAG
                     )
                 } else {
-                    router.pushController(
-                        RouterTransaction.with(SettingsController())
-                            .pushChangeHandler(HorizontalChangeHandler())
-                            .popChangeHandler(HorizontalChangeHandler())
-                    )
+                    val intent = Intent(context, SettingsActivity::class.java)
+                    startActivity(intent)
                 }
             }
         }

--- a/app/src/main/java/com/nextcloud/talk/jobs/AccountRemovalWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/AccountRemovalWorker.java
@@ -23,7 +23,10 @@
 package com.nextcloud.talk.jobs;
 
 import android.app.NotificationManager;
+import android.content.ComponentName;
 import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.os.Build;
 import android.util.Log;
 
@@ -208,5 +211,17 @@ public class AccountRemovalWorker extends Worker {
                 Log.e(TAG, "error while trying to delete user", e);
             }
         }
+        if (userManager.getUsers().blockingGet().isEmpty()) {
+            restartApp(getApplicationContext());
+        }
+    }
+
+    public static void restartApp(Context context) {
+        PackageManager packageManager = context.getPackageManager();
+        Intent intent = packageManager.getLaunchIntentForPackage(context.getPackageName());
+        ComponentName componentName = intent.getComponent();
+        Intent mainIntent = Intent.makeRestartActivityTask(componentName);
+        context.startActivity(mainIntent);
+        Runtime.getRuntime().exit(0);
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/jobs/ContactAddressBookWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/ContactAddressBookWorker.kt
@@ -23,6 +23,7 @@ package com.nextcloud.talk.jobs
 import android.Manifest
 import android.accounts.Account
 import android.accounts.AccountManager
+import android.app.Activity
 import android.content.ContentProviderOperation
 import android.content.Context
 import android.content.OperationApplicationException
@@ -39,7 +40,6 @@ import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import autodagger.AutoInjector
-import com.bluelinelabs.conductor.Controller
 import com.google.gson.Gson
 import com.nextcloud.talk.BuildConfig
 import com.nextcloud.talk.R
@@ -470,7 +470,7 @@ class ContactAddressBookWorker(val context: Context, workerParameters: WorkerPar
             }
         }
 
-        fun checkPermission(controller: Controller, context: Context): Boolean {
+        fun checkPermission(activity: Activity, context: Context): Boolean {
             if (ContextCompat.checkSelfPermission(
                     context,
                     Manifest.permission.WRITE_CONTACTS
@@ -480,7 +480,7 @@ class ContactAddressBookWorker(val context: Context, workerParameters: WorkerPar
                         Manifest.permission.READ_CONTACTS
                     ) != PackageManager.PERMISSION_GRANTED
             ) {
-                controller.requestPermissions(
+                activity.requestPermissions(
                     arrayOf(
                         Manifest.permission.WRITE_CONTACTS,
                         Manifest.permission.READ_CONTACTS

--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -203,16 +203,6 @@ class SettingsActivity : BaseActivity() {
         if (currentUser != null) {
             binding.baseUrlText.text = Uri.parse(currentUser!!.baseUrl).host
             setupServerAgeWarning()
-
-            // TODO: fix reauthorize
-            // binding.settingsReauthorize?.addPreferenceClickListener {
-            //     router.pushController(
-            //         RouterTransaction.with(WebViewLoginController(currentUser!!.baseUrl, true))
-            //             .pushChangeHandler(VerticalChangeHandler())
-            //             .popChangeHandler(VerticalChangeHandler())
-            //     )
-            // }
-
             if (currentUser!!.displayName != null) {
                 binding.displayNameText.text = currentUser!!.displayName
             }
@@ -268,9 +258,9 @@ class SettingsActivity : BaseActivity() {
 
     private fun setupPhoneBookIntegration() {
         if (CapabilitiesUtilNew.isPhoneBookIntegrationAvailable(currentUser!!)) {
-            binding.settingsPhoneBookIntegration?.visibility = View.VISIBLE
+            binding.settingsPhoneBookIntegration.visibility = View.VISIBLE
         } else {
-            binding.settingsPhoneBookIntegration?.visibility = View.GONE
+            binding.settingsPhoneBookIntegration.visibility = View.GONE
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -217,8 +217,8 @@ class SettingsActivity : BaseActivity() {
         setupMessageView()
 
         binding.avatarContainer.setOnClickListener {
-            val intent = Intent(activity, ProfileActivity::class.java)
-            activity!!.startActivity(intent)
+            val intent = Intent(this, ProfileActivity::class.java)
+            startActivity(intent)
         }
 
         themeCategories()

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -31,6 +31,23 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/settings_appbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/settings_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="@color/appbar"
+            android:theme="?attr/actionBarPopupTheme"
+            app:layout_scrollFlags="scroll|enterAlways"
+            app:navigationIconTint="@color/fontAppbar"
+            app:popupTheme="@style/appActionBarPopupMenu"
+            app:titleTextColor="@color/fontAppbar"
+            tools:title="@string/nc_app_product_name" />
+    </com.google.android.material.appbar.AppBarLayout>
+
     <com.yarolegovich.mp.MaterialPreferenceCategory
         android:id="@+id/message_view"
         android:layout_width="match_parent"
@@ -258,11 +275,12 @@
         apc:cardElevation="0dp"
         apc:mpc_title="@string/nc_settings_advanced_title">
 
-        <com.yarolegovich.mp.MaterialStandardPreference
-            android:id="@+id/settings_reauthorize"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            apc:mp_title="@string/nc_settings_reauthorize" />
+        <!-- TODO: fix reauthorize -->
+<!--        <com.yarolegovich.mp.MaterialStandardPreference-->
+<!--            android:id="@+id/settings_reauthorize"-->
+<!--            android:layout_width="match_parent"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            apc:mp_title="@string/nc_settings_reauthorize" />-->
 
         <com.yarolegovich.mp.MaterialStandardPreference
             android:id="@+id/settings_client_cert"

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -275,13 +275,6 @@
         apc:cardElevation="0dp"
         apc:mpc_title="@string/nc_settings_advanced_title">
 
-        <!-- TODO: fix reauthorize -->
-<!--        <com.yarolegovich.mp.MaterialStandardPreference-->
-<!--            android:id="@+id/settings_reauthorize"-->
-<!--            android:layout_width="match_parent"-->
-<!--            android:layout_height="wrap_content"-->
-<!--            apc:mp_title="@string/nc_settings_reauthorize" />-->
-
         <com.yarolegovich.mp.MaterialStandardPreference
             android:id="@+id/settings_client_cert"
             android:layout_width="match_parent"


### PR DESCRIPTION
this PR replaces controllers with Activities, see https://github.com/nextcloud/talk-android/issues/1551

TODO or for follow up PR's:
- For now RingtoneSelectionController is not used (only important for Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
- Reauthorize account is **temporarily** removed
- better solutions for account removal?


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)