### PR TITLE
close Call notification when onError is triggered.

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.kt
@@ -857,6 +857,10 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
 
                 override fun onError(e: Throwable) {
                     Log.e(TAG, "Error in getPeersForCall", e)
+                    if (isCallNotificationVisible) {
+                        showMissedCallNotification()
+                    }
+                    removeNotification(pushMessage.timestamp.toInt())
                 }
 
                 override fun onComplete() {


### PR DESCRIPTION
this should fix https://github.com/nextcloud/talk-android/issues/3456

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)