### PR TITLE
hide button for open conversations when adding participants

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/contacts/ContactsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/contacts/ContactsActivity.kt
@@ -147,6 +147,7 @@ class ContactsActivity :
         }
         if (isAddingParticipantsView) {
             binding.callHeaderLayout.visibility = View.GONE
+            binding.listOpenConversations.visibility = View.GONE
         } else {
             binding.listOpenConversations.setOnClickListener {
                 listOpenConversations()


### PR DESCRIPTION
## reproduce
in conversation settings, select "add participants"

without this fix:
"Open conversations" button is shown at the top

with this fix:
"Open conversations" button is hidden

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)