### PR TITLE
Fixing activity transitions

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/BaseActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/BaseActivity.kt
@@ -80,8 +80,8 @@ open class BaseActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         NextcloudTalkApplication.sharedApplication!!.componentApplication.inject(this)
         window.requestFeature(Window.FEATURE_ACTIVITY_TRANSITIONS)
-        window.enterTransition = Slide(Gravity.RIGHT)
-        window.exitTransition = Slide(Gravity.LEFT)
+        window.enterTransition = Slide(Gravity.END)
+        window.exitTransition = Slide(Gravity.START)
         super.onCreate(savedInstanceState)
     }
 

--- a/app/src/main/java/com/nextcloud/talk/activities/BaseActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/BaseActivity.kt
@@ -25,8 +25,11 @@ package com.nextcloud.talk.activities
 import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Bundle
+import android.transition.Slide
 import android.util.Log
+import android.view.Gravity
 import android.view.View
+import android.view.Window
 import android.view.WindowManager
 import android.webkit.SslErrorHandler
 import androidx.appcompat.app.AlertDialog
@@ -76,6 +79,9 @@ open class BaseActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         NextcloudTalkApplication.sharedApplication!!.componentApplication.inject(this)
+        window.requestFeature(Window.FEATURE_ACTIVITY_TRANSITIONS)
+        window.enterTransition = Slide(Gravity.RIGHT)
+        window.exitTransition = Slide(Gravity.LEFT)
         super.onCreate(savedInstanceState)
     }
 

--- a/app/src/main/java/com/nextcloud/talk/activities/BaseActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/BaseActivity.kt
@@ -25,8 +25,11 @@ package com.nextcloud.talk.activities
 import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Bundle
+import android.transition.Slide
 import android.util.Log
+import android.view.Gravity
 import android.view.View
+import android.view.Window
 import android.view.WindowManager
 import android.webkit.SslErrorHandler
 import androidx.appcompat.app.AlertDialog
@@ -76,6 +79,11 @@ open class BaseActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         NextcloudTalkApplication.sharedApplication!!.componentApplication.inject(this)
+        with(window) {
+            requestFeature(Window.FEATURE_ACTIVITY_TRANSITIONS)
+            window.enterTransition = Slide(Gravity.LEFT)
+            window.exitTransition = Slide(Gravity.RIGHT)
+        }
         super.onCreate(savedInstanceState)
     }
 

--- a/app/src/main/java/com/nextcloud/talk/activities/BaseActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/BaseActivity.kt
@@ -80,8 +80,12 @@ open class BaseActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         NextcloudTalkApplication.sharedApplication!!.componentApplication.inject(this)
         window.requestFeature(Window.FEATURE_ACTIVITY_TRANSITIONS)
-        window.enterTransition = Slide(Gravity.END)
-        window.exitTransition = Slide(Gravity.START)
+        val startAnimation = Slide(Gravity.END)
+        startAnimation.duration = ANIMATION_DURATION
+        val endAnimation = Slide(Gravity.START)
+        endAnimation.duration = ANIMATION_DURATION
+        window.enterTransition = startAnimation
+        window.exitTransition = endAnimation
         super.onCreate(savedInstanceState)
     }
 
@@ -197,6 +201,7 @@ open class BaseActivity : AppCompatActivity() {
     }
 
     companion object {
-        private val TAG = "BaseActivity"
+        private const val TAG = "BaseActivity"
+        private const val ANIMATION_DURATION: Long = 50
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/activities/BaseActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/BaseActivity.kt
@@ -25,11 +25,8 @@ package com.nextcloud.talk.activities
 import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Bundle
-import android.transition.Slide
 import android.util.Log
-import android.view.Gravity
 import android.view.View
-import android.view.Window
 import android.view.WindowManager
 import android.webkit.SslErrorHandler
 import androidx.appcompat.app.AlertDialog
@@ -79,11 +76,6 @@ open class BaseActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         NextcloudTalkApplication.sharedApplication!!.componentApplication.inject(this)
-        with(window) {
-            requestFeature(Window.FEATURE_ACTIVITY_TRANSITIONS)
-            window.enterTransition = Slide(Gravity.LEFT)
-            window.exitTransition = Slide(Gravity.RIGHT)
-        }
         super.onCreate(savedInstanceState)
     }
 

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -28,6 +28,7 @@ import android.Manifest;
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.annotation.SuppressLint;
+import android.app.ActivityOptions;
 import android.app.PendingIntent;
 import android.app.RemoteAction;
 import android.content.BroadcastReceiver;
@@ -1973,7 +1974,8 @@ public class CallActivity extends CallBaseActivity {
                         bundle.putParcelable(KEY_USER_ENTITY, conversationUser);
                         bundle.putBoolean(KEY_CALL_VOICE_ONLY, isVoiceOnlyCall);
                         intent.putExtras(bundle);
-                        startActivity(intent);
+                        startActivity(intent,
+                                      ActivityOptions.makeSceneTransitionAnimation(CallActivity.this).toBundle());
                         finish();
                     } else if (shutDownView) {
                         finish();

--- a/app/src/main/java/com/nextcloud/talk/activities/CallNotificationActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallNotificationActivity.kt
@@ -22,6 +22,7 @@
 package com.nextcloud.talk.activities
 
 import android.annotation.SuppressLint
+import android.app.ActivityOptions
 import android.content.Intent
 import android.content.res.Configuration
 import android.os.Build
@@ -183,7 +184,7 @@ class CallNotificationActivity : CallBaseActivity() {
 
             val intent = Intent(this, CallActivity::class.java)
             intent.putExtras(originalBundle!!)
-            startActivity(intent)
+            startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
         } else {
             Log.w(TAG, "conversation was still null when clicked to answer call. User has to click another time.")
         }

--- a/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
@@ -25,6 +25,7 @@
  */
 package com.nextcloud.talk.activities
 
+import android.app.ActivityOptions
 import android.app.KeyguardManager
 import android.content.Context
 import android.content.Intent
@@ -208,7 +209,7 @@ class MainActivity : BaseActivity(), ActionBarProvider {
         val intent = Intent(this, ConversationsListActivity::class.java)
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
         intent.putExtras(Bundle())
-        startActivity(intent)
+        startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
     }
 
     fun addAccount() {

--- a/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
@@ -25,7 +25,6 @@
  */
 package com.nextcloud.talk.activities
 
-import android.app.ActivityOptions
 import android.app.KeyguardManager
 import android.content.Context
 import android.content.Intent
@@ -209,7 +208,7 @@ class MainActivity : BaseActivity(), ActionBarProvider {
         val intent = Intent(this, ConversationsListActivity::class.java)
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
         intent.putExtras(Bundle())
-        startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
+        startActivity(intent)
     }
 
     fun addAccount() {

--- a/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
@@ -208,7 +208,7 @@ class MainActivity : BaseActivity(), ActionBarProvider {
         val intent = Intent(this, ConversationsListActivity::class.java)
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
         intent.putExtras(Bundle())
-        startActivity(intent)
+        startActivity(intent) // no transition else it messes up loading ConversationListActivity
     }
 
     fun addAccount() {

--- a/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
@@ -25,6 +25,7 @@
  */
 package com.nextcloud.talk.activities
 
+import android.app.ActivityOptions
 import android.app.KeyguardManager
 import android.content.Context
 import android.content.Intent
@@ -156,7 +157,7 @@ class MainActivity : BaseActivity(), ActionBarProvider {
         if (keyguardManager.isKeyguardSecure && appPreferences.isScreenLocked) {
             if (!SecurityUtils.checkIfWeAreAuthenticated(appPreferences.screenLockTimeout)) {
                 val lockIntent = Intent(context, LockedActivity::class.java)
-                startActivity(lockIntent)
+                startActivity(lockIntent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
             }
         }
     }
@@ -221,7 +222,8 @@ class MainActivity : BaseActivity(), ActionBarProvider {
 
     private fun handleActionFromContact(intent: Intent) {
         if (intent.action == Intent.ACTION_VIEW && intent.data != null) {
-            val cursor = contentResolver.query(intent.data!!, null, null, null, null)
+            val cursor =
+                contentResolver.query(intent.data!!, null, null, null, null)
 
             var userId = ""
             if (cursor != null) {
@@ -310,7 +312,11 @@ class MainActivity : BaseActivity(), ActionBarProvider {
 
                                 val chatIntent = Intent(context, ChatActivity::class.java)
                                 chatIntent.putExtras(bundle)
-                                startActivity(chatIntent)
+                                startActivity(
+                                    chatIntent,
+                                    ActivityOptions.makeSceneTransitionAnimation(this@MainActivity)
+                                        .toBundle()
+                                )
                             }
 
                             override fun onError(e: Throwable) {
@@ -353,13 +359,13 @@ class MainActivity : BaseActivity(), ActionBarProvider {
                 }
                 val callNotificationIntent = Intent(this, CallNotificationActivity::class.java)
                 intent.extras?.let { callNotificationIntent.putExtras(it) }
-                startActivity(callNotificationIntent)
+                startActivity(callNotificationIntent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
             } else {
                 logRouterBackStack(router!!)
 
                 val chatIntent = Intent(context, ChatActivity::class.java)
                 chatIntent.putExtras(intent.extras!!)
-                startActivity(chatIntent)
+                startActivity(chatIntent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
 
                 logRouterBackStack(router!!)
             }

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -361,7 +361,7 @@ class ChatActivity :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         NextcloudTalkApplication.sharedApplication!!.componentApplication.inject(this)
-        window.exitTransition = Slide(Gravity.RIGHT) // weird but needed for consistent transitions
+        window.exitTransition = Slide(Gravity.END) // weird but needed for consistent transitions
         binding = ActivityChatBinding.inflate(layoutInflater)
         setupActionBar()
         setContentView(binding.root)

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -361,7 +361,7 @@ class ChatActivity :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         NextcloudTalkApplication.sharedApplication!!.componentApplication.inject(this)
-        window.exitTransition = Slide(Gravity.RIGHT)
+        window.exitTransition = Slide(Gravity.RIGHT) // weird but needed for consistent transitions
         binding = ActivityChatBinding.inflate(layoutInflater)
         setupActionBar()
         setContentView(binding.root)

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -1259,7 +1259,7 @@ class ChatActivity :
                 val chatIntent = Intent(context, ChatActivity::class.java)
                 chatIntent.putExtras(bundle)
                 chatIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                startActivity(chatIntent)
+                startActivity(chatIntent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
             }
         }
     }
@@ -3071,7 +3071,7 @@ class ChatActivity :
                     ApplicationWideCurrentRoomHolder.getInstance().isDialing = true
                     val callIntent = getIntentForCall(isVoiceOnlyCall, callWithoutNotification)
                     if (callIntent != null) {
-                        startActivity(callIntent)
+                        startActivity(callIntent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
                     }
                 }
             }
@@ -3333,7 +3333,11 @@ class ChatActivity :
                                     val chatIntent = Intent(context, ChatActivity::class.java)
                                     chatIntent.putExtras(bundle)
                                     chatIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                                    startActivity(chatIntent)
+                                    startActivity(
+                                        chatIntent,
+                                        ActivityOptions.makeSceneTransitionAnimation(this@ChatActivity)
+                                            .toBundle()
+                                    )
                                 }
                             }
 
@@ -3658,11 +3662,19 @@ class ChatActivity :
                                 val chatIntent = Intent(context, ChatActivity::class.java)
                                 chatIntent.putExtras(bundle)
                                 chatIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                                startActivity(chatIntent)
+                                startActivity(
+                                    chatIntent,
+                                    ActivityOptions.makeSceneTransitionAnimation(this@ChatActivity)
+                                        .toBundle()
+                                )
                             }
                         } else {
                             conversationIntent.putExtras(bundle)
-                            startActivity(conversationIntent)
+                            startActivity(
+                                conversationIntent,
+                                ActivityOptions.makeSceneTransitionAnimation(this@ChatActivity)
+                                    .toBundle()
+                            )
                             Handler().postDelayed(
                                 {
                                     if (!isDestroyed) {

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -30,6 +30,7 @@ package com.nextcloud.talk.chat
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.app.ActivityOptions
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
@@ -159,8 +160,8 @@ import com.nextcloud.talk.remotefilebrowser.activities.RemoteFileBrowserActivity
 import com.nextcloud.talk.repositories.reactions.ReactionsRepository
 import com.nextcloud.talk.shareditems.activities.SharedItemsActivity
 import com.nextcloud.talk.signaling.SignalingMessageReceiver
-import com.nextcloud.talk.translate.ui.TranslateActivity
 import com.nextcloud.talk.signaling.SignalingMessageSender
+import com.nextcloud.talk.translate.ui.TranslateActivity
 import com.nextcloud.talk.ui.bottom.sheet.ProfileBottomSheet
 import com.nextcloud.talk.ui.dialog.AttachmentDialog
 import com.nextcloud.talk.ui.dialog.MessageActionsDialog
@@ -313,8 +314,9 @@ class ChatActivity :
     private val onBackPressedCallback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
             val intent = Intent(this@ChatActivity, ConversationsListActivity::class.java)
+            val bundle = ActivityOptions.makeSceneTransitionAnimation(this@ChatActivity).toBundle()
             intent.putExtras(Bundle())
-            startActivity(intent)
+            startActivity(intent, bundle)
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -58,6 +58,7 @@ import android.text.InputFilter
 import android.text.SpannableStringBuilder
 import android.text.TextUtils
 import android.text.TextWatcher
+import android.transition.Slide
 import android.util.Log
 import android.util.TypedValue
 import android.view.Gravity
@@ -360,7 +361,7 @@ class ChatActivity :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         NextcloudTalkApplication.sharedApplication!!.componentApplication.inject(this)
-
+        window.exitTransition = Slide(Gravity.RIGHT)
         binding = ActivityChatBinding.inflate(layoutInflater)
         setupActionBar()
         setContentView(binding.root)
@@ -2079,7 +2080,7 @@ class ChatActivity :
 
         val intent = Intent(this, LocationPickerActivity::class.java)
         intent.putExtra(KEY_ROOM_TOKEN, roomToken)
-        startActivity(intent)
+        startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
     }
 
     private fun showConversationInfoScreen() {
@@ -2090,7 +2091,7 @@ class ChatActivity :
 
         val intent = Intent(this, ConversationInfoActivity::class.java)
         intent.putExtras(bundle)
-        startActivity(intent)
+        startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
     }
 
     private fun setupMentionAutocomplete() {
@@ -3000,7 +3001,7 @@ class ChatActivity :
             SharedItemsActivity.KEY_USER_IS_OWNER_OR_MODERATOR,
             currentConversation?.isParticipantOwnerOrModerator
         )
-        startActivity(intent)
+        startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
     }
 
     private fun startMessageSearch() {
@@ -3364,7 +3365,7 @@ class ChatActivity :
 
         val intent = Intent(this, ConversationsListActivity::class.java)
         intent.putExtras(bundle)
-        startActivity(intent)
+        startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
     }
 
     fun markAsUnread(message: IMessage?) {
@@ -3417,7 +3418,7 @@ class ChatActivity :
 
         val intent = Intent(this, TranslateActivity::class.java)
         intent.putExtras(bundle)
-        startActivity(intent)
+        startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
     }
 
     private fun hasVisibleItems(message: ChatMessage): Boolean {

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -314,9 +314,8 @@ class ChatActivity :
     private val onBackPressedCallback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
             val intent = Intent(this@ChatActivity, ConversationsListActivity::class.java)
-            val bundle = ActivityOptions.makeSceneTransitionAnimation(this@ChatActivity).toBundle()
             intent.putExtras(Bundle())
-            startActivity(intent, bundle)
+            startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this@ChatActivity).toBundle())
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -58,7 +58,6 @@ import android.text.InputFilter
 import android.text.SpannableStringBuilder
 import android.text.TextUtils
 import android.text.TextWatcher
-import android.transition.Slide
 import android.util.Log
 import android.util.TypedValue
 import android.view.Gravity
@@ -361,7 +360,6 @@ class ChatActivity :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         NextcloudTalkApplication.sharedApplication!!.componentApplication.inject(this)
-        window.exitTransition = Slide(Gravity.END) // weird but needed for consistent transitions
         binding = ActivityChatBinding.inflate(layoutInflater)
         setupActionBar()
         setContentView(binding.root)

--- a/app/src/main/java/com/nextcloud/talk/contacts/ContactsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/contacts/ContactsActivity.kt
@@ -23,6 +23,7 @@
  */
 package com.nextcloud.talk.contacts
 
+import android.app.ActivityOptions
 import android.app.SearchManager
 import android.content.Context
 import android.content.Intent
@@ -363,7 +364,11 @@ class ContactsActivity :
                                 val chatIntent = Intent(context, ChatActivity::class.java)
                                 chatIntent.putExtras(bundle)
                                 chatIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                                startActivity(chatIntent)
+                                startActivity(
+                                    chatIntent,
+                                    ActivityOptions.makeSceneTransitionAnimation(this@ContactsActivity)
+                                        .toBundle()
+                                )
                             }
 
                             override fun onError(e: Throwable) {
@@ -746,7 +751,7 @@ class ContactsActivity :
         val chatIntent = Intent(context, ChatActivity::class.java)
         chatIntent.putExtras(openConversationEvent.bundle!!)
         chatIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-        startActivity(chatIntent)
+        startActivity(chatIntent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
 
         contactsBottomDialog?.dismiss()
     }
@@ -822,7 +827,10 @@ class ContactsActivity :
                     val chatIntent = Intent(context, ChatActivity::class.java)
                     chatIntent.putExtras(bundle)
                     chatIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                    startActivity(chatIntent)
+                    startActivity(
+                        chatIntent,
+                        ActivityOptions.makeSceneTransitionAnimation(this@ContactsActivity).toBundle()
+                    )
                 }
 
                 override fun onError(e: Throwable) {

--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
@@ -29,6 +29,7 @@
 package com.nextcloud.talk.conversationinfo
 
 import android.annotation.SuppressLint
+import android.app.ActivityOptions
 import android.content.Intent
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
@@ -240,7 +241,7 @@ class ConversationInfoActivity :
 
             val intent = Intent(this, ConversationInfoEditActivity::class.java)
             intent.putExtras(bundle)
-            startActivity(intent)
+            startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
         }
         return true
     }
@@ -282,7 +283,7 @@ class ConversationInfoActivity :
         intent.putExtra(BundleKeys.KEY_ROOM_TOKEN, conversationToken)
         intent.putExtra(BundleKeys.KEY_USER_ENTITY, conversationUser as Parcelable)
         intent.putExtra(SharedItemsActivity.KEY_USER_IS_OWNER_OR_MODERATOR, conversation?.isParticipantOwnerOrModerator)
-        startActivity(intent)
+        startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
     }
 
     private fun setupWebinaryView() {
@@ -555,7 +556,7 @@ class ConversationInfoActivity :
 
         val intent = Intent(this, ContactsActivity::class.java)
         intent.putExtras(bundle)
-        startActivity(intent)
+        startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
     }
 
     private fun leaveConversation() {
@@ -569,7 +570,7 @@ class ConversationInfoActivity :
 
             val intent = Intent(context, MainActivity::class.java)
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-            startActivity(intent)
+            startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
         }
     }
 
@@ -640,7 +641,7 @@ class ConversationInfoActivity :
             )
             val intent = Intent(context, MainActivity::class.java)
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-            startActivity(intent)
+            startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -42,7 +42,9 @@ import android.os.Bundle
 import android.os.Handler
 import android.text.InputType
 import android.text.TextUtils
+import android.transition.Slide
 import android.util.Log
+import android.view.Gravity
 import android.view.Menu
 import android.view.MenuItem
 import android.view.MotionEvent
@@ -200,7 +202,8 @@ class ConversationsListActivity :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         NextcloudTalkApplication.sharedApplication!!.componentApplication.inject(this)
-
+        // weird but needed for consistent <-- --> sliding n/c of onBackPressedCallBack in ChatActivity
+        window.enterTransition = Slide(Gravity.START)
         binding = ControllerConversationsRvBinding.inflate(layoutInflater)
         setupActionBar()
         setContentView(binding.root)

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -29,6 +29,7 @@ package com.nextcloud.talk.conversationlist
 
 import android.animation.AnimatorInflater
 import android.annotation.SuppressLint
+import android.app.ActivityOptions
 import android.app.SearchManager
 import android.content.Context
 import android.content.Intent
@@ -745,7 +746,7 @@ class ConversationsListActivity :
                 newFragment.show(supportFragmentManager, ChooseAccountDialogFragment.TAG)
             } else {
                 val intent = Intent(context, SettingsActivity::class.java)
-                startActivity(intent)
+                startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
             }
         }
 
@@ -793,7 +794,7 @@ class ConversationsListActivity :
     private fun showNewConversationsScreen() {
         val intent = Intent(context, ContactsActivity::class.java)
         intent.putExtra(KEY_NEW_CONVERSATION, true)
-        startActivity(intent)
+        startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
     }
 
     private fun dispose(disposable: Disposable?) {
@@ -1161,7 +1162,7 @@ class ConversationsListActivity :
 
         val intent = Intent(context, ChatActivity::class.java)
         intent.putExtras(bundle)
-        startActivity(intent)
+        startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
 
         clearIntentAction()
     }
@@ -1253,7 +1254,7 @@ class ConversationsListActivity :
                     WorkManager.getInstance().enqueue(accountRemovalWork)
                     if (otherUserExists) {
                         finish()
-                        startActivity(intent)
+                        startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
                     } else if (!otherUserExists) {
                         Log.d(TAG, "No other users found. AccountRemovalWorker will restart the app.")
                     }
@@ -1294,7 +1295,7 @@ class ConversationsListActivity :
                     WorkManager.getInstance().enqueue(accountRemovalWork)
                     if (otherUserExists) {
                         finish()
-                        startActivity(intent)
+                        startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
                     } else if (!otherUserExists) {
                         restartApp(this)
                     }

--- a/app/src/main/java/com/nextcloud/talk/location/GeocodingActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/location/GeocodingActivity.kt
@@ -20,6 +20,7 @@
 
 package com.nextcloud.talk.location
 
+import android.app.ActivityOptions
 import android.app.SearchManager
 import android.content.Context
 import android.content.Intent
@@ -116,7 +117,7 @@ class GeocodingActivity :
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
             intent.putExtra(BundleKeys.KEY_ROOM_TOKEN, roomToken)
             intent.putExtra(BundleKeys.KEY_GEOCODING_RESULT, geocodingResult)
-            startActivity(intent)
+            startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
         }
     }
 
@@ -184,7 +185,7 @@ class GeocodingActivity :
                     val intent = Intent(context, LocationPickerActivity::class.java)
                     intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
                     intent.putExtra(BundleKeys.KEY_ROOM_TOKEN, roomToken)
-                    startActivity(intent)
+                    startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this@GeocodingActivity).toBundle())
                     return true
                 }
             })

--- a/app/src/main/java/com/nextcloud/talk/location/GeocodingActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/location/GeocodingActivity.kt
@@ -168,7 +168,7 @@ class GeocodingActivity :
             searchView?.maxWidth = Int.MAX_VALUE
             searchView?.inputType = InputType.TYPE_TEXT_VARIATION_FILTER
             var imeOptions = EditorInfo.IME_ACTION_DONE or EditorInfo.IME_FLAG_NO_FULLSCREEN
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && appPreferences!!.isKeyboardIncognito) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && appPreferences.isKeyboardIncognito) {
                 imeOptions = imeOptions or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
             }
             searchView?.imeOptions = imeOptions
@@ -185,7 +185,10 @@ class GeocodingActivity :
                     val intent = Intent(context, LocationPickerActivity::class.java)
                     intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
                     intent.putExtra(BundleKeys.KEY_ROOM_TOKEN, roomToken)
-                    startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this@GeocodingActivity).toBundle())
+                    startActivity(
+                        intent,
+                        ActivityOptions.makeSceneTransitionAnimation(this@GeocodingActivity).toBundle()
+                    )
                     return true
                 }
             })

--- a/app/src/main/java/com/nextcloud/talk/location/LocationPickerActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/location/LocationPickerActivity.kt
@@ -24,6 +24,7 @@ package com.nextcloud.talk.location
 
 import android.Manifest
 import android.app.Activity
+import android.app.ActivityOptions
 import android.app.SearchManager
 import android.content.Context
 import android.content.Intent
@@ -244,7 +245,7 @@ class LocationPickerActivity :
             val intent = Intent(this, GeocodingActivity::class.java)
             intent.putExtra(BundleKeys.KEY_GEOCODING_QUERY, query)
             intent.putExtra(KEY_ROOM_TOKEN, roomToken)
-            startActivity(intent)
+            startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
         }
         return true
     }

--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -28,6 +28,7 @@ package com.nextcloud.talk.settings
 import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.app.Activity
+import android.app.ActivityOptions
 import android.app.KeyguardManager
 import android.content.Context
 import android.content.DialogInterface
@@ -225,7 +226,7 @@ class SettingsActivity : BaseActivity() {
 
         binding.avatarContainer.setOnClickListener {
             val intent = Intent(this, ProfileActivity::class.java)
-            startActivity(intent)
+            startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
         }
 
         themeCategories()
@@ -280,7 +281,7 @@ class SettingsActivity : BaseActivity() {
                     NotificationUtils.NotificationChannels.NOTIFICATION_CHANNEL_CALLS_V4.name
                 )
 
-                startActivity(intent)
+                startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
             }
             binding.settingsMessageSound.setOnClickListener {
                 val intent = Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS)
@@ -289,7 +290,7 @@ class SettingsActivity : BaseActivity() {
                     Settings.EXTRA_CHANNEL_ID,
                     NotificationUtils.NotificationChannels.NOTIFICATION_CHANNEL_MESSAGES_V4.name
                 )
-                startActivity(intent)
+                startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
             }
         } else {
             Log.e(TAG, "setupSoundSettings currently not supported for versions < Build.VERSION_CODES.O")
@@ -469,7 +470,7 @@ class SettingsActivity : BaseActivity() {
         if (otherUserExists) {
             // TODO: find better solution once Conductor is removed
             finish()
-            startActivity(intent)
+            startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(this).toBundle())
         } else if (!otherUserExists) {
             Log.d(TAG, "No other users found. AccountRemovalWorker will restart the app.")
         }

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/ChooseAccountDialogFragment.java
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/ChooseAccountDialogFragment.java
@@ -25,6 +25,7 @@
 package com.nextcloud.talk.ui.dialog;
 
 import android.annotation.SuppressLint;
+import android.app.ActivityOptions;
 import android.app.Dialog;
 import android.content.Intent;
 import android.net.Uri;
@@ -189,12 +190,12 @@ public class ChooseAccountDialogFragment extends DialogFragment {
             // TODO: change this when conductor is removed
             Intent intent = new Intent(getContext(), MainActivity.class);
             intent.putExtra(ADD_ACCOUNT, true);
-            startActivity(intent);
+            startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(getActivity()).toBundle());
             dismiss();
         });
         binding.manageSettings.setOnClickListener(v -> {
             Intent intent = new Intent(getContext(), SettingsActivity.class);
-            startActivity(intent);
+            startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(getActivity()).toBundle());
             dismiss();
         });
 
@@ -310,7 +311,7 @@ public class ChooseAccountDialogFragment extends DialogFragment {
                         // have a smoother transition. However the handling in onNewIntent() in
                         // ConversationListActivity must be improved for this.
                         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                        startActivity(intent);
+                        startActivity(intent, ActivityOptions.makeSceneTransitionAnimation(getActivity()).toBundle());
 
                         dismiss();
                     }

--- a/app/src/main/res/layout/activity_conversation_info.xml
+++ b/app/src/main/res/layout/activity_conversation_info.xml
@@ -78,10 +78,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:animateLayoutChanges="true"
-                android:visibility="gone"
+                android:visibility="visible"
                 apc:cardBackgroundColor="@color/bg_default"
-                apc:cardElevation="0dp"
-                tools:visibility="visible">
+                apc:cardElevation="0dp">
 
                 <RelativeLayout
                     android:layout_width="match_parent"
@@ -161,24 +160,24 @@
                     layout="@layout/notification_settings_item"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:visibility="gone"
-                    tools:visibility="visible" />
+                    android:visibility="visible"
+                     />
 
                 <include
                     android:id="@+id/webinar_info_view"
                     layout="@layout/webinar_info_item"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:visibility="gone"
-                    tools:visibility="visible" />
+                    android:visibility="visible"
+                     />
 
                 <include
                     android:id="@+id/guest_access_view"
                     layout="@layout/guest_access_settings_item"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:visibility="gone"
-                    tools:visibility="visible" />
+                    android:visibility="visible"
+                     />
 
             </LinearLayout>
 

--- a/app/src/main/res/layout/controller_contacts_rv.xml
+++ b/app/src/main/res/layout/controller_contacts_rv.xml
@@ -82,15 +82,15 @@
     <include
         android:id="@+id/conversation_privacy_toggle"
         layout="@layout/conversation_privacy_toggle"
-        android:visibility="gone" />
+        android:visibility="visible" />
 
     <include
         android:id="@+id/join_conversation_via_link"
         layout="@layout/join_conversation_via_link"
-        android:visibility="gone" />
+        android:visibility="visible" />
 
     <include
         android:id="@+id/controller_generic_rv"
         layout="@layout/controller_generic_rv"
-        android:visibility="gone" />
+        android:visibility="visible" />
 </LinearLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -44,6 +44,9 @@
         <item name="popupMenuStyle">@style/ChatSendButtonMenu</item>
         <item name="dialogCornerRadius">@dimen/dialogBorderRadius</item>
         <item name="android:windowBackground">@color/bg_default</item>
+        <item name="android:windowActivityTransitions">true</item>
+        <item name="android:windowEnterTransition">@android:transition/slide_left</item>
+        <item name="android:windowExitTransition">@android:transition/slide_right</item>
     </style>
 
     <style name="ThemeOverlay.AppTheme.PopupMenu" parent="ThemeOverlay.Material3.Dark">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -44,9 +44,6 @@
         <item name="popupMenuStyle">@style/ChatSendButtonMenu</item>
         <item name="dialogCornerRadius">@dimen/dialogBorderRadius</item>
         <item name="android:windowBackground">@color/bg_default</item>
-        <item name="android:windowActivityTransitions">true</item>
-        <item name="android:windowEnterTransition">@android:transition/slide_left</item>
-        <item name="android:windowExitTransition">@android:transition/slide_right</item>
     </style>
 
     <style name="ThemeOverlay.AppTheme.PopupMenu" parent="ThemeOverlay.Material3.Dark">


### PR DESCRIPTION
Fixes #2957 

Signed-off-by: Julius Linus julius.linus@nextcloud.com

Transitions are <-- --> Slide behavior, nothing special just using the default `Slide(Gravity.START)` or `Slide(Gravity.END)`

I think I hit everything, I checked with `ctrl + shift + r`. I didn't do anything with `AccountVertificationController` because that still used conductor or anything that used `browserIntent` or anything with `context.startActivity`

I only tested it out on my emulator, so I'm not sure if it's consistent on different devices, but I think it should be. 

https://github.com/nextcloud/talk-android/assets/69230048/959d9251-16d0-4c7e-9a11-1a109654368a

### 🚧 TODO
- [x] get it working
- [ ] get it reviewed

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)