### PR TITLE
Fix: Use of parameterized constructor with fragments

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -4259,12 +4259,7 @@ class ChatActivity :
 
         val chatApiVersion = ApiUtils.getChatApiVersion(spreedCapabilities, intArrayOf(ApiUtils.API_V1, 1))
 
-        val newFragment: DialogFragment = DateTimePickerFragment.newInstance(
-            roomToken,
-            message!!.id,
-            chatViewModel,
-            chatApiVersion
-        )
+        val newFragment: DialogFragment = DateTimePickerFragment.newInstance(roomToken, message!!.id, chatApiVersion)
         newFragment.show(supportFragmentManager, DateTimePickerFragment.TAG)
     }
 

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -978,10 +978,7 @@ class ConversationsListActivity :
         updateFilterConversationButtonColor()
 
         binding.filterConversationsButton.setOnClickListener {
-            val newFragment: DialogFragment = FilterConversationFragment.newInstance(
-                filterState,
-                this
-            )
+            val newFragment = FilterConversationFragment.newInstance(filterState)
             newFragment.show(supportFragmentManager, FilterConversationFragment.TAG)
         }
 

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/DateTimePickerFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/DateTimePickerFragment.kt
@@ -37,6 +37,7 @@ import com.google.android.material.timepicker.TimeFormat
 import com.nextcloud.android.common.ui.theme.utils.ColorRole
 import com.nextcloud.talk.R
 import com.nextcloud.talk.application.NextcloudTalkApplication
+import com.nextcloud.talk.chat.ChatActivity
 import com.nextcloud.talk.chat.viewmodels.ChatViewModel
 import com.nextcloud.talk.databinding.DialogDateTimePickerBinding
 import com.nextcloud.talk.ui.theme.ViewThemeUtils
@@ -47,18 +48,15 @@ import javax.inject.Inject
 
 @Suppress("TooManyFunctions")
 @AutoInjector(NextcloudTalkApplication::class)
-class DateTimePickerFragment(
-    token: String,
-    id: String,
-    chatViewModel: ChatViewModel,
-    private val chatApiVersion: Int
-) : DialogFragment() {
+class DateTimePickerFragment : DialogFragment() {
+
     lateinit var binding: DialogDateTimePickerBinding
     private var dialogView: View? = null
-    private var viewModel = chatViewModel
+    private lateinit var viewModel: ChatViewModel
     private var currentTimeStamp: Long? = null
-    private var roomToken = token
-    private var messageId = id
+    private lateinit var roomToken: String
+    private lateinit var messageId: String
+    private var chatApiVersion: Int = -1
     private var laterTodayTimeStamp = 0L
     private var tomorrowTimeStamp = 0L
     private var weekendTimeStamp = 0L
@@ -73,6 +71,12 @@ class DateTimePickerFragment(
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         binding = DialogDateTimePickerBinding.inflate(LayoutInflater.from(context))
         dialogView = binding.root
+        viewModel = (requireActivity() as ChatActivity).chatViewModel
+        arguments?.let {
+            roomToken = it.getString(TOKEN_ARG, "")
+            messageId = it.getString(ID_ARG, "")
+            chatApiVersion = it.getInt(CHAT_API_VERSION_ARG)
+        }
         return MaterialAlertDialogBuilder(requireContext()).setView(dialogView).create()
     }
 
@@ -304,14 +308,20 @@ class DateTimePickerFragment(
         private const val ONE_SEC = 1000
         private const val HOUR_EIGHT_AM = 8
         private const val HOUR_SIX_PM = 18
+        private const val TOKEN_ARG = "TOKEN_ARG"
+        private const val ID_ARG = "ID_ARG"
+        private const val CHAT_API_VERSION_ARG = "CHAT_API_VERSION_ARG"
 
         @JvmStatic
-        fun newInstance(token: String, id: String, chatViewModel: ChatViewModel, chatApiVersion: Int) =
-            DateTimePickerFragment(
-                token,
-                id,
-                chatViewModel,
-                chatApiVersion
-            )
+        fun newInstance(token: String, id: String, chatApiVersion: Int): DateTimePickerFragment {
+            val args = Bundle()
+            args.putString(TOKEN_ARG, token)
+            args.putString(ID_ARG, id)
+            args.putInt(CHAT_API_VERSION_ARG, chatApiVersion)
+
+            val dateTimePickerFragment = DateTimePickerFragment()
+            dateTimePickerFragment.arguments = args
+            return dateTimePickerFragment
+        }
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/FilterConversationFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/FilterConversationFragment.kt
@@ -128,9 +128,7 @@ class FilterConversationFragment : DialogFragment() {
         private const val FILTER_STATE_ARG = "FILTER_STATE_ARG"
 
         @JvmStatic
-        fun newInstance(
-            savedFilterState: MutableMap<String, Boolean>
-        ): FilterConversationFragment {
+        fun newInstance(savedFilterState: MutableMap<String, Boolean>): FilterConversationFragment {
             val filterConversationFragment = FilterConversationFragment()
             val args = Bundle()
             args.putSerializable(FILTER_STATE_ARG, HashMap(savedFilterState))

--- a/app/src/main/res/layout/dialog_date_time_picker.xml
+++ b/app/src/main/res/layout/dialog_date_time_picker.xml
@@ -17,202 +17,208 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     tools:background="@color/white">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="@dimen/standard_margin"
-        android:orientation="horizontal">
-
-        <com.google.android.material.textview.MaterialTextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:text="@string/nc_remind"
-            android:layout_weight="1"
-            android:textSize="@dimen/md_title_textsize" />
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/date_time_picker_timestamp"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            tools:text="Apr 15th, 8:00 AM"
-            android:textSize="@dimen/supporting_text_text_size"
-            android:textStyle="bold" />
-
-    </LinearLayout>
-
-
-    <com.google.android.material.divider.MaterialDivider
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
-
-    <LinearLayout
-        android:id="@+id/date_time_picker_later_today"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="?android:attr/selectableItemBackground"
-        android:orientation="horizontal"
-        android:padding="@dimen/standard_padding">
-
-        <com.google.android.material.textview.MaterialTextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="@string/later_today"
-            android:textSize="@dimen/headline_text_size" />
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/date_time_picker_later_today_textview"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textSize="@dimen/headline_text_size"
-            android:text="" />
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/date_time_picker_tomorrow"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="?android:attr/selectableItemBackground"
-        android:orientation="horizontal"
-        android:padding="@dimen/standard_padding">
-
-        <com.google.android.material.textview.MaterialTextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="@string/tomorrow"
-            android:textSize="@dimen/headline_text_size" />
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/date_time_picker_tomorrow_textview"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textSize="@dimen/headline_text_size"
-            android:text="" />
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/date_time_picker_weekend"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="?android:attr/selectableItemBackground"
-        android:orientation="horizontal"
-        android:padding="@dimen/standard_padding">
-
-        <com.google.android.material.textview.MaterialTextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="@string/this_weekend"
-            android:textSize="@dimen/headline_text_size" />
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/date_time_picker_weekend_textview"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textSize="@dimen/headline_text_size"
-            android:text="" />
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/date_time_picker_next_week"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="?android:attr/selectableItemBackground"
-        android:orientation="horizontal"
-        android:padding="@dimen/standard_padding">
-
-        <com.google.android.material.textview.MaterialTextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="@string/next_week"
-            android:textSize="@dimen/headline_text_size" />
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/date_time_picker_next_week_textview"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textSize="@dimen/headline_text_size"
-            android:text="" />
-    </LinearLayout>
-
-    <com.google.android.material.divider.MaterialDivider
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
-
-    <LinearLayout
-        android:id="@+id/date_time_picker_custom"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:padding="@dimen/standard_padding"
-        android:background="?android:attr/selectableItemBackground">
-
-        <ImageView
-            android:id="@+id/date_time_picker_custom_icon"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:src="@drawable/baseline_calendar_month_24"
-            android:paddingEnd="@dimen/standard_double_padding"
-            tools:ignore="RtlSymmetry"
-            android:contentDescription="@string/calendar" />
-
-        <com.google.android.material.textview.MaterialTextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:text="@string/custom"
-            android:layout_weight="1"
-            android:textSize="@dimen/headline_text_size" />
-    </LinearLayout>
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:orientation="vertical">
 
         <LinearLayout
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:layout_weight="1">
+            android:layout_margin="@dimen/standard_margin"
+            android:orientation="horizontal">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/nc_remind"
+                android:textSize="@dimen/md_title_textsize" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/date_time_picker_timestamp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="@dimen/supporting_text_text_size"
+                android:textStyle="bold"
+                tools:text="Apr 15th, 8:00 AM" />
+
+        </LinearLayout>
+
+
+        <com.google.android.material.divider.MaterialDivider
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <LinearLayout
+            android:id="@+id/date_time_picker_later_today"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?android:attr/selectableItemBackground"
+            android:orientation="horizontal"
+            android:padding="@dimen/standard_padding">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/later_today"
+                android:textSize="@dimen/headline_text_size" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/date_time_picker_later_today_textview"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text=""
+                android:textSize="@dimen/headline_text_size" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/date_time_picker_tomorrow"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?android:attr/selectableItemBackground"
+            android:orientation="horizontal"
+            android:padding="@dimen/standard_padding">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/tomorrow"
+                android:textSize="@dimen/headline_text_size" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/date_time_picker_tomorrow_textview"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text=""
+                android:textSize="@dimen/headline_text_size" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/date_time_picker_weekend"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?android:attr/selectableItemBackground"
+            android:orientation="horizontal"
+            android:padding="@dimen/standard_padding">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/this_weekend"
+                android:textSize="@dimen/headline_text_size" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/date_time_picker_weekend_textview"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text=""
+                android:textSize="@dimen/headline_text_size" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/date_time_picker_next_week"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?android:attr/selectableItemBackground"
+            android:orientation="horizontal"
+            android:padding="@dimen/standard_padding">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/next_week"
+                android:textSize="@dimen/headline_text_size" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/date_time_picker_next_week_textview"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text=""
+                android:textSize="@dimen/headline_text_size" />
+        </LinearLayout>
+
+        <com.google.android.material.divider.MaterialDivider
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <LinearLayout
+            android:id="@+id/date_time_picker_custom"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?android:attr/selectableItemBackground"
+            android:orientation="horizontal"
+            android:padding="@dimen/standard_padding">
+
+            <ImageView
+                android:id="@+id/date_time_picker_custom_icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:contentDescription="@string/calendar"
+                android:paddingEnd="@dimen/standard_double_padding"
+                android:src="@drawable/baseline_calendar_month_24"
+                tools:ignore="RtlSymmetry" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/custom"
+                android:textSize="@dimen/headline_text_size" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/button_delete"
+                    style="@style/Button.Borderless"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:minHeight="@dimen/min_size_clickable_area"
+                    android:text="@string/nc_delete"
+                    android:textColor="@color/design_default_color_error" />
+
+            </LinearLayout>
 
             <com.google.android.material.button.MaterialButton
-                android:id="@+id/button_delete"
+                android:id="@+id/button_set"
                 style="@style/Button.Borderless"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:minHeight="@dimen/min_size_clickable_area"
-                android:text="@string/nc_delete"
-                android:textColor="@color/design_default_color_error" />
+                android:text="@string/set" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/button_close"
+                style="@style/Button.Borderless"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:minHeight="@dimen/min_size_clickable_area"
+                android:text="@string/close" />
 
         </LinearLayout>
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/button_set"
-            style="@style/Button.Borderless"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:minHeight="@dimen/min_size_clickable_area"
-            android:text="@string/set" />
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/button_close"
-            style="@style/Button.Borderless"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="end"
-            android:minHeight="@dimen/min_size_clickable_area"
-            android:text="@string/close" />
 
     </LinearLayout>
-
-
-</LinearLayout>
+</ScrollView>


### PR DESCRIPTION
Fixes: #3676

### FilterConversationFragment

https://github.com/nextcloud/talk-android/assets/111801812/4a6b607e-d84d-48ab-8d3f-6a423904fd0e

### DateTimePickerFragment

https://github.com/nextcloud/talk-android/assets/111801812/f89c48e3-1b72-42e7-a19f-e5a47515b320

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)