### PR TITLE
Fixed bug with continuous voice recording

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -2142,19 +2142,15 @@ class ChatActivity :
     }
 
     private fun stopAndSendAudioRecording() {
-        if (isVoiceRecordingInProgress) {
-            stopAudioRecording()
-            Log.d(TAG, "stopped and sent audio recording")
-            val uri = Uri.fromFile(File(currentVoiceRecordFile))
-            uploadFile(uri.toString(), true)
-        }
+        stopAudioRecording()
+        Log.d(TAG, "stopped and sent audio recording")
+        val uri = Uri.fromFile(File(currentVoiceRecordFile))
+        uploadFile(uri.toString(), true)
     }
 
     private fun stopAndDiscardAudioRecording() {
-        if (isVoiceRecordingInProgress) {
-            stopAudioRecording()
-            Log.d(TAG, "stopped and discarded audio recording")
-        }
+        stopAudioRecording()
+        Log.d(TAG, "stopped and discarded audio recording")
 
         val cachedFile = File(currentVoiceRecordFile)
         cachedFile.delete()


### PR DESCRIPTION
fixed bug with audio messages not sending after pausing in continuous voice recording mode. I must have forgotten to remove those two if statements, when fixing a previous bug.

[voice-recording-bug-fix.webm](https://github.com/nextcloud/talk-android/assets/69230048/b2e18e5f-3c93-4cd5-98bc-12864a02e677)


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)