### PR TITLE
Update Chinese translation

### DIFF
--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -259,7 +259,7 @@
     <string name="nc_remove_circle_and_members">删除圈子和成员</string>
     <string name="nc_remove_from_favorites">取消收藏</string>
     <string name="nc_remove_group_and_members">移除群组和成员</string>
-    <string name="nc_remove_participant">远程参与者</string>
+    <string name="nc_remove_participant">移除参与者</string>
     <string name="nc_rename">重命名会话</string>
     <string name="nc_reply">回复</string>
     <string name="nc_reply_privately">私下回复</string>


### PR DESCRIPTION
Updated one line translation:
nc_remove_participant should be translated as "移除参与者" instead of "远程参与者".