### PR TITLE
Revert Android Auto support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -109,11 +109,6 @@
         tools:replace="label, icon, theme, name, allowBackup">
 
         <meta-data
-        android:name="com.google.android.gms.car.application"
-        android:resource="@xml/automotive_app_desc"/>
-
-
-        <meta-data
             android:name="android.max_aspect"
             android:value="10" />
 

--- a/app/src/main/res/xml/automotive_app_desc.xml
+++ b/app/src/main/res/xml/automotive_app_desc.xml
@@ -1,3 +1,0 @@
-<automotiveApp>
-    <uses name="notification" />
-</automotiveApp>


### PR DESCRIPTION
This PR reverts https://github.com/nextcloud/talk-android/pull/3225

The reason for this is that somehow Google playstore doesn't accept the app anymore when Android Auto support is enabled. There were multiple emails exchanged with google, but there is no reason given that makes sense why the app is declined. Some vague hint was that is is related to Android Auto, and indeed removing Android Auto support finally solved that the app was accepted again.

One reason from Google was "We could not access the in-app content with the login credentials that you have provided". But the credentials are provided and working. So it doesn't make sense why/how this is related to Android Auto.

For now i give up to understand what's going wrong with the google playstore policy checks.

Further hints might be at https://developer.android.com/docs/quality-guidelines/car-app-quality.


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)