### PR TITLE
avoid NPE when context is not known when creating conversation

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/conversation/CreateConversationDialogFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversation/CreateConversationDialogFragment.kt
@@ -208,6 +208,7 @@ class CreateConversationDialogFragment : DialogFragment() {
                     Log.e(TAG, "Failed to create conversation")
                     showError()
                 }
+
                 else -> {}
             }
         }
@@ -256,13 +257,14 @@ class CreateConversationDialogFragment : DialogFragment() {
     }
 
     private fun initiateConversation(roomToken: String) {
-        val bundle = Bundle()
-        bundle.putString(BundleKeys.KEY_ROOM_TOKEN, roomToken)
-
-        val chatIntent = Intent(context, ChatActivity::class.java)
-        chatIntent.putExtras(bundle)
-        chatIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-        startActivity(chatIntent)
+        activity?.let {
+            val bundle = Bundle()
+            bundle.putString(BundleKeys.KEY_ROOM_TOKEN, roomToken)
+            val chatIntent = Intent(it, ChatActivity::class.java)
+            chatIntent.putExtras(bundle)
+            chatIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            startActivity(chatIntent)
+        }
 
         dismiss()
     }


### PR DESCRIPTION
NPE without this fix:

```
Exception java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String android.content.Context.getPackageName()' on a null object reference
  at android.content.ComponentName.<init> (ComponentName.java:132)
  at android.content.Intent.<init> (Intent.java:8269)
  at com.nextcloud.talk.conversation.CreateConversationDialogFragment.initiateConversation (CreateConversationDialogFragment.kt:276)
  at com.nextcloud.talk.conversation.CreateConversationDialogFragment.access$initiateConversation (CreateConversationDialogFragment.kt:63)
  at com.nextcloud.talk.conversation.CreateConversationDialogFragment$addParticipants$1.invoke (CreateConversationDialogFragment.kt:257)
  at com.nextcloud.talk.conversation.CreateConversationDialogFragment$addParticipants$1.invoke (CreateConversationDialogFragment.kt:248)
  at com.nextcloud.talk.conversation.CreateConversationDialogFragment$sam$androidx_lifecycle_Observer$0.onChanged
  at androidx.lifecycle.LiveData.considerNotify (LiveData.java:133)
  at androidx.lifecycle.LiveData.dispatchingValue (LiveData.java:151)
  at androidx.lifecycle.LiveData.setValue (LiveData.java:309)
  at androidx.lifecycle.MutableLiveData.setValue (MutableLiveData.java:50)
  at androidx.lifecycle.LiveData$1.run (LiveData.java:93)
  at android.os.Handler.handleCallback (Handler.java:958)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:230)
  at android.os.Looper.loop (Looper.java:319)
  at android.app.ActivityThread.main (ActivityThread.java:8893)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:608)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1103)
```

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)