### PR TITLE
Cancel upload from notification

### DIFF
--- a/app/src/main/res/drawable/ic_cancel_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_cancel_white_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2zM17,15.59L15.59,17 12,13.41 8.41,17 7,15.59 10.59,12 7,8.41 8.41,7 12,10.59 15.59,7 17,8.41 13.41,12 17,15.59z"/>
+</vector>


### PR DESCRIPTION
Fix: #2374 
### 🖼️ Screenshots

https://github.com/nextcloud/talk-android/assets/111801812/80029b82-07b3-43a0-9da9-c2ce8cd93c4a

### Functionality Check 
- Folder which is created to upload chunks gets deleted.
- Due to deletion no chunks of the file are left on the server so if we try to upload the same file again it would start from beginning.
- Worker which does the uploading work is cancelled.
- Notification of uploading file is also cancelled.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)