### PR TITLE
Remove flickering background on the app bar

### DIFF
--- a/app/src/main/res/layout/activity_conversations.xml
+++ b/app/src/main/res/layout/activity_conversations.xml
@@ -36,7 +36,9 @@
         android:clipChildren="true"
         android:clipToPadding="false"
         android:windowContentOverlay="@null"
-        app:elevation="0dp">
+        app:elevation="0dp"
+        app:liftOnScrollTargetViewId="@id/recycler_view"
+        app:liftOnScrollColor="@color/bg_default">
 
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/search_toolbar"


### PR DESCRIPTION
Resolves #3688.

This pull request resolves the issue of the conversation's top app bar experiencing flickering due to scrolling the conversations to the bottom.

This issue is caused by the material library update from 1.10.0 to 1.11.0.  

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)