### PR TITLE
bump version to 17.2.0 Alpha01

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,8 +46,8 @@ android {
 
         // mayor.minor.hotfix.increment (for increment: 01-50=Alpha / 51-89=RC / 90-99=stable)
         // xx   .xxx  .xx    .xx
-        versionCode 170100020
-        versionName "17.10.0 Alpha 20"
+        versionCode 170200001
+        versionName "17.20.0 Alpha 01"
 
         flavorDimensions "default"
         renderscriptTargetApi 19


### PR DESCRIPTION
please be aware that Alpha versions for
17.20.* are meant to be 17.2.*

This is because of a typo that happened in 17.1


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)