### PR TITLE
Fix establishing of call connection on HPB

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.java
@@ -1942,7 +1942,8 @@ public class CallActivity extends CallBaseActivity {
             removeCallParticipant(sessionId);
         }
 
-        ApplicationWideCurrentRoomHolder.getInstance().clear();
+        ApplicationWideCurrentRoomHolder.getInstance().setInCall(false);
+        ApplicationWideCurrentRoomHolder.getInstance().setDialing(false);
         hangupNetworkCalls(shutDownView);
     }
 


### PR DESCRIPTION
fix #1725 
fix #1712

Fix establishing of call connection when try to connect a second time on HPB

Everytime a second attempt was made to enter a call, the connection failed.
How to reproduce:

- Enter the ChatActivity 
-> joins the room (so the new session is in the ApplicationWideCurrentRoomHolder)

- Start call
-> in the CallActivity we don't join again and instead execute callOrJoinRoomViaWebSocket()

- Call connection is successful

- Hangup on android
-> the ApplicationWideCurrentRoomHolder gets cleared (so also it's session)

- Staying in the chat and start the call another time
-> When we open CallActivity another time, ApplicationWideCurrentRoomHolder.sessionId is empty.Because of this, in joinRoomAndCall, joinRoom is executed again.
But as we are still in the room and have a session, joinRoom is problematic because on serverside in SignalingController - if there is still a session - it's considered as old.
So Nextcloud now sends a backend message (disinvite) to the external signaling controller that the session (of the first join) was removed.
So the External signaling server removes the session and closes the websocket. (The message for this might be improved, see https://github.com/strukturag/nextcloud-spreed-signaling/issues/512)

As the websocket is now closed, it won't be possible for the android app to send any signaling message anymore. There will just be the connecting screen and the call connection fails.


## Solution for now:
ApplicationWideCurrentRoomHolder.getInstance().clear() should not be executed when hanging up, so the session won't be cleared and in the next attempt to start the call the room is not joined again mistakenly. 
Instead to clear the `ApplicationWideCurrentRoomHolder`, only 
```
setInCall(false);    
setDialing(false);
```
are set so that the method isNotInCall() in ChatActivity remains working correctly.


### Followup TODOs

- [ ] followup improvements regarding the isConnected state in WebSocketInstance
- [ ] check lifecycle behaviour of ChatActivity together with ApplicationWideCurrentRoomHolder. When leaving ChatActivity sessionIdAfterRoomJoined remains currently while it's empty in ApplicationWideCurrentRoomHolder ....
- [ ] check session in com.nextcloud.talk.webrtc.WebSocketInstance#joinRoomWithRoomTokenAndSession (not only roomToken)
- [ ] ....

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)