### PR TITLE
Animated GIFS in Chat

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/PreviewMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/PreviewMessageViewHolder.kt
@@ -42,6 +42,7 @@ import com.nextcloud.talk.utils.DisplayUtils
 import com.nextcloud.talk.utils.DrawableUtils.getDrawableResourceIdForMimeType
 import com.nextcloud.talk.utils.FileViewerUtils
 import com.nextcloud.talk.utils.FileViewerUtils.ProgressUi
+import com.nextcloud.talk.utils.MimetypeUtils.isGif
 import com.nextcloud.talk.utils.message.MessageUtils
 import com.stfalcon.chatkit.messages.MessageHolders.IncomingImageMessageViewHolder
 import io.reactivex.Single
@@ -232,6 +233,10 @@ abstract class PreviewMessageViewHolder(itemView: View?, payload: Any?) :
 
         if (message.selectedIndividualHashMap!!.containsKey(KEY_MIMETYPE)) {
             val mimetype = message.selectedIndividualHashMap!![KEY_MIMETYPE]
+            if (isGif(mimetype!!)) {
+                return message
+            }
+
             val drawableResourceId = getDrawableResourceIdForMimeType(mimetype)
             var drawable = ContextCompat.getDrawable(context!!, drawableResourceId)
             if (drawable != null &&

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -1081,7 +1081,6 @@ class ChatActivity :
                 } catch (e: Exception) {
                     Log.e(TAG, "Error in ImageLoading in initAdapter $e")
                 }
-
             },
             this
         )

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -50,7 +50,6 @@ import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.view.ContextThemeWrapper
-import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.core.content.PermissionChecker
 import androidx.core.content.PermissionChecker.PERMISSION_GRANTED
@@ -188,7 +187,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
-import pl.droidsonroids.gif.GifDrawable
 import retrofit2.HttpException
 import retrofit2.Response
 import java.io.File
@@ -1077,27 +1075,10 @@ class ChatActivity :
             initMessageHolders(),
             ImageLoader { imageView, url, data ->
                 try {
-                    if ((data is ChatMessage)) { // It's a GIF
-                        val filename = data.selectedIndividualHashMap!!["name"]
-                        val path = context.cacheDir.absolutePath + "/" + filename
-                        val file = File(context.cacheDir, filename!!)
-                        if (file.exists()) {
-                            val gifFromUri = GifDrawable(path)
-                            imageView.setImageDrawable(gifFromUri)
-                        } else {
-                            // TODO download file to cache can't be called here -_-, need to figure out another way
-                            // to get this preloaded, likely in PreviewMessageViewHolder
-                            val placeholder = ContextCompat.getDrawable(context, R.drawable.ic_mimetype_file)
-                            imageView.setImageDrawable(placeholder)
-                            downloadFileToCache(data, false) {
-                                val gifFromUri = GifDrawable(path)
-                                imageView.setImageDrawable(gifFromUri)
-                            }
-                        }
-                    } else { // Not a GIF
+                    if ((data !is ChatMessage)) { // It's Not a GIF
                         imageView.loadAvatarOrImagePreview(url!!, conversationUser!!, data as Drawable?)
                     }
-                } catch (e: java.lang.IllegalStateException) {
+                } catch (e: Exception) {
                     Log.e(TAG, "Error in ImageLoading in initAdapter $e")
                 }
 

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -50,6 +50,7 @@ import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.view.ContextThemeWrapper
+import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.core.content.PermissionChecker
 import androidx.core.content.PermissionChecker.PERMISSION_GRANTED
@@ -187,6 +188,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
+import pl.droidsonroids.gif.GifDrawable
 import retrofit2.HttpException
 import retrofit2.Response
 import java.io.File
@@ -1073,8 +1075,32 @@ class ChatActivity :
         adapter = TalkMessagesListAdapter(
             senderId,
             initMessageHolders(),
-            ImageLoader { imageView, url, placeholder ->
-                imageView.loadAvatarOrImagePreview(url!!, conversationUser!!, placeholder as Drawable?)
+            ImageLoader { imageView, url, data ->
+                try {
+                    if ((data is ChatMessage)) { // It's a GIF
+                        val filename = data.selectedIndividualHashMap!!["name"]
+                        val path = context.cacheDir.absolutePath + "/" + filename
+                        val file = File(context.cacheDir, filename!!)
+                        if (file.exists()) {
+                            val gifFromUri = GifDrawable(path)
+                            imageView.setImageDrawable(gifFromUri)
+                        } else {
+                            // TODO download file to cache can't be called here -_-, need to figure out another way
+                            // to get this preloaded, likely in PreviewMessageViewHolder
+                            val placeholder = ContextCompat.getDrawable(context, R.drawable.ic_mimetype_file)
+                            imageView.setImageDrawable(placeholder)
+                            downloadFileToCache(data, false) {
+                                val gifFromUri = GifDrawable(path)
+                                imageView.setImageDrawable(gifFromUri)
+                            }
+                        }
+                    } else { // Not a GIF
+                        imageView.loadAvatarOrImagePreview(url!!, conversationUser!!, data as Drawable?)
+                    }
+                } catch (e: java.lang.IllegalStateException) {
+                    Log.e(TAG, "Error in ImageLoading in initAdapter $e")
+                }
+
             },
             this
         )
@@ -3384,10 +3410,6 @@ class ChatActivity :
         val messageTemp = message as ChatMessage
         messageTemp.lastEditTimestamp = message.lastEditTimestamp
 
-        val index = adapter?.getMessagePositionById(messageTemp.id) ?: 0
-        val adapterMsg = adapter?.items?.get(index)?.item as ChatMessage
-
-        messageTemp.parentMessage = adapterMsg.parentMessage
         messageTemp.isOneToOneConversation =
             currentConversation?.type == ConversationType.ROOM_TYPE_ONE_TO_ONE_CALL
         messageTemp.activeUser = conversationUser

--- a/app/src/main/res/layout/item_custom_incoming_preview_message.xml
+++ b/app/src/main/res/layout/item_custom_incoming_preview_message.xml
@@ -67,7 +67,6 @@
                 android:id="@id/image"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:minHeight="200dp"
                 tools:src="@drawable/ic_call_black_24dp"
                 tools:ignore="ContentDescription" />
 

--- a/app/src/main/res/layout/item_custom_incoming_preview_message.xml
+++ b/app/src/main/res/layout/item_custom_incoming_preview_message.xml
@@ -63,11 +63,11 @@
             app:layout_wrapBefore="true"
             tools:visibility="gone">
 
-            <ImageView
+            <pl.droidsonroids.gif.GifImageView
                 android:id="@id/image"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:scaleType="fitStart"
+                android:minHeight="200dp"
                 tools:src="@drawable/ic_call_black_24dp"
                 tools:ignore="ContentDescription" />
 

--- a/app/src/main/res/layout/item_custom_outcoming_preview_message.xml
+++ b/app/src/main/res/layout/item_custom_outcoming_preview_message.xml
@@ -39,11 +39,11 @@
             app:layout_flexGrow="1"
             app:layout_wrapBefore="true">
 
-            <ImageView
+            <pl.droidsonroids.gif.GifImageView
                 android:id="@id/image"
                 android:layout_width="match_parent"
+                android:minHeight="200dp"
                 android:layout_height="wrap_content"
-                android:scaleType="fitStart"
                 tools:src="@drawable/ic_call_black_24dp"
                 tools:ignore="ContentDescription" />
 

--- a/app/src/main/res/layout/item_custom_outcoming_preview_message.xml
+++ b/app/src/main/res/layout/item_custom_outcoming_preview_message.xml
@@ -42,7 +42,6 @@
             <pl.droidsonroids.gif.GifImageView
                 android:id="@id/image"
                 android:layout_width="match_parent"
-                android:minHeight="200dp"
                 android:layout_height="wrap_content"
                 tools:src="@drawable/ic_call_black_24dp"
                 tools:ignore="ContentDescription" />


### PR DESCRIPTION
- fixes #3975 

Paused to focus on offline support

### 🖼️ Screenshots

[issue-3975-gifphy-2.webm](https://github.com/user-attachments/assets/f2ed284f-b22b-4a77-8f75-ca1985c1e764)


### 🚧 TODO

- [x] Fix Downloading to Cache
- [x] Make Gifs bigger
- [ ] Fix weird bug with images. Gifs are saved to cache, but the placeholder image is an unrelated photo. 
    - [x] Debug the previewMessageViewHolder. isGif is working, it's a problem with the image loader.
    - [x] Debug the image loader. Image loader works fine, its the link that's an Image. But getting the gif link leads to an SSL exception -_-. 
    - [ ] Debug the GifImageView. Perhaps it's saving previous image state, which could be messing things up. 

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)