### PR TITLE
fix to set ConversationType for "Note to self"

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.kt
@@ -28,7 +28,6 @@ import com.nextcloud.talk.extensions.loadConversationAvatar
 import com.nextcloud.talk.extensions.loadNoteToSelfAvatar
 import com.nextcloud.talk.extensions.loadSystemAvatar
 import com.nextcloud.talk.extensions.loadUserAvatar
-import com.nextcloud.talk.models.domain.ConversationModel
 import com.nextcloud.talk.models.json.chat.ChatMessage
 import com.nextcloud.talk.models.json.conversations.Conversation
 import com.nextcloud.talk.models.json.conversations.Conversation.ConversationType
@@ -36,7 +35,6 @@ import com.nextcloud.talk.ui.StatusDrawable
 import com.nextcloud.talk.ui.theme.ViewThemeUtils
 import com.nextcloud.talk.utils.CapabilitiesUtil.hasSpreedFeatureCapability
 import com.nextcloud.talk.utils.SpreedFeatures
-import com.nextcloud.talk.utils.ConversationUtils
 import com.nextcloud.talk.utils.DisplayUtils
 
 import eu.davidea.flexibleadapter.FlexibleAdapter
@@ -170,19 +168,12 @@ class ConversationItem(
                     }
                 }
 
-                ConversationType.DUMMY -> {
-                    if (ConversationUtils.isNoteToSelfConversation(
-                            ConversationModel.mapToConversationModel(model)
-                        )
-                    ) {
-                        holder.binding.dialogAvatar.loadNoteToSelfAvatar()
-                    }
-                }
-
                 ConversationType.ROOM_GROUP_CALL,
                 ConversationType.FORMER_ONE_TO_ONE,
                 ConversationType.ROOM_PUBLIC_CALL ->
                     holder.binding.dialogAvatar.loadConversationAvatar(user, model, false, viewThemeUtils)
+                ConversationType.NOTE_TO_SELF ->
+                    holder.binding.dialogAvatar.loadNoteToSelfAvatar()
 
                 else -> holder.binding.dialogAvatar.visibility = View.GONE
             }

--- a/app/src/main/java/com/nextcloud/talk/models/domain/ConversationModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/domain/ConversationModel.kt
@@ -122,7 +122,8 @@ enum class ConversationType {
     ROOM_GROUP_CALL,
     ROOM_PUBLIC_CALL,
     ROOM_SYSTEM,
-    FORMER_ONE_TO_ONE
+    FORMER_ONE_TO_ONE,
+    NOTE_TO_SELF
 }
 
 enum class ParticipantType {

--- a/app/src/main/java/com/nextcloud/talk/models/json/conversations/Conversation.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/conversations/Conversation.kt
@@ -238,7 +238,8 @@ data class Conversation(
         ROOM_GROUP_CALL,
         ROOM_PUBLIC_CALL,
         ROOM_SYSTEM,
-        FORMER_ONE_TO_ONE
+        FORMER_ONE_TO_ONE,
+        NOTE_TO_SELF
     }
 
     enum class ObjectType {

--- a/app/src/main/java/com/nextcloud/talk/models/json/converters/EnumRoomTypeConverter.java
+++ b/app/src/main/java/com/nextcloud/talk/models/json/converters/EnumRoomTypeConverter.java
@@ -23,6 +23,8 @@ public class EnumRoomTypeConverter extends IntBasedTypeConverter<Conversation.Co
                 return Conversation.ConversationType.ROOM_SYSTEM;
             case 5:
                 return Conversation.ConversationType.FORMER_ONE_TO_ONE;
+            case 6:
+                return Conversation.ConversationType.NOTE_TO_SELF;
             default:
                 return Conversation.ConversationType.DUMMY;
         }
@@ -43,6 +45,8 @@ public class EnumRoomTypeConverter extends IntBasedTypeConverter<Conversation.Co
                 return 4;
             case FORMER_ONE_TO_ONE:
                 return 5;
+            case NOTE_TO_SELF:
+                return 6;
             default:
                 return 0;
         }

--- a/app/src/main/java/com/nextcloud/talk/utils/ConversationUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/ConversationUtils.kt
@@ -13,7 +13,6 @@ import com.nextcloud.talk.models.json.capabilities.SpreedCapability
 
 object ConversationUtils {
     private val TAG = ConversationUtils::class.java.simpleName
-    private const val NOTE_TO_SELF = "Note to self"
 
     fun isPublic(conversation: ConversationModel): Boolean {
         return ConversationType.ROOM_PUBLIC_CALL == conversation.type
@@ -76,6 +75,6 @@ object ConversationUtils {
     }
 
     fun isNoteToSelfConversation(currentConversation: ConversationModel?): Boolean {
-        return currentConversation != null && currentConversation.name == NOTE_TO_SELF
+        return currentConversation != null && currentConversation.type == ConversationType.NOTE_TO_SELF
     }
 }


### PR DESCRIPTION
fix #3547
followup fix for https://github.com/nextcloud/talk-android/pull/3351/files#diff-ae89ba240692c2742cc545fd2f57ae82d78e9fce03e3bedc5cfc1af8acbcc1a0R93
blocks https://github.com/nextcloud/talk-android/pull/3812/files#r1568518960

Fix to check if a conversation is "Note to self" by checking the ConversationType instead to check conversation name by hardcoded string

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)