### PR TITLE
fix to hide messageInputFragment when user has no restriction to write

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -577,7 +577,6 @@ class ChatActivity :
 
                     invalidateOptionsMenu()
                     checkShowCallButtons()
-                    checkShowMessageInputView()
                     checkLobbyState()
                     updateRoomTimerHandler()
                 }
@@ -603,6 +602,9 @@ class ChatActivity :
                     loadAvatarForStatusBar()
                     setupSwipeToReply()
                     setActionBarTitle()
+
+                    checkShowCallButtons()
+                    checkLobbyState()
                     updateRoomTimerHandler()
 
                     val urlForChatting = ApiUtils.getUrlForChat(chatApiVersion, conversationUser?.baseUrl, roomToken)
@@ -1892,12 +1894,12 @@ class ChatActivity :
             } else {
                 binding.lobby.lobbyView.visibility = View.GONE
                 binding.messagesListView.visibility = View.VISIBLE
-                binding.fragmentContainerActivityChat.visibility = View.VISIBLE
+                checkShowMessageInputView()
             }
         } else {
             binding.lobby.lobbyView.visibility = View.GONE
             binding.messagesListView.visibility = View.VISIBLE
-            binding.fragmentContainerActivityChat.visibility = View.VISIBLE
+            checkShowMessageInputView()
         }
     }
 


### PR DESCRIPTION
fix #4238

The messageInputFragment was hidden by checkShowMessageInputView(), but it was immediately shown again by checkLobbyState()

This fix will execute checkShowMessageInputView() inside checkLobbyState() in the correct order.

Additionally, the check
checkLobbyState()
has to be already executed in
GetCapabilitiesInitialLoadState
as well as
checkShowCallButtons()

Otherwise the expected behavior would only be set after 30 seconds.

An improvemnt for the future must be to improve the capabilities handling.

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)