### PR TITLE
Handle new capabilities json structure

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/data/user/model/User.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/user/model/User.kt
@@ -44,7 +44,7 @@ data class User(
 ) : Parcelable {
 
     fun getMaxMessageLength(): Int {
-        return capabilities?.spreedCapability?.config?.get("chat")?.get("max-length")?.toInt()
+        return (capabilities?.spreedCapability?.config?.get("chat")?.get("max-length") as? String)?.toInt()
             ?: DEFAULT_CHAT_MESSAGE_LENGTH
     }
 
@@ -53,7 +53,7 @@ data class User(
     }
 
     fun canUserCreateGroupConversations(): Boolean {
-        val canCreateValue = capabilities?.spreedCapability?.config?.get("conversations")?.get("can-create")
+        val canCreateValue = capabilities?.spreedCapability?.config?.get("conversations")?.get("can-create") as? String
         canCreateValue?.let {
             return it.toBoolean()
         }

--- a/app/src/main/java/com/nextcloud/talk/models/json/capabilities/SpreedCapability.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/capabilities/SpreedCapability.kt
@@ -24,7 +24,10 @@ package com.nextcloud.talk.models.json.capabilities
 import android.os.Parcelable
 import com.bluelinelabs.logansquare.annotation.JsonField
 import com.bluelinelabs.logansquare.annotation.JsonObject
+
 import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.RawValue
+import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
 
 @Parcelize
@@ -34,7 +37,8 @@ data class SpreedCapability(
     @JsonField(name = ["features"])
     var features: List<String>?,
     @JsonField(name = ["config"])
-    var config: HashMap<String, HashMap<String, String>>?
+    var config: HashMap<String, HashMap<String, @RawValue @Contextual
+            Any>>?
 ) : Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
     constructor() : this(null, null)

--- a/app/src/main/java/com/nextcloud/talk/utils/database/user/CapabilitiesUtilNew.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/database/user/CapabilitiesUtilNew.kt
@@ -67,8 +67,8 @@ object CapabilitiesUtilNew {
         if (user?.capabilities?.spreedCapability?.config?.containsKey("chat") == true) {
             val chatConfigHashMap = user.capabilities!!.spreedCapability!!.config!!["chat"]
             if (chatConfigHashMap?.containsKey("max-length") == true) {
-                val chatSize = chatConfigHashMap["max-length"]!!.toInt()
-                return if (chatSize > 0) {
+                val chatSize = (chatConfigHashMap["max-length"]!! as? String)?.toInt()
+                return if (chatSize != null && chatSize > 0) {
                     chatSize
                 } else {
                     DEFAULT_CHAT_SIZE
@@ -85,7 +85,7 @@ object CapabilitiesUtilNew {
 
     fun isReadStatusAvailable(user: User): Boolean {
         if (user.capabilities?.spreedCapability?.config?.containsKey("chat") == true) {
-            val map: Map<String, String>? = user.capabilities!!.spreedCapability!!.config!!["chat"]
+            val map: Map<String, Any>? = user.capabilities!!.spreedCapability!!.config!!["chat"]
             return map != null && map.containsKey("read-privacy")
         }
         return false
@@ -95,7 +95,7 @@ object CapabilitiesUtilNew {
         if (user.capabilities?.spreedCapability?.config?.containsKey("chat") == true) {
             val map = user.capabilities!!.spreedCapability!!.config!!["chat"]
             if (map?.containsKey("read-privacy") == true) {
-                return map["read-privacy"]!!.toInt() == 1
+                return (map["read-privacy"]!! as? String)?.toInt() == 1
             }
         }
 
@@ -107,9 +107,9 @@ object CapabilitiesUtilNew {
         if (hasSpreedFeatureCapability(user, "recording-v1") &&
             user.capabilities?.spreedCapability?.config?.containsKey("call") == true
         ) {
-            val map: Map<String, String>? = user.capabilities!!.spreedCapability!!.config!!["call"]
+            val map: Map<String, Any>? = user.capabilities!!.spreedCapability!!.config!!["call"]
             if (map != null && map.containsKey("recording")) {
-                return map["recording"].toBoolean()
+                return (map["recording"] as? String).toBoolean()
             }
         }
         return false
@@ -126,7 +126,7 @@ object CapabilitiesUtilNew {
         if (user.capabilities?.spreedCapability?.config?.containsKey("attachments") == true) {
             val map = user.capabilities!!.spreedCapability!!.config!!["attachments"]
             if (map?.containsKey("folder") == true) {
-                return map["folder"]
+                return map["folder"] as? String
             }
         }
         return "/Talk"
@@ -157,7 +157,7 @@ object CapabilitiesUtilNew {
                 capabilities.spreedCapability!!.config!!["call"] != null &&
                 capabilities.spreedCapability!!.config!!["call"]!!.containsKey("enabled")
             ) {
-                java.lang.Boolean.parseBoolean(capabilities.spreedCapability!!.config!!["call"]!!["enabled"])
+                java.lang.Boolean.parseBoolean(capabilities.spreedCapability!!.config!!["call"]!!["enabled"] as? String)
             } else {
                 // older nextcloud versions without the capability can't disable the calls
                 true


### PR DESCRIPTION
fix #2962

Because of "supported-reactions" and "predefined-backgrounds" the capabilities cannot be parsed with 
`var config: HashMap<String, HashMap<String, String>>?`

This is now
`var config: HashMap<String, HashMap<String, @RawValue @Contextual Any>>?` while always checking for the type when accessing the values.

```
"config": {
                        "attachments": {
                            "allowed": true,
                            "folder": "/Talk"
                        },
                        "call": {
                            "enabled": true,
                            "breakout-rooms": true,
                            "recording": true,
                            "supported-reactions": [
                                "❤️",
                                "🎉",
                                "👏",
                                "👍",
                                "👎",
                                "😂",
                                "🤩",
                                "🤔",
                                "😲",
                                "😥"
                            ],
                            "predefined-backgrounds": [
                                "1.jpg",
                                "2.jpg",
                                "3.jpg",
                                "4.jpg",
                                "5.jpg",
                                "6.jpg"
                            ],
                            "can-upload-background": true
                        },
                        "chat": {
```

"supported-reactions" and "predefined-backgrounds" are not handled yet.


Signed-off-by: Marcel Hibbe <dev@mhibbe.de>


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)