### PR TITLE
fix to load chat for old server version

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -1744,7 +1744,9 @@ class CallActivity : CallBaseActivity() {
     }
 
     private fun startCallTimeCounter(callStartTime: Long?) {
-        if (callStartTime != null && hasSpreedFeatureCapability(
+        if (callStartTime != null &&
+            callStartTime != 0L &&
+            hasSpreedFeatureCapability(
                 conversationUser!!.capabilities!!.spreedCapability!!, SpreedFeatures.RECORDING_V1
             )
         ) {

--- a/app/src/main/java/com/nextcloud/talk/models/json/conversations/Conversation.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/conversations/Conversation.kt
@@ -144,16 +144,16 @@ data class Conversation(
     var callRecording: Int = 0,
 
     @JsonField(name = ["avatarVersion"])
-    var avatarVersion: String? = null,
+    var avatarVersion: String? = "",
 
     // Be aware that variables with "is" at the beginning will lead to the error:
     // "@JsonField annotation can only be used on private fields if both getter and setter are present."
     // Instead, name it with "has" at the beginning: isCustomAvatar -> hasCustomAvatar
     @JsonField(name = ["isCustomAvatar"])
-    var hasCustomAvatar: Boolean? = null,
+    var hasCustomAvatar: Boolean? = false,
 
     @JsonField(name = ["callStartTime"])
-    var callStartTime: Long? = null,
+    var callStartTime: Long? = 0L,
 
     @JsonField(name = ["recordingConsent"])
     var recordingConsentRequired: Int = 0,


### PR DESCRIPTION
With server version 23.0.12 it happened that the chat did not load because values were null. Now default values in json model are set

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)