### PR TITLE
set light or dark bar colors for login screens instead primary color

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/account/AccountVerificationActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/account/AccountVerificationActivity.kt
@@ -91,7 +91,7 @@ class AccountVerificationActivity : BaseActivity() {
         requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         setContentView(binding.root)
         actionBar?.hide()
-        setupPrimaryColors()
+        setupSystemColors()
 
         handleIntent()
     }

--- a/app/src/main/java/com/nextcloud/talk/account/ServerSelectionActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/account/ServerSelectionActivity.kt
@@ -78,7 +78,7 @@ class ServerSelectionActivity : BaseActivity() {
         requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         setContentView(binding.root)
         actionBar?.hide()
-        setupPrimaryColors()
+        setupSystemColors()
 
         onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
     }

--- a/app/src/main/java/com/nextcloud/talk/account/SwitchAccountActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/account/SwitchAccountActivity.kt
@@ -86,7 +86,7 @@ class SwitchAccountActivity : BaseActivity() {
         requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         setContentView(binding.root)
         setupActionBar()
-        setupPrimaryColors()
+        setupSystemColors()
 
         Configuration.getInstance().load(context, PreferenceManager.getDefaultSharedPreferences(context))
 

--- a/app/src/main/java/com/nextcloud/talk/account/WebViewLoginActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/account/WebViewLoginActivity.kt
@@ -114,7 +114,7 @@ class WebViewLoginActivity : BaseActivity() {
         requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         setContentView(binding.root)
         actionBar?.hide()
-        setupPrimaryColors()
+        setupSystemColors()
 
         onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
         handleIntent()

--- a/app/src/main/java/com/nextcloud/talk/activities/BaseActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/BaseActivity.kt
@@ -108,19 +108,6 @@ open class BaseActivity : AppCompatActivity() {
         colorizeNavigationBar()
     }
 
-    fun setupPrimaryColors() {
-        if (resources != null) {
-            DisplayUtils.applyColorToStatusBar(
-                this,
-                ResourcesCompat.getColor(resources!!, R.color.colorPrimary, null)
-            )
-            DisplayUtils.applyColorToNavigationBar(
-                window,
-                ResourcesCompat.getColor(resources!!, R.color.colorPrimary, null)
-            )
-        }
-    }
-
     open fun colorizeStatusBar() {
         if (resources != null) {
             if (appBarLayoutType == AppBarLayoutType.SEARCH_BAR) {


### PR DESCRIPTION
especially for branded clients the primary color might not look good.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://github.com/nextcloud/talk-android/assets/2932790/d8801219-69d6-4fc5-b564-c78a3eaccbe5) | ![grafik](https://github.com/nextcloud/talk-android/assets/2932790/b1c045f4-bf36-4b56-92d3-7c3d2207fc67)

🏚️ Before | 🏡 After
---|---
![grafik](https://github.com/nextcloud/talk-android/assets/2932790/774e1f71-6ea3-46c0-ac3e-e487bbddfd98) | ![grafik](https://github.com/nextcloud/talk-android/assets/2932790/88f038da-2fdd-483c-90fa-912d9b1f8928)


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)