### PR TITLE
Fix call feature parsing

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/data/user/model/User.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/user/model/User.kt
@@ -43,30 +43,9 @@ data class User(
     var scheduledForDeletion: Boolean = FALSE
 ) : Parcelable {
 
-    fun getMaxMessageLength(): Int {
-        return (capabilities?.spreedCapability?.config?.get("chat")?.get("max-length") as? String)?.toInt()
-            ?: DEFAULT_CHAT_MESSAGE_LENGTH
-    }
-
-    fun getAttachmentsConfig(key: String): Any? {
-        return capabilities?.spreedCapability?.config?.get("attachments")?.get(key)
-    }
-
-    fun canUserCreateGroupConversations(): Boolean {
-        val canCreateValue = capabilities?.spreedCapability?.config?.get("conversations")?.get("can-create") as? String
-        canCreateValue?.let {
-            return it.toBoolean()
-        }
-        return true
-    }
-
     fun getCredentials(): String = ApiUtils.getCredentials(username, token)
 
     fun hasSpreedFeatureCapability(capabilityName: String): Boolean {
         return capabilities?.spreedCapability?.features?.contains(capabilityName) ?: false
-    }
-
-    companion object {
-        const val DEFAULT_CHAT_MESSAGE_LENGTH: Int = 1000
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/utils/database/user/CapabilitiesUtilNew.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/database/user/CapabilitiesUtilNew.kt
@@ -157,7 +157,7 @@ object CapabilitiesUtilNew {
                 capabilities.spreedCapability!!.config!!["call"] != null &&
                 capabilities.spreedCapability!!.config!!["call"]!!.containsKey("enabled")
             ) {
-                java.lang.Boolean.parseBoolean(capabilities.spreedCapability!!.config!!["call"]!!["enabled"] as? String)
+                java.lang.Boolean.parseBoolean(capabilities.spreedCapability!!.config!!["call"]!!["enabled"].toString())
             } else {
                 // older nextcloud versions without the capability can't disable the calls
                 true

--- a/app/src/main/java/com/nextcloud/talk/utils/database/user/CapabilitiesUtilNew.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/database/user/CapabilitiesUtilNew.kt
@@ -67,8 +67,8 @@ object CapabilitiesUtilNew {
         if (user?.capabilities?.spreedCapability?.config?.containsKey("chat") == true) {
             val chatConfigHashMap = user.capabilities!!.spreedCapability!!.config!!["chat"]
             if (chatConfigHashMap?.containsKey("max-length") == true) {
-                val chatSize = (chatConfigHashMap["max-length"]!! as? String)?.toInt()
-                return if (chatSize != null && chatSize > 0) {
+                val chatSize = (chatConfigHashMap["max-length"]!!.toString()).toInt()
+                return if (chatSize > 0) {
                     chatSize
                 } else {
                     DEFAULT_CHAT_SIZE
@@ -95,7 +95,7 @@ object CapabilitiesUtilNew {
         if (user.capabilities?.spreedCapability?.config?.containsKey("chat") == true) {
             val map = user.capabilities!!.spreedCapability!!.config!!["chat"]
             if (map?.containsKey("read-privacy") == true) {
-                return (map["read-privacy"]!! as? String)?.toInt() == 1
+                return (map["read-privacy"]!!.toString()).toInt() == 1
             }
         }
 
@@ -109,7 +109,7 @@ object CapabilitiesUtilNew {
         ) {
             val map: Map<String, Any>? = user.capabilities!!.spreedCapability!!.config!!["call"]
             if (map != null && map.containsKey("recording")) {
-                return (map["recording"] as? String).toBoolean()
+                return (map["recording"].toString()).toBoolean()
             }
         }
         return false
@@ -126,7 +126,7 @@ object CapabilitiesUtilNew {
         if (user.capabilities?.spreedCapability?.config?.containsKey("attachments") == true) {
             val map = user.capabilities!!.spreedCapability!!.config!!["attachments"]
             if (map?.containsKey("folder") == true) {
-                return map["folder"] as? String
+                return map["folder"].toString()
             }
         }
         return "/Talk"


### PR DESCRIPTION
~~Parse value as String which should work for old values (Strings) and new Values (Boolean)~~

This PR fixes bugs that were introduced with https://github.com/nextcloud/talk-android/pull/2963/files
Basically replacing `as? String` (which would result in null) with `toString()` 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)