### PR TITLE
build(qa): Switch deprecated `set-output` to `$GITHUB_OUTPUT`

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if secrets are available
-        run: echo "::set-output name=ok::${{ secrets.KS_PASS != '' }}"
+        run: echo "ok=${{ secrets.KS_PASS != '' }}" >> "$GITHUB_OUTPUT"
         id: check-secrets
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         if: ${{ steps.check-secrets.outputs.ok == 'true' }}


### PR DESCRIPTION
https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/

### 🖼️ Screenshots

🏚️ Before | 🏡 After

N/A

### 🚧 TODO

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)