### PR TITLE
WIP set Workers as expedited.

### DIFF
--- a/app/src/gplay/java/com/nextcloud/talk/jobs/GetFirebasePushTokenWorker.kt
+++ b/app/src/gplay/java/com/nextcloud/talk/jobs/GetFirebasePushTokenWorker.kt
@@ -25,6 +25,7 @@ import android.content.Context
 import android.util.Log
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
@@ -59,6 +60,7 @@ class GetFirebasePushTokenWorker(val context: Context, workerParameters: WorkerP
                         .build()
                 val pushRegistrationWork = OneTimeWorkRequest.Builder(PushRegistrationWorker::class.java)
                     .setInputData(data)
+                    .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                     .build()
                 WorkManager.getInstance(context).enqueue(pushRegistrationWork)
             }

--- a/app/src/gplay/java/com/nextcloud/talk/services/firebase/NCFirebaseMessagingService.kt
+++ b/app/src/gplay/java/com/nextcloud/talk/services/firebase/NCFirebaseMessagingService.kt
@@ -26,6 +26,7 @@ package com.nextcloud.talk.services.firebase
 import android.util.Log
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import autodagger.AutoInjector
 import com.google.firebase.messaging.FirebaseMessagingService
@@ -67,7 +68,9 @@ class NCFirebaseMessagingService : FirebaseMessagingService() {
                 .putString(BundleKeys.KEY_NOTIFICATION_SIGNATURE, signature)
                 .build()
             val notificationWork =
-                OneTimeWorkRequest.Builder(NotificationWorker::class.java).setInputData(messageData)
+                OneTimeWorkRequest.Builder(NotificationWorker::class.java)
+                    .setInputData(messageData)
+                    .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                     .build()
             WorkManager.getInstance().enqueue(notificationWork)
         }
@@ -85,6 +88,7 @@ class NCFirebaseMessagingService : FirebaseMessagingService() {
         ).build()
         val pushRegistrationWork = OneTimeWorkRequest.Builder(PushRegistrationWorker::class.java)
             .setInputData(data)
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
             .build()
         WorkManager.getInstance().enqueue(pushRegistrationWork)
     }

--- a/app/src/gplay/java/com/nextcloud/talk/utils/ClosedInterfaceImpl.kt
+++ b/app/src/gplay/java/com/nextcloud/talk/utils/ClosedInterfaceImpl.kt
@@ -27,6 +27,7 @@ import android.content.Intent
 import androidx.work.Data
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
 import autodagger.AutoInjector
@@ -86,6 +87,7 @@ class ClosedInterfaceImpl : ClosedInterface, ProviderInstaller.ProviderInstallLi
             .build()
         val pushRegistrationWork = OneTimeWorkRequest.Builder(PushRegistrationWorker::class.java)
             .setInputData(data)
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
             .build()
         WorkManager.getInstance().enqueue(pushRegistrationWork)
     }
@@ -105,6 +107,7 @@ class ClosedInterfaceImpl : ClosedInterface, ProviderInstaller.ProviderInstallLi
             TimeUnit.HOURS
         )
             .setInputData(data)
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
             .build()
 
         WorkManager.getInstance()

--- a/app/src/main/java/com/nextcloud/talk/application/NextcloudTalkApplication.kt
+++ b/app/src/main/java/com/nextcloud/talk/application/NextcloudTalkApplication.kt
@@ -38,6 +38,7 @@ import androidx.multidex.MultiDex
 import androidx.multidex.MultiDexApplication
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
 import autodagger.AutoComponent
@@ -189,10 +190,18 @@ class NextcloudTalkApplication : MultiDexApplication(), LifecycleObserver {
     }
 
     private fun initWorkers() {
-        val accountRemovalWork = OneTimeWorkRequest.Builder(AccountRemovalWorker::class.java).build()
-        val capabilitiesUpdateWork = OneTimeWorkRequest.Builder(CapabilitiesWorker::class.java).build()
-        val signalingSettingsWork = OneTimeWorkRequest.Builder(SignalingSettingsWorker::class.java).build()
-        val websocketConnectionsWorker = OneTimeWorkRequest.Builder(WebsocketConnectionsWorker::class.java).build()
+        val accountRemovalWork = OneTimeWorkRequest.Builder(AccountRemovalWorker::class.java)
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+            .build()
+        val capabilitiesUpdateWork = OneTimeWorkRequest.Builder(CapabilitiesWorker::class.java)
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+            .build()
+        val signalingSettingsWork = OneTimeWorkRequest.Builder(SignalingSettingsWorker::class.java)
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+            .build()
+        val websocketConnectionsWorker = OneTimeWorkRequest.Builder(WebsocketConnectionsWorker::class.java)
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+            .build()
 
         WorkManager.getInstance(applicationContext)
             .beginWith(accountRemovalWork)
@@ -205,7 +214,8 @@ class NextcloudTalkApplication : MultiDexApplication(), LifecycleObserver {
             CapabilitiesWorker::class.java,
             HALF_DAY,
             TimeUnit.HOURS
-        ).build()
+        )
+            .build()
         WorkManager.getInstance(applicationContext).enqueueUniquePeriodicWork(
             "DailyCapabilitiesUpdateWork",
             ExistingPeriodicWorkPolicy.REPLACE,

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -90,6 +90,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import autodagger.AutoInjector
@@ -1507,6 +1508,7 @@ class ChatActivity :
         val downloadWorker: OneTimeWorkRequest = OneTimeWorkRequest.Builder(DownloadFileToCacheWorker::class.java)
             .setInputData(data)
             .addTag(fileId)
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
             .build()
 
         WorkManager.getInstance().enqueue(downloadWorker)
@@ -1817,6 +1819,7 @@ class ChatActivity :
                                 .build()
                             val worker = OneTimeWorkRequest.Builder(ShareOperationWorker::class.java)
                                 .setInputData(data)
+                                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                                 .build()
                             WorkManager.getInstance().enqueue(worker)
                         }

--- a/app/src/main/java/com/nextcloud/talk/contacts/ContactsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/contacts/ContactsActivity.kt
@@ -41,6 +41,7 @@ import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.MenuItemCompat
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import autodagger.AutoInjector
 import com.bluelinelabs.logansquare.LoganSquare
@@ -371,7 +372,10 @@ class ContactsActivity :
         data.putStringArray(BundleKeys.KEY_SELECTED_CIRCLES, circleIdsArray)
         val addParticipantsToConversationWorker: OneTimeWorkRequest = OneTimeWorkRequest.Builder(
             AddParticipantsToConversation::class.java
-        ).setInputData(data.build()).build()
+        )
+            .setInputData(data.build())
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+            .build()
         WorkManager.getInstance().enqueue(addParticipantsToConversationWorker)
         finish()
     }

--- a/app/src/main/java/com/nextcloud/talk/controllers/AccountVerificationController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/AccountVerificationController.kt
@@ -32,6 +32,7 @@ import android.view.View
 import android.widget.Toast
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import autodagger.AutoInjector
 import com.bluelinelabs.conductor.RouterTransaction
@@ -369,6 +370,7 @@ class AccountVerificationController(args: Bundle? = null) : BaseController(
         val pushRegistrationWork =
             OneTimeWorkRequest.Builder(PushRegistrationWorker::class.java)
                 .setInputData(data)
+                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                 .build()
         WorkManager.getInstance().enqueue(pushRegistrationWork)
     }
@@ -426,6 +428,7 @@ class AccountVerificationController(args: Bundle? = null) : BaseController(
         val pushNotificationWork =
             OneTimeWorkRequest.Builder(CapabilitiesWorker::class.java)
                 .setInputData(userData)
+                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                 .build()
         WorkManager.getInstance().enqueue(pushNotificationWork)
     }
@@ -437,8 +440,11 @@ class AccountVerificationController(args: Bundle? = null) : BaseController(
                 .build()
         val signalingSettings = OneTimeWorkRequest.Builder(SignalingSettingsWorker::class.java)
             .setInputData(userData)
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
             .build()
-        val websocketConnectionsWorker = OneTimeWorkRequest.Builder(WebsocketConnectionsWorker::class.java).build()
+        val websocketConnectionsWorker = OneTimeWorkRequest.Builder(WebsocketConnectionsWorker::class.java)
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+            .build()
 
         WorkManager.getInstance(applicationContext!!)
             .beginWith(signalingSettings)

--- a/app/src/main/java/com/nextcloud/talk/controllers/WebViewLoginController.kt
+++ b/app/src/main/java/com/nextcloud/talk/controllers/WebViewLoginController.kt
@@ -44,6 +44,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.res.ResourcesCompat
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import autodagger.AutoInjector
 import com.bluelinelabs.conductor.RouterTransaction
@@ -376,6 +377,7 @@ class WebViewLoginController(args: Bundle? = null) : BaseController(
                             PushRegistrationWorker::class.java
                         )
                             .setInputData(data)
+                            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                             .build()
 
                         WorkManager.getInstance().enqueue(pushRegistrationWork)

--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
@@ -43,6 +43,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import autodagger.AutoInjector
 import com.afollestad.materialdialogs.LayoutMode.WRAP_CONTENT
@@ -539,10 +540,10 @@ class ConversationInfoActivity :
     private fun leaveConversation() {
         workerData?.let {
             WorkManager.getInstance(context).enqueue(
-                OneTimeWorkRequest.Builder(
-                    LeaveConversationWorker::class
-                        .java
-                ).setInputData(it).build()
+                OneTimeWorkRequest.Builder(LeaveConversationWorker::class.java)
+                    .setInputData(it)
+                    .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                    .build()
             )
 
             val intent = Intent(context, MainActivity::class.java)
@@ -614,7 +615,10 @@ class ConversationInfoActivity :
             WorkManager.getInstance(context).enqueue(
                 OneTimeWorkRequest.Builder(
                     DeleteConversationWorker::class.java
-                ).setInputData(it).build()
+                )
+                    .setInputData(it)
+                    .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                    .build()
             )
             val intent = Intent(context, MainActivity::class.java)
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -58,6 +58,7 @@ import androidx.fragment.app.DialogFragment
 import androidx.recyclerview.widget.RecyclerView
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import autodagger.AutoInjector
 import coil.imageLoader
@@ -1275,7 +1276,9 @@ class ConversationsListActivity :
                     val otherUserExists = userManager
                         .scheduleUserForDeletionWithId(currentUser!!.id!!)
                         .blockingGet()
-                    val accountRemovalWork = OneTimeWorkRequest.Builder(AccountRemovalWorker::class.java).build()
+                    val accountRemovalWork = OneTimeWorkRequest.Builder(AccountRemovalWorker::class.java)
+                        .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                        .build()
                     WorkManager.getInstance().enqueue(accountRemovalWork)
                     if (otherUserExists) {
                         finish()
@@ -1393,7 +1396,9 @@ class ConversationsListActivity :
                     val otherUserExists = userManager
                         .scheduleUserForDeletionWithId(currentUser!!.id!!)
                         .blockingGet()
-                    val accountRemovalWork = OneTimeWorkRequest.Builder(AccountRemovalWorker::class.java).build()
+                    val accountRemovalWork = OneTimeWorkRequest.Builder(AccountRemovalWorker::class.java)
+                        .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                        .build()
                     WorkManager.getInstance().enqueue(accountRemovalWork)
                     if (otherUserExists) {
                         finish()
@@ -1434,7 +1439,10 @@ class ConversationsListActivity :
 
     private fun deleteConversation(data: Data) {
         val deleteConversationWorker =
-            OneTimeWorkRequest.Builder(DeleteConversationWorker::class.java).setInputData(data).build()
+            OneTimeWorkRequest.Builder(DeleteConversationWorker::class.java)
+                .setInputData(data)
+                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                .build()
         WorkManager.getInstance().enqueue(deleteConversationWorker)
     }
 

--- a/app/src/main/java/com/nextcloud/talk/jobs/AccountRemovalWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/AccountRemovalWorker.java
@@ -51,6 +51,7 @@ import java.util.zip.CRC32;
 import javax.inject.Inject;
 
 import androidx.annotation.NonNull;
+import androidx.work.ForegroundInfo;
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
 import autodagger.AutoInjector;
@@ -80,6 +81,12 @@ public class AccountRemovalWorker extends Worker {
 
     public AccountRemovalWorker(@NonNull Context context, @NonNull WorkerParameters workerParams) {
         super(context, workerParams);
+    }
+
+    @Override
+    public ForegroundInfo getForegroundInfo(){
+
+        return null;
     }
 
     @NonNull

--- a/app/src/main/java/com/nextcloud/talk/jobs/ContactAddressBookWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/ContactAddressBookWorker.kt
@@ -36,6 +36,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.os.ConfigurationCompat
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
@@ -458,7 +459,9 @@ class ContactAddressBookWorker(val context: Context, workerParameters: WorkerPar
             ) {
                 WorkManager.getInstance().enqueue(
                     OneTimeWorkRequest.Builder(ContactAddressBookWorker::class.java)
-                        .setInputData(Data.Builder().putBoolean(KEY_FORCE, false).build()).build()
+                        .setInputData(Data.Builder().putBoolean(KEY_FORCE, false).build())
+                        .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                        .build()
                 )
             }
         }
@@ -480,6 +483,7 @@ class ContactAddressBookWorker(val context: Context, workerParameters: WorkerPar
                     .enqueue(
                         OneTimeWorkRequest.Builder(ContactAddressBookWorker::class.java)
                             .setInputData(Data.Builder().putBoolean(KEY_FORCE, true).build())
+                            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                             .build()
                     )
                 return true
@@ -492,6 +496,7 @@ class ContactAddressBookWorker(val context: Context, workerParameters: WorkerPar
                 .enqueue(
                     OneTimeWorkRequest.Builder(ContactAddressBookWorker::class.java)
                         .setInputData(Data.Builder().putBoolean(DELETE_ALL, true).build())
+                        .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                         .build()
                 )
         }

--- a/app/src/main/java/com/nextcloud/talk/jobs/ShareOperationWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/ShareOperationWorker.kt
@@ -25,6 +25,7 @@ import android.content.Context
 import android.util.Log
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
@@ -110,6 +111,7 @@ class ShareOperationWorker(context: Context, workerParams: WorkerParameters) : W
                 .build()
             val shareWorker = OneTimeWorkRequest.Builder(ShareOperationWorker::class.java)
                 .setInputData(data)
+                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                 .build()
             WorkManager.getInstance().enqueue(shareWorker)
         }

--- a/app/src/main/java/com/nextcloud/talk/jobs/UploadAndShareFilesWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/UploadAndShareFilesWorker.kt
@@ -36,6 +36,7 @@ import androidx.core.app.NotificationCompat
 import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
@@ -336,6 +337,7 @@ class UploadAndShareFilesWorker(val context: Context, workerParameters: WorkerPa
                 .build()
             val uploadWorker: OneTimeWorkRequest = OneTimeWorkRequest.Builder(UploadAndShareFilesWorker::class.java)
                 .setInputData(data)
+                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                 .build()
             WorkManager.getInstance().enqueueUniqueWork(fileUri, ExistingWorkPolicy.KEEP, uploadWorker)
         }

--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -58,6 +58,7 @@ import androidx.appcompat.view.ContextThemeWrapper
 import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import autodagger.AutoInjector
@@ -230,7 +231,9 @@ class SettingsActivity : BaseActivity() {
     }
 
     private fun loadCapabilitiesAndUpdateSettings() {
-        val capabilitiesWork = OneTimeWorkRequest.Builder(CapabilitiesWorker::class.java).build()
+        val capabilitiesWork = OneTimeWorkRequest.Builder(CapabilitiesWorker::class.java)
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+            .build()
         WorkManager.getInstance(context).enqueue(capabilitiesWork)
 
         WorkManager.getInstance(context).getWorkInfoByIdLiveData(capabilitiesWork.id)
@@ -470,7 +473,9 @@ class SettingsActivity : BaseActivity() {
 
     private fun removeCurrentAccount() {
         val otherUserExists = userManager.scheduleUserForDeletionWithId(currentUser!!.id!!).blockingGet()
-        val accountRemovalWork = OneTimeWorkRequest.Builder(AccountRemovalWorker::class.java).build()
+        val accountRemovalWork = OneTimeWorkRequest.Builder(AccountRemovalWorker::class.java)
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+            .build()
         WorkManager.getInstance(this).enqueue(accountRemovalWork)
         if (otherUserExists) {
             // TODO: find better solution once Conductor is removed
@@ -883,7 +888,11 @@ class SettingsActivity : BaseActivity() {
         ) {
             WorkManager
                 .getInstance(this)
-                .enqueue(OneTimeWorkRequest.Builder(ContactAddressBookWorker::class.java).build())
+                .enqueue(
+                    OneTimeWorkRequest.Builder(ContactAddressBookWorker::class.java)
+                        .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                        .build()
+                )
             checkForPhoneNumber()
         } else {
             appPreferences.setPhoneBookIntegration(false)

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/ConversationsListBottomDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/ConversationsListBottomDialog.kt
@@ -26,6 +26,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import autodagger.AutoInjector
 import com.bluelinelabs.conductor.Conductor
@@ -159,9 +160,9 @@ class ConversationsListBottomDialog(
             val data = dataBuilder.build()
 
             val leaveConversationWorker =
-                OneTimeWorkRequest.Builder(LeaveConversationWorker::class.java).setInputData(
-                    data
-                ).build()
+                OneTimeWorkRequest.Builder(LeaveConversationWorker::class.java).setInputData(data)
+                    .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                    .build()
             WorkManager.getInstance().enqueue(leaveConversationWorker)
 
             dismiss()

--- a/app/src/main/java/com/nextcloud/talk/utils/FileViewerUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/FileViewerUtils.kt
@@ -34,6 +34,7 @@ import androidx.core.content.FileProvider
 import androidx.emoji2.widget.EmojiTextView
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import com.nextcloud.talk.R
@@ -315,6 +316,7 @@ class FileViewerUtils(private val context: Context, private val user: User) {
         downloadWorker = OneTimeWorkRequest.Builder(DownloadFileToCacheWorker::class.java)
             .setInputData(data)
             .addTag(fileInfo.fileId)
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
             .build()
         WorkManager.getInstance().enqueue(downloadWorker)
         progressUi.progressBar?.visibility = View.VISIBLE


### PR DESCRIPTION
TODO:
According to
https://developer.android.com/guide/background/persistent/getting-started/define-work#backwards-compat getForegroundInfo() should be implemented in the workers..

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)