### PR TITLE
Handle audio focus and becoming noisy

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
@@ -48,6 +48,11 @@ class ChatViewModel @Inject constructor(private val repository: ChatRepository) 
     open class GetReminderExistState(val reminder: Reminder) : ViewState
 
     private val _getReminderExistState: MutableLiveData<ViewState> = MutableLiveData(GetReminderStartState)
+
+    var isPausedDueToBecomingNoisy = false
+    var receiverRegistered = false
+    var receiverUnregistered = false
+
     val getReminderExistState: LiveData<ViewState>
         get() = _getReminderExistState
 

--- a/app/src/main/java/com/nextcloud/talk/fullscreenfile/FullScreenMediaActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/fullscreenfile/FullScreenMediaActivity.kt
@@ -44,6 +44,7 @@ import androidx.core.view.marginBottom
 import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
 import androidx.fragment.app.DialogFragment
+import androidx.media3.common.AudioAttributes
 import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
@@ -165,7 +166,10 @@ class FullScreenMediaActivity : AppCompatActivity() {
     }
 
     private fun initializePlayer() {
-        player = ExoPlayer.Builder(applicationContext).build()
+        player = ExoPlayer.Builder(applicationContext)
+            .setAudioAttributes(AudioAttributes.DEFAULT, true)
+            .setHandleAudioBecomingNoisy(true)
+            .build()
         binding.playerView.player = player
     }
 
@@ -202,6 +206,7 @@ class FullScreenMediaActivity : AppCompatActivity() {
         windowInsetsController.show(WindowInsetsCompat.Type.systemBars())
         supportActionBar?.show()
     }
+
     private fun applyWindowInsets() {
         val playerView = binding.playerView
         val exoControls = playerView.findViewById<FrameLayout>(R.id.exo_bottom_bar)


### PR DESCRIPTION
- [x] Handle Audio focus
- [x] Handle Audio becoming noisy

### Handle audio focus -->

The player will handle the audio focus shifts. Basically It would:
- Pause the already playing media when this player is started.
- Or If some other media starts this player would pause itself.
This would avoid two media's playing at the same time.

https://github.com/nextcloud/talk-android/assets/111801812/da9d2fcc-f389-42d9-b075-95be6b8dadf8

https://github.com/nextcloud/talk-android/assets/111801812/978668e7-1082-40bd-9c00-33a29dbd2417


### Handle audio becoming noisy -->

> When a headset is unplugged or a Bluetooth device disconnected, the audio stream automatically reroutes to the built-in speaker. If you listen to music at a high volume, this can be a noisy surprise.
> 
> Users usually expect apps that include a music player with onscreen playback controls to pause playback in this case. Other apps, like games that don't include controls, should keep playing. The user can adjust the volume with the device's hardware controls.
>
[See More](https://developer.android.com/guide/topics/media/platform/output#becoming-noisy)

https://github.com/nextcloud/talk-android/assets/111801812/c6a18a00-d9b3-4b3c-907a-4f5531812687

You can see here after turning of bluetooth the playback pauses.

https://github.com/nextcloud/talk-android/assets/111801812/bc25ccfc-6717-4eef-8c3b-aaada64300a8

Here after removing earphones playback pauses.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)