### PR TITLE
Adjusting translation provider

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/api/NcApi.java
+++ b/app/src/main/java/com/nextcloud/talk/api/NcApi.java
@@ -49,6 +49,7 @@ import com.nextcloud.talk.models.json.unifiedsearch.UnifiedSearchOverall;
 import com.nextcloud.talk.models.json.userprofile.UserProfileFieldsOverall;
 import com.nextcloud.talk.models.json.userprofile.UserProfileOverall;
 import com.nextcloud.talk.polls.repositories.model.PollOverall;
+import com.nextcloud.talk.translate.repositories.model.LanguagesOverall;
 import com.nextcloud.talk.translate.repositories.model.TranslationsOverall;
 
 import java.util.List;
@@ -674,6 +675,10 @@ public interface NcApi {
                                                      @Query("text") String text,
                                                      @Query("toLanguage") String toLanguage,
                                                      @Nullable @Query("fromLanguage") String fromLanguage);
+
+    @GET
+    Observable<LanguagesOverall> getLanguages(@Header("Authorization") String authorization,
+                                              @Url String url);
 
     @GET
     Observable<ReminderOverall> getReminder(@Header("Authorization") String authorization,

--- a/app/src/main/java/com/nextcloud/talk/translate/repositories/TranslateRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/translate/repositories/TranslateRepository.kt
@@ -1,5 +1,6 @@
 package com.nextcloud.talk.translate.repositories
 
+import com.nextcloud.talk.translate.repositories.model.Language
 import io.reactivex.Observable
 
 interface TranslateRepository {
@@ -11,4 +12,9 @@ interface TranslateRepository {
         toLanguage: String,
         fromLanguage: String?
     ): Observable<String>
+
+    fun getLanguages(
+        authorization: String,
+        url: String
+    ): Observable<List<Language>>
 }

--- a/app/src/main/java/com/nextcloud/talk/translate/repositories/TranslateRepositoryImpl.kt
+++ b/app/src/main/java/com/nextcloud/talk/translate/repositories/TranslateRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.nextcloud.talk.translate.repositories
 
 import com.nextcloud.talk.api.NcApi
+import com.nextcloud.talk.translate.repositories.model.Language
 import io.reactivex.Observable
 import javax.inject.Inject
 
@@ -14,5 +15,9 @@ class TranslateRepositoryImpl @Inject constructor(private val ncApi: NcApi) : Tr
         fromLanguage: String?
     ): Observable<String> {
         return ncApi.translateMessage(authorization, url, text, toLanguage, fromLanguage).map { it.ocs?.data!!.text }
+    }
+
+    override fun getLanguages(authorization: String, url: String): Observable<List<Language>> {
+        return ncApi.getLanguages(authorization, url).map { it.ocs?.data?.languages }
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/translate/repositories/model/Language.kt
+++ b/app/src/main/java/com/nextcloud/talk/translate/repositories/model/Language.kt
@@ -22,17 +22,20 @@ package com.nextcloud.talk.translate.repositories.model
 import android.os.Parcelable
 import com.bluelinelabs.logansquare.annotation.JsonField
 import com.bluelinelabs.logansquare.annotation.JsonObject
-import com.nextcloud.talk.models.json.generic.GenericMeta
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 @JsonObject
-data class TranslateOCS(
-    @JsonField(name = ["meta"])
-    var meta: GenericMeta?,
-    @JsonField(name = ["data"])
-    var data: TranslateData?
+data class Language(
+    @JsonField(name = ["from"])
+    var from: String?,
+    @JsonField(name = ["fromLabel"])
+    var fromLabel: String?,
+    @JsonField(name = ["to"])
+    var to: String?,
+    @JsonField(name = ["toLabel"])
+    var toLabel: String?
 ) : Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
-    constructor() : this(null, TranslateData())
+    constructor() : this(null, null, null, null)
 }

--- a/app/src/main/java/com/nextcloud/talk/translate/repositories/model/LanguagesData.kt
+++ b/app/src/main/java/com/nextcloud/talk/translate/repositories/model/LanguagesData.kt
@@ -22,17 +22,16 @@ package com.nextcloud.talk.translate.repositories.model
 import android.os.Parcelable
 import com.bluelinelabs.logansquare.annotation.JsonField
 import com.bluelinelabs.logansquare.annotation.JsonObject
-import com.nextcloud.talk.models.json.generic.GenericMeta
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 @JsonObject
-data class TranslateOCS(
-    @JsonField(name = ["meta"])
-    var meta: GenericMeta?,
-    @JsonField(name = ["data"])
-    var data: TranslateData?
+data class LanguagesData(
+    @JsonField(name = ["languageDetection"])
+    var languageDetection: Boolean?,
+    @JsonField(name = ["languages"])
+    var languages: List<Language>?
 ) : Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
-    constructor() : this(null, TranslateData())
+    constructor() : this(null, null)
 }

--- a/app/src/main/java/com/nextcloud/talk/translate/repositories/model/LanguagesOCS.kt
+++ b/app/src/main/java/com/nextcloud/talk/translate/repositories/model/LanguagesOCS.kt
@@ -27,12 +27,12 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 @JsonObject
-data class TranslateOCS(
+data class LanguagesOCS(
     @JsonField(name = ["meta"])
     var meta: GenericMeta?,
     @JsonField(name = ["data"])
-    var data: TranslateData?
+    var data: LanguagesData?
 ) : Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
-    constructor() : this(null, TranslateData())
+    constructor() : this(null, null)
 }

--- a/app/src/main/java/com/nextcloud/talk/translate/repositories/model/LanguagesOverall.kt
+++ b/app/src/main/java/com/nextcloud/talk/translate/repositories/model/LanguagesOverall.kt
@@ -22,17 +22,14 @@ package com.nextcloud.talk.translate.repositories.model
 import android.os.Parcelable
 import com.bluelinelabs.logansquare.annotation.JsonField
 import com.bluelinelabs.logansquare.annotation.JsonObject
-import com.nextcloud.talk.models.json.generic.GenericMeta
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 @JsonObject
-data class TranslateOCS(
-    @JsonField(name = ["meta"])
-    var meta: GenericMeta?,
-    @JsonField(name = ["data"])
-    var data: TranslateData?
+class LanguagesOverall(
+    @JsonField(name = ["ocs"])
+    var ocs: LanguagesOCS?
 ) : Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
-    constructor() : this(null, TranslateData())
+    constructor() : this(null)
 }

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
@@ -57,7 +57,6 @@ import io.reactivex.Observer
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
-import org.json.JSONArray
 import javax.inject.Inject
 
 @AutoInjector(NextcloudTalkApplication::class)
@@ -94,8 +93,7 @@ class MessageActionsDialog(
         initMenuItemTranslate(
             !message.isDeleted &&
                 ChatMessage.MessageType.REGULAR_TEXT_MESSAGE == message.getCalculateMessageType() &&
-                CapabilitiesUtilNew.isTranslationsSupported(user) &&
-                JSONArray((CapabilitiesUtilNew.getLanguages(user) as ArrayList<*>).toArray()).length() > 0
+                CapabilitiesUtilNew.isTranslationsSupported(user)
         )
         initMenuReplyToMessage(message.replyable && hasChatPermission)
         initMenuReplyPrivately(

--- a/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
@@ -532,6 +532,10 @@ public class ApiUtils {
         return baseUrl + ocsApiVersion + "/translation/translate";
     }
 
+    public static String getUrlForLanguages(String baseUrl) {
+        return baseUrl + ocsApiVersion + "/translation/languages";
+    }
+
     public static String getUrlForReminder(User user, String roomToken, String messageId, int version) {
         String url = ApiUtils.getUrlForChatMessage(version, user.getBaseUrl(), roomToken, messageId);
         return url + "/reminder";

--- a/app/src/main/java/com/nextcloud/talk/utils/database/user/CapabilitiesUtilNew.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/database/user/CapabilitiesUtilNew.kt
@@ -214,12 +214,8 @@ object CapabilitiesUtilNew {
 
     @JvmStatic
     fun isLinkPreviewAvailable(user: User): Boolean {
-        if (user.capabilities?.coreCapability?.referenceApi != null &&
+        return user.capabilities?.coreCapability?.referenceApi != null &&
             user.capabilities?.coreCapability?.referenceApi == "true"
-        ) {
-            return true
-        }
-        return false
     }
 
     fun isTranslationsSupported(user: User?): Boolean {
@@ -227,18 +223,11 @@ object CapabilitiesUtilNew {
             val capabilities = user.capabilities
             return capabilities?.spreedCapability?.config?.containsKey("chat") == true &&
                 capabilities.spreedCapability!!.config!!["chat"] != null &&
-                capabilities.spreedCapability!!.config!!["chat"]!!.containsKey("translations")
+                capabilities.spreedCapability!!.config!!["chat"]!!.containsKey("has-translation-providers") &&
+                capabilities.spreedCapability!!.config!!["chat"]!!["has-translation-providers"] == true
         }
 
         return false
-    }
-
-    fun getLanguages(user: User?): Any? {
-        return if (isTranslationsSupported(user)) {
-            user!!.capabilities!!.spreedCapability!!.config!!["chat"]!!["translations"]
-        } else {
-            null
-        }
     }
 
     fun isRemindSupported(user: User?): Boolean {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -722,4 +722,6 @@ How to translate with transifex:
     <string name="started_a_call">started a call</string>
     <string name="nc_settings_phone_book_integration_phone_number_dialog_429">Error 429 Too Many Requests</string>
     <string name="nc_caption">Caption</string>
+    <string name="languages_error_title">Retrieval failed</string>
+    <string name="languages_error_message">Languages could not be retrieved</string>
 </resources>


### PR DESCRIPTION
- fixes #3347 


Adjusting the translation feature to use the new API [docs](https://docs.nextcloud.com/server/latest/developer_manual/client_apis/OCS/ocs-translation-api.html#get-available-translation-options). 

[issue-3347-1.webm](https://github.com/nextcloud/talk-android/assets/69230048/7318994f-e1d1-4378-b807-81c1819d2636)

<img width="274" alt="image" src="https://github.com/nextcloud/talk-android/assets/69230048/5701ff99-3910-446f-bf07-64c6ee997876">

- Added 4 new model data classes
- Added the new API function to NcApi
- Implemented the changes in the Repository + ViewModel
- Implemented the changes in the Activity
- Added some helper functions to support impl

Signed-off-by: Julius Linus <julius.linus@nextcloud.com>

### 🚧 TODO

- [x] message actions dialog
- [x] API function
- [x] repository implementation
- [x] view model
- [x] finish activity
- [x] test it
- [ ] review

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)