### PR TITLE
fix to show all participants in conversation info

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
@@ -495,7 +495,7 @@ class ConversationInfoActivity :
 
         val layoutManager = SmoothScrollLinearLayoutManager(this)
         binding.recyclerView.layoutManager = layoutManager
-        binding.recyclerView.setHasFixedSize(true)
+        binding.recyclerView.setHasFixedSize(false)
         binding.recyclerView.adapter = adapter
         binding.recyclerView.isNestedScrollingEnabled = false
         adapter!!.addListener(this)

--- a/app/src/main/res/layout/activity_conversation_info.xml
+++ b/app/src/main/res/layout/activity_conversation_info.xml
@@ -49,7 +49,7 @@
         android:indeterminateTintMode="src_in"
         tools:visibility="gone" />
 
-    <ScrollView
+    <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
@@ -413,5 +413,5 @@
                 </LinearLayout>
             </LinearLayout>
         </LinearLayout>
-    </ScrollView>
+    </androidx.core.widget.NestedScrollView>
 </LinearLayout>


### PR DESCRIPTION
fix #3324

In general it's a bad idea to use recyclerview inside scrollviews because of poor performance! So this is only a fix until everything is replaced with jetpack compose.

`setHasFixedSize` and `isNestedScrollingEnabled` were set to `false`. This might not be necessary for the current implementation, but it's [recommended](https://momen-zaq.medium.com/recyclerview-with-nestedscrollview-best-practices-and-how-to-avoid-it-152fd9ce46d9) when using NestedScrollView.


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)