### PR TITLE
Implement status infos on chat view for 1on1 conversations

### DIFF
--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -37,6 +37,7 @@
         android:id="@+id/chat_appbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
+
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/chat_toolbar"
             android:layout_width="match_parent"
@@ -45,9 +46,66 @@
             android:theme="?attr/actionBarPopupTheme"
             app:layout_scrollFlags="scroll|enterAlways"
             app:navigationIconTint="@color/fontAppbar"
-            app:popupTheme="@style/appActionBarPopupMenu"
-            app:titleTextColor="@color/fontAppbar"
-            tools:title="@string/nc_app_product_name" />
+            app:popupTheme="@style/appActionBarPopupMenu">
+
+            <FrameLayout
+                android:id="@+id/chat_toolbar_avatar_container"
+                android:layout_width="46dp"
+                android:layout_height="46dp"
+                android:layout_marginEnd="@dimen/standard_half_margin"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <ImageView
+                    android:id="@+id/chat_toolbar_avatar"
+                    android:layout_width="42dp"
+                    android:layout_height="42dp"
+                    android:layout_gravity="start|center_vertical"
+                    android:contentDescription="@null"
+                    tools:src="@drawable/ic_avatar_group" />
+
+                <ImageView
+                    android:id="@+id/chat_toolbar_status"
+                    android:layout_width="18dp"
+                    android:layout_height="18dp"
+                    android:layout_gravity="end|bottom"
+                    android:contentDescription="@null"
+                    tools:src="@drawable/online_status" />
+
+            </FrameLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="center_vertical"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/chat_toolbar_title"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:lines="1"
+                    android:text="@string/nc_app_product_name"
+                    android:textColor="@color/fontAppbar"
+                    android:textSize="22sp" />
+
+                <androidx.emoji2.widget.EmojiTextView
+                    android:id="@+id/chat_toolbar_status_message"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:lines="1"
+                    android:text="@string/nc_app_product_name"
+                    android:textColor="@color/fontAppbar"
+                    android:textSize="12sp"
+                    android:visibility="gone"
+                    tools:text="Offline"
+                    tools:visibility="visible" />
+
+            </LinearLayout>
+
+        </com.google.android.material.appbar.MaterialToolbar>
     </com.google.android.material.appbar.AppBarLayout>
 
     <RelativeLayout


### PR DESCRIPTION
Resolves #2515

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | ![Screenshot_20230727_215841](https://github.com/nextcloud/talk-android/assets/1315170/2f55a146-bd85-4ea5-aeba-6f39b90aa596)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)