### PR TITLE
remove theming of call buttons to remove disabled look for dark mode

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -2733,18 +2733,6 @@ class ChatActivity :
         super.onCreateOptionsMenu(menu)
         menuInflater.inflate(R.menu.menu_conversation, menu)
 
-        context.let {
-            viewThemeUtils.platform.colorToolbarMenuIcon(
-                it,
-                menu.findItem(R.id.conversation_voice_call)
-            )
-
-            viewThemeUtils.platform.colorToolbarMenuIcon(
-                it,
-                menu.findItem(R.id.conversation_video_call)
-            )
-        }
-
         if (conversationUser?.userId == "?") {
             menu.removeItem(R.id.conversation_info)
         } else {


### PR DESCRIPTION
In dark mode, the call buttons looked like disabled otherwise.

There is still the 3-dots menu next to the call icons which looks like disabled for dark and light mode. But this is a different bug that needs to be fixed in another branch(could not find the reason for now).

fix #4012

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![grafik](https://github.com/user-attachments/assets/dcdb5f13-0da4-41a7-ba54-b61887665f4f) | ![grafik](https://github.com/user-attachments/assets/3f8740ca-fb75-4ccd-9d53-e6827821f791)

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)