### PR TITLE
fixes share link

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
@@ -347,6 +347,7 @@ class MessageInputFragment : Fragment() {
 
         if (chatActivity.sharedText.isNotEmpty()) {
             binding.fragmentMessageInputView.inputEditText?.setText(chatActivity.sharedText)
+            submitMessage(false)
         }
 
         binding.fragmentMessageInputView.setAttachmentsListener {


### PR DESCRIPTION
# Resolves #4010 

## The problem was:
- when sharing a link with nextcloud talk the link disappears.

## General Observations:
- Depending on the Type that is shared with nextcloud talk the behavior of the app differs:
  - e.g. when sharing a text it is copied into the `sharedText` in `ConversationsListActivity` which then opens the `chatActivity`  which then opens `MessageInputFragment`, where then the `sharedText` is set into the `binding.fragmentMessageInputView.inputEditText`, but then not send.
  - when sharing a photo `showSendFilesConfirmDialog` gets called in `ConversationsListActivity` which then uploads the photo
   
## How it is fixed
- just send the message with the `sharedText` in `MessageInputFragment`

## Problems with  the fix
- there is no confirmation dialog, if one really wants to share a link with a certain chat (which could be bad for a person like me, that likes to accidentally press the wrong chat) 
- it is not possible to share a link without notification

### 🚧 TODO

- [ ] get some feedback

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)