### PR TITLE
Bump nextcloud.android-common:ui from 0.11.0 to 0.12.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -306,7 +306,7 @@ dependencies {
 
      implementation 'androidx.activity:activity-ktx:1.7.2'
 
-    implementation 'com.github.nextcloud.android-common:ui:0.11.0'
+    implementation 'com.github.nextcloud.android-common:ui:0.12.0'
 
     implementation 'com.github.nextcloud-deps:android-talk-webrtc:110.5481.0'
 }


### PR DESCRIPTION
Fixes #3194

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)