### PR TITLE
use X-Chat-Last-Common-Read to fix read status

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -918,7 +918,11 @@ class ChatActivity :
                                 collapseSystemMessages()
                             }
 
-                            updateReadStatusOfAllMessages(chatMessageList[0].jsonMessageId)
+                            val newXChatLastCommonRead = state.response.headers()["X-Chat-Last-Common-Read"]?.let {
+                                Integer.parseInt(it)
+                            }
+
+                            updateReadStatusOfAllMessages(newXChatLastCommonRead)
 
                             processCallStartedMessages(chatMessageList)
 
@@ -927,7 +931,7 @@ class ChatActivity :
                             chatViewModel.refreshChatParams(
                                 setupFieldsForPullChatMessages(
                                     true,
-                                    chatMessageList[0].jsonMessageId,
+                                    newXChatLastCommonRead,
                                     true
                                 )
                             )


### PR DESCRIPTION
Without this commit, the read status was broken as [X-Chat-Last-Common-Read](https://nextcloud-talk.readthedocs.io/en/latest/chat/#receive-chat-messages-of-a-conversation) was not used. It was removed by https://github.com/nextcloud/talk-android/pull/3630

As a result all messages were marked as unread after waiting for 30 seconds.

With this commit the X-Chat-Last-Common-Read is used again. Messages are marked as read again also after 30 seconds.


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)