### PR TITLE
Message drafts are now saved

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -480,6 +480,10 @@ class ChatActivity :
     override fun onStart() {
         super.onStart()
         active = true
+        context.getSharedPreferences(localClassName, MODE_PRIVATE).apply {
+            val text = getString(roomToken, "")
+            binding.messageInputView.messageInput.setText(text)
+        }
     }
 
     override fun onStop() {
@@ -494,6 +498,14 @@ class ChatActivity :
         }
         if (currentlyPlayedVoiceMessage != null) {
             stopMediaPlayer(currentlyPlayedVoiceMessage!!)
+        }
+        val text = binding.messageInputView.messageInput.text.toString()
+        val previous = context.getSharedPreferences(localClassName, MODE_PRIVATE).getString(roomToken, "null")
+        if (text != previous) {
+            context.getSharedPreferences(localClassName, MODE_PRIVATE).edit().apply {
+                putString(roomToken, text)
+                apply()
+            }
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -698,5 +698,6 @@ How to translate with transifex:
     <string name="nc_settings_socks_value" translatable="false">1080</string>
     <string name="this_is_a_test_message">This is a test message</string>
     <string name="continuous_voice_message_recording">Lock recording for continuously recording of the voice message</string>
+    <string name="saved_draft_message">Saved draft message.</string>
 
 </resources>


### PR DESCRIPTION
fixes #1918 

- Drafts are now saved in between rooms.

[issue-1918-draft-messages-2.webm](https://github.com/nextcloud/talk-android/assets/69230048/5321acc1-02aa-4472-9e02-2aa90d0bf725)


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)