### PR TITLE
Made the Participant List in Conversation Info Scrollable

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
@@ -441,7 +441,7 @@ class ConversationInfoActivity :
         binding.recyclerView.layoutManager = layoutManager
         binding.recyclerView.setHasFixedSize(true)
         binding.recyclerView.adapter = adapter
-        binding.recyclerView.isNestedScrollingEnabled = false
+        binding.recyclerView.isNestedScrollingEnabled = true
         adapter!!.addListener(this)
     }
 

--- a/app/src/main/res/layout/activity_conversation_info.xml
+++ b/app/src/main/res/layout/activity_conversation_info.xml
@@ -329,7 +329,7 @@
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/recycler_view"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
+                    android:layout_height="215dp"
                     tools:listitem="@layout/rv_item_conversation_info_participant" />
             </LinearLayout>
 


### PR DESCRIPTION
Resolves - https://github.com/nextcloud/talk-android/issues/3324
Made the Participant List in Conversation Info Scrollable, allowing users to navigate through the list of participants. 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)