### PR TITLE
fix to hide open conversations after returning from search

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -592,7 +592,7 @@ class ConversationsListActivity :
 
                 override fun onMenuItemActionCollapse(item: MenuItem): Boolean {
                     adapter!!.setHeadersShown(false)
-                    if (!filterState.containsValue(true)) filterableConversationItems = searchableConversationItems
+                    if (!filterState.containsValue(true)) filterableConversationItems = conversationItemsWithHeader
                     adapter!!.updateDataSet(filterableConversationItems, false)
                     adapter!!.hideAllHeaders()
                     if (searchHelper != null) {


### PR DESCRIPTION
How to test:

pre-requirement:
There are open conversations

without this commit:
1. go to search screen
2. go back to conversation list -> all open conversations are listed below own conversations

with this commit:
1. go to search screen
2. go back to conversation list -> only own conversations are listed


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)