### PR TITLE
avoid NPE for websocket (typing indicator only available with HPB)

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -323,7 +323,7 @@ class ChatActivity :
 
     private val conversationMessageListener = object : SignalingMessageReceiver.ConversationMessageListener {
         override fun onStartTyping(session: String) {
-            if (!CapabilitiesUtilNew.isTypingStatusPrivate(conversationUser!!)) {
+            if (isTypingStatusEnabled()) {
                 var name = webSocketInstance?.getDisplayNameForSession(session)
 
                 if (name != null && !typingParticipants.contains(session)) {
@@ -337,7 +337,7 @@ class ChatActivity :
         }
 
         override fun onStopTyping(session: String) {
-            if (!CapabilitiesUtilNew.isTypingStatusPrivate(conversationUser!!)) {
+            if (isTypingStatusEnabled()) {
                 typingParticipants.remove(session)
                 updateTypingIndicator()
             }
@@ -991,11 +991,7 @@ class ChatActivity :
     }
 
     fun sendStartTypingMessage() {
-        if (webSocketInstance == null) {
-            return
-        }
-
-        if (!CapabilitiesUtilNew.isTypingStatusPrivate(conversationUser!!)) {
+        if (isTypingStatusEnabled()) {
             if (typingTimer == null) {
                 for ((sessionId, participant) in webSocketInstance?.getUserMap()!!) {
                     val ncSignalingMessage = NCSignalingMessage()
@@ -1024,7 +1020,7 @@ class ChatActivity :
     }
 
     fun sendStopTypingMessage() {
-        if (!CapabilitiesUtilNew.isTypingStatusPrivate(conversationUser!!)) {
+        if (isTypingStatusEnabled()) {
             typingTimer = null
 
             for ((sessionId, participant) in webSocketInstance?.getUserMap()!!) {
@@ -1034,6 +1030,11 @@ class ChatActivity :
                 signalingMessageSender!!.send(ncSignalingMessage)
             }
         }
+    }
+
+    private fun isTypingStatusEnabled(): Boolean {
+        return webSocketInstance != null &&
+            !CapabilitiesUtilNew.isTypingStatusPrivate(conversationUser!!)
     }
 
     private fun getRoomInfo() {


### PR DESCRIPTION
### 🚧 TODO

- [ ] hide setting when no webSocket available

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)