### PR TITLE
Use new Result APIs instead of startActivityForResult() and onActivityResult().

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/profile/ProfileActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/profile/ProfileActivity.kt
@@ -10,7 +10,6 @@
 package com.nextcloud.talk.profile
 
 import android.app.Activity
-import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.drawable.ColorDrawable
 import android.net.Uri
@@ -24,6 +23,8 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
 import androidx.core.net.toFile
@@ -50,13 +51,13 @@ import com.nextcloud.talk.ui.dialog.ScopeDialog
 import com.nextcloud.talk.ui.theme.ViewThemeUtils
 import com.nextcloud.talk.users.UserManager
 import com.nextcloud.talk.utils.ApiUtils
-import com.nextcloud.talk.utils.SpreedFeatures
+import com.nextcloud.talk.utils.CapabilitiesUtil
 import com.nextcloud.talk.utils.DisplayUtils
 import com.nextcloud.talk.utils.Mimetype.IMAGE_JPG
 import com.nextcloud.talk.utils.Mimetype.IMAGE_PREFIX_GENERIC
 import com.nextcloud.talk.utils.PickImage
 import com.nextcloud.talk.utils.PickImage.Companion.REQUEST_PERMISSION_CAMERA
-import com.nextcloud.talk.utils.CapabilitiesUtil
+import com.nextcloud.talk.utils.SpreedFeatures
 import io.reactivex.Observer
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
@@ -87,6 +88,31 @@ class ProfileActivity : BaseActivity() {
 
     private lateinit var pickImage: PickImage
 
+    private val startImagePickerForResult =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            handleResult(it) { result ->
+                pickImage.onImagePickerResult(result.data) { uri ->
+                    uploadAvatar(uri.toFile())
+                }
+            }
+        }
+
+    private val startSelectRemoteFilesIntentForResult = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) {
+        handleResult(it) { result ->
+            pickImage.onSelectRemoteFilesResult(startImagePickerForResult, result.data)
+        }
+    }
+
+    private val startTakePictureIntentForResult = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) {
+        handleResult(it) { result ->
+            pickImage.onTakePictureResult(startImagePickerForResult, result.data)
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         NextcloudTalkApplication.sharedApplication!!.componentApplication.inject(this)
@@ -106,9 +132,15 @@ class ProfileActivity : BaseActivity() {
         val credentials = ApiUtils.getCredentials(currentUser!!.username, currentUser!!.token)
 
         pickImage = PickImage(this, currentUser)
-        binding.avatarUpload.setOnClickListener { pickImage.selectLocal() }
-        binding.avatarChoose.setOnClickListener { pickImage.selectRemote() }
-        binding.avatarCamera.setOnClickListener { pickImage.takePicture() }
+        binding.avatarUpload.setOnClickListener {
+            pickImage.selectLocal(startImagePickerForResult = startImagePickerForResult)
+        }
+        binding.avatarChoose.setOnClickListener {
+            pickImage.selectRemote(startSelectRemoteFilesIntentForResult = startSelectRemoteFilesIntentForResult)
+        }
+        binding.avatarCamera.setOnClickListener {
+            pickImage.takePicture(startTakePictureIntentForResult = startTakePictureIntentForResult)
+        }
         binding.avatarDelete.setOnClickListener {
             ncApi.deleteAvatar(
                 credentials,
@@ -479,7 +511,7 @@ class ProfileActivity : BaseActivity() {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
         if (requestCode == REQUEST_PERMISSION_CAMERA) {
             if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                pickImage.takePicture()
+                pickImage.takePicture(startTakePictureIntentForResult = startTakePictureIntentForResult)
             } else {
                 Snackbar
                     .make(binding.root, context.getString(R.string.take_photo_permission), Snackbar.LENGTH_LONG)
@@ -488,19 +520,14 @@ class ProfileActivity : BaseActivity() {
         }
     }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.onActivityResult(requestCode, resultCode, data)
-        when (resultCode) {
-            Activity.RESULT_OK -> {
-                pickImage.handleActivityResult(
-                    requestCode,
-                    resultCode,
-                    data
-                ) { uploadAvatar(it.toFile()) }
-            }
+    private fun handleResult(result: ActivityResult, onResult: (result: ActivityResult) -> Unit) {
+        when (result.resultCode) {
+            Activity.RESULT_OK -> onResult(result)
+
             ImagePicker.RESULT_ERROR -> {
-                Snackbar.make(binding.root, getError(data), Snackbar.LENGTH_SHORT).show()
+                Snackbar.make(binding.root, getError(result.data), Snackbar.LENGTH_SHORT).show()
             }
+
             else -> {
                 Log.i(TAG, "Task Cancelled")
             }

--- a/app/src/main/java/com/nextcloud/talk/utils/PickImage.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/PickImage.kt
@@ -1,9 +1,11 @@
 /*
  * Nextcloud Talk - Android Client
  *
+ * SPDX-FileCopyrightText: 2024 Parneet Singh <gurayaparneet@gmail.com>
  * SPDX-FileCopyrightText: 2022 Tim Krüger <t@timkrueger.me>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
+
 package com.nextcloud.talk.utils
 
 import android.app.Activity
@@ -13,6 +15,7 @@ import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.Bundle
 import android.util.Log
+import androidx.activity.result.ActivityResultLauncher
 import autodagger.AutoInjector
 import com.github.dhaval2404.imagepicker.ImagePicker
 import com.github.dhaval2404.imagepicker.constant.ImageProvider
@@ -48,17 +51,19 @@ class PickImage(
         NextcloudTalkApplication.sharedApplication!!.componentApplication.inject(this)
     }
 
-    fun selectLocal() {
+    fun selectLocal(startImagePickerForResult: ActivityResultLauncher<Intent>) {
         ImagePicker.Companion.with(activity)
             .provider(ImageProvider.GALLERY)
             .crop()
             .cropSquare()
             .compress(MAX_SIZE)
             .maxResultSize(MAX_SIZE, MAX_SIZE)
-            .createIntent { intent -> this.activity.startActivityForResult(intent, REQUEST_CODE_IMAGE_PICKER) }
+            .createIntent { intent ->
+                startImagePickerForResult.launch(intent)
+            }
     }
 
-    private fun selectLocal(file: File) {
+    private fun selectLocal(startImagePickerForResult: ActivityResultLauncher<Intent>, file: File) {
         ImagePicker.Companion.with(activity)
             .provider(ImageProvider.URI)
             .crop()
@@ -66,25 +71,23 @@ class PickImage(
             .compress(MAX_SIZE)
             .maxResultSize(MAX_SIZE, MAX_SIZE)
             .setUri(Uri.fromFile(file))
-            .createIntent { intent -> this.activity.startActivityForResult(intent, REQUEST_CODE_IMAGE_PICKER) }
+            .createIntent { intent ->
+                startImagePickerForResult.launch(intent)
+            }
     }
 
-    fun selectRemote() {
+    fun selectRemote(startSelectRemoteFilesIntentForResult: ActivityResultLauncher<Intent>) {
         val bundle = Bundle()
         bundle.putString(BundleKeys.KEY_MIME_TYPE_FILTER, Mimetype.IMAGE_PREFIX)
 
         val avatarIntent = Intent(activity, RemoteFileBrowserActivity::class.java)
         avatarIntent.putExtras(bundle)
-
-        this.activity.startActivityForResult(avatarIntent, REQUEST_CODE_SELECT_REMOTE_FILES)
+        startSelectRemoteFilesIntentForResult.launch(avatarIntent)
     }
 
-    fun takePicture() {
+    fun takePicture(startTakePictureIntentForResult: ActivityResultLauncher<Intent>) {
         if (permissionUtil.isCameraPermissionGranted()) {
-            activity.startActivityForResult(
-                TakePhotoActivity.createIntent(activity),
-                REQUEST_CODE_TAKE_PICTURE
-            )
+            startTakePictureIntentForResult.launch(TakePhotoActivity.createIntent(activity))
         } else {
             activity.requestPermissions(
                 arrayOf(android.Manifest.permission.CAMERA),
@@ -93,7 +96,7 @@ class PickImage(
         }
     }
 
-    private fun handleAvatar(remotePath: String?) {
+    private fun handleAvatar(startImagePickerForResult: ActivityResultLauncher<Intent>, remotePath: String?) {
         val uri = currentUser!!.baseUrl + "/index.php/apps/files/api/v1/thumbnail/512/512/" +
             Uri.encode(remotePath, "/")
         val downloadCall = ncApi.downloadResizedImage(
@@ -102,7 +105,10 @@ class PickImage(
         )
         downloadCall.enqueue(object : Callback<ResponseBody> {
             override fun onResponse(call: Call<ResponseBody>, response: Response<ResponseBody>) {
-                saveBitmapAndPassToImagePicker(BitmapFactory.decodeStream(response.body()!!.byteStream()))
+                saveBitmapAndPassToImagePicker(
+                    startImagePickerForResult,
+                    BitmapFactory.decodeStream(response.body()!!.byteStream())
+                )
             }
 
             override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
@@ -112,9 +118,12 @@ class PickImage(
     }
 
     // only possible with API26
-    private fun saveBitmapAndPassToImagePicker(bitmap: Bitmap) {
+    private fun saveBitmapAndPassToImagePicker(
+        startImagePickerForResult: ActivityResultLauncher<Intent>,
+        bitmap: Bitmap
+    ) {
         val file: File = saveBitmapToTempFile(bitmap) ?: return
-        selectLocal(file)
+        selectLocal(startImagePickerForResult, file)
     }
 
     private fun saveBitmapToTempFile(bitmap: Bitmap): File? {
@@ -145,35 +154,21 @@ class PickImage(
         )
     }
 
-    fun handleActivityResult(requestCode: Int, resultCode: Int, data: Intent?, handleImage: (uri: Uri) -> Unit) {
-        if (resultCode != Activity.RESULT_OK) {
-            Log.w(
-                TAG,
-                "Check result code before calling " +
-                    "'PickImage#handleActivtyResult'. It should be ${Activity.RESULT_OK}, but it is $resultCode!"
-            )
-            return
-        }
+    fun onImagePickerResult(data: Intent?, handleImage: (uri: Uri) -> Unit) {
+        val uri: Uri = data?.data!!
+        handleImage(uri)
+    }
 
-        when (requestCode) {
-            REQUEST_CODE_IMAGE_PICKER -> {
-                val uri: Uri = data?.data!!
-                handleImage(uri)
-            }
-            REQUEST_CODE_SELECT_REMOTE_FILES -> {
-                val pathList = data?.getStringArrayListExtra(RemoteFileBrowserActivity.EXTRA_SELECTED_PATHS)
-                if (pathList?.size!! >= 1) {
-                    handleAvatar(pathList[0])
-                }
-            }
-            REQUEST_CODE_TAKE_PICTURE -> {
-                data?.data?.path?.let {
-                    selectLocal(File(it))
-                }
-            }
-            else -> {
-                Log.w(TAG, "Unknown intent request code")
-            }
+    fun onSelectRemoteFilesResult(startImagePickerForResult: ActivityResultLauncher<Intent>, data: Intent?) {
+        val pathList = data?.getStringArrayListExtra(RemoteFileBrowserActivity.EXTRA_SELECTED_PATHS)
+        if (pathList?.size!! >= 1) {
+            handleAvatar(startImagePickerForResult, pathList[0])
+        }
+    }
+
+    fun onTakePictureResult(startImagePickerForResult: ActivityResultLauncher<Intent>, data: Intent?) {
+        data?.data?.path?.let {
+            selectLocal(startImagePickerForResult, File(it))
         }
     }
 
@@ -182,9 +177,6 @@ class PickImage(
         private const val MAX_SIZE: Int = 1024
         private const val AVATAR_PATH = "photos/avatar.png"
         private const val FULL_QUALITY: Int = 100
-        const val REQUEST_CODE_IMAGE_PICKER: Int = 1
-        const val REQUEST_CODE_TAKE_PICTURE: Int = 2
         const val REQUEST_PERMISSION_CAMERA: Int = 1
-        const val REQUEST_CODE_SELECT_REMOTE_FILES = 22
     }
 }


### PR DESCRIPTION
Resolves: #3742


### Functionality Checks
 Functionalities listed below uses new result APIs and working correctly

- **ChatActivity**
- [x] Share Contact
- [x] Take Photo
- [x] Take Video
- [x] Upload From Device
- [x] Share from Remote instance
- [x] Message Search

- **LockedActivity** 

- **Pick Image in both ProfileActivity & ConversationInfoEditActivity**
- [x] Local upload
- [x] Remote upload
- [x] Camera capture upload 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)