### PR TITLE
fix long click in ChooseAccountDialogFragment

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/ChooseAccountDialogFragment.java
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/ChooseAccountDialogFragment.java
@@ -176,6 +176,7 @@ public class ChooseAccountDialogFragment extends DialogFragment {
             }
 
             adapter.addListener(onSwitchItemClickListener);
+            adapter.addListener(onSwitchItemLongClickListener);
             adapter.updateDataSet(userItems, false);
         }
     }
@@ -319,6 +320,11 @@ public class ChooseAccountDialogFragment extends DialogFragment {
                 return true;
             }
         };
+
+        private final FlexibleAdapter.OnItemLongClickListener onSwitchItemLongClickListener =
+            position -> {
+                // do nothing. OnItemLongClickListener is necessary anyway so the activity won't handle the event
+            };
 
     private void drawStatus() {
         float size = DisplayUtils.convertDpToPixel(STATUS_SIZE_IN_DP, getContext());


### PR DESCRIPTION
otherwise the list in the ConversationListActivity would handle it which results in unexpected user actions dialog popup

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)