### PR TITLE
Added a ProgressBar to display while uploading Pics/Files

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -143,6 +143,7 @@ import com.nextcloud.talk.extensions.loadAvatarOrImagePreview
 import com.nextcloud.talk.jobs.DownloadFileToCacheWorker
 import com.nextcloud.talk.jobs.ShareOperationWorker
 import com.nextcloud.talk.jobs.UploadAndShareFilesWorker
+import com.nextcloud.talk.jobs.UploadAndShareFilesWorker.Companion.upload
 import com.nextcloud.talk.location.LocationPickerActivity
 import com.nextcloud.talk.messagesearch.MessageSearchActivity
 import com.nextcloud.talk.models.domain.ConversationModel
@@ -3254,12 +3255,15 @@ class ChatActivity :
 
         try {
             require(fileUri.isNotEmpty())
-            UploadAndShareFilesWorker.upload(
+            upload(
+                context,
                 fileUri,
                 room,
                 currentConversation?.displayName!!,
                 metaData
-            )
+            ) { showProgressBar: Boolean ->
+                binding.idprogressbar.visibility = if (showProgressBar) View.VISIBLE else View.GONE
+            }
         } catch (e: IllegalArgumentException) {
             context.resources?.getString(R.string.nc_upload_failed)?.let {
                 Snackbar.make(binding.root, it, Snackbar.LENGTH_LONG)

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -3256,7 +3256,6 @@ class ChatActivity :
         try {
             require(fileUri.isNotEmpty())
             upload(
-                context,
                 fileUri,
                 room,
                 currentConversation?.displayName!!,

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -131,6 +131,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.BehaviorSubject
+import kotlinx.coroutines.DelicateCoroutinesApi
 import org.apache.commons.lang3.builder.CompareToBuilder
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -1343,11 +1344,26 @@ class ConversationsListActivity :
         try {
             filesToShare?.forEach {
                 UploadAndShareFilesWorker.upload(
+                    context,
                     it,
                     selectedConversation!!.token!!,
                     selectedConversation!!.displayName!!,
                     null
-                )
+                ) { success ->
+                    if (success) {
+                        Snackbar.make(
+                            binding.root,
+                            context.resources.getString(R.string.nc_upload_success),
+                            Snackbar.LENGTH_LONG
+                        ).show()
+                    } else {
+                        Snackbar.make(
+                            binding.root,
+                            context.resources.getString(R.string.nc_upload_failed),
+                            Snackbar.LENGTH_LONG
+                        ).show()
+                    }
+                }
             }
         } catch (e: IllegalArgumentException) {
             Snackbar.make(binding.root, context.resources.getString(R.string.nc_upload_failed), Snackbar.LENGTH_LONG)

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -1343,7 +1343,6 @@ class ConversationsListActivity :
         try {
             filesToShare?.forEach {
                 UploadAndShareFilesWorker.upload(
-                    context,
                     it,
                     selectedConversation!!.token!!,
                     selectedConversation!!.displayName!!,

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -131,7 +131,6 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.BehaviorSubject
-import kotlinx.coroutines.DelicateCoroutinesApi
 import org.apache.commons.lang3.builder.CompareToBuilder
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode

--- a/app/src/main/java/com/nextcloud/talk/jobs/UploadAndShareFilesWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/UploadAndShareFilesWorker.kt
@@ -18,10 +18,13 @@ import android.os.Build
 import android.os.Bundle
 import android.os.SystemClock
 import android.util.Log
+import android.widget.Toast
+import android.widget.Toast
 import androidx.core.app.NotificationCompat
 import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
+import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
@@ -382,7 +385,15 @@ class UploadAndShareFilesWorker(val context: Context, workerParameters: WorkerPa
             }
         }
 
-        fun upload(fileUri: String, roomToken: String, conversationName: String, metaData: String?) {
+        fun upload(
+            fileUri: String,
+            roomToken: String,
+            conversationName: String,
+            metaData: String?,
+            progressBarCallback: (Boolean) -> Unit
+        ) {
+            progressBarCallback(true)
+
             val data: Data = Data.Builder()
                 .putString(DEVICE_SOURCE_FILE, fileUri)
                 .putString(ROOM_TOKEN, roomToken)
@@ -394,5 +405,9 @@ class UploadAndShareFilesWorker(val context: Context, workerParameters: WorkerPa
                 .build()
             WorkManager.getInstance().enqueueUniqueWork(fileUri, ExistingWorkPolicy.KEEP, uploadWorker)
         }
+    }
+
+    private fun showToast(context: Context, message: String) {
+        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/jobs/UploadAndShareFilesWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/UploadAndShareFilesWorker.kt
@@ -19,12 +19,10 @@ import android.os.Bundle
 import android.os.SystemClock
 import android.util.Log
 import android.widget.Toast
-import android.widget.Toast
 import androidx.core.app.NotificationCompat
 import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
-import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
@@ -38,13 +36,13 @@ import com.nextcloud.talk.upload.chunked.ChunkedFileUploader
 import com.nextcloud.talk.upload.chunked.OnDataTransferProgressListener
 import com.nextcloud.talk.upload.normal.FileUploader
 import com.nextcloud.talk.users.UserManager
+import com.nextcloud.talk.utils.CapabilitiesUtil
 import com.nextcloud.talk.utils.FileUtils
 import com.nextcloud.talk.utils.NotificationUtils
 import com.nextcloud.talk.utils.RemoteFileUtils
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_FROM_NOTIFICATION_START_CALL
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_INTERNAL_USER_ID
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_ROOM_TOKEN
-import com.nextcloud.talk.utils.CapabilitiesUtil
 import com.nextcloud.talk.utils.permissions.PlatformPermissionUtil
 import com.nextcloud.talk.utils.preferences.AppPreferences
 import okhttp3.MediaType.Companion.toMediaTypeOrNull

--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -157,6 +157,22 @@
             app:textAutoLink="all"
             tools:visibility="visible" />
 
+        <LinearLayout
+            android:id="@+id/idprogressbar"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_centerInParent="true"
+            android:gravity="center_vertical"
+            android:orientation="vertical"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <ProgressBar
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center" />
+        </LinearLayout>
+
         <com.nextcloud.ui.popupbubble.PopupBubble
             android:id="@+id/popupBubbleView"
             android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -506,6 +506,7 @@ How to translate with transifex:
     <string name="nc_upload_video_from_cam">Take video</string>
     <string name="nc_create_poll">Create poll</string>
     <string name="nc_upload_from_cloud">Share from %1$s</string>
+    <string name="nc_upload_success">Upload Succeeded</string>
     <string name="nc_upload_failed">Sorry, upload failed</string>
     <string name="nc_upload_choose_local_files">Choose files</string>
     <string name="nc_upload_confirm_send_multiple">Send these files to %1$s?</string>


### PR DESCRIPTION
Resolves #2500 

## Overview
This pull request introduces a ProgressBar to enhance the user experience during file uploads. The ProgressBar provides visual feedback on the upload progress, making it more intuitive for users.

## Changes Made:

### Upload Functionality:

- Modified the upload function to handle ProgressBar visibility.
- The ProgressBar is set to VISIBLE during the upload process and GONE when the upload is complete.

### WorkManager Integration:

- Utilized WorkManager for managing the background file upload task.
- Enqueued unique work to ensure proper handling of the upload task.

### Observing WorkManager State:

- Implemented an observer for the WorkManager to track the state of the file upload.
- The ProgressBar is hidden once the upload is completed, and appropriate notifications are displayed.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)