### PR TITLE
sleep one second before websocket reconnect

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketInstance.kt
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketInstance.kt
@@ -41,6 +41,7 @@ import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import java.io.IOException
+import java.lang.Thread.sleep
 import javax.inject.Inject
 
 @AutoInjector(NextcloudTalkApplication::class)
@@ -127,6 +128,7 @@ class WebSocketInstance internal constructor(
             isConnected = false
             messagesQueue = ArrayList()
         }
+        sleep(ONE_SECOND)
         restartWebSocket()
     }
 
@@ -485,5 +487,6 @@ class WebSocketInstance internal constructor(
     companion object {
         private const val TAG = "WebSocketInstance"
         private const val NORMAL_CLOSURE = 1000
+        private const val ONE_SECOND: Long = 1000
     }
 }


### PR DESCRIPTION
otherwise it's an endless loop without delay which may stress the devices...


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)