### PR TITLE
fix to display text that was sent to app via "share to"

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
@@ -247,11 +247,13 @@ class MessageInputFragment : Fragment() {
     }
 
     private fun restoreState() {
-        requireContext().getSharedPreferences(chatActivity.localClassName, AppCompatActivity.MODE_PRIVATE).apply {
-            val text = getString(chatActivity.roomToken, "")
-            val cursor = getInt(chatActivity.roomToken + CURSOR_KEY, 0)
-            binding.fragmentMessageInputView.messageInput.setText(text)
-            binding.fragmentMessageInputView.messageInput.setSelection(cursor)
+        if (binding.fragmentMessageInputView.inputEditText.text.isEmpty()) {
+            requireContext().getSharedPreferences(chatActivity.localClassName, AppCompatActivity.MODE_PRIVATE).apply {
+                val text = getString(chatActivity.roomToken, "")
+                val cursor = getInt(chatActivity.roomToken + CURSOR_KEY, 0)
+                binding.fragmentMessageInputView.messageInput.setText(text)
+                binding.fragmentMessageInputView.messageInput.setSelection(cursor)
+            }
         }
     }
 


### PR DESCRIPTION
fix #4010

the bug was, that the sent text was overwritten with "" in restoreState.

With this fix the saved state is only applied when the input field is empty (which means there was nothing shared)


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)