### PR TITLE
Implemented delete-messages-unlimited feature

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -4692,8 +4692,10 @@ class ChatActivity :
         val isOlderThanSixHours = message
             .createdAt
             .before(Date(System.currentTimeMillis() - AGE_THRESHOLD_FOR_DELETE_MESSAGE))
-       val hasDeleteMessagesUnlimitedCapability = CapabilitiesUtil.hasSpreedFeatureCapability(spreedCapabilities,
-           SpreedFeatures.DELETE_MESSAGES_UNLIMITED)
+        val hasDeleteMessagesUnlimitedCapability = CapabilitiesUtil.hasSpreedFeatureCapability(
+            spreedCapabilities,
+            SpreedFeatures.DELETE_MESSAGES_UNLIMITED
+        )
 
         return when {
             !isUserAllowedByPrivileges -> false

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -4689,12 +4689,20 @@ class ChatActivity :
     private fun isShowMessageDeletionButton(message: ChatMessage): Boolean {
         val isUserAllowedByPrivileges = userAllowedByPrivilages(message)
 
+        val isOlderThanSixHours = message
+            .createdAt
+            .before(Date(System.currentTimeMillis() - AGE_THRESHOLD_FOR_DELETE_MESSAGE))
+       val hasDeleteMessagesUnlimitedCapability = CapabilitiesUtil.hasSpreedFeatureCapability(spreedCapabilities,
+           SpreedFeatures.DELETE_MESSAGES_UNLIMITED)
+
         return when {
             !isUserAllowedByPrivileges -> false
+            !hasDeleteMessagesUnlimitedCapability && isOlderThanSixHours -> false
             message.systemMessageType != ChatMessage.SystemMessageType.DUMMY -> false
             message.isDeleted -> false
             !CapabilitiesUtil.hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.DELETE_MESSAGES) -> false
             !participantPermissions.hasChatPermission() -> false
+            hasDeleteMessagesUnlimitedCapability -> true
             else -> true
         }
     }
@@ -4902,6 +4910,7 @@ class ChatActivity :
         private const val GET_ROOM_INFO_DELAY_NORMAL: Long = 30000
         private const val GET_ROOM_INFO_DELAY_LOBBY: Long = 5000
         private const val HTTP_CODE_OK: Int = 200
+        private const val AGE_THRESHOLD_FOR_DELETE_MESSAGE: Int = 21600000 // (6 hours in millis = 6 * 3600 * 1000)
         private const val REQUEST_CODE_CHOOSE_FILE: Int = 555
         private const val REQUEST_CODE_SELECT_CONTACT: Int = 666
         private const val REQUEST_CODE_MESSAGE_SEARCH: Int = 777

--- a/app/src/main/java/com/nextcloud/talk/utils/CapabilitiesUtil.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/CapabilitiesUtil.kt
@@ -66,7 +66,8 @@ enum class SpreedFeatures(val value: String) {
     LOCKED_ONE_TO_ONE("locked-one-to-one-rooms"),
     CHAT_PERMISSION("chat-permission"),
     CONVERSATION_PERMISSION("conversation-permissions"),
-    FEDERATION_V1("federation-v1")
+    FEDERATION_V1("federation-v1"),
+    DELETE_MESSAGES_UNLIMITED("delete-messages-unlimited")
 }
 
 @Suppress("TooManyFunctions")


### PR DESCRIPTION
Resolves #3614.

If the "delete-messages-unlimited" capability is available, deleting messages without any time restriction is possible; otherwise, the time limit for deleting messages is six hours.

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)