### PR TITLE
WIP one-to-one behaves like mentioned

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/FilterConversationFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/FilterConversationFragment.kt
@@ -145,14 +145,15 @@ class FilterConversationFragment(
         for ((k, v) in filterState) {
             if (v) {
                 when (k) {
-                    MENTION -> result = (result && conversation.unreadMention) || (
-                        result &&
-                            (
-                                conversation.type == Conversation.ConversationType.ROOM_TYPE_ONE_TO_ONE_CALL ||
-                                    conversation.type == Conversation.ConversationType.FORMER_ONE_TO_ONE
-                                ) &&
-                            (conversation.unreadMessages > 0)
-                        )
+                    MENTION -> result = (result && conversation.unreadMention) ||
+                        (
+                            result &&
+                                (
+                                    conversation.type == Conversation.ConversationType.ROOM_TYPE_ONE_TO_ONE_CALL ||
+                                        conversation.type == Conversation.ConversationType.FORMER_ONE_TO_ONE
+                                    ) &&
+                                (conversation.unreadMessages > 0)
+                            )
                     UNREAD -> result = result && (conversation.unreadMessages > 0)
                 }
             }

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/FilterConversationFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/FilterConversationFragment.kt
@@ -147,7 +147,10 @@ class FilterConversationFragment(
                 when (k) {
                     MENTION -> result = (result && conversation.unreadMention) || (
                         result &&
-                            (conversation.type == Conversation.ConversationType.ROOM_TYPE_ONE_TO_ONE_CALL) &&
+                            (
+                                conversation.type == Conversation.ConversationType.ROOM_TYPE_ONE_TO_ONE_CALL ||
+                                    conversation.type == Conversation.ConversationType.FORMER_ONE_TO_ONE
+                                ) &&
                             (conversation.unreadMessages > 0)
                         )
                     UNREAD -> result = result && (conversation.unreadMessages > 0)

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/FilterConversationFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/FilterConversationFragment.kt
@@ -145,7 +145,11 @@ class FilterConversationFragment(
         for ((k, v) in filterState) {
             if (v) {
                 when (k) {
-                    MENTION -> result = result && conversation.unreadMention
+                    MENTION -> result = (result && conversation.unreadMention) || (
+                        result &&
+                            (conversation.type == Conversation.ConversationType.ROOM_TYPE_ONE_TO_ONE_CALL) &&
+                            (conversation.unreadMessages > 0)
+                        )
                     UNREAD -> result = result && (conversation.unreadMessages > 0)
                 }
             }


### PR DESCRIPTION
Clicking on the mentioned filter used to only bring up mentions, direct or @all, now it also brings up all unread conversations that are 1:1 too, regardless if they contain a mention or not. 

Signed-off-by: Julius Linus julius.linus@nextcloud.com

### 🖼️ Screenshots

🏚️ Before

https://github.com/nextcloud/talk-android/assets/69230048/9e7e0de7-c705-4d12-a79f-199663de7bed



🏡 After

https://github.com/nextcloud/talk-android/assets/69230048/8bfa057b-a69a-42b9-8571-ff432bfd611b

### 🏁 Checklist
- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)