### PR TITLE
allow screenOrientation for ChatActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -215,7 +215,6 @@
 
         <activity
             android:name=".chat.ChatActivity"
-            android:screenOrientation="portrait"
             android:theme="@style/AppTheme" />
 
         <activity


### PR DESCRIPTION
this was temporarily disabled as a workaround because of https://github.com/nextcloud/talk-android/issues/3146 (So after screen rotation it could happen that chat was not updated.)

Now that the issue is solved, portrait mode will be allowed again


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)