### PR TITLE
Add copy to clipboard action for translations

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/translate/TranslateActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/translate/TranslateActivity.kt
@@ -21,6 +21,9 @@
  */
 package com.nextcloud.talk.translate
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.text.method.ScrollingMovementMethod
@@ -73,6 +76,7 @@ class TranslateActivity : BaseActivity() {
         setupSystemColors()
         setupTextViews()
         setupSpinners()
+        setupCopyButton()
         getLanguageOptions()
 
         if (savedInstanceState == null) {
@@ -94,6 +98,19 @@ class TranslateActivity : BaseActivity() {
         super.onSaveInstanceState(outState)
     }
 
+    private fun setupCopyButton() {
+        viewThemeUtils.material.colorMaterialButtonPrimaryFilled(binding.copyTranslatedMessage)
+        binding.copyTranslatedMessage.setOnClickListener {
+            val clipboardManager =
+                getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+            val clipData = ClipData.newPlainText(
+                resources?.getString(R.string.nc_app_product_name),
+                binding.translatedMessageTextview.text?.toString()
+            )
+            clipboardManager.setPrimaryClip(clipData)
+        }
+    }
+
     private fun setupActionBar() {
         setSupportActionBar(binding.translationToolbar)
         binding.translationToolbar.setNavigationOnClickListener {
@@ -107,14 +124,19 @@ class TranslateActivity : BaseActivity() {
     }
 
     private fun setupTextViews() {
-        val original = binding.originalMessageTextview
-        val translation = binding.translatedMessageTextview
+        viewThemeUtils.talk.themeIncomingMessageBubble(
+            binding.originalMessageTextview,
+            grouped = true,
+            deleted = false
+        )
+        viewThemeUtils.talk.themeIncomingMessageBubble(
+            binding.translatedMessageTextview,
+            grouped = true,
+            deleted = false
+        )
 
-        viewThemeUtils.talk.themeIncomingMessageBubble(original, grouped = true, deleted = false)
-        viewThemeUtils.talk.themeIncomingMessageBubble(translation, grouped = true, deleted = false)
-
-        original.movementMethod = ScrollingMovementMethod()
-        translation.movementMethod = ScrollingMovementMethod()
+        binding.originalMessageTextview.movementMethod = ScrollingMovementMethod()
+        binding.translatedMessageTextview.movementMethod = ScrollingMovementMethod()
 
         val bundle = intent.extras
         binding.originalMessageTextview.text = bundle?.getString(BundleKeys.KEY_TRANSLATE_MESSAGE)
@@ -163,13 +185,13 @@ class TranslateActivity : BaseActivity() {
             ?.subscribe(object : Observer<TranslationsOverall> {
                 override fun onSubscribe(d: Disposable) {
                     enableSpinners(false)
-                    binding.translatedMessageTextview.visibility = View.GONE
+                    binding.translatedMessageContainer.visibility = View.GONE
                     binding.progressBar.visibility = View.VISIBLE
                 }
 
                 override fun onNext(translationOverall: TranslationsOverall) {
                     binding.progressBar.visibility = View.GONE
-                    binding.translatedMessageTextview.visibility = View.VISIBLE
+                    binding.translatedMessageContainer.visibility = View.VISIBLE
                     binding.translatedMessageTextview.text = translationOverall.ocs?.data?.text
                 }
 

--- a/app/src/main/res/layout-land/activity_translate.xml
+++ b/app/src/main/res/layout-land/activity_translate.xml
@@ -3,7 +3,9 @@
   ~ Nextcloud Talk application
   ~
   ~ @author Julius Linus
+  ~ @author Andy Scherzinger
   ~ Copyright (C) 2023 Julius Linus <julius.linus@nextcloud.com>
+  ~ Copyright (C) 2023 Andy Scherzinger <info@andy-scherzinger.de>
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
@@ -99,44 +101,69 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:paddingBottom="@dimen/standard_padding">
+            android:orientation="vertical">
 
-            <TextView
-                android:id="@+id/original_message_textview"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/standard_margin"
-                android:layout_marginEnd="@dimen/standard_margin"
-                android:layout_weight="1"
-                android:background="@drawable/shape_grouped_incoming_message"
-                android:padding="@dimen/dialog_padding"
-                android:scrollbars="vertical"
-                android:text=""
-                android:textColor="@color/nc_incoming_text_default"
-                android:textSize="@dimen/message_text_size" />
+                android:orientation="horizontal"
+                android:paddingBottom="@dimen/standard_padding">
 
-            <TextView
-                android:id="@+id/translated_message_textview"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/standard_margin"
-                android:layout_marginEnd="@dimen/standard_margin"
-                android:layout_weight="1"
-                android:background="@drawable/shape_grouped_incoming_message"
-                android:padding="@dimen/dialog_padding"
-                android:scrollbars="vertical"
-                android:text=""
-                android:textColor="@color/nc_incoming_text_default"
-                android:textSize="@dimen/message_text_size"
-                android:visibility="visible" />
+                <TextView
+                    android:id="@+id/original_message_textview"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/standard_margin"
+                    android:layout_marginEnd="@dimen/standard_margin"
+                    android:layout_weight="1"
+                    android:background="@drawable/shape_grouped_incoming_message"
+                    android:padding="@dimen/dialog_padding"
+                    android:scrollbars="vertical"
+                    android:textColor="@color/nc_incoming_text_default"
+                    android:textSize="@dimen/message_text_size"
+                    tools:text="This is the last message\nof an incredibly long two line conversation text" />
+
+                <LinearLayout
+                    android:id="@+id/translated_message_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/standard_margin"
+                    android:layout_marginEnd="@dimen/standard_margin"
+                    android:layout_weight="1"
+                    android:orientation="vertical"
+                    android:visibility="visible">
+
+                    <TextView
+                        android:id="@+id/translated_message_textview"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@drawable/shape_grouped_incoming_message"
+                        android:padding="@dimen/dialog_padding"
+                        android:scrollbars="vertical"
+                        android:textColor="@color/nc_incoming_text_default"
+                        android:textSize="@dimen/message_text_size"
+                        tools:text="This is the last message\nof an incredibly long two line conversation text" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/copy_translated_message"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="end"
+                        android:layout_marginTop="@dimen/standard_half_margin"
+                        android:text="@string/translation_copy_translated_text"
+                        app:icon="@drawable/ic_content_copy" />
+
+                </LinearLayout>
+
+            </LinearLayout>
 
             <ProgressBar
                 android:id="@+id/progressBar"
                 style="?android:attr/progressBarStyle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:visibility="gone" />
+                android:visibility="gone"
+                tools:visibility="visible" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/activity_translate.xml
+++ b/app/src/main/res/layout/activity_translate.xml
@@ -3,7 +3,9 @@
   ~ Nextcloud Talk application
   ~
   ~ @author Julius Linus
+  ~ @author Andy Scherzinger
   ~ Copyright (C) 2023 Julius Linus <julius.linus@nextcloud.com>
+  ~ Copyright (C) 2023 Andy Scherzinger <info@andy-scherzinger.de>
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
@@ -110,36 +112,51 @@
                 android:layout_marginStart="@dimen/standard_margin"
                 android:layout_marginEnd="@dimen/standard_margin"
                 android:layout_marginBottom="@dimen/standard_margin"
-                android:layout_weight="1"
                 android:background="@drawable/shape_grouped_incoming_message"
                 android:padding="@dimen/dialog_padding"
                 android:scrollbars="vertical"
-                android:text=""
+                tools:text="This is the last message\nof an incredibly long two line conversation text"
                 android:textColor="@color/nc_incoming_text_default"
                 android:textSize="@dimen/message_text_size" />
 
-            <TextView
-                android:id="@+id/translated_message_textview"
+            <LinearLayout
+                android:id="@+id/translated_message_container"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/standard_margin"
                 android:layout_marginEnd="@dimen/standard_margin"
-                android:layout_marginBottom="@dimen/standard_margin"
-                android:layout_weight="1"
-                android:background="@drawable/shape_grouped_incoming_message"
-                android:padding="@dimen/dialog_padding"
-                android:scrollbars="vertical"
-                android:text=""
-                android:textColor="@color/nc_incoming_text_default"
-                android:textSize="@dimen/message_text_size"
-                android:visibility="visible" />
+                android:orientation="vertical"
+                android:visibility="visible">
+
+                <TextView
+                    android:id="@+id/translated_message_textview"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/standard_half_margin"
+                    android:background="@drawable/shape_grouped_incoming_message"
+                    android:padding="@dimen/dialog_padding"
+                    android:scrollbars="vertical"
+                    tools:text="This is the last message\nof an incredibly long two line conversation text"
+                    android:textColor="@color/nc_incoming_text_default"
+                    android:textSize="@dimen/message_text_size" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/copy_translated_message"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="end"
+                    android:text="@string/translation_copy_translated_text"
+                    app:icon="@drawable/ic_content_copy" />
+
+            </LinearLayout>
 
             <ProgressBar
                 android:id="@+id/progressBar"
                 style="?android:attr/progressBarStyle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:visibility="gone" />
+                android:visibility="gone"
+                tools:visibility="visible" />
 
         </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -664,5 +664,6 @@ How to translate with transifex:
     <string name="translation_device_settings">Device settings</string>
     <string name="translation_error_title">Translation failed</string>
     <string name="translation_error_message">Could not detect language</string>
+    <string name="translation_copy_translated_text">Copy translated text</string>
 
 </resources>


### PR DESCRIPTION
...and fix layout issues for landscape mode while loading

on sermo (messages are faked!):
portrait|landscape
---|---
![Screenshot_20230517_233520](https://github.com/nextcloud/talk-android/assets/1315170/c2a9e596-9d76-4995-bc59-a9b885591d98)|![Screenshot_20230517_233537](https://github.com/nextcloud/talk-android/assets/1315170/2af4b6b1-9da2-4272-9896-f758c5255100)

spinner positioning fixed (IDE layouting mode):
portrait|landscape
---|---
<img width="403" alt="2023-05-17 23_38_25-talk-android-issue_2931 – layout_activity_translate xml  talk-android-issue_2931" src="https://github.com/nextcloud/talk-android/assets/1315170/1d7a465b-d631-4f70-979b-1e5032c22357">|<img width="343" alt="2023-05-17 23_38_53-talk-android-issue_2931 – land_activity_translate xml" src="https://github.com/nextcloud/talk-android/assets/1315170/6596cb45-d00f-4288-bb7e-00f84a332749">

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)