### PR TITLE
fix to not remove call buttons for federated conversations after 30 seconds

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -2812,10 +2812,7 @@ class ChatActivity :
                 menu.removeItem(R.id.shared_items)
             }
 
-            if (currentConversation!!.remoteServer != null) {
-                menu.removeItem(R.id.conversation_video_call)
-                menu.removeItem(R.id.conversation_voice_call)
-            } else if (CapabilitiesUtil.isAbleToCall(spreedCapabilities)) {
+            if (CapabilitiesUtil.isAbleToCall(spreedCapabilities)) {
                 conversationVoiceCallMenuItem = menu.findItem(R.id.conversation_voice_call)
                 conversationVideoMenuItem = menu.findItem(R.id.conversation_video_call)
 


### PR DESCRIPTION
After 30 seconds (when the capabilities were updated) the call buttons of federated conversations were sometimes removed (the logic was added back then when fed calls were not implemented).

However this happened not always because of the check `if (this::spreedCapabilities.isInitialized) {....` 
It seems this check sometimes is false when it's supposed to be true. This has be to further investigated and has to be be simplified/improved by a cleaner architecture.

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)