### PR TITLE
remove FOREGROUND_SERVICE_PHONE_CALL

### DIFF
--- a/app/src/gplay/AndroidManifest.xml
+++ b/app/src/gplay/AndroidManifest.xml
@@ -23,8 +23,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_PHONE_CALL" />
-
     <application
         android:name=".application.NextcloudTalkApplication"
         android:allowBackup="true"


### PR DESCRIPTION
followup to https://github.com/nextcloud/talk-android/pull/3533


FOREGROUND_SERVICE_PHONE_CALL is removed because it is not necessary.

Seems it was introduced when moving to Android 14 because NCFirebaseMessagingService originally contained android:foregroundServiceType="phoneCall"

But this foregroundServiceType is not allowed/necessary for NCFirebaseMessagingService so it was removed, but it was forgotten to also remove FOREGROUND_SERVICE_PHONE_CALL permission.

This commit will remove FOREGROUND_SERVICE_PHONE_CALL permission so release process on gplay won't complain.


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)