### PR TITLE
Feature/noid/federation invitation fixes

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -3799,7 +3799,7 @@ class ChatActivity :
             chatMessage.isFormerOneToOneConversation =
                 (currentConversation?.type == ConversationType.FORMER_ONE_TO_ONE)
             chatMessage.activeUser = conversationUser
-            chatMessage.roomToken = roomToken
+            chatMessage.token = roomToken
         }
 
         if (adapter != null) {

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/viewmodels/ConversationsListViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/viewmodels/ConversationsListViewModel.kt
@@ -83,7 +83,11 @@ class ConversationsListViewModel @Inject constructor(
         }
 
         override fun onNext(invitationsModel: InvitationsModel) {
-            if (invitationsModel.user.userId?.equals(userManager.currentUser.blockingGet().userId) == true) {
+            val currentUser = userManager.currentUser.blockingGet()
+
+            if (invitationsModel.user.userId?.equals(currentUser.userId) == true &&
+                invitationsModel.user.baseUrl?.equals(currentUser.baseUrl) == true
+            ) {
                 if (invitationsModel.invitations.isNotEmpty()) {
                     _getFederationInvitationsViewState.value = GetFederationInvitationsSuccessState(true)
                 } else {

--- a/app/src/main/java/com/nextcloud/talk/extensions/ImageViewExtensions.kt
+++ b/app/src/main/java/com/nextcloud/talk/extensions/ImageViewExtensions.kt
@@ -136,7 +136,7 @@ fun ImageView.loadFederatedUserAvatar(message: ChatMessage): io.reactivex.dispos
     return loadFederatedUserAvatar(
         message.activeUser!!,
         message.activeUser!!.baseUrl!!,
-        message.roomToken,
+        message.token!!,
         cloudId,
         darkTheme,
         requestBigSize,

--- a/app/src/main/java/com/nextcloud/talk/invitation/InvitationsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/invitation/InvitationsActivity.kt
@@ -32,6 +32,7 @@ import com.nextcloud.talk.R
 import com.nextcloud.talk.activities.BaseActivity
 import com.nextcloud.talk.api.NcApi
 import com.nextcloud.talk.application.NextcloudTalkApplication
+import com.nextcloud.talk.chat.ChatActivity
 import com.nextcloud.talk.conversationlist.ConversationsListActivity
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.databinding.ActivityInvitationsBinding
@@ -39,6 +40,7 @@ import com.nextcloud.talk.invitation.adapters.InvitationsAdapter
 import com.nextcloud.talk.invitation.data.ActionEnum
 import com.nextcloud.talk.invitation.data.Invitation
 import com.nextcloud.talk.invitation.viewmodels.InvitationsViewModel
+import com.nextcloud.talk.utils.bundle.BundleKeys
 import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import javax.inject.Inject
 
@@ -151,17 +153,12 @@ class InvitationsActivity : BaseActivity() {
 
                 is InvitationsViewModel.InvitationActionSuccessState -> {
                     if (state.action == ActionEnum.ACCEPT) {
-                        // val bundle = Bundle()
-                        // bundle.putString(BundleKeys.KEY_ROOM_TOKEN, ????) // ???
-                        //
-                        // val chatIntent = Intent(context, ChatActivity::class.java)
-                        // chatIntent.putExtras(bundle)
-                        // chatIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                        // startActivity(chatIntent)
-
-                        val intent = Intent(this, ConversationsListActivity::class.java)
-                        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                        startActivity(intent)
+                        val bundle = Bundle()
+                        bundle.putString(BundleKeys.KEY_ROOM_TOKEN, state.invitation.localToken)
+                        val chatIntent = Intent(context, ChatActivity::class.java)
+                        chatIntent.putExtras(bundle)
+                        chatIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                        startActivity(chatIntent)
                     } else {
                         // adapter.currentList.remove(state.invitation)
                         // adapter.notifyDataSetChanged()  // leads to UnsupportedOperationException ?!

--- a/app/src/main/java/com/nextcloud/talk/invitation/data/Invitation.kt
+++ b/app/src/main/java/com/nextcloud/talk/invitation/data/Invitation.kt
@@ -21,15 +21,15 @@
 package com.nextcloud.talk.invitation.data
 
 data class Invitation(
-    var id: Int,
-    var userId: String,
-    var state: Int,
-    var localRoomId: Int,
-    var accessToken: String?,
-    var remoteServerUrl: String,
-    var remoteToken: String,
-    var remoteAttendeeId: Int,
-    var inviterCloudId: String,
-    var inviterDisplayName: String,
-    var roomName: String
+    var id: Int = 0,
+    var state: Int = 0,
+    var localCloudId: String? = null,
+    var localToken: String? = null,
+    var remoteAttendeeId: Int = 0,
+    var remoteServerUrl: String? = null,
+    var remoteToken: String? = null,
+    var roomName: String? = null,
+    var userId: String? = null,
+    var inviterCloudId: String? = null,
+    var inviterDisplayName: String? = null
 )

--- a/app/src/main/java/com/nextcloud/talk/invitation/data/InvitationsRepositoryImpl.kt
+++ b/app/src/main/java/com/nextcloud/talk/invitation/data/InvitationsRepositoryImpl.kt
@@ -66,16 +66,16 @@ class InvitationsRepositoryImpl(private val ncApi: NcApi) :
             filteredInvitations.map { invitation ->
                 Invitation(
                     invitation.id,
-                    invitation.userId!!,
                     invitation.state,
-                    invitation.localRoomId,
-                    invitation.accessToken!!,
+                    invitation.localCloudId!!,
+                    invitation.localToken!!,
+                    invitation.remoteAttendeeId,
                     invitation.remoteServerUrl!!,
                     invitation.remoteToken!!,
-                    invitation.remoteAttendeeId,
+                    invitation.roomName!!,
+                    invitation.userId!!,
                     invitation.inviterCloudId!!,
-                    invitation.inviterDisplayName!!,
-                    invitation.roomName!!
+                    invitation.inviterDisplayName!!
                 )
             }
         )

--- a/app/src/main/java/com/nextcloud/talk/models/json/chat/ChatMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/chat/ChatMessage.kt
@@ -159,9 +159,7 @@ data class ChatMessage(
 
     var hiddenByCollapse: Boolean = false,
 
-    var openWhenDownloaded: Boolean = true,
-
-    var roomToken: String = ""
+    var openWhenDownloaded: Boolean = true
 
 ) : Parcelable, MessageContentType, MessageContentType.Image {
 

--- a/app/src/main/java/com/nextcloud/talk/models/json/invitation/Invitation.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/invitation/Invitation.kt
@@ -29,27 +29,28 @@ import kotlinx.parcelize.Parcelize
 data class Invitation(
     @JsonField(name = ["id"])
     var id: Int = 0,
-    @JsonField(name = ["userId"])
-    var userId: String? = null,
     @JsonField(name = ["state"])
     var state: Int = 0,
-    @JsonField(name = ["localRoomId"])
-    var localRoomId: Int = 0,
-    @JsonField(name = ["accessToken"])
-    var accessToken: String? = null,
+    @JsonField(name = ["localCloudId"])
+    var localCloudId: String? = null,
+    @JsonField(name = ["localToken"])
+    var localToken: String? = null,
+    @JsonField(name = ["remoteAttendeeId"])
+    var remoteAttendeeId: Int = 0,
     @JsonField(name = ["remoteServerUrl"])
     var remoteServerUrl: String? = null,
     @JsonField(name = ["remoteToken"])
     var remoteToken: String? = null,
-    @JsonField(name = ["remoteAttendeeId"])
-    var remoteAttendeeId: Int = 0,
+    @JsonField(name = ["roomName"])
+    var roomName: String? = null,
+    @JsonField(name = ["userId"])
+    var userId: String? = null,
     @JsonField(name = ["inviterCloudId"])
     var inviterCloudId: String? = null,
     @JsonField(name = ["inviterDisplayName"])
-    var inviterDisplayName: String? = null,
-    @JsonField(name = ["roomName"])
-    var roomName: String? = null
+    var inviterDisplayName: String? = null
+
 ) : Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
-    constructor() : this(0, null, 0, 0, null, null, null, 0, null, null, null)
+    constructor() : this(0, 0, null, null, 0, null, null, null, null, null, null)
 }

--- a/app/src/main/java/com/nextcloud/talk/utils/message/MessageUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/message/MessageUtils.kt
@@ -138,7 +138,7 @@ class MessageUtils(val context: Context) {
                             themingContext,
                             messageStringInternal,
                             id!!,
-                            message.roomToken,
+                            message.token,
                             individualHashMap["name"]!!,
                             individualHashMap["type"]!!,
                             message.activeUser!!,


### PR DESCRIPTION
This PR will
- adapt models to changed federation invitations API
- fix to show/hide invitation panel when userId is the same for logged in accounts
- open federated chat after accepting the invite
- delete roomToken for ChatMessage (use "token" which was already in place)


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)