### PR TITLE
fix to keep text of message-editing after 30sec

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -1159,15 +1159,6 @@ class ChatActivity :
         val filters = arrayOfNulls<InputFilter>(1)
         val lengthFilter = CapabilitiesUtil.getMessageMaxLength(spreedCapabilities)
 
-        binding.editView.editMessageView.visibility = View.GONE
-
-        if (editableBehaviorSubject.value!!) {
-            val editableText = Editable.Factory.getInstance().newEditable(editMessage.message)
-            binding.messageInputView.inputEditText.text = editableText
-            binding.messageInputView.inputEditText.setSelection(editableText.length)
-            binding.editView.editMessage.setText(editMessage.message)
-        }
-
         filters[0] = InputFilter.LengthFilter(lengthFilter)
         binding.messageInputView.inputEditText?.filters = filters
 
@@ -1229,9 +1220,6 @@ class ChatActivity :
             uploadFile(it.toString(), false)
         }
         initVoiceRecordButton()
-        if (editableBehaviorSubject.value!!) {
-            setEditUI()
-        }
 
         if (sharedText.isNotEmpty()) {
             binding.messageInputView.inputEditText?.setText(sharedText)
@@ -1243,17 +1231,6 @@ class ChatActivity :
 
         binding.messageInputView.button?.setOnClickListener {
             submitMessage(false)
-        }
-
-        binding.messageInputView.editMessageButton.setOnClickListener {
-            if (editMessage.message == editedTextBehaviorSubject.value!!) {
-                clearEditUI()
-                return@setOnClickListener
-            }
-            editMessageAPI(editMessage, editedMessageText = editedTextBehaviorSubject.value!!)
-        }
-        binding.editView.clearEdit.setOnClickListener {
-            clearEditUI()
         }
 
         if (CapabilitiesUtil.hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.SILENT_SEND)) {
@@ -4918,6 +4895,24 @@ class ChatActivity :
         editableBehaviorSubject.onNext(true)
         editMessage = message
         initMessageInputView()
+
+        setEditUI()
+
+        val editableText = Editable.Factory.getInstance().newEditable(editMessage.message)
+        binding.messageInputView.inputEditText.text = editableText
+        binding.messageInputView.inputEditText.setSelection(editableText.length)
+        binding.editView.editMessage.text = editMessage.message
+
+        binding.messageInputView.editMessageButton.setOnClickListener {
+            if (editMessage.message == editedTextBehaviorSubject.value!!) {
+                clearEditUI()
+                return@setOnClickListener
+            }
+            editMessageAPI(editMessage, editedMessageText = editedTextBehaviorSubject.value!!)
+        }
+        binding.editView.clearEdit.setOnClickListener {
+            clearEditUI()
+        }
     }
 
     companion object {


### PR DESCRIPTION
Without this fix, the text when editing a message was lost after pulling chat messages (30sec), because inputEditText was initialized again with the initial text

As a fix, message editing is only initialized once when the edit button was clicked.


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)