### PR TITLE
fix to show accounts from older servers in switch account dialog

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/ChooseAccountDialogFragment.java
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/ChooseAccountDialogFragment.java
@@ -170,27 +170,21 @@ public class ChooseAccountDialogFragment extends DialogFragment {
 
                             @Override
                             public void onNext(InvitationsModel invitationsModel) {
-                                Participant participant;
-                                participant = new Participant();
-                                participant.setActorType(Participant.ActorType.USERS);
-                                participant.setActorId(userId);
-                                participant.setDisplayName(finalUserEntity.getDisplayName());
-                                userItems.add(
-                                    new AdvancedUserItem(
-                                        participant,
-                                        finalUserEntity,
-                                        null,
-                                        viewThemeUtils,
-                                        invitationsModel.getInvitations().size()
-                                    ));
-                                adapter.addListener(onSwitchItemClickListener);
-                                adapter.addListener(onSwitchItemLongClickListener);
-                                adapter.updateDataSet(userItems, false);
+                                addAccountToSwitcherList(
+                                    userId,
+                                    finalUserEntity,
+                                    invitationsModel.getInvitations().size()
+                                );
                             }
 
                             @Override
                             public void onError(@io.reactivex.annotations.NonNull Throwable e) {
                                 Log.e(TAG, "Failed to fetch invitations", e);
+                                addAccountToSwitcherList(
+                                    userId,
+                                    finalUserEntity,
+                                    0
+                                );
                             }
 
                             @Override
@@ -201,6 +195,29 @@ public class ChooseAccountDialogFragment extends DialogFragment {
                 }
             }
         }
+    }
+
+    private void addAccountToSwitcherList(
+        String userId,
+        User finalUserEntity,
+        int actionsRequiredCount
+    ) {
+        Participant participant;
+        participant = new Participant();
+        participant.setActorType(Participant.ActorType.USERS);
+        participant.setActorId(userId);
+        participant.setDisplayName(finalUserEntity.getDisplayName());
+        userItems.add(
+            new AdvancedUserItem(
+                participant,
+                finalUserEntity,
+                null,
+                viewThemeUtils,
+                actionsRequiredCount
+            ));
+        adapter.addListener(onSwitchItemClickListener);
+        adapter.addListener(onSwitchItemLongClickListener);
+        adapter.updateDataSet(userItems, false);
     }
 
     private void setupListeners(User user) {


### PR DESCRIPTION
if invitations were not supported (or failed for some reason), the account did not show up.

This was one scenario how it could happen that accounts did not show up in account switcher dialog. fix #2446

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)