### PR TITLE
fix endless loop when opening urls and files app is not installed.

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -2668,15 +2668,15 @@ class ChatActivity :
             if (uri.startsWith(user.baseUrl!!)) {
                 if (UriUtils.isInstanceInternalFileShareUrl(user.baseUrl!!, uri)) {
                     // https://cloud.nextcloud.com/f/41
-                    val fileViewerUtils = FileViewerUtils(this, user)
+                    val fileViewerUtils = FileViewerUtils(applicationContext, user)
                     fileViewerUtils.openFileInFilesApp(uri, UriUtils.extractInstanceInternalFileShareFileId(uri))
                 } else if (UriUtils.isInstanceInternalFileUrl(user.baseUrl!!, uri)) {
                     // https://cloud.nextcloud.com/apps/files/?dir=/Engineering&fileid=41
-                    val fileViewerUtils = FileViewerUtils(this, user)
+                    val fileViewerUtils = FileViewerUtils(applicationContext, user)
                     fileViewerUtils.openFileInFilesApp(uri, UriUtils.extractInstanceInternalFileFileId(uri))
                 } else if (UriUtils.isInstanceInternalFileUrlNew(user.baseUrl!!, uri)) {
                     // https://cloud.nextcloud.com/apps/files/?dir=/Engineering&fileid=41
-                    val fileViewerUtils = FileViewerUtils(this, user)
+                    val fileViewerUtils = FileViewerUtils(applicationContext, user)
                     fileViewerUtils.openFileInFilesApp(uri, UriUtils.extractInstanceInternalFileFileIdNew(uri))
                 } else {
                     super.startActivity(intent)


### PR DESCRIPTION
followup to #3329

Without this fix, the ChatActivity would be started again in FileViewerUtils. There was an endless loop between ChatActivity and FileViewerUtils because of the wrong context. Instead to open the browser, the app did nothing or freezed.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)