### PR TITLE
Fix to open conversation list when navigating back 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -222,6 +222,7 @@
             android:name=".chat.ChatActivity"
             android:theme="@style/AppTheme"
             android:launchMode="singleInstance"
+            android:noHistory="true"
             android:screenOrientation="portrait" />
 
         <activity

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -579,6 +579,12 @@ class ChatActivity :
         viewThemeUtils.material.themeToolbar(binding.chatToolbar)
     }
 
+    override fun onBackPressed() {
+        val intent = Intent(this, ConversationsListActivity::class.java)
+        intent.putExtras(Bundle())
+        startActivity(intent)
+    }
+
     private fun initAdapter() {
         val senderId = if (!conversationUser!!.userId.equals("?")) {
             "users/" + conversationUser!!.userId


### PR DESCRIPTION
Fix to open conversation list when navigating back after chat was opened by notification

fix #2959 which was when working on https://github.com/nextcloud/talk-android/issues/1551


created https://github.com/nextcloud/talk-android/issues/2961 to migrate away from onBackPressed


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)