### PR TITLE
Fix to delete user when unregister for notifications failed

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/jobs/AccountRemovalWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/AccountRemovalWorker.java
@@ -129,6 +129,7 @@ public class AccountRemovalWorker extends Worker {
                         @Override
                         public void onError(@io.reactivex.annotations.NonNull Throwable e) {
                             Log.e(TAG, "error while trying to unregister Device For Notifications", e);
+                            initiateUserDeletion(user);
                         }
 
                         @Override
@@ -137,7 +138,7 @@ public class AccountRemovalWorker extends Worker {
                         }
                     });
             } else {
-                deleteUser(user);
+                initiateUserDeletion(user);
             }
         }
 
@@ -172,15 +173,13 @@ public class AccountRemovalWorker extends Worker {
                             }
                         }
 
-                        if (user.getId() != null) {
-                            WebSocketConnectionHelper.deleteExternalSignalingInstanceForUserEntity(user.getId());
-                        }
-                        deleteAllEntriesForAccountIdentifier(user);
+                        initiateUserDeletion(user);
                     }
 
                     @Override
                     public void onError(Throwable e) {
                         Log.e(TAG, "error while trying to unregister Device For Notification With Proxy", e);
+                        initiateUserDeletion(user);
                     }
 
                     @Override
@@ -190,8 +189,10 @@ public class AccountRemovalWorker extends Worker {
                 });
     }
 
-    private void deleteAllEntriesForAccountIdentifier(User user) {
+    private void initiateUserDeletion(User user) {
         if (user.getId() != null) {
+            WebSocketConnectionHelper.deleteExternalSignalingInstanceForUserEntity(user.getId());
+
             try {
                 arbitraryStorageManager.deleteAllEntriesForAccountIdentifier(user.getId());
                 deleteUser(user);


### PR DESCRIPTION
it's not yet tested, but from my pov this should...
fix #3243
fix #3105

Not sure for which cases unregister for notifications might fail, maybe @nickvergessen knows best.
Further improvements for user deletions will come with https://github.com/nextcloud/talk-android/pull/3436

### 🚧 TODO

- [ ] do some manual debugging/testing

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)