### PR TITLE
Avoid to fetchSignalingSettings in onMicrophoneClick

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -1050,9 +1050,6 @@ class CallActivity : CallBaseActivity() {
             binding!!.microphoneButton.setImageResource(R.drawable.ic_mic_off_white_24px)
             toggleMedia(false, false)
         }
-        if (isVoiceOnlyCall && !isConnectionEstablished) {
-            fetchSignalingSettings()
-        }
         if (!canPublishAudioStream) {
             // In the case no audio stream will be published it's not needed to check microphone permissions
             return


### PR DESCRIPTION
followup for  #3216

Avoid duplicated call of fetchSignalingSettings via onMicrophoneClick. fetchSignalingSettings is already called from checkDevicePermissions(). From my pov it shouldn't be triggered in onMicrophoneClick() again, at least i can not think of any scenario and while testing everything worked as expected.

The duplicated call was there since ever(?), but after implementing #3216 this also caused the call duration timer to be run twice.


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)