### PR TITLE
Message draft bug fix

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -1004,7 +1004,11 @@ class ChatActivity :
     @SuppressLint("ClickableViewAccessibility")
     private fun initVoiceRecordButton() {
         if (!isVoiceRecordingLocked) {
-            showMicrophoneButton(true)
+            if (binding.messageInputView.messageInput.text!!.isNotEmpty()) {
+                showMicrophoneButton(false)
+            } else {
+                showMicrophoneButton(true)
+            }
         } else if (isVoiceRecordingInProgress) {
             binding.messageInputView.playPauseBtn.visibility = View.GONE
             binding.messageInputView.seekBar.visibility = View.GONE
@@ -3979,9 +3983,11 @@ class ChatActivity :
 
     private fun showMicrophoneButton(show: Boolean) {
         if (show && CapabilitiesUtilNew.hasSpreedFeatureCapability(conversationUser, "voice-message-sharing")) {
+            Log.d(TAG, "Microphone shown")
             binding.messageInputView.messageSendButton.visibility = View.GONE
             binding.messageInputView.recordAudioButton.visibility = View.VISIBLE
         } else {
+            Log.d(TAG, "Microphone hidden")
             binding.messageInputView.messageSendButton.visibility = View.VISIBLE
             binding.messageInputView.recordAudioButton.visibility = View.GONE
         }


### PR DESCRIPTION
Fixes [this](https://github.com/nextcloud/talk-android/pull/3224#issuecomment-1686413712)

Small bug fix, when returning to a message draft the send button image is now shown instead of the voice record button.

[message-draft-bug-1-after.webm](https://github.com/nextcloud/talk-android/assets/69230048/132e9807-023e-4dd1-a078-a50df04874c0)


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)