### PR TITLE
TimePicker format matches locale of device

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/DateTimePickerFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/DateTimePickerFragment.kt
@@ -21,6 +21,7 @@ package com.nextcloud.talk.ui.dialog
 
 import android.app.Dialog
 import android.os.Bundle
+import android.text.format.DateFormat
 import android.text.format.DateUtils
 import android.view.LayoutInflater
 import android.view.View
@@ -32,6 +33,7 @@ import com.google.android.material.datepicker.DateValidatorPointForward
 import com.google.android.material.datepicker.MaterialDatePicker
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.timepicker.MaterialTimePicker
+import com.google.android.material.timepicker.TimeFormat
 import com.nextcloud.android.common.ui.theme.utils.ColorRole
 import com.nextcloud.talk.R
 import com.nextcloud.talk.application.NextcloudTalkApplication
@@ -229,9 +231,10 @@ class DateTimePickerFragment(
     }
 
     private fun setUpTimePicker(year: Int, month: Int, day: Int, weekInYear: Int) {
-        val timePicker = MaterialTimePicker
-            .Builder()
+        val locale = if (DateFormat.is24HourFormat(requireContext())) TimeFormat.CLOCK_24H else TimeFormat.CLOCK_12H
+        val timePicker = MaterialTimePicker.Builder()
             .setTitleText(R.string.nc_remind)
+            .setTimeFormat(locale)
             .build()
 
         timePicker.addOnPositiveButtonClickListener {


### PR DESCRIPTION
fixes #3326 

Google's default time format is 12hr, I switched it to the time format of the device itself, whether it be 12 or 24

### 🖼️ Screenshots

🏚️ Before

[issue-3326-before.webm](https://github.com/nextcloud/talk-android/assets/69230048/82f2b1fe-1d72-49f8-8634-2d903ad7e4ba)

🏡 After

[issue-3326-after.webm](https://github.com/nextcloud/talk-android/assets/69230048/0d7b7dad-f777-4d86-a00d-23d6019d367f)

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)