### PR TITLE
Group mentions

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/items/MentionAutocompleteItem.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/MentionAutocompleteItem.java
@@ -58,6 +58,8 @@ public class MentionAutocompleteItem extends AbstractFlexibleItem<ParticipantIte
     public static final String SOURCE_CALLS = "calls";
     public static final String SOURCE_GUESTS = "guests";
 
+    public static final String SOURCE_GROUPS = "groups";
+
     private String source;
     private final String objectId;
     private final String displayName;
@@ -153,7 +155,7 @@ public class MentionAutocompleteItem extends AbstractFlexibleItem<ParticipantIte
             holder.binding.secondaryText.setText("@" + objectId);
         }
 
-        if (SOURCE_CALLS.equals(source)) {
+        if (SOURCE_CALLS.equals(source) || SOURCE_GROUPS.equals(source)) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 ImageViewExtensionsKt.loadAvatar(
                     holder.binding.avatarView,

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingTextMessageViewHolder.kt
@@ -226,7 +226,7 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) : MessageHolde
             val individualHashMap = message.messageParameters!![key]
             if (individualHashMap != null) {
                 when (individualHashMap["type"]) {
-                    "user", "guest", "call" -> {
+                    "user", "guest", "call", "user-group" -> {
                         val chip = if (individualHashMap["id"] == message.activeUser!!.userId) {
                             R.xml.chip_you
                         } else {

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
@@ -190,7 +190,7 @@ class OutcomingTextMessageViewHolder(itemView: View) : OutcomingTextMessageViewH
             val individualHashMap: HashMap<String?, String?>? = message.messageParameters!![key]
             if (individualHashMap != null) {
                 when (individualHashMap["type"]) {
-                    "user", "guest", "call" -> {
+                    "user", "guest", "call", "user-group" -> {
                         val chip = if (individualHashMap["id"] == message.activeUser!!.userId) {
                             R.xml.chip_you
                         } else {

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -2188,7 +2188,10 @@ class ChatActivity :
             for (i in mentionSpans.indices) {
                 mentionSpan = mentionSpans[i]
                 var mentionId = mentionSpan.id
-                if (mentionId.contains(" ") || mentionId.startsWith("guest/")) {
+                if (mentionId.contains(" ") ||
+                    mentionId.startsWith("guest/") ||
+                    mentionId.startsWith("group/")
+                ) {
                     mentionId = "\"" + mentionId + "\""
                 }
                 editable.replace(editable.getSpanStart(mentionSpan), editable.getSpanEnd(mentionSpan), "@$mentionId")

--- a/app/src/main/java/com/nextcloud/talk/utils/DisplayUtils.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/DisplayUtils.java
@@ -182,9 +182,10 @@ public class DisplayUtils {
 
         int drawable;
 
-        boolean isCall = "call".equals(type) || "calls".equals(type);
+        boolean isCallOrGroup =
+            "call".equals(type) || "calls".equals(type) || "groups".equals(type) || "user-group".equals(type);
 
-        if (!isCall) {
+        if (!isCallOrGroup) {
             if (chipResource == R.xml.chip_you) {
                 drawable = R.drawable.mention_chip;
             } else {
@@ -198,7 +199,7 @@ public class DisplayUtils {
 
         chip.setBounds(0, 0, chip.getIntrinsicWidth(), chip.getIntrinsicHeight());
 
-        if (!isCall) {
+        if (!isCallOrGroup) {
             String url = ApiUtils.getUrlForAvatar(conversationUser.getBaseUrl(), id, true);
             if ("guests".equals(type) || "guest".equals(type)) {
                 url = ApiUtils.getUrlForGuestAvatar(


### PR DESCRIPTION
* Server issue: https://github.com/nextcloud/spreed/issues/6339
* Server PR: https://github.com/nextcloud/spreed/pull/6340

Resolves #2860 

### 🖼️ Screenshots

Suggestion items | Mention chip in edit field | Mention chip in outgoing message
---|---|---
![Screenshot_20230418_120821](https://user-images.githubusercontent.com/1315170/232745340-173485b9-6842-42ba-815e-b5c3afe9ff3a.png) | ![Screenshot_20230418_125914](https://user-images.githubusercontent.com/1315170/232757370-898724c6-4ff1-47bb-8d90-d9f2faa9be2a.png) | ![Screenshot_20230418_153650](https://user-images.githubusercontent.com/1315170/232794848-4a05c785-f8ae-4683-8d44-348f65ff4dcf.png)

### 🚧 TODO

Some details:
- [x] Similar to guests group mentions work with double quotes and specifying the type: `@"group/admin"`
- [x] Suggestions for groups should be shown when autocompleting
  * They are returned on the mentions endpoint, identify by `source=groups` and should be shown with label and group icon in the dropdown list
- [x] Group mentions should be rendered in the chat afterwards
  * They are like normal user and `@all` mentions just rich object parameters, this time with type `user-group`. We display them like all other mentions as a chip with a group icon as "avatar" (2 persons)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)