### PR TITLE
shows edit message view only when user edits a message

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -510,6 +510,8 @@ class ChatActivity :
         setContentView(binding.root)
         setupSystemColors()
 
+        binding.messageInputView.messageSendButton.visibility = View.GONE
+
         conversationUser = currentUserProvider.currentUser.blockingGet()
 
         handleIntent(intent)

--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -249,7 +249,8 @@
             layout="@layout/edit_message_view"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="6dp" >
+            android:layout_marginEnd="6dp"
+            android:visibility="gone">
         </include>
 
         <com.nextcloud.talk.ui.MessageInput


### PR DESCRIPTION
Resolves #3765.

The edit message view is only shown when the user edits a message. 

### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)