### PR TITLE
Handle received signaling messages for call reactions

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -2861,6 +2861,10 @@ public class CallActivity extends CallBaseActivity {
                 addParticipantDisplayItem(callParticipantModel, "screen");
             }
         }
+
+        @Override
+        public void onReaction(String reaction) {
+        }
     }
 
     private class InternalSignalingMessageSender implements SignalingMessageSender {

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -2806,6 +2806,10 @@ public class CallActivity extends CallBaseActivity {
         }
 
         @Override
+        public void onReaction(String reaction) {
+        }
+
+        @Override
         public void onUnshareScreen() {
             endPeerConnection(sessionId, "screen");
         }

--- a/app/src/main/java/com/nextcloud/talk/adapters/ParticipantDisplayItem.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/ParticipantDisplayItem.java
@@ -34,7 +34,16 @@ public class ParticipantDisplayItem {
 
     private final CallParticipantModel callParticipantModel;
 
-    private final CallParticipantModel.Observer callParticipantModelObserver = this::updateFromModel;
+    private final CallParticipantModel.Observer callParticipantModelObserver = new CallParticipantModel.Observer() {
+        @Override
+        public void onChange() {
+            updateFromModel();
+        }
+
+        @Override
+        public void onReaction(String reaction) {
+        }
+    };
 
     private String userId;
     private PeerConnection.IceConnectionState iceConnectionState;

--- a/app/src/main/java/com/nextcloud/talk/call/CallParticipant.java
+++ b/app/src/main/java/com/nextcloud/talk/call/CallParticipant.java
@@ -42,6 +42,7 @@ public class CallParticipant {
 
         @Override
         public void onReaction(String reaction) {
+            callParticipantModel.emitReaction(reaction);
         }
 
         @Override

--- a/app/src/main/java/com/nextcloud/talk/call/CallParticipant.java
+++ b/app/src/main/java/com/nextcloud/talk/call/CallParticipant.java
@@ -41,6 +41,10 @@ public class CallParticipant {
         }
 
         @Override
+        public void onReaction(String reaction) {
+        }
+
+        @Override
         public void onUnshareScreen() {
         }
     };

--- a/app/src/main/java/com/nextcloud/talk/call/CallParticipantModel.java
+++ b/app/src/main/java/com/nextcloud/talk/call/CallParticipantModel.java
@@ -42,11 +42,15 @@ import java.util.Objects;
  * Getters called after receiving a notification are guaranteed to provide at least the value that triggered the
  * notification, but it may return even a more up to date one (so getting the value again on the following
  * notification may return the same value as before).
+ *
+ * Besides onChange(), which notifies about changes in the model values, CallParticipantModel.Observer provides
+ * additional methods to be notified about one-time events that are not reflected in the model values, like reactions.
  */
 public class CallParticipantModel {
 
     public interface Observer {
         void onChange();
+        void onReaction(String reaction);
     }
 
     protected class Data<T> {
@@ -68,7 +72,7 @@ public class CallParticipantModel {
         }
     }
 
-    private final CallParticipantModelNotifier callParticipantModelNotifier = new CallParticipantModelNotifier();
+    protected final CallParticipantModelNotifier callParticipantModelNotifier = new CallParticipantModelNotifier();
 
     protected final String sessionId;
 

--- a/app/src/main/java/com/nextcloud/talk/call/CallParticipantModelNotifier.java
+++ b/app/src/main/java/com/nextcloud/talk/call/CallParticipantModelNotifier.java
@@ -83,4 +83,16 @@ class CallParticipantModelNotifier {
             }
         }
     }
+
+    public synchronized void notifyReaction(String reaction) {
+        for (CallParticipantModelObserverOn observerOn : new ArrayList<>(callParticipantModelObserversOn)) {
+            if (observerOn.handler == null || observerOn.handler.getLooper() == Looper.myLooper()) {
+                observerOn.observer.onReaction(reaction);
+            } else {
+                observerOn.handler.post(() -> {
+                    observerOn.observer.onReaction(reaction);
+                });
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/nextcloud/talk/call/MutableCallParticipantModel.java
+++ b/app/src/main/java/com/nextcloud/talk/call/MutableCallParticipantModel.java
@@ -72,4 +72,8 @@ public class MutableCallParticipantModel extends CallParticipantModel {
     public void setScreenMediaStream(MediaStream screenMediaStream) {
         this.screenMediaStream.setValue(screenMediaStream);
     }
+
+    public void emitReaction(String reaction) {
+        this.callParticipantModelNotifier.notifyReaction(reaction);
+    }
 }

--- a/app/src/main/java/com/nextcloud/talk/models/json/signaling/NCMessagePayload.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/signaling/NCMessagePayload.kt
@@ -42,8 +42,10 @@ data class NCMessagePayload(
     @JsonField(name = ["state"])
     var state: Boolean? = null,
     @JsonField(name = ["timestamp"])
-    var timestamp: Long? = null
+    var timestamp: Long? = null,
+    @JsonField(name = ["reaction"])
+    var reaction: String? = null
 ) : Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
-    constructor() : this(null, null, null, null, null, null, null)
+    constructor() : this(null, null, null, null, null, null, null, null)
 }

--- a/app/src/main/java/com/nextcloud/talk/signaling/CallParticipantMessageNotifier.java
+++ b/app/src/main/java/com/nextcloud/talk/signaling/CallParticipantMessageNotifier.java
@@ -93,6 +93,12 @@ class CallParticipantMessageNotifier {
         }
     }
 
+    public void notifyReaction(String sessionId, String reaction) {
+        for (SignalingMessageReceiver.CallParticipantMessageListener listener : getListenersFor(sessionId)) {
+            listener.onReaction(reaction);
+        }
+    }
+
     public synchronized void notifyUnshareScreen(String sessionId) {
         for (SignalingMessageReceiver.CallParticipantMessageListener listener : getListenersFor(sessionId)) {
             listener.onUnshareScreen();

--- a/app/src/main/java/com/nextcloud/talk/signaling/SignalingMessageReceiver.java
+++ b/app/src/main/java/com/nextcloud/talk/signaling/SignalingMessageReceiver.java
@@ -149,6 +149,7 @@ public abstract class SignalingMessageReceiver {
      */
     public interface CallParticipantMessageListener {
         void onRaiseHand(boolean state, long timestamp);
+        void onReaction(String reaction);
         void onUnshareScreen();
     }
 
@@ -558,6 +559,57 @@ public abstract class SignalingMessageReceiver {
             }
 
             callParticipantMessageNotifier.notifyRaiseHand(sessionId, state, timestamp);
+
+            return;
+        }
+
+        if ("reaction".equals(type)) {
+            // Message schema (external signaling server):
+            // {
+            //     "type": "message",
+            //     "message": {
+            //         "sender": {
+            //             ...
+            //         },
+            //         "data": {
+            //             "to": #STRING#,
+            //             "roomType": "video",
+            //             "type": "reaction",
+            //             "payload": {
+            //                 "reaction": #STRING#,
+            //             },
+            //             "from": #STRING#,
+            //         },
+            //     },
+            // }
+            //
+            // Message schema (internal signaling server):
+            // {
+            //     "type": "message",
+            //     "data": {
+            //         "to": #STRING#,
+            //         "roomType": "video",
+            //         "type": "reaction",
+            //         "payload": {
+            //             "reaction": #STRING#,
+            //         },
+            //         "from": #STRING#,
+            //     },
+            // }
+
+            NCMessagePayload payload = signalingMessage.getPayload();
+            if (payload == null) {
+                // Broken message, this should not happen.
+                return;
+            }
+
+            String reaction = payload.getReaction();
+            if (reaction == null) {
+                // Broken message, this should not happen.
+                return;
+            }
+
+            callParticipantMessageNotifier.notifyReaction(sessionId, reaction);
 
             return;
         }

--- a/app/src/test/java/com/nextcloud/talk/call/CallParticipantModelTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/call/CallParticipantModelTest.kt
@@ -55,4 +55,11 @@ class CallParticipantModelTest {
         callParticipantModel!!.setRaisedHand(true, 4815162342L)
         Mockito.verify(mockedCallParticipantModelObserver, Mockito.only())?.onChange()
     }
+
+    @Test
+    fun testEmitReaction() {
+        callParticipantModel!!.addObserver(mockedCallParticipantModelObserver)
+        callParticipantModel!!.emitReaction("theReaction")
+        Mockito.verify(mockedCallParticipantModelObserver, Mockito.only())?.onReaction("theReaction")
+    }
 }

--- a/app/src/test/java/com/nextcloud/talk/signaling/SignalingMessageReceiverCallParticipantTest.java
+++ b/app/src/test/java/com/nextcloud/talk/signaling/SignalingMessageReceiverCallParticipantTest.java
@@ -85,6 +85,26 @@ public class SignalingMessageReceiverCallParticipantTest {
     }
 
     @Test
+    public void testCallParticipantMessageReaction() {
+        SignalingMessageReceiver.CallParticipantMessageListener mockedCallParticipantMessageListener =
+            mock(SignalingMessageReceiver.CallParticipantMessageListener.class);
+
+        signalingMessageReceiver.addListener(mockedCallParticipantMessageListener, "theSessionId");
+
+        NCSignalingMessage signalingMessage = new NCSignalingMessage();
+        signalingMessage.setFrom("theSessionId");
+        signalingMessage.setType("reaction");
+        signalingMessage.setRoomType("theRoomType");
+        NCMessagePayload messagePayload = new NCMessagePayload();
+        messagePayload.setType("reaction");
+        messagePayload.setReaction("theReaction");
+        signalingMessage.setPayload(messagePayload);
+        signalingMessageReceiver.processSignalingMessage(signalingMessage);
+
+        verify(mockedCallParticipantMessageListener, only()).onReaction("theReaction");
+    }
+
+    @Test
     public void testCallParticipantMessageUnshareScreen() {
         SignalingMessageReceiver.CallParticipantMessageListener mockedCallParticipantMessageListener =
             mock(SignalingMessageReceiver.CallParticipantMessageListener.class);


### PR DESCRIPTION
Besides the handling of received signaling messages for call reactions this pull request changes how the toast for raised hands is created. Although listening from the signaling was working fine and the new way unfortunately adds a "lot" of extra code it is conceptually "more correct", as the UI should not directly deal with the signaling if there is a higher abstraction available. Nevertheless, this change should ease adding support for other similar features, like displaying reactions.

### 🚧 TODO

- [X] Emit events in the CallParticipantModel to listen to them in #2984 - `reactionAnimator.addReaction(reaction, callParticipantModel.getNick()` should be called in [`CallParticipantEventDisplayer.onReaction()`](https://github.com/nextcloud/talk-android/pull/2995/files#diff-f6b412014fb6599f5c372bb7378899d7b0d72f3f9c74a9f888a6e38705c41121R2903 ) (but please note that I have not actually tested it :-) )
