### PR TITLE
add rest of SpreedFeatures to Enums

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.kt
@@ -50,10 +50,11 @@ import com.nextcloud.talk.models.json.conversations.Conversation
 import com.nextcloud.talk.models.json.conversations.Conversation.ConversationType
 import com.nextcloud.talk.ui.StatusDrawable
 import com.nextcloud.talk.ui.theme.ViewThemeUtils
+import com.nextcloud.talk.utils.CapabilitiesUtil.hasSpreedFeatureCapability
 import com.nextcloud.talk.utils.SpreedFeatures
 import com.nextcloud.talk.utils.ConversationUtils
 import com.nextcloud.talk.utils.DisplayUtils
-import com.nextcloud.talk.utils.CapabilitiesUtil.hasSpreedFeatureCapability
+
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.items.AbstractFlexibleItem
 import eu.davidea.flexibleadapter.items.IFilterable

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/ConversationsListBottomDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/ConversationsListBottomDialog.kt
@@ -47,6 +47,7 @@ import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_INTERNAL_USER_ID
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_ROOM_TOKEN
 import com.nextcloud.talk.utils.CapabilitiesUtil
+import com.nextcloud.talk.utils.SpreedFeatures
 import io.reactivex.Observer
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
@@ -107,7 +108,7 @@ class ConversationsListBottomDialog(
     private fun initItemsVisibility() {
         val hasFavoritesCapability = CapabilitiesUtil.hasSpreedFeatureCapability(
             currentUser.capabilities?.spreedCapability!!,
-            "favorites"
+            SpreedFeatures.FAVORITES
         )
         val canModerate = conversation.canModerate(currentUser)
 
@@ -120,17 +121,15 @@ class ConversationsListBottomDialog(
 
         binding.conversationMarkAsRead.visibility = setVisibleIf(
             conversation.unreadMessages > 0 && CapabilitiesUtil.hasSpreedFeatureCapability(
-                currentUser
-                    .capabilities?.spreedCapability!!,
-                "chat-read-marker"
+                currentUser.capabilities?.spreedCapability!!,
+                SpreedFeatures.CHAT_READ_MARKER
             )
         )
 
         binding.conversationMarkAsUnread.visibility = setVisibleIf(
             conversation.unreadMessages <= 0 && CapabilitiesUtil.hasSpreedFeatureCapability(
-                currentUser
-                    .capabilities?.spreedCapability!!,
-                "chat-unread"
+                currentUser.capabilities?.spreedCapability!!,
+                SpreedFeatures.CHAT_UNREAD
             )
         )
 

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
@@ -106,7 +106,7 @@ class MessageActionsDialog(
 
     private val isMessageEditable = CapabilitiesUtil.hasSpreedFeatureCapability(
         spreedCapabilities,
-        "edit-messages"
+        SpreedFeatures.EDIT_MESSAGES
     ) && messageHasRegularText && !isOlderThanTwentyFourHours && isUserAllowedToEdit
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -166,7 +166,7 @@ class MessageActionsDialog(
         )
         initMenuRemindMessage(
             !message.isDeleted && CapabilitiesUtil.hasSpreedFeatureCapability
-                (spreedCapabilities, "remind-me-later")
+                (spreedCapabilities, SpreedFeatures.REMIND_ME_LATER)
         )
         initMenuMarkAsUnread(
             message.previousMessageId > NO_PREVIOUS_MESSAGE_ID &&

--- a/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.kt
@@ -156,17 +156,17 @@ object ApiUtils {
         val spreedCapabilities = user.capabilities!!.spreedCapability
         for (version in versions) {
             if (spreedCapabilities != null) {
-                if (hasSpreedFeatureCapability(spreedCapabilities, "signaling-v$version")) {
+                if (spreedCapabilities.features!!.contains("signaling-v$version")) {
                     return version
                 }
                 if (version == API_V2 &&
-                    hasSpreedFeatureCapability(spreedCapabilities, "sip-support") &&
-                    !hasSpreedFeatureCapability(spreedCapabilities, "signaling-v3")
+                    hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.SIP_SUPPORT) &&
+                    !hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.SIGNALING_V3)
                 ) {
                     return version
                 }
                 if (version == API_V1 &&
-                    !hasSpreedFeatureCapability(spreedCapabilities, "signaling-v3")
+                    !hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.SIGNALING_V3)
                 ) {
                     // Has no capability, we just assume it is always there when there is no v3 or later
                     return version
@@ -180,7 +180,7 @@ object ApiUtils {
     @Throws(NoSupportedApiException::class)
     fun getChatApiVersion(spreedCapabilities: SpreedCapability, versions: IntArray): Int {
         for (version in versions) {
-            if (version == API_V1 && hasSpreedFeatureCapability(spreedCapabilities, "chat-v2")) {
+            if (version == API_V1 && hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.CHAT_V2)) {
                 // Do not question that chat-v2 capability shows the availability of api/v1/ endpoint *see no evil*
                 return version
             }

--- a/app/src/main/java/com/nextcloud/talk/utils/CapabilitiesUtil.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/CapabilitiesUtil.kt
@@ -52,7 +52,20 @@ enum class SpreedFeatures(val value: String) {
     TEMP_USER_AVATAR_API("temp-user-avatar-api"),
     PHONEBOOK_SEARCH("phonebook-search"),
     GEO_LOCATION_SHARING("geo-location-sharing"),
-    TALK_POLLS("talk-polls")
+    TALK_POLLS("talk-polls"),
+    FAVORITES("favorites"),
+    CHAT_READ_MARKER("chat-read-marker"),
+    CHAT_UNREAD("chat-unread"),
+    EDIT_MESSAGES("edit-messages"),
+    REMIND_ME_LATER("remind-me-later"),
+    CHAT_V2("chat-v2"),
+    SIP_SUPPORT("sip-support"),
+    SIGNALING_V3("signaling-v3"),
+    ROOM_DESCRIPTION("room-description"),
+    UNIFIED_SEARCH("unified-search"),
+    LOCKED_ONE_TO_ONE("locked-one-to-one-rooms"),
+    CHAT_PERMISSION("chat-permission"),
+    CONVERSATION_PERMISSION("conversation-permissions")
 }
 
 @Suppress("TooManyFunctions")
@@ -85,15 +98,6 @@ object CapabilitiesUtil {
     fun hasSpreedFeatureCapability(spreedCapabilities: SpreedCapability, spreedFeatures: SpreedFeatures): Boolean {
         if (spreedCapabilities.features != null) {
             return spreedCapabilities.features!!.contains(spreedFeatures.value)
-        }
-        return false
-    }
-
-    @JvmStatic
-    @Deprecated("Add your capability to Capability enums and use hasSpreedFeatureCapability with enum.")
-    fun hasSpreedFeatureCapability(spreedCapabilities: SpreedCapability, capabilityName: String): Boolean {
-        if (spreedCapabilities.features != null) {
-            return spreedCapabilities.features!!.contains(capabilityName)
         }
         return false
     }
@@ -147,11 +151,11 @@ object CapabilitiesUtil {
     }
 
     fun isConversationDescriptionEndpointAvailable(spreedCapabilities: SpreedCapability): Boolean {
-        return hasSpreedFeatureCapability(spreedCapabilities, "room-description")
+        return hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.ROOM_DESCRIPTION)
     }
 
     fun isUnifiedSearchAvailable(spreedCapabilities: SpreedCapability): Boolean {
-        return hasSpreedFeatureCapability(spreedCapabilities, "unified-search")
+        return hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.UNIFIED_SEARCH)
     }
 
     fun isAbleToCall(spreedCapabilities: SpreedCapability): Boolean {

--- a/app/src/main/java/com/nextcloud/talk/utils/ConversationUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/ConversationUtils.kt
@@ -45,7 +45,7 @@ object ConversationUtils {
 
     fun isLockedOneToOne(conversation: ConversationModel, spreedCapabilities: SpreedCapability): Boolean {
         return conversation.type == ConversationType.ROOM_TYPE_ONE_TO_ONE_CALL &&
-            CapabilitiesUtil.hasSpreedFeatureCapability(spreedCapabilities, "locked-one-to-one-rooms")
+            CapabilitiesUtil.hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.LOCKED_ONE_TO_ONE)
     }
 
     fun canModerate(conversation: ConversationModel, spreedCapabilities: SpreedCapability): Boolean {

--- a/app/src/main/java/com/nextcloud/talk/utils/ParticipantPermissions.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/ParticipantPermissions.kt
@@ -53,7 +53,7 @@ class ParticipantPermissions(
     private fun hasConversationPermissions(): Boolean {
         return CapabilitiesUtil.hasSpreedFeatureCapability(
             spreedCapabilities,
-            "conversation-permissions"
+            SpreedFeatures.CONVERSATION_PERMISSION
         )
     }
 
@@ -90,7 +90,7 @@ class ParticipantPermissions(
     }
 
     fun hasChatPermission(): Boolean {
-        if (CapabilitiesUtil.hasSpreedFeatureCapability(spreedCapabilities, "chat-permission")) {
+        if (CapabilitiesUtil.hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.CHAT_PERMISSION)) {
             return hasChatPermission
         }
         // if capability is not available then the spreed version doesn't support to restrict this

--- a/app/src/main/java/com/nextcloud/talk/utils/preferences/preferencestorage/DatabaseStorageModule.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/preferences/preferencestorage/DatabaseStorageModule.java
@@ -34,6 +34,7 @@ import com.nextcloud.talk.data.storage.model.ArbitraryStorage;
 import com.nextcloud.talk.data.user.model.User;
 import com.nextcloud.talk.models.json.generic.GenericOverall;
 import com.nextcloud.talk.utils.ApiUtils;
+import com.nextcloud.talk.utils.SpreedFeatures;
 import com.nextcloud.talk.utils.UserIdUtils;
 import com.nextcloud.talk.utils.CapabilitiesUtil;
 
@@ -158,8 +159,10 @@ public class DatabaseStorageModule {
                 });
 
         } else if ("conversation_info_message_notifications_dropdown".equals(key)) {
-            if (CapabilitiesUtil.hasSpreedFeatureCapability(conversationUser.getCapabilities().getSpreedCapability(), "notification" +
-                "-levels")) {
+            if (CapabilitiesUtil.hasSpreedFeatureCapability(
+                conversationUser.getCapabilities().getSpreedCapability(),
+                SpreedFeatures.NOTIFICATION_LEVELS)
+            ) {
                 if (TextUtils.isEmpty(messageNotificationLevel) || !messageNotificationLevel.equals(value)) {
                     int intValue;
                     switch (value) {


### PR DESCRIPTION
due to bad wifi in train just a tiny PR that i could do without reliable internet:

followup to https://github.com/nextcloud/talk-android/pull/3663 to add all spreed capabilies to enum.


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)