### PR TITLE
Follow up fixes for the Waveform SeekBar

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -894,12 +894,7 @@ class ChatActivity :
             message.isDownloadingVoiceMessage = true
             adapter?.update(message)
             CoroutineScope(Dispatchers.Default).launch {
-                val bars = if (message.actorDisplayName == conversationUser?.displayName) {
-                    NUM_BARS_OUTCOMING
-                } else {
-                    NUM_BARS_INCOMING
-                }
-                val r = AudioUtils.audioFileToFloatArray(file, bars)
+                val r = AudioUtils.audioFileToFloatArray(file)
                 message.voiceMessageFloatArray = r
                 withContext(Dispatchers.Main) {
                     startPlayback(message)
@@ -4275,7 +4270,5 @@ class ChatActivity :
         private const val TYPING_INTERVAL_TO_SEND_NEXT_TYPING_MESSAGE = 1000L
         private const val TYPING_STARTED_SIGNALING_MESSAGE_TYPE = "startedTyping"
         private const val TYPING_STOPPED_SIGNALING_MESSAGE_TYPE = "stoppedTyping"
-        private const val NUM_BARS_OUTCOMING: Int = 38
-        private const val NUM_BARS_INCOMING: Int = 50
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/ui/WaveformSeekBar.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/WaveformSeekBar.kt
@@ -28,6 +28,7 @@ import android.graphics.Paint
 import android.util.AttributeSet
 import androidx.annotation.ColorInt
 import androidx.appcompat.widget.AppCompatSeekBar
+import com.nextcloud.talk.utils.AudioUtils
 import kotlin.math.roundToInt
 
 class WaveformSeekBar : AppCompatSeekBar {
@@ -58,9 +59,20 @@ class WaveformSeekBar : AppCompatSeekBar {
         invalidate()
     }
 
+    /**
+     * Sets the wave data of the seekbar. Shrinks the data to a calculated number of bars based off the width of the
+     * seekBar. The greater the width, the more bars displayed.
+     *
+     * Note: bar gap = (usableWidth - waveData.size * DEFAULT_BAR_WIDTH) / (waveData.size - 1).toFloat()
+     * therefore, the gap is determined by the width of the seekBar by extension.
+     */
     fun setWaveData(data: FloatArray) {
-        waveData = data
-        invalidate()
+        val usableWidth = width - paddingLeft - paddingRight
+        if (usableWidth > 0) {
+            val numBars = if (usableWidth > VALUE_100) (usableWidth / WIDTH_DIVISOR) else usableWidth / 2f
+            waveData = AudioUtils.shrinkFloatArray(data, numBars.roundToInt())
+            invalidate()
+        }
     }
 
     private fun init() {
@@ -109,6 +121,8 @@ class WaveformSeekBar : AppCompatSeekBar {
     companion object {
         private const val DEFAULT_BAR_WIDTH: Int = 2
         private const val MAX_HEIGHT_DIVISOR: Float = 4.0f
+        private const val WIDTH_DIVISOR = 20f
+        private const val VALUE_100 = 100
         private val Int.dp: Int
             get() = (this * Resources.getSystem().displayMetrics.density).roundToInt()
     }

--- a/app/src/main/java/com/nextcloud/talk/utils/AudioUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/AudioUtils.kt
@@ -42,12 +42,14 @@ object AudioUtils {
     private val TAG = AudioUtils::class.java.simpleName
     private const val VALUE_10 = 10
     private const val TIME_LIMIT = 5000
+    private const val DEFAULT_SIZE = 500
 
     /**
-     * Suspension function, returns a FloatArray containing the values of an audio file squeezed between [0,1)
+     * Suspension function, returns a FloatArray of size 500, containing the values of an audio file squeezed between
+     * [0,1)
      */
     @Throws(IOException::class)
-    suspend fun audioFileToFloatArray(file: File, size: Int): FloatArray {
+    suspend fun audioFileToFloatArray(file: File): FloatArray {
         return suspendCoroutine {
             val startTime = SystemClock.elapsedRealtime()
             var result = mutableListOf<Float>()
@@ -142,22 +144,18 @@ object AudioUtils {
             while (result.size <= 0) {
                 continue
             }
-            it.resume(shrinkFloatArray(result.toFloatArray(), size))
+            it.resume(shrinkFloatArray(result.toFloatArray(), DEFAULT_SIZE))
         }
     }
 
-    private fun shrinkFloatArray(data: FloatArray, size: Int): FloatArray {
+    fun shrinkFloatArray(data: FloatArray, size: Int): FloatArray {
         val result = FloatArray(size)
         val scale = data.size / size
         var begin = 0
         var end = scale
         for (i in 0 until size) {
             val arr = data.copyOfRange(begin, end)
-            var sum = 0f
-            for (j in arr.indices) {
-                sum += arr[j]
-            }
-            result[i] = (sum / arr.size)
+            result[i] = arr.average().toFloat()
             begin += scale
             end += scale
         }

--- a/app/src/main/res/layout/item_custom_incoming_voice_message.xml
+++ b/app/src/main/res/layout/item_custom_incoming_voice_message.xml
@@ -113,10 +113,11 @@
                 android:id="@+id/voiceMessageDuration"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/standard_margin"
+                android:layout_marginStart="@dimen/standard_half_margin"
                 android:layout_gravity="center"
                 android:layout_weight="1"
                 android:visibility="invisible"
+                android:textColor="@color/high_emphasis_text"
                 tools:text="02:30"
                 tools:visibility="visible" />
 

--- a/app/src/main/res/layout/item_custom_outcoming_voice_message.xml
+++ b/app/src/main/res/layout/item_custom_outcoming_voice_message.xml
@@ -97,10 +97,11 @@
                 android:id="@+id/voiceMessageDuration"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/standard_margin"
+                android:layout_marginStart="@dimen/standard_half_margin"
                 android:layout_gravity="center"
                 android:layout_weight="1"
                 android:visibility="invisible"
+                android:textColor="@color/high_emphasis_text"
                 tools:text="02:30"
                 tools:visibility="visible" />
 


### PR DESCRIPTION
Fixes [this](https://github.com/nextcloud/talk-android/pull/3202#issuecomment-1662220530)

- Larger Bar gap
- Centered time below play/pause button
- Time is the same color as the play/pause button

Unfortunately, I wasn't able to fix the play time size. It's puzzling as on paper they should be equal 
![image](https://github.com/nextcloud/talk-android/assets/69230048/8f982e9c-6619-4fe9-b694-aa24aeecb424)
I believe that there is some underlying logic morphing the timestamp in `fun showReactions` located in the `com.nextcloud.talk.adapters.messages.Reaction`, but I didn't want to mess with it. 

---
I did some refactoring, so now the number of bars is calculated based off the width of the SeekBar itself. And by extension, the bar gap should also be calculated based off the width of the SeekBar, therefore no matter the size, it should always maintain a good ratio.

### Before
[follow-up-waveform-seekbar-fixes-before.webm](https://github.com/nextcloud/talk-android/assets/69230048/fd942f91-e72b-4d86-892b-ab2a56708d93)

### After
[follow-up-waveform-seekbar-fixes-after.webm](https://github.com/nextcloud/talk-android/assets/69230048/f547ee99-5dba-41f7-95c7-fc7a999512d9)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)