### PR TITLE
Share message text to other apps

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -347,6 +347,7 @@ class ChatActivity :
     private var isVoicePreviewPlaying: Boolean = false
 
     private var recorder: MediaRecorder? = null
+
     private enum class MediaRecorderState {
         INITIAL,
         INITIALIZED,
@@ -356,6 +357,7 @@ class ChatActivity :
         RELEASED,
         ERROR
     }
+
     private var mediaRecorderState: MediaRecorderState = MediaRecorderState.INITIAL
 
     private var voicePreviewMediaPlayer: MediaPlayer? = null
@@ -4516,6 +4518,16 @@ class ChatActivity :
         Log.d(TAG, " | currentConversation?.displayName: ${currentConversation?.displayName}")
         Log.d(TAG, " | sessionIdAfterRoomJoined: $sessionIdAfterRoomJoined")
         Log.d(TAG, " |-----------------------------------------------")
+    }
+
+    fun shareMessageText(message: String) {
+        val sendIntent: Intent = Intent().apply {
+            action = Intent.ACTION_SEND
+            putExtra(Intent.EXTRA_TEXT, message)
+            type = "text/plain"
+        }
+        val shareIntent = Intent.createChooser(sendIntent, getString(R.string.share))
+        startActivity(shareIntent)
     }
 
     companion object {

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
@@ -79,6 +79,12 @@ class MessageActionsDialog(
 
     private lateinit var popup: EmojiPopup
 
+    private val messageHasFileAttachment =
+        ChatMessage.MessageType.SINGLE_NC_ATTACHMENT_MESSAGE == message.getCalculateMessageType()
+
+    private val messageHasRegularText = ChatMessage.MessageType.REGULAR_TEXT_MESSAGE == message
+        .getCalculateMessageType() && !message.isDeleted
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         NextcloudTalkApplication.sharedApplication?.componentApplication?.inject(this)
@@ -112,7 +118,7 @@ class MessageActionsDialog(
             message.previousMessageId > NO_PREVIOUS_MESSAGE_ID &&
                 ChatMessage.MessageType.SYSTEM_MESSAGE != message.getCalculateMessageType()
         )
-        initMenuShare(ChatMessage.MessageType.SINGLE_NC_ATTACHMENT_MESSAGE == message.getCalculateMessageType())
+        initMenuShare(messageHasFileAttachment || messageHasRegularText)
         initMenuItemOpenNcApp(
             ChatMessage.MessageType.SINGLE_NC_ATTACHMENT_MESSAGE == message.getCalculateMessageType()
         )
@@ -330,10 +336,17 @@ class MessageActionsDialog(
 
         dialogMessageActionsBinding.menuTranslateMessage.visibility = getVisibility(visible)
     }
+
     private fun initMenuShare(visible: Boolean) {
-        if (visible) {
+        if (messageHasFileAttachment) {
             dialogMessageActionsBinding.menuShare.setOnClickListener {
                 chatActivity.checkIfSharable(message)
+                dismiss()
+            }
+        }
+        if (messageHasRegularText) {
+            dialogMessageActionsBinding.menuShare.setOnClickListener {
+                message.message?.let { messageText -> chatActivity.shareMessageText(messageText) }
                 dismiss()
             }
         }


### PR DESCRIPTION
### 🖼️ Screenshots


![no_message_Sharing](https://github.com/nextcloud/talk-android/assets/101803542/3162c509-94c1-45a6-9ba0-0ab0b3ec0a30)    ![Share_message_text](https://github.com/nextcloud/talk-android/assets/101803542/1a997e9e-91fe-4e1e-b797-bbfba3b6d5a1)

Resolves #1487

This pull request adds the feature to share the text message to other apps. 

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)