### PR TITLE
Add manifest permission to post notifications

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -87,6 +87,8 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+
     <permission
         android:name="${applicationId}.${broadcastPermission}"
         android:protectionLevel="signature" />


### PR DESCRIPTION
This fixes the problem where notifications (specifically, file upload progress) won't show for generic or qa build variants on Android 13.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

Fixes https://github.com/nextcloud/talk-android/issues/3106
