### PR TITLE
Remove use of setSystemUiVisibility in previews #3372

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/FullScreenImageActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/FullScreenImageActivity.kt
@@ -62,27 +62,31 @@ class FullScreenImageActivity : AppCompatActivity() {
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return if (item.itemId == android.R.id.home) {
-            onBackPressedDispatcher.onBackPressed()
-            true
-        } else if (item.itemId == R.id.share) {
-            val shareUri = FileProvider.getUriForFile(
-                this,
-                BuildConfig.APPLICATION_ID,
-                File(path)
-            )
-
-            val shareIntent: Intent = Intent().apply {
-                action = Intent.ACTION_SEND
-                putExtra(Intent.EXTRA_STREAM, shareUri)
-                type = IMAGE_PREFIX_GENERIC
-                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        return when (item.itemId) {
+            android.R.id.home -> {
+                onBackPressedDispatcher.onBackPressed()
+                true
             }
-            startActivity(Intent.createChooser(shareIntent, resources.getText(R.string.send_to)))
+            R.id.share -> {
+                val shareUri = FileProvider.getUriForFile(
+                    this,
+                    BuildConfig.APPLICATION_ID,
+                    File(path)
+                )
 
-            true
-        } else {
-            super.onOptionsItemSelected(item)
+                val shareIntent: Intent = Intent().apply {
+                    action = Intent.ACTION_SEND
+                    putExtra(Intent.EXTRA_STREAM, shareUri)
+                    type = IMAGE_PREFIX_GENERIC
+                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                }
+                startActivity(Intent.createChooser(shareIntent, resources.getText(R.string.send_to)))
+
+                true
+            }
+            else -> {
+                super.onOptionsItemSelected(item)
+            }
         }
     }
 
@@ -96,7 +100,7 @@ class FullScreenImageActivity : AppCompatActivity() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
         initWindowInsetsController()
         applyWindowInsets()
-        binding.photoView.setOnPhotoTapListener { view, x, y ->
+        binding.photoView.setOnPhotoTapListener { _, _, _ ->
             toggleFullscreen()
         }
         binding.photoView.setOnOutsidePhotoTapListener {
@@ -185,7 +189,7 @@ class FullScreenImageActivity : AppCompatActivity() {
     }
 
     companion object {
-        private val TAG = "FullScreenImageActivity"
+        private const val TAG = "FullScreenImageActivity"
         private const val HUNDRED_MB = 100 * 1024 * 1024
         private const val MAX_SCALE = 6.0f
         private const val MEDIUM_SCALE = 2.45f

--- a/app/src/main/java/com/nextcloud/talk/activities/FullScreenMediaActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/FullScreenMediaActivity.kt
@@ -73,27 +73,31 @@ class FullScreenMediaActivity : AppCompatActivity() {
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return if (item.itemId == android.R.id.home) {
-            onBackPressedDispatcher.onBackPressed()
-            true
-        } else if (item.itemId == R.id.share) {
-            val shareUri = FileProvider.getUriForFile(
-                this,
-                BuildConfig.APPLICATION_ID,
-                File(path)
-            )
-
-            val shareIntent: Intent = Intent().apply {
-                action = Intent.ACTION_SEND
-                putExtra(Intent.EXTRA_STREAM, shareUri)
-                type = VIDEO_PREFIX_GENERIC
-                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        return when (item.itemId) {
+            android.R.id.home -> {
+                onBackPressedDispatcher.onBackPressed()
+                true
             }
-            startActivity(Intent.createChooser(shareIntent, resources.getText(R.string.send_to)))
+            R.id.share -> {
+                val shareUri = FileProvider.getUriForFile(
+                    this,
+                    BuildConfig.APPLICATION_ID,
+                    File(path)
+                )
 
-            true
-        } else {
-            super.onOptionsItemSelected(item)
+                val shareIntent: Intent = Intent().apply {
+                    action = Intent.ACTION_SEND
+                    putExtra(Intent.EXTRA_STREAM, shareUri)
+                    type = VIDEO_PREFIX_GENERIC
+                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                }
+                startActivity(Intent.createChooser(shareIntent, resources.getText(R.string.send_to)))
+
+                true
+            }
+            else -> {
+                super.onOptionsItemSelected(item)
+            }
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/activities/FullScreenMediaActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/FullScreenMediaActivity.kt
@@ -30,14 +30,23 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
-import android.view.View
+import android.view.ViewGroup.MarginLayoutParams
 import android.view.WindowManager
+import android.widget.FrameLayout
 import androidx.annotation.OptIn
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.FileProvider
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
+import androidx.core.view.marginBottom
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
 import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.DefaultTimeBar
 import androidx.media3.ui.PlayerView
 import autodagger.AutoInjector
 import com.nextcloud.talk.BuildConfig
@@ -56,6 +65,7 @@ class FullScreenMediaActivity : AppCompatActivity() {
 
     private var playWhenReadyState: Boolean = true
     private var playBackPosition: Long = 0L
+    private lateinit var windowInsetsController: WindowInsetsControllerCompat
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.menu_preview, menu)
@@ -90,7 +100,7 @@ class FullScreenMediaActivity : AppCompatActivity() {
     @OptIn(UnstableApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         val fileName = intent.getStringExtra("FILE_NAME")
         val isAudioOnly = intent.getBooleanExtra("AUDIO_ONLY", false)
 
@@ -110,14 +120,15 @@ class FullScreenMediaActivity : AppCompatActivity() {
             binding.playerView.controllerShowTimeoutMs = 0
         }
 
+        initWindowInsetsController()
+        applyWindowInsets()
+
         binding.playerView.setControllerVisibilityListener(
             PlayerView.ControllerVisibilityListener { v ->
                 if (v != 0) {
-                    hideSystemUI()
-                    supportActionBar?.hide()
+                    enterImmersiveMode()
                 } else {
-                    showSystemUI()
-                    supportActionBar?.show()
+                    exitImmersiveMode()
                 }
             }
         )
@@ -158,22 +169,44 @@ class FullScreenMediaActivity : AppCompatActivity() {
         player = null
     }
 
-    private fun hideSystemUI() {
-        window.decorView.systemUiVisibility = (
-            View.SYSTEM_UI_FLAG_IMMERSIVE
-                or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                or View.SYSTEM_UI_FLAG_FULLSCREEN
-            )
+    private fun initWindowInsetsController() {
+        windowInsetsController = WindowCompat.getInsetsController(window, window.decorView)
+        windowInsetsController.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
     }
 
-    private fun showSystemUI() {
-        window.decorView.systemUiVisibility = (
-            View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+    private fun enterImmersiveMode() {
+        windowInsetsController.hide(WindowInsetsCompat.Type.systemBars())
+        supportActionBar?.hide()
+    }
+
+    private fun exitImmersiveMode() {
+        windowInsetsController.show(WindowInsetsCompat.Type.systemBars())
+        supportActionBar?.show()
+    }
+    private fun applyWindowInsets() {
+        val playerView = binding.playerView
+        val exoControls = playerView.findViewById<FrameLayout>(R.id.exo_bottom_bar)
+        val exoProgress = playerView.findViewById<DefaultTimeBar>(R.id.exo_progress)
+        val progressBottomMargin = exoProgress.marginBottom
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, windowInsets ->
+            val insets = windowInsets.getInsets(
+                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type
+                    .displayCutout()
             )
+            binding.mediaviewToolbar.updateLayoutParams<MarginLayoutParams> {
+                topMargin = insets.top
+            }
+            exoControls.updateLayoutParams<MarginLayoutParams> {
+                bottomMargin = insets.bottom
+            }
+            exoProgress.updateLayoutParams<MarginLayoutParams> {
+                bottomMargin = insets.bottom + progressBottomMargin
+            }
+            exoControls.updatePadding(left = insets.left, right = insets.right)
+            exoProgress.updatePadding(left = insets.left, right = insets.right)
+            binding.mediaviewToolbar.updatePadding(left = insets.left, right = insets.right)
+            WindowInsetsCompat.CONSUMED
+        }
     }
 }

--- a/app/src/main/res/layout/activity_full_screen_image.xml
+++ b/app/src/main/res/layout/activity_full_screen_image.xml
@@ -28,7 +28,6 @@
     android:id="@+id/image_wrapper_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
     tools:context=".activities.FullScreenImageActivity">
 
     <com.google.android.material.appbar.MaterialToolbar

--- a/app/src/main/res/layout/activity_full_screen_media.xml
+++ b/app/src/main/res/layout/activity_full_screen_media.xml
@@ -25,7 +25,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
     tools:context=".activities.FullScreenMediaActivity">
 
     <androidx.appcompat.widget.Toolbar

--- a/app/src/main/res/values-v27/styles.xml
+++ b/app/src/main/res/values-v27/styles.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="FullScreenImageTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:windowBackground">@color/black</item>
+        <item name="android:navigationBarColor">@color/transparent</item>
+        <item name="android:statusBarColor">@color/transparent</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowActionBar">true</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+    </style>
+
+    <style name="FullScreenMediaTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:windowBackground">@color/black</item>
+        <item name="android:navigationBarColor">@color/black</item>
+        <item name="android:statusBarColor">@color/transparent</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowActionBar">true</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -217,20 +217,20 @@
 
     <style name="FullScreenImageTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="android:windowBackground">@color/black</item>
-        <item name="android:navigationBarColor">@color/black</item>
+        <item name="android:navigationBarColor">@color/transparent</item>
+        <item name="android:statusBarColor">@color/transparent</item>
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowActionBar">true</item>
-        <item name="android:windowFullscreen">true</item>
-        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
     </style>
 
     <style name="FullScreenMediaTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="android:windowBackground">@color/black</item>
         <item name="android:navigationBarColor">@color/black</item>
+        <item name="android:statusBarColor">@color/transparent</item>
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowActionBar">true</item>
-        <item name="android:windowFullscreen">true</item>
-        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
     </style>
 
     <style name="TextInputLayoutTheme" parent="Theme.AppCompat">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -221,7 +221,6 @@
         <item name="android:statusBarColor">@color/transparent</item>
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowActionBar">true</item>
-        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
     </style>
 
     <style name="FullScreenMediaTheme" parent="Theme.AppCompat.Light.NoActionBar">
@@ -230,7 +229,6 @@
         <item name="android:statusBarColor">@color/transparent</item>
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowActionBar">true</item>
-        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
     </style>
 
     <style name="TextInputLayoutTheme" parent="Theme.AppCompat">


### PR DESCRIPTION
Solves: #3372 

### What this PR includes?

- [x] Replace deprecated `setSystemUiVisibility(int)` with `WindowInsetsController`.
- [x] Rendering Images in Fullscreen (including the display notch area).
- [x] In Video view the status bar also hide/show on tapping along with other views (navigation bar, player control view) as opposed to earlier behaviour where status bar used to be hidden all the time.



## 🏚️ Before 
https://github.com/nextcloud/talk-android/assets/111801812/142258b1-1db8-4bea-8866-9ccf46974d45

##  🏡 After
https://github.com/nextcloud/talk-android/assets/111801812/b3919ac0-2261-4f24-a6e5-b3ff9eee077d

### 🏁 Checklist


- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)