### PR TITLE
Small Bug fix - Privacy button in settings not working

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -60,7 +60,6 @@ import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import autodagger.AutoInjector
-import com.afollestad.materialdialogs.utils.MDUtil.getStringArray
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.textfield.TextInputLayout
@@ -104,6 +103,7 @@ import java.net.URISyntaxException
 import java.util.Locale
 import javax.inject.Inject
 
+@Suppress("LargeClass", "TooManyFunctions")
 @AutoInjector(NextcloudTalkApplication::class)
 class SettingsActivity : BaseActivity() {
     private lateinit var binding: ActivitySettingsBinding
@@ -393,9 +393,11 @@ class SettingsActivity : BaseActivity() {
                 screenSecurityChangeListener = it
             }
         )
-        var pos = getStringArray(R.array.screen_lock_timeout_entry_values).indexOf(appPreferences.screenLockTimeout)
+        var pos = resources.getStringArray(R.array.screen_lock_timeout_entry_values).indexOf(
+            appPreferences.screenLockTimeout
+        )
         binding.settingsScreenLockTimeoutLayoutDropdown.setText(
-            getStringArray(R.array.screen_lock_timeout_descriptions)[pos]
+            resources.getStringArray(R.array.screen_lock_timeout_descriptions)[pos]
         )
         binding.settingsScreenLockTimeoutLayoutDropdown.setSimpleItems(R.array.screen_lock_timeout_descriptions)
         binding.settingsScreenLockTimeoutLayoutDropdown.setOnItemClickListener { _, _, position, _ ->
@@ -408,11 +410,11 @@ class SettingsActivity : BaseActivity() {
                 screenLockTimeoutChangeListener = it
             }
         )
-        pos = getStringArray(R.array.theme_entry_values).indexOf(appPreferences.theme)
-        binding.settingsTheme.setText(getStringArray(R.array.theme_descriptions)[pos])
+        pos = resources.getStringArray(R.array.theme_entry_values).indexOf(appPreferences.theme)
+        binding.settingsTheme.setText(resources.getStringArray(R.array.theme_descriptions)[pos])
         binding.settingsTheme.setSimpleItems(R.array.theme_descriptions)
         binding.settingsTheme.setOnItemClickListener { _, _, position, _ ->
-            val entryVal: String = getStringArray(R.array.theme_entry_values)[position]
+            val entryVal: String = resources.getStringArray(R.array.theme_entry_values)[position]
             appPreferences.theme = entryVal
         }
         appPreferences.registerThemeChangeListener(ThemeChangeListener().also { themeChangeListener = it })
@@ -426,9 +428,7 @@ class SettingsActivity : BaseActivity() {
                 readPrivacyChangeListener = it
             }
         )
-        binding.settingsPrivacy.setOnClickListener {
-            readPrivacyChangeListener!!.onChanged(!binding.settingsReadPrivacySwitch.isChecked)
-        }
+
         appPreferences.registerTypingStatusChangeListener(
             TypingStatusChangeListener().also {
                 typingStatusChangeListener = it
@@ -527,7 +527,7 @@ class SettingsActivity : BaseActivity() {
         binding.settingsProxyChoice.setText(appPreferences.proxyType)
         binding.settingsProxyChoice.setSimpleItems(R.array.proxy_type_descriptions)
         binding.settingsProxyChoice.setOnItemClickListener { _, _, position, _ ->
-            val entryVal = getStringArray(R.array.proxy_type_descriptions)[position]
+            val entryVal = resources.getStringArray(R.array.proxy_type_descriptions)[position]
             appPreferences.proxyType = entryVal
         }
 


### PR DESCRIPTION
I didn't remove a couple lines of code after removing ```MaterialPreferences``` a while back. Also cleaned up ```SettingsActivity``` a bit because it was annoying me 😐 

### 🖼️ Screenshots

🏚️ Before 

[bug_fix_privacy_button_before.webm](https://github.com/nextcloud/talk-android/assets/69230048/bc790d9b-60f0-45d2-ba2f-e09e8a6a4a73)

🏡 After

[bug_fix_privacy_button_after.webm](https://github.com/nextcloud/talk-android/assets/69230048/57643c8d-385b-472a-a3c0-9e8ab6601d66)


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)