### PR TITLE
Renaming strings from circles to teams.

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/items/ParticipantItem.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/ParticipantItem.java
@@ -221,7 +221,7 @@ public class ParticipantItem extends AbstractFlexibleItem<ParticipantItem.Partic
                     userType = NextcloudTalkApplication
                         .Companion
                         .getSharedApplication()
-                        .getString(R.string.nc_circle);
+                        .getString(R.string.nc_team);
                 }
                 break;
             case 4:

--- a/app/src/main/java/com/nextcloud/talk/contacts/ContactsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/contacts/ContactsActivity.kt
@@ -565,7 +565,7 @@ class ContactsActivity :
                 resources!!.getString(R.string.nc_groups)
             }
             participant.calculatedActorType == Participant.ActorType.CIRCLES -> {
-                resources!!.getString(R.string.nc_circles)
+                resources!!.getString(R.string.nc_teams)
             }
             else -> {
                 participant.displayName!!.substring(0, 1).uppercase(Locale.getDefault())

--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
@@ -1237,7 +1237,7 @@ class ConversationInfoActivity :
             val items = mutableListOf(
                 BasicListItemWithImage(
                     R.drawable.ic_delete_grey600_24dp,
-                    context.getString(R.string.nc_remove_circle_and_members)
+                    context.getString(R.string.nc_remove_team_and_members)
                 )
             )
             MaterialDialog(this, BottomSheet(WRAP_CONTENT)).show {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -361,7 +361,7 @@ How to translate with transifex:
     <string name="nc_demote">Demote from moderator</string>
     <string name="nc_promote">Promote to moderator</string>
     <string name="nc_remove_participant">Remove participant</string>
-    <string name="nc_remove_circle_and_members">Remove circle and members</string>
+    <string name="nc_remove_team_and_members">Remove team and members</string>
     <string name="nc_remove_group_and_members">Remove group and members</string>
     <string name="nc_attendee_pin">Pin: %1$s</string>
 
@@ -464,9 +464,9 @@ How to translate with transifex:
     <string name="nc_limit_hit">%s characters limit has been hit</string>
     <string name="nc_email">Email</string>
     <string name="nc_group">Group</string>
-    <string name="nc_circle">Circle</string>
+    <string name="nc_team">Team</string>
     <string name="nc_groups">Groups</string>
-    <string name="nc_circles">Circles</string>
+    <string name="nc_teams">Teams</string>
     <string name="nc_participants">Participants</string>
     <string name="nc_participants_add">Add participants</string>
 


### PR DESCRIPTION

Resolves #3651

This PR renames strings from circles to teams.


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)