### PR TITLE
Show description in open conversation list

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -3474,39 +3474,34 @@ class ChatActivity :
                 ""
             }
 
-        val statusMessageView = binding.chatToolbar.findViewById<TextView>(R.id.chat_toolbar_status_message)
         if (currentConversation?.type == ConversationType.ROOM_TYPE_ONE_TO_ONE_CALL) {
             var statusMessage = ""
             if (currentConversation?.statusIcon != null) {
                 statusMessage += currentConversation?.statusIcon
             }
-
             if (currentConversation?.statusMessage != null) {
                 statusMessage += currentConversation?.statusMessage
             }
-
-            if (statusMessage.isNotEmpty()) {
-                viewThemeUtils.platform.colorTextView(statusMessageView, ColorRole.ON_SURFACE)
-                statusMessageView.text = statusMessage
-                statusMessageView.visibility = View.VISIBLE
-            } else {
-                statusMessageView.visibility = View.GONE
-            }
+            statusMessageViewContents(statusMessage)
         } else {
-            var descriptionMessage = ""
             if (currentConversation?.type == ConversationType.ROOM_GROUP_CALL ||
                 currentConversation?.type == ConversationType.ROOM_PUBLIC_CALL
             ) {
+                var descriptionMessage = ""
                 descriptionMessage += currentConversation?.description
-
-                if (descriptionMessage.isNotEmpty()) {
-                    viewThemeUtils.platform.colorTextView(statusMessageView, ColorRole.ON_SURFACE)
-                    statusMessageView.text = descriptionMessage
-                    statusMessageView.visibility = View.VISIBLE
-                } else {
-                    statusMessageView.visibility = View.GONE
-                }
+                statusMessageViewContents(descriptionMessage)
             }
+        }
+    }
+
+    private fun statusMessageViewContents(statusMessageContent: String) {
+        val statusMessageView = binding.chatToolbar.findViewById<TextView>(R.id.chat_toolbar_status_message)
+        if (statusMessageContent.isNotEmpty()) {
+            viewThemeUtils.platform.colorTextView(statusMessageView, ColorRole.ON_SURFACE)
+            statusMessageView.text = statusMessageContent
+            statusMessageView.visibility = View.VISIBLE
+        } else {
+            statusMessageView.visibility = View.GONE
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -182,6 +182,7 @@ import com.nextcloud.talk.ui.recyclerview.MessageSwipeCallback
 import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.AudioUtils
 import com.nextcloud.talk.utils.CapabilitiesUtil
+import com.nextcloud.talk.utils.CharPolicy
 import com.nextcloud.talk.utils.ContactUtils
 import com.nextcloud.talk.utils.ConversationUtils
 import com.nextcloud.talk.utils.DateConstants
@@ -190,7 +191,6 @@ import com.nextcloud.talk.utils.DisplayUtils
 import com.nextcloud.talk.utils.FileUtils
 import com.nextcloud.talk.utils.FileViewerUtils
 import com.nextcloud.talk.utils.ImageEmojiEditText
-import com.nextcloud.talk.utils.CharPolicy
 import com.nextcloud.talk.utils.Mimetype
 import com.nextcloud.talk.utils.NotificationUtils
 import com.nextcloud.talk.utils.ParticipantPermissions
@@ -3493,7 +3493,20 @@ class ChatActivity :
                 statusMessageView.visibility = View.GONE
             }
         } else {
-            statusMessageView.visibility = View.GONE
+            var descriptionMessage = ""
+            if (currentConversation?.type == ConversationType.ROOM_GROUP_CALL ||
+                currentConversation?.type == ConversationType.ROOM_PUBLIC_CALL
+            ) {
+                descriptionMessage += currentConversation?.description
+
+                if (descriptionMessage.isNotEmpty()) {
+                    viewThemeUtils.platform.colorTextView(statusMessageView, ColorRole.ON_SURFACE)
+                    statusMessageView.text = descriptionMessage
+                    statusMessageView.visibility = View.VISIBLE
+                } else {
+                    statusMessageView.visibility = View.GONE
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/openconversations/adapters/OpenConversationsAdapter.kt
+++ b/app/src/main/java/com/nextcloud/talk/openconversations/adapters/OpenConversationsAdapter.kt
@@ -36,6 +36,7 @@ class OpenConversationsAdapter(val user: User, private val onClick: (OpenConvers
         fun bindItem(conversation: OpenConversation) {
             currentConversation = conversation
             itemBinding.nameText.text = conversation.displayName
+            itemBinding.descriptionText.text = conversation.description
 
             // load avatar from server when https://github.com/nextcloud/spreed/issues/9600 is solved
             // itemBinding.avatarView.loadUserAvatar(user, conversation.displayName, true, false)

--- a/app/src/main/java/com/nextcloud/talk/openconversations/adapters/OpenConversationsAdapter.kt
+++ b/app/src/main/java/com/nextcloud/talk/openconversations/adapters/OpenConversationsAdapter.kt
@@ -7,7 +7,9 @@
 package com.nextcloud.talk.openconversations.adapters
 
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
+import android.widget.RelativeLayout
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -34,9 +36,17 @@ class OpenConversationsAdapter(val user: User, private val onClick: (OpenConvers
         }
 
         fun bindItem(conversation: OpenConversation) {
+            val nameTextLayoutParams: RelativeLayout.LayoutParams = itemBinding.nameText.layoutParams as
+                RelativeLayout.LayoutParams
+
             currentConversation = conversation
             itemBinding.nameText.text = conversation.displayName
-            itemBinding.descriptionText.text = conversation.description
+            if (conversation.description == "") {
+                itemBinding.descriptionText.visibility = View.GONE
+                nameTextLayoutParams.addRule(RelativeLayout.CENTER_VERTICAL)
+            } else {
+                itemBinding.descriptionText.text = conversation.description
+            }
 
             // load avatar from server when https://github.com/nextcloud/spreed/issues/9600 is solved
             // itemBinding.avatarView.loadUserAvatar(user, conversation.displayName, true, false)

--- a/app/src/main/java/com/nextcloud/talk/openconversations/data/OpenConversation.kt
+++ b/app/src/main/java/com/nextcloud/talk/openconversations/data/OpenConversation.kt
@@ -9,5 +9,6 @@ package com.nextcloud.talk.openconversations.data
 data class OpenConversation(
     var roomId: String,
     var roomToken: String,
-    var displayName: String
+    var displayName: String,
+    var description: String?
 )

--- a/app/src/main/java/com/nextcloud/talk/openconversations/data/OpenConversationsRepositoryImpl.kt
+++ b/app/src/main/java/com/nextcloud/talk/openconversations/data/OpenConversationsRepositoryImpl.kt
@@ -34,7 +34,8 @@ class OpenConversationsRepositoryImpl(private val ncApi: NcApi, currentUserProvi
                 OpenConversation(
                     conversation.roomId!!,
                     conversation.token!!,
-                    conversation.name!!
+                    conversation.name!!,
+                    conversation.description ?: ""
                 )
             }
         )

--- a/app/src/main/res/layout/activity_open_conversations.xml
+++ b/app/src/main/res/layout/activity_open_conversations.xml
@@ -30,10 +30,10 @@
     </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/open_conversations_recycler_view"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:layoutManager="LinearLayoutManager"/>
+        android:id="@+id/open_conversations_recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layoutManager="LinearLayoutManager" />
 
     <LinearLayout
         android:id="@+id/progress_bar_wrapper"

--- a/app/src/main/res/layout/rv_item_open_conversation.xml
+++ b/app/src/main/res/layout/rv_item_open_conversation.xml
@@ -22,7 +22,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_toEndOf="@id/avatar_view"
-        android:layout_marginTop="4dp"
+        android:layout_marginTop="@dimen/standard_quarter_margin"
         android:ellipsize="end"
         android:lines="1"
         android:textAlignment="viewStart"
@@ -35,7 +35,7 @@
         android:layout_height="wrap_content"
         android:layout_toEndOf="@id/avatar_view"
         android:layout_below= "@id/name_text"
-        android:paddingTop="4dp"
+        android:paddingTop="@dimen/standard_quarter_margin"
         android:ellipsize="end"
         android:lines="1"
         android:textAlignment="viewStart"
@@ -45,8 +45,8 @@
 
     <ImageView
         android:id="@+id/avatar_view"
-        android:layout_width="52dp"
-        android:layout_height="52dp"
+        android:layout_width="@dimen/avatar_size_open_conversation_list"
+        android:layout_height="@dimen/avatar_size_open_conversation_list"
         android:layout_centerVertical="true"
         android:layout_marginEnd="@dimen/standard_margin"
         android:contentDescription="@string/avatar" />

--- a/app/src/main/res/layout/rv_item_open_conversation.xml
+++ b/app/src/main/res/layout/rv_item_open_conversation.xml
@@ -21,18 +21,32 @@
         android:id="@+id/name_text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_centerVertical="true"
         android:layout_toEndOf="@id/avatar_view"
+        android:layout_marginTop="4dp"
         android:ellipsize="end"
         android:lines="1"
         android:textAlignment="viewStart"
         android:textAppearance="@style/ListItem"
         tools:text="Jane Doe" />
 
+    <androidx.emoji2.widget.EmojiTextView
+        android:id="@+id/description_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_toEndOf="@id/avatar_view"
+        android:layout_below= "@id/name_text"
+        android:paddingTop="4dp"
+        android:ellipsize="end"
+        android:lines="1"
+        android:textAlignment="viewStart"
+        android:textColor="@color/low_emphasis_text"
+        android:textSize="14sp"
+        tools:text="Jane Doe" />
+
     <ImageView
         android:id="@+id/avatar_view"
-        android:layout_width="@dimen/avatar_size"
-        android:layout_height="@dimen/avatar_size"
+        android:layout_width="60dp"
+        android:layout_height="60dp"
         android:layout_centerVertical="true"
         android:layout_marginEnd="@dimen/standard_margin"
         android:contentDescription="@string/avatar" />

--- a/app/src/main/res/layout/rv_item_open_conversation.xml
+++ b/app/src/main/res/layout/rv_item_open_conversation.xml
@@ -40,13 +40,13 @@
         android:lines="1"
         android:textAlignment="viewStart"
         android:textColor="@color/low_emphasis_text"
-        android:textSize="14sp"
+        android:textSize="13sp"
         tools:text="Jane Doe" />
 
     <ImageView
         android:id="@+id/avatar_view"
-        android:layout_width="60dp"
-        android:layout_height="60dp"
+        android:layout_width="52dp"
+        android:layout_height="52dp"
         android:layout_centerVertical="true"
         android:layout_marginEnd="@dimen/standard_margin"
         android:contentDescription="@string/avatar" />

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -23,6 +23,7 @@
     <dimen name="avatar_size">40dp</dimen>
     <dimen name="avatar_size_app_bar">30dp</dimen>
     <dimen name="avatar_size_big">96dp</dimen>
+    <dimen name="avatar_size_open_conversation_list">52dp</dimen>
 
     <dimen name="chat_text_size">14sp</dimen>
     <dimen name="message_bubble_corners_radius">20dp</dimen>


### PR DESCRIPTION
Resolves #3892

- [x] adds conversation description in open conversation list.
- [x] adds conversation description in chat activity.

###

 🖼️ Screenshots
🏚️ Before | 🏡 After
--|---
![no description in open conversation list](https://github.com/nextcloud/talk-android/assets/101803542/c381177f-4733-4a23-965a-9735d02f31a4)|![with description in open conversation list](https://github.com/nextcloud/talk-android/assets/101803542/c0aa7d3a-fc0a-4dc4-9105-ecb8edea6f3d)|
![no description in chat activity](https://github.com/nextcloud/talk-android/assets/101803542/d5a7acba-ec7e-4071-adb2-d67b0bbf66a3)|![description in chat activity](https://github.com/nextcloud/talk-android/assets/101803542/177f3bbd-f198-4aa6-b510-5f2e8c757563)|

### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)