### PR TITLE
show call time and hint for one-hour calls

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/models/json/conversations/Conversation.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/conversations/Conversation.kt
@@ -152,7 +152,10 @@ data class Conversation(
     // "@JsonField annotation can only be used on private fields if both getter and setter are present."
     // Instead, name it with "has" at the beginning: isCustomAvatar -> hasCustomAvatar
     @JsonField(name = ["isCustomAvatar"])
-    var hasCustomAvatar: Boolean? = null
+    var hasCustomAvatar: Boolean? = null,
+
+    @JsonField(name = ["callStartTime"])
+    var callStartTime: Long? = null
 
 ) : Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'

--- a/app/src/main/java/com/nextcloud/talk/utils/permissions/PlatformPermissionUtilImpl.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/permissions/PlatformPermissionUtilImpl.kt
@@ -102,6 +102,7 @@ class PlatformPermissionUtilImpl(private val context: Context) : PlatformPermiss
         }
     }
 
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
     override fun isPostNotificationsPermissionGranted(): Boolean {
         return PermissionChecker.checkSelfPermission(
             context,

--- a/app/src/main/java/com/nextcloud/talk/utils/singletons/ApplicationWideCurrentRoomHolder.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/singletons/ApplicationWideCurrentRoomHolder.java
@@ -35,6 +35,8 @@ public class ApplicationWideCurrentRoomHolder {
     private boolean isDialing = false;
     private String session = "";
 
+    private Long callStartTime = null;
+
     public static ApplicationWideCurrentRoomHolder getInstance() {
         return holder;
     }
@@ -95,5 +97,13 @@ public class ApplicationWideCurrentRoomHolder {
 
     public void setSession(String session) {
         this.session = session;
+    }
+
+    public Long getCallStartTime() {
+        return callStartTime;
+    }
+
+    public void setCallStartTime(Long callStartTime) {
+        this.callStartTime = callStartTime;
     }
 }

--- a/app/src/main/res/layout/call_activity.xml
+++ b/app/src/main/res/layout/call_activity.xml
@@ -136,6 +136,18 @@
                     tools:text="Voice Call" />
 
                 <TextView
+                    android:id="@+id/call_duration"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textAlignment="center"
+                    android:textColor="@color/white"
+                    android:textSize="16sp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="00:22" />
+
+                <TextView
                     android:id="@+id/callConversationNameTextView"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -256,6 +256,7 @@ How to translate with transifex:
     <string name="raise_hand">Raise hand</string>
     <string name="lower_hand">Lower hand</string>
     <string name="restrict_join_other_room_while_call">It\'s not possible to join other rooms while being in a call</string>
+    <string name="call_running_since_one_hour">Note the call is running since 1 hour already.</string>
 
     <!-- Picture in Picture -->
     <string name="nc_pip_microphone_mute">Mute microphone</string>


### PR DESCRIPTION
resolve #3175

### 🖼️ Screenshots

Call screen with call time | Info when call is running since one hour (faked for 20s)
-------- | -------- 
![grafik](https://github.com/nextcloud/talk-android/assets/2932790/0f79074e-5a11-471c-836b-1a7dc49b25e4) | ![grafik](https://github.com/nextcloud/talk-android/assets/2932790/ecf127d9-d697-4763-a408-bd4c92c6cb19)






### 🚧 TODO

- [x] check capability
- [x] fix multiple calls of fetchSignalingSettings -> fix via #3219 as it might need some attention if this causes other bugs
- [x] no hardcoding for strings
- [x] hide time when no participants in call
- [x] set value for 1 hour (instead 10s)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)