### PR TITLE
Fix crash on sendStopTypingMessage

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -2114,7 +2114,8 @@ class ChatActivity :
             typingTimer = null
             typedWhileTypingTimerIsRunning = false
 
-            for ((sessionId, _) in webSocketInstance?.getUserMap()!!) {
+            val concurrentSafeHashMap = webSocketInstance?.getUserMap()!!
+            for ((sessionId, _) in concurrentSafeHashMap) {
                 val ncSignalingMessage = NCSignalingMessage()
                 ncSignalingMessage.to = sessionId
                 ncSignalingMessage.type = TYPING_STOPPED_SIGNALING_MESSAGE_TYPE


### PR DESCRIPTION
- fixes #3734 

[ConcurrentModificationException](https://developer.android.com/reference/java/util/ConcurrentModificationException)
>This exception may be thrown by methods that have detected concurrent modification of an object when such modification is not permissible.
>
>For example, it is not generally permissible for one thread to modify a Collection while another thread is iterating over it. In general, the results of the iteration are undefined under these circumstances. Some Iterator implementations (including those of all the general purpose collection implementations provided by the JRE) may choose to throw this exception if this behavior is detected. Iterators that do this are known as fail-fast iterators, as they fail quickly and cleanly, rather that risking arbitrary, non-deterministic behavior at an undetermined time in the future.

I believe that the HashMap returned by `webSocketInstance?.getUserMap()!!` might be changing during the implicit iterator calls in the for-each loop. I think, copying to a separate variable would prevent this, as any changes to the underlying map during iteration won't be reflected in the copied map unless it's reassigned.


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)