### PR TITLE
Add support for federated calls

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -2517,10 +2517,12 @@ class CallActivity : CallBaseActivity() {
         }
         val defaultGuestNick = resources.getString(R.string.nc_nick_guest)
         val participantDisplayItem = ParticipantDisplayItem(
+            context,
             baseUrl,
             defaultGuestNick,
             rootEglBase,
             videoStreamType,
+            roomToken,
             callParticipantModel
         )
         val sessionId = callParticipantModel.sessionId

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -2160,6 +2160,10 @@ class CallActivity : CallBaseActivity() {
             Log.d(TAG, "   newSession joined: $sessionId")
             addCallParticipant(sessionId)
 
+            if (participant.actorType != null && participant.actorId != null) {
+                callParticipants[sessionId]!!.setActor(participant.actorType, participant.actorId)
+            }
+
             val userId = participant.userId
             if (userId != null) {
                 callParticipants[sessionId]!!.setUserId(userId)

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -1453,7 +1453,7 @@ class CallActivity : CallBaseActivity() {
     private fun fetchSignalingSettings() {
         Log.d(TAG, "fetchSignalingSettings")
         val apiVersion = ApiUtils.getSignalingApiVersion(conversationUser, intArrayOf(ApiUtils.API_V3, 2, 1))
-        ncApi!!.getSignalingSettings(credentials, ApiUtils.getUrlForSignalingSettings(apiVersion, baseUrl))
+        ncApi!!.getSignalingSettings(credentials, ApiUtils.getUrlForSignalingSettings(apiVersion, baseUrl, roomToken!!))
             .subscribeOn(Schedulers.io())
             .retry(API_RETRIES)
             .observeOn(AndroidSchedulers.mainThread())

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -1633,8 +1633,8 @@ class CallActivity : CallBaseActivity() {
     private fun callOrJoinRoomViaWebSocket() {
         if (hasExternalSignalingServer) {
             webSocketClient!!.joinRoomWithRoomTokenAndSession(
-		roomToken!!, callSession, externalSignalingServer!!.federation
-	    )
+                roomToken!!, callSession, externalSignalingServer!!.federation
+            )
         } else {
             performCall()
         }

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -1632,8 +1632,9 @@ class CallActivity : CallBaseActivity() {
 
     private fun callOrJoinRoomViaWebSocket() {
         if (hasExternalSignalingServer) {
-            webSocketClient!!.joinRoomWithRoomTokenAndSession(roomToken!!, callSession,
-                externalSignalingServer!!.federation)
+            webSocketClient!!.joinRoomWithRoomTokenAndSession(
+		roomToken!!, callSession, externalSignalingServer!!.federation
+	    )
         } else {
             performCall()
         }

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -1475,6 +1475,8 @@ class CallActivity : CallBaseActivity() {
                                 signalingSettingsOverall.ocs!!.settings!!.externalSignalingServer
                             externalSignalingServer!!.externalSignalingTicket =
                                 signalingSettingsOverall.ocs!!.settings!!.externalSignalingTicket
+                            externalSignalingServer!!.federation =
+                                signalingSettingsOverall.ocs!!.settings!!.federation
                             hasExternalSignalingServer = true
                         } else {
                             hasExternalSignalingServer = false

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -1632,7 +1632,8 @@ class CallActivity : CallBaseActivity() {
 
     private fun callOrJoinRoomViaWebSocket() {
         if (hasExternalSignalingServer) {
-            webSocketClient!!.joinRoomWithRoomTokenAndSession(roomToken!!, callSession)
+            webSocketClient!!.joinRoomWithRoomTokenAndSession(roomToken!!, callSession,
+                externalSignalingServer!!.federation)
         } else {
             performCall()
         }

--- a/app/src/main/java/com/nextcloud/talk/adapters/ParticipantDisplayItem.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/ParticipantDisplayItem.java
@@ -14,6 +14,7 @@ import android.text.TextUtils;
 
 import com.nextcloud.talk.call.CallParticipantModel;
 import com.nextcloud.talk.call.RaisedHand;
+import com.nextcloud.talk.models.json.participants.Participant;
 import com.nextcloud.talk.utils.ApiUtils;
 
 import org.webrtc.EglBase;
@@ -38,6 +39,8 @@ public class ParticipantDisplayItem {
 
     private final CallParticipantModel callParticipantModel;
 
+    private Participant.ActorType actorType;
+    private String actorId;
     private String userId;
     private PeerConnection.IceConnectionState iceConnectionState;
     private String nick;
@@ -82,6 +85,8 @@ public class ParticipantDisplayItem {
     }
 
     private void updateFromModel() {
+        actorType = callParticipantModel.getActorType();
+        actorId = callParticipantModel.getActorId();
         userId = callParticipantModel.getUserId();
         nick = callParticipantModel.getNick();
 
@@ -166,6 +171,8 @@ public class ParticipantDisplayItem {
     public String toString() {
         return "ParticipantSession{" +
                 "userId='" + userId + '\'' +
+                ", actorType='" + actorType + '\'' +
+                ", actorId='" + actorId + '\'' +
                 ", session='" + session + '\'' +
                 ", nick='" + nick + '\'' +
                 ", urlForAvatar='" + urlForAvatar + '\'' +

--- a/app/src/main/java/com/nextcloud/talk/adapters/ParticipantDisplayItem.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/ParticipantDisplayItem.java
@@ -8,6 +8,7 @@
  */
 package com.nextcloud.talk.adapters;
 
+import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
 import android.text.TextUtils;
@@ -16,6 +17,7 @@ import com.nextcloud.talk.call.CallParticipantModel;
 import com.nextcloud.talk.call.RaisedHand;
 import com.nextcloud.talk.models.json.participants.Participant;
 import com.nextcloud.talk.utils.ApiUtils;
+import com.nextcloud.talk.utils.DisplayUtils;
 
 import org.webrtc.EglBase;
 import org.webrtc.MediaStream;
@@ -30,12 +32,16 @@ public class ParticipantDisplayItem {
 
     private final ParticipantDisplayItemNotifier participantDisplayItemNotifier = new ParticipantDisplayItemNotifier();
 
+    private final Context context;
+
     private final String baseUrl;
     private final String defaultGuestNick;
     private final EglBase rootEglBase;
 
     private final String session;
     private final String streamType;
+
+    private final String roomToken;
 
     private final CallParticipantModel callParticipantModel;
 
@@ -65,14 +71,18 @@ public class ParticipantDisplayItem {
         }
     };
 
-    public ParticipantDisplayItem(String baseUrl, String defaultGuestNick, EglBase rootEglBase, String streamType,
-                                  CallParticipantModel callParticipantModel) {
+    public ParticipantDisplayItem(Context context, String baseUrl, String defaultGuestNick, EglBase rootEglBase,
+                                  String streamType, String roomToken, CallParticipantModel callParticipantModel) {
+        this.context = context;
+
         this.baseUrl = baseUrl;
         this.defaultGuestNick = defaultGuestNick;
         this.rootEglBase = rootEglBase;
 
         this.session = callParticipantModel.getSessionId();
         this.streamType = streamType;
+
+        this.roomToken = roomToken;
 
         this.callParticipantModel = callParticipantModel;
         this.callParticipantModel.addObserver(callParticipantModelObserver, handler);
@@ -112,7 +122,10 @@ public class ParticipantDisplayItem {
     }
 
     private void updateUrlForAvatar() {
-        if (!TextUtils.isEmpty(userId)) {
+        if (actorType == Participant.ActorType.FEDERATED) {
+            int darkTheme = DisplayUtils.INSTANCE.isDarkModeOn(context) ? 1 : 0;
+            urlForAvatar = ApiUtils.getUrlForFederatedAvatar(baseUrl, roomToken, actorId, darkTheme, true);
+        } else if (!TextUtils.isEmpty(userId)) {
             urlForAvatar = ApiUtils.getUrlForAvatar(baseUrl, userId, true);
         } else {
             urlForAvatar = ApiUtils.getUrlForGuestAvatar(baseUrl, getNick(), true);

--- a/app/src/main/java/com/nextcloud/talk/call/CallParticipant.java
+++ b/app/src/main/java/com/nextcloud/talk/call/CallParticipant.java
@@ -6,6 +6,7 @@
  */
 package com.nextcloud.talk.call;
 
+import com.nextcloud.talk.models.json.participants.Participant;
 import com.nextcloud.talk.signaling.SignalingMessageReceiver;
 import com.nextcloud.talk.webrtc.PeerConnectionWrapper;
 
@@ -130,6 +131,10 @@ public class CallParticipant {
 
     public CallParticipantModel getCallParticipantModel() {
         return callParticipantModel;
+    }
+
+    public void setActor(Participant.ActorType actorType, String actorId) {
+        callParticipantModel.setActor(actorType, actorId);
     }
 
     public void setUserId(String userId) {

--- a/app/src/main/java/com/nextcloud/talk/call/CallParticipantList.java
+++ b/app/src/main/java/com/nextcloud/talk/call/CallParticipantList.java
@@ -122,6 +122,8 @@ public class CallParticipantList {
 
         private Participant copyParticipant(Participant participant) {
             Participant copiedParticipant = new Participant();
+            copiedParticipant.setActorId(participant.getActorId());
+            copiedParticipant.setActorType(participant.getActorType());
             copiedParticipant.setInCall(participant.getInCall());
             copiedParticipant.setInternal(participant.getInternal());
             copiedParticipant.setLastPing(participant.getLastPing());

--- a/app/src/main/java/com/nextcloud/talk/call/CallParticipantModel.java
+++ b/app/src/main/java/com/nextcloud/talk/call/CallParticipantModel.java
@@ -8,6 +8,8 @@ package com.nextcloud.talk.call;
 
 import android.os.Handler;
 
+import com.nextcloud.talk.models.json.participants.Participant;
+
 import org.webrtc.MediaStream;
 import org.webrtc.PeerConnection;
 
@@ -25,6 +27,8 @@ import java.util.Objects;
  *
  * Audio and video in screen shares, on the other hand, are always seen as available.
  *
+ * Actor type and actor id will be set only in Talk >= 20.
+ *
  * Clients of the model can observe it with CallParticipantModel.Observer to be notified when any value changes.
  * Getters called after receiving a notification are guaranteed to provide at least the value that triggered the
  * notification, but it may return even a more up to date one (so getting the value again on the following
@@ -39,6 +43,8 @@ public class CallParticipantModel {
 
     protected final String sessionId;
 
+    protected Data<Participant.ActorType> actorType;
+    protected Data<String> actorId;
     protected Data<String> userId;
     protected Data<String> nick;
 
@@ -81,6 +87,8 @@ public class CallParticipantModel {
     public CallParticipantModel(String sessionId) {
         this.sessionId = sessionId;
 
+        this.actorType = new Data<>();
+        this.actorId = new Data<>();
         this.userId = new Data<>();
         this.nick = new Data<>();
 
@@ -99,6 +107,14 @@ public class CallParticipantModel {
 
     public String getSessionId() {
         return sessionId;
+    }
+
+    public Participant.ActorType getActorType() {
+        return actorType.getValue();
+    }
+
+    public String getActorId() {
+        return actorId.getValue();
     }
 
     public String getUserId() {

--- a/app/src/main/java/com/nextcloud/talk/call/MutableCallParticipantModel.java
+++ b/app/src/main/java/com/nextcloud/talk/call/MutableCallParticipantModel.java
@@ -6,6 +6,8 @@
  */
 package com.nextcloud.talk.call;
 
+import com.nextcloud.talk.models.json.participants.Participant;
+
 import org.webrtc.MediaStream;
 import org.webrtc.PeerConnection;
 
@@ -18,6 +20,11 @@ public class MutableCallParticipantModel extends CallParticipantModel {
 
     public MutableCallParticipantModel(String sessionId) {
         super(sessionId);
+    }
+
+    public void setActor(Participant.ActorType actorType, String actorId) {
+        this.actorType.setValue(actorType);
+        this.actorId.setValue(actorId);
     }
 
     public void setUserId(String userId) {

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -2437,8 +2437,10 @@ class ChatActivity :
 
         if (currentConversation!!.remoteServer != null) {
             val apiVersion = ApiUtils.getSignalingApiVersion(conversationUser!!, intArrayOf(ApiUtils.API_V3, 2, 1))
-            ncApi!!.getSignalingSettings(credentials, ApiUtils.getUrlForSignalingSettings(apiVersion, conversationUser!!.baseUrl,
-                roomToken!!)).blockingSubscribe(object : Observer<SignalingSettingsOverall> {
+            ncApi!!.getSignalingSettings(
+                credentials,
+                ApiUtils.getUrlForSignalingSettings(apiVersion, conversationUser!!.baseUrl, roomToken!!)
+            ).blockingSubscribe(object : Observer<SignalingSettingsOverall> {
                 override fun onSubscribe(d: Disposable) {
                     // unused atm
                 }
@@ -3239,7 +3241,7 @@ class ChatActivity :
             val lon = data["longitude"]!!
             metaData =
                 "{\"type\":\"geo-location\",\"id\":\"geo:$lat,$lon\",\"latitude\":\"$lat\"," +
-                "\"longitude\":\"$lon\",\"name\":\"$name\"}"
+                    "\"longitude\":\"$lon\",\"name\":\"$name\"}"
         }
 
         when (type) {

--- a/app/src/main/java/com/nextcloud/talk/models/ExternalSignalingServer.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/ExternalSignalingServer.kt
@@ -10,6 +10,7 @@ package com.nextcloud.talk.models
 import android.os.Parcelable
 import com.bluelinelabs.logansquare.annotation.JsonField
 import com.bluelinelabs.logansquare.annotation.JsonObject
+import com.nextcloud.talk.models.json.signaling.settings.FederationSettings
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -18,8 +19,10 @@ data class ExternalSignalingServer(
     @JsonField(name = ["externalSignalingServer"])
     var externalSignalingServer: String? = null,
     @JsonField(name = ["externalSignalingTicket"])
-    var externalSignalingTicket: String? = null
+    var externalSignalingTicket: String? = null,
+    @JsonField(name = ["federation"])
+    var federation: FederationSettings? = null
 ) : Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
-    constructor() : this(null, null)
+    constructor() : this(null, null, null)
 }

--- a/app/src/main/java/com/nextcloud/talk/models/json/signaling/settings/FederationHelloAuthParams.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/signaling/settings/FederationHelloAuthParams.kt
@@ -17,7 +17,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class FederationHelloAuthParams(
     @JsonField(name = ["token"])
-    var token: String? = null,
+    var token: String? = null
 ) : Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
     constructor() : this(null)

--- a/app/src/main/java/com/nextcloud/talk/models/json/signaling/settings/FederationHelloAuthParams.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/signaling/settings/FederationHelloAuthParams.kt
@@ -1,0 +1,24 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.models.json.signaling.settings
+
+import android.os.Parcelable
+import com.bluelinelabs.logansquare.annotation.JsonField
+import com.bluelinelabs.logansquare.annotation.JsonObject
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.Serializable
+
+@Parcelize
+@JsonObject
+@Serializable
+data class FederationHelloAuthParams(
+    @JsonField(name = ["token"])
+    var token: String? = null,
+) : Parcelable {
+    // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
+    constructor() : this(null)
+}

--- a/app/src/main/java/com/nextcloud/talk/models/json/signaling/settings/FederationSettings.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/signaling/settings/FederationSettings.kt
@@ -1,8 +1,7 @@
 /*
  * Nextcloud Talk - Android Client
  *
- * SPDX-FileCopyrightText: 2022 Andy Scherzinger <info@andy-scherzinger.de>
- * SPDX-FileCopyrightText: 2017 Mario Danic <mario@lovelyhq.com>
+ * SPDX-FileCopyrightText: 2024 Daniel Calviño Sánchez <danxuliu@gmail.com>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 package com.nextcloud.talk.models.json.signaling.settings
@@ -16,17 +15,15 @@ import kotlinx.serialization.Serializable
 @Parcelize
 @JsonObject
 @Serializable
-data class SignalingSettings(
-    @JsonField(name = ["stunservers"])
-    var stunServers: List<IceServer>? = null,
-    @JsonField(name = ["turnservers"])
-    var turnServers: List<IceServer>? = null,
+data class FederationSettings(
     @JsonField(name = ["server"])
-    var externalSignalingServer: String? = null,
-    @JsonField(name = ["ticket"])
-    var externalSignalingTicket: String? = null,
-    @JsonField(name = ["federation"])
-    var federation: FederationSettings? = null
+    var server: String? = null,
+    @JsonField(name = ["nextcloudServer"])
+    var nextcloudServer: String? = null,
+    @JsonField(name = ["helloAuthParams"])
+    var helloAuthParams: FederationHelloAuthParams? = null,
+    @JsonField(name = ["roomId"])
+    var roomId: String? = null
 ) : Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
     constructor() : this(null, null, null, null)

--- a/app/src/main/java/com/nextcloud/talk/models/json/websocket/RoomFederationWebSocketMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/websocket/RoomFederationWebSocketMessage.kt
@@ -1,0 +1,28 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.models.json.websocket
+
+import android.os.Parcelable
+import com.bluelinelabs.logansquare.annotation.JsonField
+import com.bluelinelabs.logansquare.annotation.JsonObject
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+@JsonObject
+class RoomFederationWebSocketMessage(
+    @JsonField(name = ["signaling"])
+    var signaling: String? = null,
+    @JsonField(name = ["url"])
+    var url: String? = null,
+    @JsonField(name = ["roomid"])
+    var roomid: String? = null,
+    @JsonField(name = ["token"])
+    var token: String? = null
+) : Parcelable {
+    // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
+    constructor() : this(null, null, null, null)
+}

--- a/app/src/main/java/com/nextcloud/talk/models/json/websocket/RoomWebSocketMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/websocket/RoomWebSocketMessage.kt
@@ -20,8 +20,10 @@ class RoomWebSocketMessage(
     @JsonField(name = ["sessionid"])
     var sessionId: String? = null,
     @JsonField(name = ["properties"])
-    var roomPropertiesWebSocketMessage: RoomPropertiesWebSocketMessage? = null
+    var roomPropertiesWebSocketMessage: RoomPropertiesWebSocketMessage? = null,
+    @JsonField(name = ["federation"])
+    var roomFederationWebSocketMessage: RoomFederationWebSocketMessage? = null
 ) : Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
-    constructor() : this(null, null, null)
+    constructor() : this(null, null, null, null)
 }

--- a/app/src/main/java/com/nextcloud/talk/signaling/SignalingMessageReceiver.java
+++ b/app/src/main/java/com/nextcloud/talk/signaling/SignalingMessageReceiver.java
@@ -6,6 +6,7 @@
  */
 package com.nextcloud.talk.signaling;
 
+import com.nextcloud.talk.models.json.converters.EnumActorTypeConverter;
 import com.nextcloud.talk.models.json.converters.EnumParticipantTypeConverter;
 import com.nextcloud.talk.models.json.participants.Participant;
 import com.nextcloud.talk.models.json.signaling.NCIceCandidate;
@@ -37,6 +38,8 @@ import java.util.Map;
  * the appropriate protected methods to process the messages and notify the listeners.
  */
 public abstract class SignalingMessageReceiver {
+
+    private final EnumActorTypeConverter enumActorTypeConverter = new EnumActorTypeConverter();
 
     private final ParticipantListMessageNotifier participantListMessageNotifier = new ParticipantListMessageNotifier();
 
@@ -398,6 +401,8 @@ public abstract class SignalingMessageReceiver {
         //                     "nextcloudSessionId": #STRING#, // Optional
         //                     "internal": #BOOLEAN#, // Optional
         //                     "participantPermissions": #INTEGER#, // Talk >= 13
+        //                     "actorType": #STRING#, // Talk >= 20
+        //                     "actorId": #STRING#, // Talk >= 20
         //                 },
         //                 ...
         //             ],
@@ -447,6 +452,8 @@ public abstract class SignalingMessageReceiver {
         //             "sessionId": #STRING#,
         //             "userId": #STRING#, // Always included, although it can be empty
         //             "participantPermissions": #INTEGER#, // Talk >= 13
+        //             "actorType": #STRING#, // Talk >= 20
+        //             "actorId": #STRING#, // Talk >= 20
         //         },
         //         ...
         //     ],
@@ -490,6 +497,14 @@ public abstract class SignalingMessageReceiver {
 
         if (participantMap.get("internal") != null && Boolean.parseBoolean(participantMap.get("internal").toString())) {
             participant.setInternal(Boolean.TRUE);
+        }
+
+        if (participantMap.get("actorType") != null && !participantMap.get("actorType").toString().isEmpty()) {
+            participant.setActorType(enumActorTypeConverter.getFromString(participantMap.get("actorType").toString()));
+        }
+
+        if (participantMap.get("actorId") != null && !participantMap.get("actorId").toString().isEmpty()) {
+            participant.setActorId(participantMap.get("actorId").toString());
         }
 
         // Only in external signaling messages

--- a/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.kt
@@ -283,6 +283,10 @@ object ApiUtils {
         return getUrlForSignaling(version, baseUrl) + "/settings"
     }
 
+    fun getUrlForSignalingSettings(version: Int, baseUrl: String?, token: String): String {
+        return getUrlForSignaling(version, baseUrl) + "/settings?token=" + token
+    }
+
     fun getUrlForSignaling(version: Int, baseUrl: String?, token: String): String {
         return getUrlForSignaling(version, baseUrl) + "/" + token
     }

--- a/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketConnectionHelper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketConnectionHelper.java
@@ -12,6 +12,7 @@ import android.util.Log;
 import com.nextcloud.talk.application.NextcloudTalkApplication;
 import com.nextcloud.talk.data.user.model.User;
 import com.nextcloud.talk.models.json.signaling.NCSignalingMessage;
+import com.nextcloud.talk.models.json.signaling.settings.FederationSettings;
 import com.nextcloud.talk.models.json.websocket.ActorWebSocketMessage;
 import com.nextcloud.talk.models.json.websocket.AuthParametersWebSocketMessage;
 import com.nextcloud.talk.models.json.websocket.AuthWebSocketMessage;
@@ -19,6 +20,7 @@ import com.nextcloud.talk.models.json.websocket.CallOverallWebSocketMessage;
 import com.nextcloud.talk.models.json.websocket.CallWebSocketMessage;
 import com.nextcloud.talk.models.json.websocket.HelloOverallWebSocketMessage;
 import com.nextcloud.talk.models.json.websocket.HelloWebSocketMessage;
+import com.nextcloud.talk.models.json.websocket.RoomFederationWebSocketMessage;
 import com.nextcloud.talk.models.json.websocket.RoomOverallWebSocketMessage;
 import com.nextcloud.talk.models.json.websocket.RoomWebSocketMessage;
 import com.nextcloud.talk.utils.ApiUtils;
@@ -128,12 +130,21 @@ public class WebSocketConnectionHelper {
         return helloOverallWebSocketMessage;
     }
 
-    RoomOverallWebSocketMessage getAssembledJoinOrLeaveRoomModel(String roomId, String sessionId) {
+    RoomOverallWebSocketMessage getAssembledJoinOrLeaveRoomModel(String roomId, String sessionId,
+                                                                 FederationSettings federation) {
         RoomOverallWebSocketMessage roomOverallWebSocketMessage = new RoomOverallWebSocketMessage();
         roomOverallWebSocketMessage.setType("room");
         RoomWebSocketMessage roomWebSocketMessage = new RoomWebSocketMessage();
         roomWebSocketMessage.setRoomId(roomId);
         roomWebSocketMessage.setSessionId(sessionId);
+        if (federation != null) {
+            RoomFederationWebSocketMessage roomFederationWebSocketMessage = new RoomFederationWebSocketMessage();
+            roomFederationWebSocketMessage.setSignaling(federation.getServer());
+            roomFederationWebSocketMessage.setUrl(federation.getNextcloudServer() + "/ocs/v2.php/apps/spreed/api/v3/signaling/backend");
+            roomFederationWebSocketMessage.setRoomid(federation.getRoomId());
+            roomFederationWebSocketMessage.setToken(federation.getHelloAuthParams().getToken());
+            roomWebSocketMessage.setRoomFederationWebSocketMessage(roomFederationWebSocketMessage);
+        }
         roomOverallWebSocketMessage.setRoomWebSocketMessage(roomWebSocketMessage);
         return roomOverallWebSocketMessage;
     }

--- a/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketConnectionHelper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketConnectionHelper.java
@@ -138,11 +138,15 @@ public class WebSocketConnectionHelper {
         roomWebSocketMessage.setRoomId(roomId);
         roomWebSocketMessage.setSessionId(sessionId);
         if (federation != null) {
+            String federationAuthToken = null;
+            if (federation.getHelloAuthParams() != null) {
+                federationAuthToken = federation.getHelloAuthParams().getToken();
+            }
             RoomFederationWebSocketMessage roomFederationWebSocketMessage = new RoomFederationWebSocketMessage();
             roomFederationWebSocketMessage.setSignaling(federation.getServer());
             roomFederationWebSocketMessage.setUrl(federation.getNextcloudServer() + "/ocs/v2.php/apps/spreed/api/v3/signaling/backend");
             roomFederationWebSocketMessage.setRoomid(federation.getRoomId());
-            roomFederationWebSocketMessage.setToken(federation.getHelloAuthParams().getToken());
+            roomFederationWebSocketMessage.setToken(federationAuthToken);
             roomWebSocketMessage.setRoomFederationWebSocketMessage(roomFederationWebSocketMessage);
         }
         roomOverallWebSocketMessage.setRoomWebSocketMessage(roomWebSocketMessage);

--- a/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketInstance.kt
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketInstance.kt
@@ -369,6 +369,7 @@ class WebSocketInstance internal constructor(
         return hasMCU
     }
 
+    @Suppress("Detekt.ComplexMethod")
     fun joinRoomWithRoomTokenAndSession(
         roomToken: String,
         normalBackendSession: String?,
@@ -386,8 +387,11 @@ class WebSocketInstance internal constructor(
                 currentNormalBackendSession = ""
                 currentFederation = null
                 sendMessage(message)
-            } else if (roomToken == currentRoomToken && normalBackendSession == currentNormalBackendSession &&
-                federation?.roomId == currentFederation?.roomId && federation?.nextcloudServer == federation?.nextcloudServer
+            } else if (
+                roomToken == currentRoomToken &&
+                normalBackendSession == currentNormalBackendSession &&
+                federation?.roomId == currentFederation?.roomId &&
+                federation?.nextcloudServer == federation?.nextcloudServer
             ) {
                 Log.d(TAG, "roomToken & session are unchanged. Joining locally without to send websocket message")
                 sendRoomJoinedEvent()

--- a/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketInstance.kt
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketInstance.kt
@@ -369,8 +369,11 @@ class WebSocketInstance internal constructor(
         return hasMCU
     }
 
-    fun joinRoomWithRoomTokenAndSession(roomToken: String, normalBackendSession: String?,
-            federation: FederationSettings? = null) {
+    fun joinRoomWithRoomTokenAndSession(
+        roomToken: String,
+        normalBackendSession: String?,
+        federation: FederationSettings? = null
+    ) {
         Log.d(TAG, "joinRoomWithRoomTokenAndSession")
         Log.d(TAG, "   roomToken: $roomToken")
         Log.d(TAG, "   session: $normalBackendSession")
@@ -384,7 +387,8 @@ class WebSocketInstance internal constructor(
                 currentFederation = null
                 sendMessage(message)
             } else if (roomToken == currentRoomToken && normalBackendSession == currentNormalBackendSession &&
-                federation == currentFederation) {
+                federation?.roomId == currentFederation?.roomId && federation?.nextcloudServer == federation?.nextcloudServer
+            ) {
                 Log.d(TAG, "roomToken & session are unchanged. Joining locally without to send websocket message")
                 sendRoomJoinedEvent()
             } else {

--- a/app/src/test/java/com/nextcloud/talk/call/CallParticipantListExternalSignalingTest.java
+++ b/app/src/test/java/com/nextcloud/talk/call/CallParticipantListExternalSignalingTest.java
@@ -71,6 +71,8 @@ public class CallParticipantListExternalSignalingTest {
             participant.setSessionId(sessionId);
             participant.setType(type);
             participant.setUserId(userId);
+            participant.setActorType(Participant.ActorType.USERS);
+            participant.setActorId(userId);
 
             return participant;
         }
@@ -81,6 +83,8 @@ public class CallParticipantListExternalSignalingTest {
             participant.setLastPing(lastPing);
             participant.setSessionId(sessionId);
             participant.setType(type);
+            participant.setActorType(Participant.ActorType.GUESTS);
+            participant.setActorId("sha1-" + sessionId);
 
             return participant;
         }

--- a/app/src/test/java/com/nextcloud/talk/call/CallParticipantListInternalSignalingTest.java
+++ b/app/src/test/java/com/nextcloud/talk/call/CallParticipantListInternalSignalingTest.java
@@ -61,6 +61,8 @@ public class CallParticipantListInternalSignalingTest {
             participant.setLastPing(lastPing);
             participant.setSessionId(sessionId);
             participant.setUserId(userId);
+            participant.setActorType(Participant.ActorType.USERS);
+            participant.setActorId(userId);
 
             return participant;
         }
@@ -70,6 +72,8 @@ public class CallParticipantListInternalSignalingTest {
             participant.setInCall(inCall);
             participant.setLastPing(lastPing);
             participant.setSessionId(sessionId);
+            participant.setActorType(Participant.ActorType.GUESTS);
+            participant.setActorId("sha1-" + sessionId);
 
             return participant;
         }

--- a/app/src/test/java/com/nextcloud/talk/signaling/SignalingMessageReceiverParticipantListTest.java
+++ b/app/src/test/java/com/nextcloud/talk/signaling/SignalingMessageReceiverParticipantListTest.java
@@ -58,10 +58,12 @@ public class SignalingMessageReceiverParticipantListTest {
         user1.put("roomId", 108);
         user1.put("sessionId", "theSessionId1");
         user1.put("userId", "theUserId");
-        // If "participantPermissions" is set in any of the participants all the other participants in the message
-        // would have it too. But for test simplicity, and as it is not relevant for the processing, in this test it
-        // is included only in one of the participants.
+        // If any of the following properties is set in any of the participants all the other participants in the
+        // message would have it too. But for test simplicity, and as it is not relevant for the processing, in this
+        // test they are included only in one of the participants.
         user1.put("participantPermissions", 42);
+        user1.put("actorType", "federated_users");
+        user1.put("actorId", "theActorId");
         users.add(user1);
         Map<String, Object> user2 = new HashMap<>();
         user2.put("inCall", 0);
@@ -78,6 +80,8 @@ public class SignalingMessageReceiverParticipantListTest {
         expectedParticipant1.setLastPing(4815);
         expectedParticipant1.setSessionId("theSessionId1");
         expectedParticipant1.setUserId("theUserId");
+        expectedParticipant1.setActorType(Participant.ActorType.FEDERATED);
+        expectedParticipant1.setActorId("theActorId");
         expectedParticipantList.add(expectedParticipant1);
 
         Participant expectedParticipant2 = new Participant();
@@ -266,11 +270,13 @@ public class SignalingMessageReceiverParticipantListTest {
         user1.put("sessionId", "theSessionId1");
         user1.put("participantType", 3);
         user1.put("userId", "theUserId");
-        // If "nextcloudSessionId" or "participantPermissions" is set in any of the participants all the other
-        // participants in the message would have them too. But for test simplicity, and as it is not relevant for
-        // the processing, in this test they are included only in one of the participants.
+        // If any of the following properties is set in any of the participants all the other participants in the
+        // message would have it too. But for test simplicity, and as it is not relevant for the processing, in this
+        // test they are included only in one of the participants.
         user1.put("nextcloudSessionId", "theNextcloudSessionId");
         user1.put("participantPermissions", 42);
+        user1.put("actorType", "federated_users");
+        user1.put("actorId", "theActorId");
         users.add(user1);
         Map<String, Object> user2 = new HashMap<>();
         user2.put("inCall", 0);
@@ -289,6 +295,8 @@ public class SignalingMessageReceiverParticipantListTest {
         expectedParticipant1.setSessionId("theSessionId1");
         expectedParticipant1.setType(Participant.ParticipantType.USER);
         expectedParticipant1.setUserId("theUserId");
+        expectedParticipant1.setActorType(Participant.ActorType.FEDERATED);
+        expectedParticipant1.setActorId("theActorId");
         expectedParticipantList.add(expectedParticipant1);
 
         Participant expectedParticipant2 = new Participant();


### PR DESCRIPTION
This pull request adds support for federated calls when using the external signaling server (note that support for the external signaling server in a federated conversation was not added to the chat view, though, only to the call view for now).

To do that now the federation properties from the signaling settings are given to the external signaling server when joining a room (as described in https://github.com/nextcloud/spreed/pull/12604), and the avatar of participants in call view now take into account the `actorType` and `actorId` fields in the `participants->update` signaling message to get a federated avatar if needed (as described in https://github.com/nextcloud/spreed/pull/12863).

Both changes should be backwards compatible with older Talk versions; if an older Talk version is used the federation properties will not be included in the signaling settings and neither will be `actorType` and `actorId` in the `participants->update` signaling messages, so everything should work just as before.

## TODO

- [ ] Make it work... Right now participants in a federated conversation are not properly shown in the call view, although the federated user from Android is shown for other participants
- [ ] Probably add a little hack to prevent the call view from closing if there is no call, as due to a current bug in Talk calls are ended in the federated conversation after the initial ping expires
- [ ] Adjust code that disables call buttons in a federated conversation
- [ ] Cleanup
- [ ] Test with older versions (it should work just as before... but better be sure :-) )

## Follow-ups

- Use federated external signaling server in chats, not only in calls (needed, for example, for typing indicators)
- A little nitpick I noticed :-) It would be better if [`darkTheme` in `getUrlForFederatedAvatar`](https://github.com/nextcloud/talk-android/blob/46d3fd1569b951998848f0e0a0eae749aeb92c3d/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.kt#L376) was a boolean rather than an integer. The [server API expects a boolean](https://github.com/nextcloud/spreed/blob/1ccbf67da231c37801c1406b10000144125aec35/lib/Controller/AvatarController.php#L224) (or even [a different endpoint for a light and dark mode avatar](https://github.com/nextcloud/spreed/blob/main/appinfo/routes/routesAvatarController.php#L39-L42), and using a boolean would avoid an unnecessary conversion from a boolean to an int (which is not exclusive to the `ParticipantDisplayItem`, it can be seen in [other calls to `getUrlForFederatedAvatar`](https://github.com/nextcloud/talk-android/blob/9d62a6f7456d5980433a1e4d58a35e2f4dbbccdb/app/src/main/java/com/nextcloud/talk/utils/DisplayUtils.kt#L186-L191)).
  - Alternatively there could be just an overloaded method that accepts boolean instead of integer for the dark theme and just does the conversion from boolean to integer internally then calling the existing method


### 🏁 Checklist

- [X] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [X] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [X] 📅 Milestone is set
- [X] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)