### PR TITLE
fix unread message behavior

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -3759,7 +3759,13 @@ class ChatActivity :
     }
 
     private fun processMessagesFromTheFuture(chatMessageList: List<ChatMessage>) {
-        val insertNewMessagesNotice = (adapter?.itemCount ?: 0) > 0 && chatMessageList.isNotEmpty()
+        val newMessagesAvailable = (adapter?.itemCount ?: 0) > 0 && chatMessageList.isNotEmpty()
+        val insertNewMessagesNotice = if (newMessagesAvailable) {
+            chatMessageList.any { it.actorId != conversationUser!!.userId }
+        } else {
+            false
+        }
+
         val scrollToEndOnUpdate = layoutManager?.findFirstVisibleItemPosition() == 0
 
         if (insertNewMessagesNotice) {

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -3759,8 +3759,10 @@ class ChatActivity :
     }
 
     private fun processMessagesFromTheFuture(chatMessageList: List<ChatMessage>) {
-        val shouldAddNewMessagesNotice = layoutManager?.findFirstVisibleItemPosition()!! > 0
-        if (shouldAddNewMessagesNotice) {
+        val insertNewMessagesNotice = (adapter?.itemCount ?: 0) > 0 && chatMessageList.isNotEmpty()
+        val scrollToEndOnUpdate = layoutManager?.findFirstVisibleItemPosition() == 0
+
+        if (insertNewMessagesNotice) {
             val unreadChatMessage = ChatMessage()
             unreadChatMessage.jsonMessageId = -1
             unreadChatMessage.actorId = "-1"
@@ -3769,7 +3771,41 @@ class ChatActivity :
             adapter?.addToStart(unreadChatMessage, false)
         }
 
-        addMessagesToAdapter(shouldAddNewMessagesNotice, chatMessageList)
+        if (!scrollToEndOnUpdate) {
+            binding.popupBubbleView.isShown.let {
+                if (it) {
+                    newMessagesCount++
+                } else {
+                    newMessagesCount = 1
+                    binding.scrollDownButton.visibility = View.GONE
+                    binding.popupBubbleView.show()
+                }
+            }
+        } else {
+            binding.scrollDownButton.visibility = View.GONE
+            newMessagesCount = 0
+        }
+
+        for (chatMessage in chatMessageList) {
+            chatMessage.activeUser = conversationUser
+
+            adapter?.let {
+                chatMessage.isGrouped = (
+                    it.isPreviousSameAuthor(chatMessage.actorId, -1) &&
+                        it.getSameAuthorLastMessagesCount(chatMessage.actorId) %
+                        GROUPED_MESSAGES_SAME_AUTHOR_THRESHOLD > 0
+                    )
+                chatMessage.isOneToOneConversation =
+                    (currentConversation?.type == ConversationType.ROOM_TYPE_ONE_TO_ONE_CALL)
+                chatMessage.isFormerOneToOneConversation =
+                    (currentConversation?.type == ConversationType.FORMER_ONE_TO_ONE)
+                it.addToStart(chatMessage, scrollToEndOnUpdate)
+            }
+        }
+
+        if (insertNewMessagesNotice && scrollToEndOnUpdate && adapter != null) {
+            scrollToFirstUnreadMessage()
+        }
     }
 
     private fun processMessagesNotFromTheFuture(chatMessageList: List<ChatMessage>) {
@@ -3811,53 +3847,6 @@ class ChatActivity :
                 it.getMessagePositionByIdInReverse("-1"),
                 binding.messagesListView.height / 2
             )
-        }
-    }
-
-    private fun addMessagesToAdapter(shouldAddNewMessagesNotice: Boolean, chatMessageList: List<ChatMessage>) {
-        val isThereANewNotice =
-            shouldAddNewMessagesNotice || adapter?.getMessagePositionByIdInReverse("-1") != -1
-        for (chatMessage in chatMessageList) {
-            chatMessage.activeUser = conversationUser
-
-            val shouldScroll =
-                !isThereANewNotice &&
-                    !shouldAddNewMessagesNotice &&
-                    layoutManager?.findFirstVisibleItemPosition() == 0 ||
-                    adapter != null &&
-                    adapter?.itemCount == 0
-
-            modifyMessageCount(shouldAddNewMessagesNotice, shouldScroll)
-
-            adapter?.let {
-                chatMessage.isGrouped = (
-                    it.isPreviousSameAuthor(chatMessage.actorId, -1) &&
-                        it.getSameAuthorLastMessagesCount(chatMessage.actorId) %
-                        GROUPED_MESSAGES_SAME_AUTHOR_THRESHOLD > 0
-                    )
-                chatMessage.isOneToOneConversation =
-                    (currentConversation?.type == ConversationType.ROOM_TYPE_ONE_TO_ONE_CALL)
-                chatMessage.isFormerOneToOneConversation =
-                    (currentConversation?.type == ConversationType.FORMER_ONE_TO_ONE)
-                it.addToStart(chatMessage, shouldScroll)
-            }
-        }
-    }
-
-    private fun modifyMessageCount(shouldAddNewMessagesNotice: Boolean, shouldScroll: Boolean) {
-        if (shouldAddNewMessagesNotice) {
-            binding.popupBubbleView.isShown.let {
-                if (it) {
-                    newMessagesCount++
-                } else {
-                    newMessagesCount = 1
-                    binding.scrollDownButton.visibility = View.GONE
-                    binding.popupBubbleView.show()
-                }
-            }
-        } else {
-            binding.scrollDownButton.visibility = View.GONE
-            newMessagesCount = 0
         }
     }
 


### PR DESCRIPTION
fix #3903

## How to test:
- receive multiple messages when not being in the conversation (or mark some message as unread yourself)
- open the conversation

### without this PR:
chat is scrolled down to the latest message

### with this PR:
chat is scrolled to the first unread message



### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)