### PR TITLE
fix to show "Note to self" icon in conversation info

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
@@ -958,10 +958,8 @@ class ConversationInfoActivity :
                 binding.avatarImage.loadSystemAvatar()
             }
 
-            ConversationType.DUMMY -> {
-                if (ConversationUtils.isNoteToSelfConversation(conversation!!)) {
-                    binding.avatarImage.loadNoteToSelfAvatar()
-                }
+            ConversationType.NOTE_TO_SELF -> {
+                binding.avatarImage.loadNoteToSelfAvatar()
             }
 
             else -> {


### PR DESCRIPTION
fix to show "Note to self" icon in conversation info

followup to https://github.com/nextcloud/talk-android/pull/3842


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)