### PR TITLE
avoid NPE in ProfileActivity because userInfo could be null

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/profile/ProfileActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/profile/ProfileActivity.kt
@@ -434,7 +434,7 @@ class ProfileActivity : BaseActivity() {
     private fun save() {
         for (item in adapter!!.displayList!!) {
             // Text
-            if (item.text != userInfo!!.getValueByField(item.field)) {
+            if (item.text != userInfo?.getValueByField(item.field)) {
                 val credentials = ApiUtils.getCredentials(currentUser!!.username, currentUser!!.token)
                 ncApi.setUserData(
                     credentials,
@@ -458,7 +458,7 @@ class ProfileActivity : BaseActivity() {
                         }
 
                         override fun onError(e: Throwable) {
-                            item.text = userInfo!!.getValueByField(item.field)!!
+                            item.text = userInfo?.getValueByField(item.field)
                             Toast.makeText(
                                 applicationContext,
                                 String.format(
@@ -479,7 +479,7 @@ class ProfileActivity : BaseActivity() {
             }
 
             // Scope
-            if (item.scope != userInfo!!.getScopeByField(item.field)) {
+            if (item.scope != userInfo?.getScopeByField(item.field)) {
                 saveScope(item, userInfo)
             }
             adapter!!.updateFilteredList()
@@ -586,7 +586,7 @@ class ProfileActivity : BaseActivity() {
                 }
 
                 override fun onError(e: Throwable) {
-                    item.scope = userInfo!!.getScopeByField(item.field)
+                    item.scope = userInfo?.getScopeByField(item.field)
                     Log.e(TAG, "Failed to saved: " + item.scope + " as " + item.field, e)
                 }
 


### PR DESCRIPTION
fix #3164

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)