### PR TITLE
Fix onLoadMore not refreshing instantly

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -3968,7 +3968,7 @@ class ChatActivity :
     }
 
     override fun onLoadMore(page: Int, totalItemsCount: Int) {
-        val calculatedPage = page / MESSAGE_PULL_LIMIT
+        val calculatedPage = totalItemsCount / PAGE_SIZE
         if (calculatedPage > 0) {
             chatViewModel.refreshChatParams(
                 setupFieldsForPullChatMessages(
@@ -4991,5 +4991,6 @@ class ChatActivity :
         private const val CURRENT_AUDIO_POSITION_KEY = "CURRENT_AUDIO_POSITION"
         private const val CURRENT_AUDIO_WAS_PLAYING_KEY = "CURRENT_AUDIO_PLAYING"
         private const val RESUME_AUDIO_TAG = "RESUME_AUDIO_TAG"
+        private const val PAGE_SIZE = 50
     }
 }


### PR DESCRIPTION
I couldn't reproduce the bug that caused the condition to be implemented, but I do faintly recall that `totalItemCount` and `page` were the same when the bug occurred, so I kept this new conditional in place to play it safe.


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)