### PR TITLE
fix to mark federated rooms as read

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/api/NcApi.java
+++ b/app/src/main/java/com/nextcloud/talk/api/NcApi.java
@@ -552,7 +552,7 @@ public interface NcApi {
     @POST
     Observable<GenericOverall> setChatReadMarker(@Header("Authorization") String authorization,
                                                  @Url String url,
-                                                 @Field("lastReadMessage") int lastReadMessage);
+                                                 @Nullable @Field("lastReadMessage") Integer lastReadMessage);
 
     // Url is: /api/{apiVersion}/chat/{token}/read
     @DELETE

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/ConversationsListBottomDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/ConversationsListBottomDialog.kt
@@ -308,6 +308,12 @@ class ConversationsListBottomDialog(
     }
 
     private fun markConversationAsRead() {
+        val messageId = if (conversation.remoteServer.isNullOrEmpty()) {
+            conversation.lastMessage!!.jsonMessageId
+        } else {
+            null
+        }
+
         ncApi.setChatReadMarker(
             credentials,
             ApiUtils.getUrlForChatReadMarker(
@@ -315,7 +321,7 @@ class ConversationsListBottomDialog(
                 currentUser.baseUrl!!,
                 conversation.token!!
             ),
-            conversation.lastMessage!!.jsonMessageId
+            messageId
         )
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
@@ -360,6 +366,7 @@ class ConversationsListBottomDialog(
             )
         }
     }
+
     private fun leaveConversation() {
         val dataBuilder = Data.Builder()
         dataBuilder.putString(KEY_ROOM_TOKEN, conversation.token)


### PR DESCRIPTION
As lastMessageId is not available for federatedRooms, the API on server side now allows the messageID to be optional. This is done by this commit: messageId is null when it's a federated room.


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)