### PR TITLE
avoid NPE when serverVersion is not known

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/account/ServerSelectionActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/account/ServerSelectionActivity.kt
@@ -321,7 +321,7 @@ class ServerSelectionActivity : BaseActivity() {
 
                     if (hasTalk) {
                         runOnUiThread {
-                            if (CapabilitiesUtil.isServerEOL(capabilitiesOverall.ocs?.data?.serverVersion?.major!!)) {
+                            if (CapabilitiesUtil.isServerEOL(capabilitiesOverall.ocs?.data?.serverVersion?.major)) {
                                 if (resources != null) {
                                     runOnUiThread {
                                         setErrorText(resources!!.getString(R.string.nc_settings_server_eol))

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -270,7 +270,7 @@ class ConversationsListActivity :
         }
         currentUser = userManager.currentUser.blockingGet()
         if (currentUser != null) {
-            if (isServerEOL(currentUser!!.serverVersion!!.major)) {
+            if (isServerEOL(currentUser!!.serverVersion?.major)) {
                 showServerEOLDialog()
                 return
             }

--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -835,7 +835,7 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
 
     private fun setupServerAgeWarning() {
         when {
-            CapabilitiesUtil.isServerEOL(currentUser!!.serverVersion!!.major) -> {
+            CapabilitiesUtil.isServerEOL(currentUser!!.serverVersion?.major) -> {
                 binding.serverAgeWarningText.setTextColor(ContextCompat.getColor((context), R.color.nc_darkRed))
                 binding.serverAgeWarningText.setText(R.string.nc_settings_server_eol)
                 binding.serverAgeWarningIcon.setColorFilter(
@@ -844,7 +844,7 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
                 )
             }
 
-            CapabilitiesUtil.isServerAlmostEOL(currentUser!!.serverVersion!!.major) -> {
+            CapabilitiesUtil.isServerAlmostEOL(currentUser!!.serverVersion?.major) -> {
                 binding.serverAgeWarningText.setTextColor(
                     ContextCompat.getColor((context), R.color.nc_darkYellow)
                 )

--- a/app/src/main/java/com/nextcloud/talk/utils/CapabilitiesUtil.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/CapabilitiesUtil.kt
@@ -8,6 +8,7 @@
  */
 package com.nextcloud.talk.utils
 
+import android.util.Log
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.models.json.capabilities.SpreedCapability
 
@@ -59,11 +60,19 @@ enum class SpreedFeatures(val value: String) {
 object CapabilitiesUtil {
 
     //region Version checks
-    fun isServerEOL(serverVersion: Int): Boolean {
+    fun isServerEOL(serverVersion: Int?): Boolean {
+        if (serverVersion == null) {
+            Log.w(TAG, "serverVersion is unknown. It is assumed that it is up to date")
+            return false
+        }
         return (serverVersion < SERVER_VERSION_MIN_SUPPORTED)
     }
 
-    fun isServerAlmostEOL(serverVersion: Int): Boolean {
+    fun isServerAlmostEOL(serverVersion: Int?): Boolean {
+        if (serverVersion == null) {
+            Log.w(TAG, "serverVersion is unknown. It is assumed that it is up to date")
+            return false
+        }
         return (serverVersion < SERVER_VERSION_SUPPORT_WARNING)
     }
 
@@ -271,6 +280,7 @@ object CapabilitiesUtil {
 
     // endregion
 
+    private val TAG = CapabilitiesUtil::class.java.simpleName
     const val DEFAULT_CHAT_SIZE = 1000
     const val RECORDING_CONSENT_NOT_REQUIRED = 0
     const val RECORDING_CONSENT_REQUIRED = 1


### PR DESCRIPTION
NPE without this fix (for 19.0.0 RC1):

```
Exception java.lang.RuntimeException:
  at android.app.ActivityThread.performResumeActivity (ActivityThread.java:4975)
  at android.app.ActivityThread.handleResumeActivity (ActivityThread.java:5008)
  at android.app.servertransaction.ResumeActivityItem.execute (ResumeActivityItem.java:54)
  at android.app.servertransaction.ActivityTransactionItem.execute (ActivityTransactionItem.java:45)
  at android.app.servertransaction.TransactionExecutor.executeLifecycleState (TransactionExecutor.java:176)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:97)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2386)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loopOnce (Looper.java:210)
  at android.os.Looper.loop (Looper.java:299)
  at android.app.ActivityThread.main (ActivityThread.java:8252)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:559)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:954)
Caused by java.lang.NullPointerException:
  at com.nextcloud.talk.conversationlist.ConversationsListActivity.onResume (ConversationsListActivity.kt:287)
  at android.app.Instrumentation.callActivityOnResume (Instrumentation.java:1565)
  at android.app.Activity.performResume (Activity.java:8668)
  at android.app.ActivityThread.performResumeActivity (ActivityThread.java:4965)
```

 The root cause may be that the CapabilitiesWorker is not finished so the serverVersion was not added to the user.


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)