### PR TITLE
Bug fix for accept call message

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/CallStartedViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/CallStartedViewHolder.kt
@@ -82,7 +82,7 @@ class CallStartedViewHolder(incomingView: View, payload: Any) :
                 true
             )
         } else {
-            ApiUtils.getUrlForAvatar(user!!.baseUrl, message.actorDisplayName, true)
+            ApiUtils.getUrlForAvatar(user!!.baseUrl, message.actorDisplayName, false)
         }
 
         val imageRequest: ImageRequest = ImageRequest.Builder(context)

--- a/app/src/main/res/layout/call_started_message.xml
+++ b/app/src/main/res/layout/call_started_message.xml
@@ -32,7 +32,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="@dimen/standard_margin"
+        android:layout_marginBottom="@dimen/standard_margin"
         android:orientation="horizontal"
         android:gravity="center">
 
@@ -65,10 +65,9 @@
             android:backgroundTint="@color/nc_darkGreen"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/standard_margin"
+            android:layout_marginEnd="@dimen/standard_margin"
             app:icon="@drawable/ic_videocam_grey_600_24dp"
             app:iconTint="@color/white"
-            android:alpha="0.8"
             android:textColor="@color/white"
             android:text="@string/video_call" />
 
@@ -78,8 +77,6 @@
             android:backgroundTint="@color/nc_darkGreen"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/standard_margin"
-            android:alpha="0.8"
             app:icon="@drawable/ic_phone"
             app:iconTint="@color/white"
             android:text="@string/audio_call"

--- a/app/src/main/res/layout/call_started_message.xml
+++ b/app/src/main/res/layout/call_started_message.xml
@@ -24,7 +24,7 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginHorizontal="@dimen/standard_double_margin"
+    android:layout_marginHorizontal="@dimen/standard_margin"
     android:padding="@dimen/standard_padding"
     tools:background="@drawable/shape_grouped_outcoming_message"
     tools:backgroundTint="@color/colorPrimaryDark">

--- a/app/src/main/res/layout/call_started_message.xml
+++ b/app/src/main/res/layout/call_started_message.xml
@@ -41,9 +41,9 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/standard_quarter_margin"
-            app:chipIcon="@drawable/accent_circle"
+            app:chipIcon="@drawable/account_circle_48dp"
             app:chipCornerRadius="@dimen/dialogBorderRadius"
-            tools:text="Jessica Fox" />
+            tools:text="Julius James Linus" />
 
         <TextView
             android:layout_width="wrap_content"
@@ -65,7 +65,7 @@
             android:backgroundTint="@color/nc_darkGreen"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/standard_half_margin"
+            android:layout_marginHorizontal="@dimen/standard_margin"
             app:icon="@drawable/ic_videocam_grey_600_24dp"
             app:iconTint="@color/white"
             android:alpha="0.8"
@@ -78,7 +78,7 @@
             android:backgroundTint="@color/nc_darkGreen"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/standard_half_margin"
+            android:layout_marginHorizontal="@dimen/standard_margin"
             android:alpha="0.8"
             app:icon="@drawable/ic_phone"
             app:iconTint="@color/white"


### PR DESCRIPTION
### 🖼️ Screenshots

Context on a OnePlus 9 Pro
![image](https://github.com/nextcloud/talk-android/assets/69230048/6313df0b-760c-4062-8486-2f1e852d781c)

Replicated in IDE
🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/talk-android/assets/69230048/2e39414d-09e4-4441-b657-fce4b2c98951) | <img width="315" alt="2023-10-04 11_29_19-talk-android-fix_accept_call_button_reformating – call_started_message xml  talk" src="https://github.com/nextcloud/talk-android/assets/1315170/a60cc4ca-ddbf-4d6b-b9c2-971518044eb8">


Note: the profile picture also didn't load in the image. I think by setting the request size to small, this changed, but I'll need to test it some more to be sure. For now I also set the default profile to the account_circle_48dp

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)