### PR TITLE
Feature/3289/recording consent

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/api/NcApi.java
+++ b/app/src/main/java/com/nextcloud/talk/api/NcApi.java
@@ -245,9 +245,11 @@ public interface NcApi {
 
     @FormUrlEncoded
     @POST
-    Observable<GenericOverall> joinCall(@Nullable @Header("Authorization") String authorization, @Url String url,
+    Observable<GenericOverall> joinCall(@Nullable @Header("Authorization") String authorization,
+                                        @Url String url,
                                         @Field("flags") Integer inCall,
-                                        @Field("silent") Boolean callWithoutNotification);
+                                        @Field("silent") Boolean callWithoutNotification,
+                                        @Nullable @Field("recordingConsent") Boolean recordingConsent);
 
     /*
     Server URL is: baseUrl + ocsApiVersion + spreedApiVersion + /call/callToken
@@ -686,4 +688,10 @@ public interface NcApi {
     Observable<ReminderOverall> setReminder(@Header("Authorization") String authorization,
                                             @Url String url,
                                             @Field("timestamp") int timestamp);
+
+    @FormUrlEncoded
+    @PUT
+    Observable<GenericOverall> setRecordingConsent(@Header("Authorization") String authorization,
+                                                    @Url String url,
+                                                    @Field("recordingConsent") int recordingConsent);
 }

--- a/app/src/main/java/com/nextcloud/talk/models/json/conversations/Conversation.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/conversations/Conversation.kt
@@ -157,7 +157,10 @@ data class Conversation(
     var hasCustomAvatar: Boolean? = null,
 
     @JsonField(name = ["callStartTime"])
-    var callStartTime: Long? = null
+    var callStartTime: Long? = null,
+
+    @JsonField(name = ["recordingConsent"])
+    var recordingConsentRequired: Int = 0
 
 ) : Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'

--- a/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.java
@@ -536,4 +536,8 @@ public class ApiUtils {
         String url = ApiUtils.getUrlForChatMessage(version, user.getBaseUrl(), roomToken, messageId);
         return url + "/reminder";
     }
+
+    public static String getUrlForRecordingConsent(int version, String baseUrl, String token) {
+        return getUrlForRoom(version, baseUrl, token) + "/recording-consent";
+    }
 }

--- a/app/src/main/java/com/nextcloud/talk/utils/database/user/CapabilitiesUtilNew.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/database/user/CapabilitiesUtilNew.kt
@@ -250,5 +250,29 @@ object CapabilitiesUtilNew {
         return false
     }
 
+    fun getRecordingConsentType(user: User?): Int {
+        if (user?.capabilities != null) {
+            val capabilities = user.capabilities
+            if (
+                capabilities?.spreedCapability?.config?.containsKey("call") == true &&
+                capabilities.spreedCapability!!.config!!["call"] != null &&
+                capabilities.spreedCapability!!.config!!["call"]!!.containsKey("recording-consent")
+            ) {
+                return when (
+                    capabilities.spreedCapability!!.config!!["call"]!!["recording-consent"].toString()
+                        .toInt()
+                ) {
+                    1 -> RECORDING_CONSENT_REQUIRED
+                    2 -> RECORDING_CONSENT_DEPEND_ON_CONVERSATION
+                    else -> RECORDING_CONSENT_NOT_REQUIRED
+                }
+            }
+        }
+        return RECORDING_CONSENT_NOT_REQUIRED
+    }
+
     const val DEFAULT_CHAT_SIZE = 1000
+    const val RECORDING_CONSENT_NOT_REQUIRED = 0
+    const val RECORDING_CONSENT_REQUIRED = 1
+    const val RECORDING_CONSENT_DEPEND_ON_CONVERSATION = 2
 }

--- a/app/src/main/res/layout/activity_conversation_info.xml
+++ b/app/src/main/res/layout/activity_conversation_info.xml
@@ -226,6 +226,12 @@
                 </LinearLayout>
             </LinearLayout>
 
+            <include
+                android:id="@+id/recording_consent_view"
+                layout="@layout/item_recording_consent"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/standard_quarter_margin" />
 
             <LinearLayout
                 android:id="@+id/conversation_settings"
@@ -260,7 +266,6 @@
                         android:lines="1"
                         android:popupTheme="@style/ThemeOverlay.AppTheme.PopupMenu"
                         android:text="" />
-
 
                 </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/layout/item_recording_consent.xml
+++ b/app/src/main/res/layout/item_recording_consent.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Nextcloud Talk application
+  ~
+  ~ @author Marcel Hibbe
+  ~ Copyright (C) 2023 Marcel Hibbe <dev@mhibbe.de>
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/recording_consent_settings"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/recording_consent_settings_category"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/standard_margin"
+        android:layout_marginEnd="@dimen/standard_margin"
+        android:paddingTop="@dimen/standard_padding"
+        android:paddingBottom="@dimen/standard_half_padding"
+        android:text="@string/recording_settings_title"
+        android:textSize="@dimen/headline_text_size"
+        android:textStyle="bold" />
+
+    <LinearLayout
+        android:id="@+id/recording_consent_for_conversation"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?android:attr/selectableItemBackground"
+        android:orientation="horizontal"
+        android:paddingStart="@dimen/standard_margin"
+        android:paddingTop="@dimen/standard_margin"
+        android:paddingEnd="@dimen/standard_margin"
+        android:paddingBottom="@dimen/standard_half_margin">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/recording_consent_for_conversation_title"
+                android:textSize="@dimen/headline_text_size" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:hint="@string/recording_consent_for_conversation_description"
+                android:textSize="@dimen/supporting_text_text_size" />
+
+        </LinearLayout>
+
+        <com.google.android.material.materialswitch.MaterialSwitch
+            android:id="@+id/recording_consent_for_conversation_switch"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_marginStart="@dimen/standard_margin"
+            android:clickable="false" />
+
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/recording_consent_all"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/standard_margin"
+        android:paddingTop="@dimen/standard_margin"
+        android:paddingEnd="@dimen/standard_margin"
+        android:paddingBottom="@dimen/standard_half_margin"
+        android:text="@string/recording_consent_all" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -606,6 +606,12 @@ How to translate with transifex:
     <string name="record_cancel_start">Cancel recording start</string>
     <string name="record_stopping">Stopping recording …</string>
     <string name="record_failed_info">The recording failed. Please contact your administrator.</string>
+    <string name="recording_consent_title">The call might be recorded.</string>
+    <string name="recording_consent_description">The recording might include your voice, video from camera, and screen share. Your consent is required before joining the call. Do you consent?</string>
+    <string name="recording_settings_title">Recording</string>
+    <string name="recording_consent_for_conversation_title">Recording consent</string>
+    <string name="recording_consent_for_conversation_description">Require recording consent before joining call in this conversation</string>
+    <string name="recording_consent_all">Recording consent is required for all calls</string>
 
     <!-- Shared items -->
     <string name="nc_shared_items">Shared items</string>
@@ -708,5 +714,4 @@ How to translate with transifex:
     <string name="audio_call">Audio Call</string>
     <string name="started_a_call">started a call</string>
     <string name="nc_settings_phone_book_integration_phone_number_dialog_429">Error 429 Too Many Requests</string>
-
 </resources>


### PR DESCRIPTION
resolve #3289

### 🖼️ Screenshots

hidden (disabled for all/ not supported) | required for all | configurable | temporarily not available (call in progress) 
------- | -------- | -------- | -------- 
![grafik](https://github.com/nextcloud/talk-android/assets/2932790/3fe2701c-617e-419b-8c8d-fc0e6e9f8503) | ![grafik](https://github.com/nextcloud/talk-android/assets/2932790/b4589009-ccf8-4a8b-b601-932bcc93cad9) | ![grafik](https://github.com/nextcloud/talk-android/assets/2932790/6f2b73ad-857a-4fcd-a83a-723f89db197d) | ![grafik](https://github.com/nextcloud/talk-android/assets/2932790/67c8522d-3c2b-44ab-9af0-5a6ec7e954ae) 

consent dialog | 
------- | 
![grafik](https://github.com/nextcloud/talk-android/assets/2932790/064a99e8-fbb3-4483-969a-6fe2aeebdd92) |


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)