### PR TITLE
Fixing contrast for the filter conversation dialog

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/FilterConversationFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/FilterConversationFragment.kt
@@ -71,7 +71,7 @@ class FilterConversationFragment : DialogFragment() {
                 unreadFilterChip,
                 mentionedFilterChip
             )
-        }.forEach(viewThemeUtils.material::themeChipFilter)
+        }.forEach(viewThemeUtils.talk::themeChipFilter)
 
         setUpChips()
     }

--- a/app/src/main/java/com/nextcloud/talk/ui/theme/TalkSpecificViewThemeUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/theme/TalkSpecificViewThemeUtils.kt
@@ -7,6 +7,7 @@
  */
 package com.nextcloud.talk.ui.theme
 
+import android.annotation.SuppressLint
 import android.annotation.TargetApi
 import android.content.Context
 import android.content.res.ColorStateList
@@ -36,10 +37,12 @@ import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.view.ViewCompat
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.card.MaterialCardView
+import com.google.android.material.chip.Chip
 import com.google.android.material.materialswitch.MaterialSwitch
 import com.nextcloud.android.common.ui.theme.MaterialSchemes
 import com.nextcloud.android.common.ui.theme.ViewThemeUtilsBase
 import com.nextcloud.android.common.ui.theme.utils.AndroidXViewThemeUtils
+import com.nextcloud.android.common.ui.util.buildColorStateList
 import com.nextcloud.talk.R
 import com.nextcloud.talk.databinding.ReactionsInsideMessageBinding
 import com.nextcloud.talk.ui.MicInputCloud
@@ -50,6 +53,7 @@ import com.nextcloud.talk.utils.DrawableUtils
 import com.nextcloud.talk.utils.message.MessageUtils
 import com.vanniktech.emoji.EmojiTextView
 import com.wooplr.spotlight.SpotlightView
+import dynamiccolor.DynamicScheme
 import dynamiccolor.MaterialDynamicColors
 import eu.davidea.flexibleadapter.utils.FlexibleUtils
 import javax.inject.Inject
@@ -214,6 +218,7 @@ class TalkSpecificViewThemeUtils @Inject constructor(
         return drawable
     }
 
+    @SuppressLint("RestrictedApi")
     fun themeSearchView(searchView: SearchView) {
         withScheme(searchView) { scheme ->
             // hacky as no default way is provided
@@ -373,6 +378,48 @@ class TalkSpecificViewThemeUtils @Inject constructor(
             } else {
                 dynamicColor.onSurfaceVariant().getArgb(scheme)
             }
+        }
+    }
+
+    private fun chipOutlineFilterColorList(scheme: DynamicScheme) =
+        buildColorStateList(
+            android.R.attr.state_checked to dynamicColor.secondaryContainer().getArgb(scheme),
+            -android.R.attr.state_checked to dynamicColor.outline().getArgb(scheme)
+        )
+
+    fun themeChipFilter(chip: Chip) {
+        withScheme(chip.context) { scheme ->
+            val backgroundColors =
+                buildColorStateList(
+                    android.R.attr.state_checked to dynamicColor.secondaryContainer().getArgb(scheme),
+                    -android.R.attr.state_checked to dynamicColor.surface().getArgb(scheme),
+                    android.R.attr.state_focused to dynamicColor.secondaryContainer().getArgb(scheme),
+                    android.R.attr.state_hovered to dynamicColor.secondaryContainer().getArgb(scheme),
+                    android.R.attr.state_pressed to dynamicColor.secondaryContainer().getArgb(scheme)
+                )
+
+            val iconColors =
+                buildColorStateList(
+                    android.R.attr.state_checked to dynamicColor.onSecondaryContainer().getArgb(scheme),
+                    -android.R.attr.state_checked to dynamicColor.surfaceVariant().getArgb(scheme),
+                    android.R.attr.state_focused to dynamicColor.onSecondaryContainer().getArgb(scheme),
+                    android.R.attr.state_hovered to dynamicColor.onSecondaryContainer().getArgb(scheme),
+                    android.R.attr.state_pressed to dynamicColor.onSecondaryContainer().getArgb(scheme)
+                )
+
+            val textColors =
+                buildColorStateList(
+                    android.R.attr.state_checked to dynamicColor.onSecondaryContainer().getArgb(scheme),
+                    -android.R.attr.state_checked to dynamicColor.onSecondaryContainer().getArgb(scheme),
+                    android.R.attr.state_hovered to dynamicColor.onSecondaryContainer().getArgb(scheme),
+                    android.R.attr.state_focused to dynamicColor.onSecondaryContainer().getArgb(scheme),
+                    android.R.attr.state_pressed to dynamicColor.onSecondaryContainer().getArgb(scheme)
+                )
+
+            chip.chipBackgroundColor = backgroundColors
+            chip.chipStrokeColor = chipOutlineFilterColorList(scheme)
+            chip.setTextColor(textColors)
+            chip.checkedIconTint = iconColors
         }
     }
 


### PR DESCRIPTION
- fixes #4075

Just copy-pasted the code from [commons](https://github.com/nextcloud/android-common/blob/24c2dd17df621bbda187d5c7407b800191d41f72/ui/src/main/java/com/nextcloud/android/common/ui/theme/utils/MaterialViewThemeUtils.kt#L569) and tweaked the text color to be `onSecondaryContainer`


### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img src="https://github.com/user-attachments/assets/267dc710-2e85-4483-86ba-d8d04875a554" width=300 > | ![Screenshot 2024-08-16 at 9 31 25 AM](https://github.com/user-attachments/assets/0be05b9f-8fbd-47de-af5d-6043b2f243e9)
![image](https://github.com/user-attachments/assets/10a3976f-b5a2-4fff-b36f-394c25737749) | ![Screenshot 2024-08-16 at 9 33 57 AM](https://github.com/user-attachments/assets/de421054-b41f-4730-8f38-e1b723fe413f)

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)