### PR TITLE
Avoid StackOverflowError when opening chat (kotlin2.0 fix)

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/MessageInput.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/MessageInput.kt
@@ -60,19 +60,19 @@ class MessageInput : MessageInput {
     }
 
     var messageInput: EmojiEditText
-        get() = messageInput
+        get() = super.messageInput
         set(messageInput) {
             super.messageInput = messageInput
         }
 
     var attachmentButton: ImageButton
-        get() = attachmentButton
+        get() = super.attachmentButton
         set(attachmentButton) {
             super.attachmentButton = attachmentButton
         }
 
     var messageSendButton: ImageButton
-        get() = messageSendButton
+        get() = super.messageSendButton
         set(messageSendButton) {
             super.messageSendButton = messageSendButton
         }


### PR DESCRIPTION
followup to https://github.com/nextcloud/talk-android/pull/3970

When opening the chat the app crashed with

2024-06-18 10:59:45.039 30757-30757 AndroidRuntime          com.nextcloud.talk2                  E  FATAL EXCEPTION: main
  Process: com.nextcloud.talk2, PID: 30757
  java.lang.StackOverflowError: stack size 8192KB
  at com.nextcloud.talk.ui.MessageInput.getMessageSendButton(MessageInput.kt:75)

Hint in AS was:
Now field from base class com.stfalcon.chatkit.messages.MessageInput shadows the property with custom getter from derived class com.nextcloud.talk.ui.MessageInput. This behavior will be changed soon in favor of the property. Please use explicit cast to com.stfalcon.chatkit.messages.MessageInput if you wish to preserve current behavior. See https://youtrack.jetbrains.com/issue/KT-55017 for details

The issue is caused by the update to kotlin2.0.
Calling the super fields fixes the issue.


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)