### PR TITLE
avoid ClassCastException on ItemLongClick in ConversationsListActivity

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -1067,8 +1067,8 @@ class ConversationsListActivity :
             Log.d(TAG, "sharing to multiple rooms not yet implemented. onItemLongClick is ignored.")
         } else {
             val clickedItem: Any? = adapter!!.getItem(position)
-            if (clickedItem != null) {
-                val conversation = (clickedItem as ConversationItem).model
+            if (clickedItem != null && clickedItem is ConversationItem) {
+                val conversation = clickedItem.model
                 conversationsListBottomDialog = ConversationsListBottomDialog(
                     this,
                     userManager.currentUser.blockingGet(),


### PR DESCRIPTION
backport of https://github.com/nextcloud/talk-android/pull/3163

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)