### PR TITLE
fix warning: tag with empty body

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -159,17 +159,17 @@
         <activity
             android:name=".activities.FullScreenImageActivity"
             android:configChanges="orientation|keyboardHidden|screenSize"
-            android:theme="@style/FullScreenImageTheme"></activity>
+            android:theme="@style/FullScreenImageTheme"/>
 
         <activity
             android:name=".activities.FullScreenMediaActivity"
             android:configChanges="orientation|keyboardHidden|screenSize"
-            android:theme="@style/FullScreenMediaTheme"></activity>
+            android:theme="@style/FullScreenMediaTheme"/>
 
         <activity
             android:name=".activities.FullScreenTextViewerActivity"
             android:configChanges="orientation|keyboardHidden|screenSize"
-            android:theme="@style/FullScreenTextTheme"></activity>
+            android:theme="@style/FullScreenTextTheme"/>
 
         <activity
             android:name=".activities.TakePhotoActivity"


### PR DESCRIPTION
Solves: #3273 
#### convert `<activity> </activity>`(because have empty body) tag to `<activity/>`.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)