### PR TITLE
fix to enable links in markdown

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/utils/message/MessageUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/message/MessageUtils.kt
@@ -11,8 +11,8 @@ import android.content.Intent
 import android.net.Uri
 import android.text.SpannableString
 import android.text.Spanned
-import android.util.Log
 import android.view.View
+import androidx.core.content.ContextCompat.startActivity
 import com.nextcloud.talk.R
 import com.nextcloud.talk.models.json.chat.ChatMessage
 import com.nextcloud.talk.ui.theme.ViewThemeUtils
@@ -155,8 +155,12 @@ class MessageUtils(val context: Context) {
             }
 
             override fun configureConfiguration(builder: MarkwonConfiguration.Builder) {
-                builder.linkResolver { view: View?, link: String? ->
-                    Log.i(TAG, "Link action not implemented $view / $link")
+                builder.linkResolver { _: View?, link: String? ->
+                    val urlIntent = Intent(
+                        Intent.ACTION_VIEW,
+                        Uri.parse(link)
+                    )
+                    startActivity(context, urlIntent, null)
                 }
             }
         })

--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -154,7 +154,6 @@
             app:outcomingTextLinkColor="@color/high_emphasis_text"
             app:outcomingTextSize="@dimen/chat_text_size"
             app:outcomingTimeTextSize="12sp"
-            app:textAutoLink="all"
             tools:visibility="visible" />
 
         <com.nextcloud.ui.popupbubble.PopupBubble


### PR DESCRIPTION
fix https://github.com/nextcloud/talk-android/issues/3633

fix to enable links in markdown when no top level domain was included in the link description.

Examples (without TLD):

[Hacker News](https://news.ycombinator.com/item?id=38457953)
[AlternativeTo](https://alternativeto.net/news/2023/11/nextcloud-welcomes-open-source-webmail-software-roundcube-to-its-platform/)
[Phoronix](https://www.phoronix.com/news/Roundcube-Nextcloud)
[BNN-Breaking](https://bnn.network/bnn-newsroom/roundcube-and-nextcloud-join-forces-in-unprecedented-open-source-partnership/)
[OSBA – Open Source Business Alliance](https://osb-alliance.de/news/nextcloud-bietet-neues-zuhause-fuer-den-e-mail-giganten-roundcube)

Examples (with TLD):

[LinuxNews.de](https://linuxnews.de/roundcube-fusioniert-mit-nextcloud/)

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Bildschirmfoto vom 2023-11-30 11-02-24 geaendert](https://github.com/nextcloud/talk-android/assets/2932790/d1b72d58-84be-4424-89cc-009e189c6372) | ![Bildschirmfoto vom 2023-11-30 11-02-33 geaendert](https://github.com/nextcloud/talk-android/assets/2932790/767d6c97-e917-4580-ac17-7d3f0f8ea096)

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)