### PR TITLE
No Edit Time limit on Note to Self Messages

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
@@ -87,11 +87,17 @@ class MessageActionsDialog(
         .before(Date(System.currentTimeMillis() - AGE_THRESHOLD_FOR_EDIT_MESSAGE))
 
     private val isUserAllowedToEdit = chatActivity.userAllowedByPrivilages(message)
-
-    private val isMessageEditable = hasSpreedFeatureCapability(
+    private var isNoTimeLimitOnNoteToSelf = hasSpreedFeatureCapability(
+        spreedCapabilities,
+        SpreedFeatures
+            .EDIT_MESSAGES_NOTE_TO_SELF
+    ) && currentConversation?.type == ConversationEnums.ConversationType.NOTE_TO_SELF
+    private var messageIsEditable = hasSpreedFeatureCapability(
         spreedCapabilities,
         SpreedFeatures.EDIT_MESSAGES
     ) && messageHasRegularText && !isOlderThanTwentyFourHours && isUserAllowedToEdit
+
+    private val isMessageEditable = isNoTimeLimitOnNoteToSelf || messageIsEditable
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/nextcloud/talk/utils/CapabilitiesUtil.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/CapabilitiesUtil.kt
@@ -54,7 +54,8 @@ enum class SpreedFeatures(val value: String) {
     CONVERSATION_PERMISSION("conversation-permissions"),
     FEDERATION_V1("federation-v1"),
     DELETE_MESSAGES_UNLIMITED("delete-messages-unlimited"),
-    BAN_V1("ban-v1")
+    BAN_V1("ban-v1"),
+    EDIT_MESSAGES_NOTE_TO_SELF("edit-messages-note-to-self")
 }
 
 @Suppress("TooManyFunctions")


### PR DESCRIPTION
Resolves https://github.com/nextcloud/talk-android/issues/4108

Allow editing of "Note to self" messages forever

### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)