### PR TITLE
open internal links for files app from any screen + open talk links inside the app

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/BaseActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/BaseActivity.kt
@@ -33,11 +33,13 @@ import com.nextcloud.talk.account.ServerSelectionActivity
 import com.nextcloud.talk.account.SwitchAccountActivity
 import com.nextcloud.talk.account.WebViewLoginActivity
 import com.nextcloud.talk.application.NextcloudTalkApplication
+import com.nextcloud.talk.chat.ChatActivity
 import com.nextcloud.talk.events.CertificateEvent
 import com.nextcloud.talk.ui.theme.ViewThemeUtils
 import com.nextcloud.talk.utils.DisplayUtils
 import com.nextcloud.talk.utils.FileViewerUtils
 import com.nextcloud.talk.utils.UriUtils
+import com.nextcloud.talk.utils.bundle.BundleKeys
 import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import com.nextcloud.talk.utils.preferences.AppPreferences
 import com.nextcloud.talk.utils.ssl.TrustManager
@@ -248,6 +250,14 @@ open class BaseActivity : AppCompatActivity() {
                     // https://cloud.nextcloud.com/apps/files/?dir=/Engineering&fileid=41
                     val fileViewerUtils = FileViewerUtils(applicationContext, user)
                     fileViewerUtils.openFileInFilesApp(uri, UriUtils.extractInstanceInternalFileFileIdNew(uri))
+                } else if (UriUtils.isInstanceInternalTalkUrl(user.baseUrl!!, uri)) {
+                    // https://cloud.nextcloud.com/call/123456789
+                    val bundle = Bundle()
+                    bundle.putString(BundleKeys.KEY_ROOM_TOKEN, UriUtils.extractRoomTokenFromTalkUrl(uri))
+                    val chatIntent = Intent(context, ChatActivity::class.java)
+                    chatIntent.putExtras(bundle)
+                    chatIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                    startActivity(chatIntent)
                 } else {
                     super.startActivity(intent)
                 }

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -120,7 +120,6 @@ import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_SWITCH_TO_ROOM
 import com.nextcloud.talk.utils.CapabilitiesUtil
 import com.nextcloud.talk.utils.CapabilitiesUtil.hasSpreedFeatureCapability
 import com.nextcloud.talk.utils.CapabilitiesUtil.isCallRecordingAvailable
-import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import com.nextcloud.talk.utils.permissions.PlatformPermissionUtil
 import com.nextcloud.talk.utils.power.PowerManagerUtils
 import com.nextcloud.talk.utils.registerPermissionHandlerBroadcastReceiver
@@ -182,10 +181,6 @@ class CallActivity : CallBaseActivity() {
     @JvmField
     @Inject
     var ncApi: NcApi? = null
-
-    @JvmField
-    @Inject
-    var currentUserProvider: CurrentUserProviderNew? = null
 
     @JvmField
     @Inject
@@ -375,7 +370,7 @@ class CallActivity : CallBaseActivity() {
         binding = CallActivityBinding.inflate(layoutInflater)
         setContentView(binding!!.root)
         hideNavigationIfNoPipAvailable()
-        conversationUser = currentUserProvider!!.currentUser.blockingGet()
+        conversationUser = currentUserProvider.currentUser.blockingGet()
         val extras = intent.extras
         roomId = extras!!.getString(KEY_ROOM_ID, "")
         roomToken = extras.getString(KEY_ROOM_TOKEN, "")

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -195,7 +195,6 @@ import com.nextcloud.talk.utils.Mimetype
 import com.nextcloud.talk.utils.NotificationUtils
 import com.nextcloud.talk.utils.ParticipantPermissions
 import com.nextcloud.talk.utils.SpreedFeatures
-import com.nextcloud.talk.utils.UriUtils
 import com.nextcloud.talk.utils.VibrationUtils
 import com.nextcloud.talk.utils.bundle.BundleKeys
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_CALL_VOICE_ONLY
@@ -209,7 +208,6 @@ import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_ROOM_ID
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_ROOM_TOKEN
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_START_CALL_AFTER_ROOM_SWITCH
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_SWITCH_TO_ROOM
-import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import com.nextcloud.talk.utils.permissions.PlatformPermissionUtil
 import com.nextcloud.talk.utils.rx.DisposableSet
 import com.nextcloud.talk.utils.singletons.ApplicationWideCurrentRoomHolder
@@ -266,9 +264,6 @@ class ChatActivity :
 
     @Inject
     lateinit var ncApi: NcApi
-
-    @Inject
-    lateinit var currentUserProvider: CurrentUserProviderNew
 
     @Inject
     lateinit var permissionUtil: PlatformPermissionUtil
@@ -3298,34 +3293,6 @@ class ChatActivity :
                 )
             )
         )
-    }
-
-    override fun startActivity(intent: Intent) {
-        val user = currentUserProvider.currentUser.blockingGet()
-        if (intent.data != null && TextUtils.equals(intent.action, Intent.ACTION_VIEW)) {
-            val uri = intent.data.toString()
-            if (uri.startsWith(user.baseUrl!!)) {
-                if (UriUtils.isInstanceInternalFileShareUrl(user.baseUrl!!, uri)) {
-                    // https://cloud.nextcloud.com/f/41
-                    val fileViewerUtils = FileViewerUtils(applicationContext, user)
-                    fileViewerUtils.openFileInFilesApp(uri, UriUtils.extractInstanceInternalFileShareFileId(uri))
-                } else if (UriUtils.isInstanceInternalFileUrl(user.baseUrl!!, uri)) {
-                    // https://cloud.nextcloud.com/apps/files/?dir=/Engineering&fileid=41
-                    val fileViewerUtils = FileViewerUtils(applicationContext, user)
-                    fileViewerUtils.openFileInFilesApp(uri, UriUtils.extractInstanceInternalFileFileId(uri))
-                } else if (UriUtils.isInstanceInternalFileUrlNew(user.baseUrl!!, uri)) {
-                    // https://cloud.nextcloud.com/apps/files/?dir=/Engineering&fileid=41
-                    val fileViewerUtils = FileViewerUtils(applicationContext, user)
-                    fileViewerUtils.openFileInFilesApp(uri, UriUtils.extractInstanceInternalFileFileIdNew(uri))
-                } else {
-                    super.startActivity(intent)
-                }
-            } else {
-                super.startActivity(intent)
-            }
-        } else {
-            super.startActivity(intent)
-        }
     }
 
     fun sendSelectLocalFileIntent() {

--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
@@ -76,7 +76,6 @@ import com.nextcloud.talk.utils.DateUtils
 import com.nextcloud.talk.utils.ShareUtils
 import com.nextcloud.talk.utils.SpreedFeatures
 import com.nextcloud.talk.utils.bundle.BundleKeys
-import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import com.nextcloud.talk.utils.preferences.preferencestorage.DatabaseStorageModule
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.common.SmoothScrollLinearLayoutManager
@@ -102,9 +101,6 @@ class ConversationInfoActivity :
 
     @Inject
     lateinit var ncApi: NcApi
-
-    @Inject
-    lateinit var currentUserProvider: CurrentUserProviderNew
 
     @Inject
     lateinit var conversationsRepository: ConversationsRepository

--- a/app/src/main/java/com/nextcloud/talk/conversationinfoedit/ConversationInfoEditActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfoedit/ConversationInfoEditActivity.kt
@@ -41,7 +41,6 @@ import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.CapabilitiesUtil
 import com.nextcloud.talk.utils.PickImage
 import com.nextcloud.talk.utils.bundle.BundleKeys
-import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import io.reactivex.Observer
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
@@ -56,9 +55,6 @@ class ConversationInfoEditActivity : BaseActivity() {
 
     @Inject
     lateinit var ncApi: NcApi
-
-    @Inject
-    lateinit var currentUserProvider: CurrentUserProviderNew
 
     @Inject
     lateinit var viewModelFactory: ViewModelProvider.Factory

--- a/app/src/main/java/com/nextcloud/talk/diagnose/DiagnoseActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/diagnose/DiagnoseActivity.kt
@@ -43,7 +43,6 @@ import com.nextcloud.talk.utils.NotificationUtils
 import com.nextcloud.talk.utils.PushUtils.Companion.LATEST_PUSH_REGISTRATION_AT_PUSH_PROXY
 import com.nextcloud.talk.utils.PushUtils.Companion.LATEST_PUSH_REGISTRATION_AT_SERVER
 import com.nextcloud.talk.utils.UserIdUtils
-import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import com.nextcloud.talk.utils.permissions.PlatformPermissionUtil
 import com.nextcloud.talk.utils.power.PowerManagerUtils
 import javax.inject.Inject
@@ -61,9 +60,6 @@ class DiagnoseActivity : BaseActivity() {
 
     @Inject
     lateinit var userManager: UserManager
-
-    @Inject
-    lateinit var currentUserProvider: CurrentUserProviderNew
 
     @Inject
     lateinit var platformPermissionUtil: PlatformPermissionUtil

--- a/app/src/main/java/com/nextcloud/talk/invitation/InvitationsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/invitation/InvitationsActivity.kt
@@ -27,7 +27,6 @@ import com.nextcloud.talk.invitation.data.ActionEnum
 import com.nextcloud.talk.invitation.data.Invitation
 import com.nextcloud.talk.invitation.viewmodels.InvitationsViewModel
 import com.nextcloud.talk.utils.bundle.BundleKeys
-import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import javax.inject.Inject
 
 @AutoInjector(NextcloudTalkApplication::class)
@@ -40,9 +39,6 @@ class InvitationsActivity : BaseActivity() {
 
     @Inject
     lateinit var viewModelFactory: ViewModelProvider.Factory
-
-    @Inject
-    lateinit var userProvider: CurrentUserProviderNew
 
     lateinit var invitationsViewModel: InvitationsViewModel
 
@@ -63,7 +59,7 @@ class InvitationsActivity : BaseActivity() {
 
         invitationsViewModel = ViewModelProvider(this, viewModelFactory)[InvitationsViewModel::class.java]
 
-        currentUser = userProvider.currentUser.blockingGet()
+        currentUser = currentUserProvider.currentUser.blockingGet()
         invitationsViewModel.fetchInvitations(currentUser)
 
         binding = ActivityInvitationsBinding.inflate(layoutInflater)

--- a/app/src/main/java/com/nextcloud/talk/messagesearch/MessageSearchActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/messagesearch/MessageSearchActivity.kt
@@ -29,7 +29,6 @@ import com.nextcloud.talk.conversationlist.ConversationsListActivity
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.databinding.ActivityMessageSearchBinding
 import com.nextcloud.talk.utils.bundle.BundleKeys
-import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import com.nextcloud.talk.utils.rx.SearchViewObservable.Companion.observeSearchView
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.items.AbstractFlexibleItem
@@ -46,9 +45,6 @@ class MessageSearchActivity : BaseActivity() {
 
     @Inject
     lateinit var viewModelFactory: ViewModelProvider.Factory
-
-    @Inject
-    lateinit var userProvider: CurrentUserProviderNew
 
     private lateinit var binding: ActivityMessageSearchBinding
     private lateinit var searchView: SearchView
@@ -77,7 +73,7 @@ class MessageSearchActivity : BaseActivity() {
         setupSystemColors()
 
         viewModel = ViewModelProvider(this, viewModelFactory)[MessageSearchViewModel::class.java]
-        user = userProvider.currentUser.blockingGet()
+        user = currentUserProvider.currentUser.blockingGet()
         val roomToken = intent.getStringExtra(BundleKeys.KEY_ROOM_TOKEN)!!
         viewModel.initialize(roomToken)
         setupStateObserver()

--- a/app/src/main/java/com/nextcloud/talk/openconversations/ListOpenConversationsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/openconversations/ListOpenConversationsActivity.kt
@@ -23,7 +23,6 @@ import com.nextcloud.talk.openconversations.adapters.OpenConversationsAdapter
 import com.nextcloud.talk.openconversations.data.OpenConversation
 import com.nextcloud.talk.openconversations.viewmodels.OpenConversationsViewModel
 import com.nextcloud.talk.utils.bundle.BundleKeys
-import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import javax.inject.Inject
 
 @AutoInjector(NextcloudTalkApplication::class)
@@ -36,9 +35,6 @@ class ListOpenConversationsActivity : BaseActivity() {
 
     @Inject
     lateinit var viewModelFactory: ViewModelProvider.Factory
-
-    @Inject
-    lateinit var userProvider: CurrentUserProviderNew
 
     lateinit var openConversationsViewModel: OpenConversationsViewModel
 
@@ -57,7 +53,7 @@ class ListOpenConversationsActivity : BaseActivity() {
         setContentView(binding.root)
         setupSystemColors()
 
-        val user = userProvider.currentUser.blockingGet()
+        val user = currentUserProvider.currentUser.blockingGet()
 
         adapter = OpenConversationsAdapter(user) { conversation -> adapterOnClick(conversation) }
         binding.openConversationsRecyclerView.adapter = adapter

--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -75,7 +75,6 @@ import com.nextcloud.talk.utils.NotificationUtils.getCallRingtoneUri
 import com.nextcloud.talk.utils.NotificationUtils.getMessageRingtoneUri
 import com.nextcloud.talk.utils.SecurityUtils
 import com.nextcloud.talk.utils.SpreedFeatures
-import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import com.nextcloud.talk.utils.permissions.PlatformPermissionUtil
 import com.nextcloud.talk.utils.power.PowerManagerUtils
 import com.nextcloud.talk.utils.preferences.AppPreferencesImpl
@@ -106,9 +105,6 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
 
     @Inject
     lateinit var userManager: UserManager
-
-    @Inject
-    lateinit var currentUserProvider: CurrentUserProviderNew
 
     @Inject
     lateinit var platformPermissionUtil: PlatformPermissionUtil

--- a/app/src/main/java/com/nextcloud/talk/shareditems/activities/SharedItemsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/shareditems/activities/SharedItemsActivity.kt
@@ -13,7 +13,6 @@ import android.os.Bundle
 import android.util.Log
 import android.view.MenuItem
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.res.ResourcesCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.GridLayoutManager
@@ -22,30 +21,23 @@ import androidx.recyclerview.widget.RecyclerView
 import autodagger.AutoInjector
 import com.google.android.material.tabs.TabLayout
 import com.nextcloud.talk.R
+import com.nextcloud.talk.activities.BaseActivity
 import com.nextcloud.talk.application.NextcloudTalkApplication
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.databinding.ActivitySharedItemsBinding
 import com.nextcloud.talk.shareditems.adapters.SharedItemsAdapter
 import com.nextcloud.talk.shareditems.model.SharedItemType
 import com.nextcloud.talk.shareditems.viewmodels.SharedItemsViewModel
-import com.nextcloud.talk.ui.theme.ViewThemeUtils
 import com.nextcloud.talk.utils.DisplayUtils
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_CONVERSATION_NAME
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_ROOM_TOKEN
-import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import javax.inject.Inject
 
 @AutoInjector(NextcloudTalkApplication::class)
-class SharedItemsActivity : AppCompatActivity() {
-
-    @Inject
-    lateinit var currentUserProvider: CurrentUserProviderNew
+class SharedItemsActivity : BaseActivity() {
 
     @Inject
     lateinit var viewModelFactory: ViewModelProvider.Factory
-
-    @Inject
-    lateinit var viewThemeUtils: ViewThemeUtils
 
     private lateinit var binding: ActivitySharedItemsBinding
     private lateinit var viewModel: SharedItemsViewModel

--- a/app/src/main/java/com/nextcloud/talk/utils/UriUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/UriUtils.kt
@@ -22,6 +22,7 @@ class UriUtils {
 
         fun isInstanceInternalFileShareUrl(baseUrl: String, url: String): Boolean {
             // https://cloud.nextcloud.com/f/41
+            // https://cloud.nextcloud.com/index.php/f/41
             return (url.startsWith("$baseUrl/f/") || url.startsWith("$baseUrl/index.php/f/")) &&
                 Regex(".*/f/\\d*").matches(url)
         }

--- a/app/src/main/java/com/nextcloud/talk/utils/UriUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/UriUtils.kt
@@ -27,8 +27,19 @@ class UriUtils {
                 Regex(".*/f/\\d*").matches(url)
         }
 
+        fun isInstanceInternalTalkUrl(baseUrl: String, url: String): Boolean {
+            // https://cloud.nextcloud.com/call/123456789
+            return (url.startsWith("$baseUrl/call/") || url.startsWith("$baseUrl/index.php/call/")) &&
+                Regex(".*/call/\\d*").matches(url)
+        }
+
         fun extractInstanceInternalFileShareFileId(url: String): String {
             // https://cloud.nextcloud.com/f/41
+            return Uri.parse(url).lastPathSegment ?: ""
+        }
+
+        fun extractRoomTokenFromTalkUrl(url: String): String {
+            // https://cloud.nextcloud.com/call/123456789
             return Uri.parse(url).lastPathSegment ?: ""
         }
 


### PR DESCRIPTION
Followup improvements to #3922

With this change, all links that target files in the same nextcloud instance will be opened in the files app, no matter on which screen the link was (e.g. useful when links are posted in conversation descriptions...).

- [x] enhance this to also handle talk links inside the app itself
    - this solves https://github.com/nextcloud/talk-android/issues/847 at least for links inside the app itself


#### How to test
- share some files url to chat & open
- share some talk url to chat & open

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)