### PR TITLE
Show accept call button in chat

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/CallStartedMessageInterface.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/CallStartedMessageInterface.kt
@@ -1,0 +1,25 @@
+/*
+ * Nextcloud Talk application
+ *
+ * @author Julius Linus
+ * Copyright (C) 2023 Julius Linus <julius.linus@nextcloud.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.nextcloud.talk.adapters.messages
+
+interface CallStartedMessageInterface {
+    fun joinAudioCall()
+    fun joinVideoCall()
+}

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/CallStartedViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/CallStartedViewHolder.kt
@@ -1,0 +1,129 @@
+/*
+ * Nextcloud Talk application
+ *
+ * @author Julius Linus
+ * Copyright (C) 2023 Julius Linus <julius.linus@nextcloud.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.nextcloud.talk.adapters.messages
+
+import android.content.Context
+import android.graphics.drawable.Drawable
+import android.view.View
+import autodagger.AutoInjector
+import coil.Coil.imageLoader
+import coil.request.ImageRequest
+import coil.target.Target
+import coil.transform.CircleCropTransformation
+import com.nextcloud.talk.application.NextcloudTalkApplication
+import com.nextcloud.talk.databinding.CallStartedMessageBinding
+import com.nextcloud.talk.models.json.chat.ChatMessage
+import com.nextcloud.talk.ui.theme.ViewThemeUtils
+import com.nextcloud.talk.users.UserManager
+import com.nextcloud.talk.utils.ApiUtils
+import com.stfalcon.chatkit.messages.MessageHolders
+import javax.inject.Inject
+
+@AutoInjector(NextcloudTalkApplication::class)
+class CallStartedViewHolder(incomingView: View, payload: Any) :
+    MessageHolders.BaseIncomingMessageViewHolder<ChatMessage>(incomingView, payload) {
+    private val binding: CallStartedMessageBinding = CallStartedMessageBinding.bind(incomingView)
+
+    @Inject
+    lateinit var context: Context
+
+    @Inject
+    lateinit var userManager: UserManager
+
+    @Inject
+    lateinit var viewThemeUtils: ViewThemeUtils
+
+    private lateinit var messageInterface: CallStartedMessageInterface
+
+    override fun onBind(message: ChatMessage) {
+        super.onBind(message)
+        NextcloudTalkApplication.sharedApplication!!.componentApplication.inject(this)
+        themeBackground()
+        setUpAvatarProfile(message)
+        binding.callAuthorChip.text = message.actorDisplayName
+        binding.joinVideoCall.setOnClickListener { messageInterface.joinVideoCall() }
+        binding.joinAudioCall.setOnClickListener { messageInterface.joinAudioCall() }
+    }
+
+    private fun themeBackground() {
+        binding.callStartedBackground.apply {
+            viewThemeUtils.talk.themeOutgoingMessageBubble(this, grouped = true, false)
+        }
+
+        binding.callAuthorChip.apply {
+            viewThemeUtils.material.colorChipBackground(this)
+        }
+    }
+
+    private fun setUpAvatarProfile(message: ChatMessage) {
+        val user = userManager.currentUser.blockingGet()
+        val url: String = if (message.actorType == "guests" || message.actorType == "guest") {
+            ApiUtils.getUrlForGuestAvatar(
+                user!!.baseUrl,
+                message.actorDisplayName,
+                true
+            )
+        } else {
+            ApiUtils.getUrlForAvatar(user!!.baseUrl, message.actorDisplayName, true)
+        }
+
+        val imageRequest: ImageRequest = ImageRequest.Builder(context)
+            .data(url)
+            .crossfade(true)
+            .transformations(CircleCropTransformation())
+            .target(object : Target {
+                override fun onStart(placeholder: Drawable?) {
+                    // unused atm
+                }
+
+                override fun onError(error: Drawable?) {
+                    // unused atm
+                }
+
+                override fun onSuccess(result: Drawable) {
+                    binding.callAuthorChip.chipIcon = result
+                }
+            })
+            .build()
+
+        imageLoader(context).enqueue(imageRequest)
+    }
+
+    fun assignCallStartedMessageInterface(inf: CallStartedMessageInterface) {
+        messageInterface = inf
+    }
+
+    override fun viewDetached() {
+        // unused atm
+    }
+
+    override fun viewAttached() {
+        // unused atm
+    }
+
+    override fun viewRecycled() {
+        // unused atm
+    }
+
+    companion object {
+        var TAG: String? = CallStartedViewHolder::class.simpleName
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/TalkMessagesListAdapter.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/TalkMessagesListAdapter.java
@@ -77,6 +77,8 @@ public class TalkMessagesListAdapter<M extends IMessage> extends MessagesListAda
 
         } else if (holder instanceof SystemMessageViewHolder) {
             ((SystemMessageViewHolder) holder).assignSystemMessageInterface(chatActivity);
+        } else if (holder instanceof CallStartedViewHolder) {
+            ((CallStartedViewHolder) holder).assignCallStartedMessageInterface(chatActivity);
         }
     }
 }

--- a/app/src/main/res/layout/call_started_message.xml
+++ b/app/src/main/res/layout/call_started_message.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Nextcloud Talk application
+  ~
+  ~ @author Julius Linus
+  ~ Copyright (C) 2023 Julius Linus <julius.linus@nextcloud.com>
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/call_started_background"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/standard_double_margin"
+    android:padding="@dimen/standard_padding"
+    tools:background="@drawable/shape_grouped_outcoming_message"
+    tools:backgroundTint="@color/colorPrimaryDark">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/standard_margin"
+        android:orientation="horizontal"
+        android:gravity="center">
+
+        <com.google.android.material.chip.Chip
+            android:id="@+id/call_author_chip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/standard_quarter_margin"
+            app:chipIcon="@drawable/accent_circle"
+            app:chipCornerRadius="@dimen/dialogBorderRadius"
+            tools:text="Jessica Fox" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/started_a_call" />
+
+    </LinearLayout>
+
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/join_video_call"
+            style="@style/Widget.Material3.Button.Icon"
+            android:backgroundTint="@color/nc_darkGreen"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/standard_half_margin"
+            app:icon="@drawable/ic_videocam_grey_600_24dp"
+            app:iconTint="@color/white"
+            android:alpha="0.8"
+            android:textColor="@color/white"
+            android:text="@string/video_call" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/join_audio_call"
+            style="@style/Widget.Material3.Button.Icon"
+            android:backgroundTint="@color/nc_darkGreen"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/standard_half_margin"
+            android:alpha="0.8"
+            app:icon="@drawable/ic_phone"
+            app:iconTint="@color/white"
+            android:text="@string/audio_call"
+            android:textColor="@color/white" />
+    </LinearLayout>
+
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -706,6 +706,9 @@ How to translate with transifex:
     <string name="custom">Custom</string>
     <string name="set">Set</string>
     <string name="calendar">Calendar</string>
+    <string name="video_call">Video Call</string>
+    <string name="audio_call">Audio Call</string>
+    <string name="started_a_call">started a call</string>
     <string name="nc_settings_phone_book_integration_phone_number_dialog_429">Error 429 Too Many Requests</string>
 
 </resources>


### PR DESCRIPTION
fixes #3260 

## Current UI
| Dark | Light | Guest |
|--------|--------|--------|
| <img width="168" alt="image" src="https://github.com/nextcloud/talk-android/assets/69230048/2a713f89-aed4-45d5-be0c-553b72cedc5e">| <img width="167" alt="image" src="https://github.com/nextcloud/talk-android/assets/69230048/d018f3e3-98f8-4c3c-98b5-091abaa5d6d2">| <img width="160" alt="image" src="https://github.com/nextcloud/talk-android/assets/69230048/8e30b917-4034-4a11-96ee-5618e66943bb">| 

## Functionality
[show-accept-button-1.webm](https://github.com/nextcloud/talk-android/assets/69230048/f798634a-b69a-4d46-bffd-6004731632fe)



- Both join audio and video buttons
- Gets deleted if call ends, persists despite state or adapter changes
- Themed

## TODO
- [x] Complete Functionality
   - [x] Get it working for guests
   - [x] Get it working for users
- [x] Finish Implementing the mention chip
- [x] detekt 😠 
- [x] review
- [ ] deal with git commit signatures

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)