### PR TITLE
manually bump to 19.0.0 Alpha 02

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,8 +33,8 @@ android {
 
         // mayor.minor.hotfix.increment (for increment: 01-50=Alpha / 51-89=RC / 90-99=stable)
         // xx   .xxx  .xx    .xx
-        versionCode 190000001
-        versionName "19.0.0 Alpha 01"
+        versionCode 190000002
+        versionName "19.0.0 Alpha 02"
 
         flavorDimensions "default"
         renderscriptTargetApi 19


### PR DESCRIPTION
there seems to be something wrong that alpha workflow did not update the apps version. Thats why gplay complains with
"Google Api Error: forbidden: Cannot update a published APK. - Cannot update a published APK." because it always tries to upload 19.0.0 Alpha 02.

On nextcloud ftp server, it was most probably always overwritten as there is an up to date alpha2 version.

Seeting the version number to 19.0.0 Alpha 02 should make sure that an alpha 3 is built on next automation run.

The root cause that the version was/is not changed by the automation is still unclear.


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)