### PR TITLE
fix: Have correct SPDX license header for logo/trademarked items

### DIFF
--- a/LICENSES/LicenseRef-NextcloudTrademarks.txt
+++ b/LICENSES/LicenseRef-NextcloudTrademarks.txt
@@ -1,0 +1,9 @@
+The Nextcloud marks
+Nextcloud and the Nextcloud logo is a registered trademark of Nextcloud GmbH in Germany and/or other countries.
+These guidelines cover the following marks pertaining both to the product names and the logo: “Nextcloud”
+and the blue/white cloud logo with or without the word Nextcloud; the service “Nextcloud Enterprise”;
+and our products: “Nextcloud Files”; “Nextcloud Groupware” and “Nextcloud Talk”.
+This set of marks is collectively referred to as the “Nextcloud marks.”
+
+Use of Nextcloud logos and other marks is only permitted under the guidelines provided by the Nextcloud GmbH.
+A copy can be found at https://nextcloud.com/trademarks/

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,9 +1,8 @@
 <!--
   ~ Nextcloud Talk - Android Client
   ~
-  ~ SPDX-FileCopyrightText: 2017-2024 Nextcloud GmbH and Nextcloud contributors~
-  ~ SPDX-FileCopyrightText: 2017-2019 Mario Danic <mario@lovelyhq.com>
-  ~ SPDX-License-Identifier: GPL-3.0-or-later
+  ~ SPDX-FileCopyrightText: 2017-2024 Nextcloud GmbH <https://nextcloud.com/trademarks/>
+  ~ SPDX-License-Identifier: LicenseRef-NextcloudTrademarks
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="108dp"

--- a/app/src/main/res/drawable/ic_logo.xml
+++ b/app/src/main/res/drawable/ic_logo.xml
@@ -1,8 +1,8 @@
 <!--
   ~ Nextcloud Talk - Android Client
   ~
-  ~ SPDX-FileCopyrightText: 2017-2024 Nextcloud GmbH
-  ~ SPDX-License-Identifier: GPL-3.0-or-later
+  ~ SPDX-FileCopyrightText: 2017-2024 Nextcloud GmbH <https://nextcloud.com/trademarks/>
+  ~ SPDX-License-Identifier: LicenseRef-NextcloudTrademarks
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="128dp"

--- a/app/src/main/res/drawable/ic_talk.xml
+++ b/app/src/main/res/drawable/ic_talk.xml
@@ -2,8 +2,8 @@
 <!--
   ~ Nextcloud Talk - Android Client
   ~
-  ~ SPDX-FileCopyrightText: Nextcloud GmbH. All rights reserved.
-  ~ SPDX-License-Identifier: GPL-3.0-or-later
+  ~ SPDX-FileCopyrightText: 2017-2024 Nextcloud GmbH <https://nextcloud.com/trademarks/>
+  ~ SPDX-License-Identifier: LicenseRef-NextcloudTrademarks
 -->
 <vector android:autoMirrored="true"
     android:height="24dp"

--- a/app/src/qa/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/qa/res/drawable/ic_launcher_foreground.xml
@@ -1,9 +1,8 @@
 <!--
   ~ Nextcloud Talk - Android Client
   ~
-  ~ SPDX-FileCopyrightText: 2017-2024 Nextcloud GmbH and Nextcloud contributors~
-  ~ SPDX-FileCopyrightText: 2017-2019 Mario Danic <mario@lovelyhq.com>
-  ~ SPDX-License-Identifier: GPL-3.0-or-later
+  ~ SPDX-FileCopyrightText: 2017-2024 Nextcloud GmbH <https://nextcloud.com/trademarks/>
+  ~ SPDX-License-Identifier: LicenseRef-NextcloudTrademarks
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="108dp"


### PR DESCRIPTION
### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)