### PR TITLE
Conversation creation modification

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -1633,7 +1633,9 @@ class CallActivity : CallBaseActivity() {
     private fun callOrJoinRoomViaWebSocket() {
         if (hasExternalSignalingServer) {
             webSocketClient!!.joinRoomWithRoomTokenAndSession(
-                roomToken!!, callSession, externalSignalingServer!!.federation
+                roomToken!!,
+                callSession,
+                externalSignalingServer!!.federation
             )
         } else {
             performCall()

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -3240,7 +3240,7 @@ class ChatActivity :
             val lon = data["longitude"]!!
             metaData =
                 "{\"type\":\"geo-location\",\"id\":\"geo:$lat,$lon\",\"latitude\":\"$lat\"," +
-                    "\"longitude\":\"$lon\",\"name\":\"$name\"}"
+                "\"longitude\":\"$lon\",\"name\":\"$name\"}"
         }
 
         when (type) {

--- a/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationActivity.kt
@@ -327,7 +327,8 @@ fun ConversationNameAndDescription(conversationCreationViewModel: ConversationCr
         label = { Text(text = stringResource(id = R.string.nc_call_name)) },
         modifier = Modifier
             .padding(start = 16.dp, end = 16.dp)
-            .fillMaxWidth()
+            .fillMaxWidth(),
+        singleLine = true
     )
     OutlinedTextField(
         value = conversationDescription.value,

--- a/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationActivity.kt
@@ -138,7 +138,7 @@ fun ConversationCreationScreen(
     context: Context,
     pickImage: PickImage
 ) {
-    val selectedImageUri  = conversationCreationViewModel.selectedImageUriState.collectAsState().value
+    val selectedImageUri = conversationCreationViewModel.selectedImageUriState.collectAsState().value
 
     val imagePickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult()
@@ -550,7 +550,6 @@ fun ConversationOptions(
 
 @Composable
 fun ShowPasswordDialog(onDismiss: () -> Unit, conversationCreationViewModel: ConversationCreationViewModel) {
-
     var password by remember { mutableStateOf("") }
 
     AlertDialog(
@@ -583,10 +582,7 @@ fun ShowPasswordDialog(onDismiss: () -> Unit, conversationCreationViewModel: Con
 }
 
 @Composable
-fun CreateConversation(
-    conversationCreationViewModel: ConversationCreationViewModel,
-    context: Context
-) {
+fun CreateConversation(conversationCreationViewModel: ConversationCreationViewModel, context: Context) {
     val selectedParticipants by conversationCreationViewModel.selectedParticipants.collectAsState()
     Box(
         modifier = Modifier

--- a/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationActivity.kt
@@ -209,7 +209,8 @@ fun ConversationCreationScreen(
                     imagePickerLauncher = imagePickerLauncher,
                     remoteFilePickerLauncher = remoteFilePickerLauncher,
                     cameraLauncher = cameraLauncher,
-                    onDeleteImage = { selectedImageUri = null }
+                    onDeleteImage = { selectedImageUri = null },
+                    selectedImageUri = selectedImageUri
                 )
 
                 ConversationNameAndDescription(conversationCreationViewModel)
@@ -258,7 +259,8 @@ fun UploadAvatar(
     imagePickerLauncher: ManagedActivityResultLauncher<Intent, ActivityResult>,
     remoteFilePickerLauncher: ManagedActivityResultLauncher<Intent, ActivityResult>,
     cameraLauncher: ManagedActivityResultLauncher<Intent, ActivityResult>,
-    onDeleteImage: () -> Unit
+    onDeleteImage: () -> Unit,
+    selectedImageUri: Uri?
 ) {
     Row(
         modifier = Modifier
@@ -299,14 +301,16 @@ fun UploadAvatar(
             )
         }
 
-        IconButton(onClick = {
-            onDeleteImage()
-        }) {
-            Icon(
-                painter = painterResource(id = R.drawable.ic_delete_grey600_24dp),
-                contentDescription = null,
-                modifier = Modifier.size(24.dp)
-            )
+        if (selectedImageUri != null) {
+            IconButton(onClick = {
+                onDeleteImage()
+            }) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_delete_grey600_24dp),
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp)
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationActivity.kt
@@ -138,14 +138,14 @@ fun ConversationCreationScreen(
     context: Context,
     pickImage: PickImage
 ) {
-    var selectedImageUri by remember { mutableStateOf<Uri?>(null) }
+    val selectedImageUri  = conversationCreationViewModel.selectedImageUriState.collectAsState().value
 
     val imagePickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult()
     ) { result ->
         if (result.resultCode == Activity.RESULT_OK) {
             pickImage.onImagePickerResult(result.data) { uri ->
-                selectedImageUri = uri
+                conversationCreationViewModel.updateSelectedImageUri(uri)
             }
         }
     }
@@ -205,18 +205,18 @@ fun ConversationCreationScreen(
                 DefaultUserAvatar(selectedImageUri)
                 UploadAvatar(
                     pickImage = pickImage,
-                    onImageSelected = { uri -> selectedImageUri = uri },
+                    onImageSelected = { uri -> conversationCreationViewModel.updateSelectedImageUri(uri) },
                     imagePickerLauncher = imagePickerLauncher,
                     remoteFilePickerLauncher = remoteFilePickerLauncher,
                     cameraLauncher = cameraLauncher,
-                    onDeleteImage = { selectedImageUri = null },
+                    onDeleteImage = { conversationCreationViewModel.updateSelectedImageUri(null) },
                     selectedImageUri = selectedImageUri
                 )
 
                 ConversationNameAndDescription(conversationCreationViewModel)
                 AddParticipants(launcher, context, conversationCreationViewModel)
                 RoomCreationOptions(conversationCreationViewModel)
-                CreateConversation(conversationCreationViewModel, context, selectedImageUri)
+                CreateConversation(conversationCreationViewModel, context)
             }
         }
     )
@@ -550,11 +550,11 @@ fun ConversationOptions(
 
 @Composable
 fun ShowPasswordDialog(onDismiss: () -> Unit, conversationCreationViewModel: ConversationCreationViewModel) {
+
     var password by remember { mutableStateOf("") }
 
     AlertDialog(
         containerColor = colorResource(id = R.color.dialog_background),
-
         onDismissRequest = onDismiss,
         confirmButton = {
             Button(onClick = {
@@ -585,8 +585,7 @@ fun ShowPasswordDialog(onDismiss: () -> Unit, conversationCreationViewModel: Con
 @Composable
 fun CreateConversation(
     conversationCreationViewModel: ConversationCreationViewModel,
-    context: Context,
-    selectedImageUri: Uri?
+    context: Context
 ) {
     val selectedParticipants by conversationCreationViewModel.selectedParticipants.collectAsState()
     Box(
@@ -600,8 +599,7 @@ fun CreateConversation(
                 conversationCreationViewModel.createRoomAndAddParticipants(
                     roomType = CompanionClass.ROOM_TYPE_GROUP,
                     conversationName = conversationCreationViewModel.roomName.value,
-                    participants = selectedParticipants.toSet(),
-                    selectedImageUri = selectedImageUri
+                    participants = selectedParticipants.toSet()
                 ) { roomToken ->
                     val bundle = Bundle()
                     bundle.putString(BundleKeys.KEY_ROOM_TOKEN, roomToken)

--- a/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationActivity.kt
@@ -138,7 +138,7 @@ fun ConversationCreationScreen(
     context: Context,
     pickImage: PickImage
 ) {
-    val selectedImageUri = conversationCreationViewModel.selectedImageUriState.collectAsState().value
+    val selectedImageUri = conversationCreationViewModel.selectedImageUri.collectAsState().value
 
     val imagePickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult()

--- a/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationViewModel.kt
@@ -33,8 +33,7 @@ class ConversationCreationViewModel @Inject constructor(
     private val roomViewState = MutableStateFlow<RoomUIState>(RoomUIState.None)
 
     private val selectedImageUri = MutableStateFlow<Uri?>(null)
-    val selectedImageUriState:StateFlow<Uri?> = selectedImageUri
-
+    val selectedImageUriState: StateFlow<Uri?> = selectedImageUri
 
     private val _currentUser = userManager.currentUser.blockingGet()
     val currentUser: User = _currentUser
@@ -43,7 +42,7 @@ class ConversationCreationViewModel @Inject constructor(
         _selectedParticipants.value = participants
     }
 
-    fun updateSelectedImageUri(uri:Uri?){
+    fun updateSelectedImageUri(uri: Uri?) {
         selectedImageUri.value = uri
     }
 

--- a/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationViewModel.kt
@@ -32,8 +32,8 @@ class ConversationCreationViewModel @Inject constructor(
     val selectedParticipants: StateFlow<List<AutocompleteUser>> = _selectedParticipants
     private val roomViewState = MutableStateFlow<RoomUIState>(RoomUIState.None)
 
-    private val selectedImageUri = MutableStateFlow<Uri?>(null)
-    val selectedImageUriState: StateFlow<Uri?> = selectedImageUri
+    private val _selectedImageUri = MutableStateFlow<Uri?>(null)
+    val selectedImageUri: StateFlow<Uri?> = _selectedImageUri
 
     private val _currentUser = userManager.currentUser.blockingGet()
     val currentUser: User = _currentUser
@@ -43,7 +43,7 @@ class ConversationCreationViewModel @Inject constructor(
     }
 
     fun updateSelectedImageUri(uri: Uri?) {
-        selectedImageUri.value = uri
+        _selectedImageUri.value = uri
     }
 
     private val _roomName = MutableStateFlow("")

--- a/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationViewModel.kt
@@ -32,11 +32,19 @@ class ConversationCreationViewModel @Inject constructor(
     val selectedParticipants: StateFlow<List<AutocompleteUser>> = _selectedParticipants
     private val roomViewState = MutableStateFlow<RoomUIState>(RoomUIState.None)
 
+    private val selectedImageUri = MutableStateFlow<Uri?>(null)
+    val selectedImageUriState:StateFlow<Uri?> = selectedImageUri
+
+
     private val _currentUser = userManager.currentUser.blockingGet()
     val currentUser: User = _currentUser
 
     fun updateSelectedParticipants(participants: List<AutocompleteUser>) {
         _selectedParticipants.value = participants
+    }
+
+    fun updateSelectedImageUri(uri:Uri?){
+        selectedImageUri.value = uri
     }
 
     private val _roomName = MutableStateFlow("")
@@ -66,7 +74,6 @@ class ConversationCreationViewModel @Inject constructor(
         roomType: String,
         conversationName: String,
         participants: Set<AutocompleteUser>,
-        selectedImageUri: Uri?,
         onRoomCreated: (String) -> Unit
     ) {
         val scope = when {
@@ -109,9 +116,7 @@ class ConversationCreationViewModel @Inject constructor(
                                 repository.setPassword(token, _password.value)
                             }
                             repository.openConversation(token, scope)
-                            if (selectedImageUri != null) {
-                                repository.uploadConversationAvatar(selectedImageUri.toFile(), token)
-                            }
+                            selectedImageUri.value?.let { repository.uploadConversationAvatar(it.toFile(), token) }
                             onRoomCreated(token)
                         } catch (exception: Exception) {
                             allowGuestsResult.value = AllowGuestsUiState.Error(exception.message ?: "")


### PR DESCRIPTION
Resolves #4249 

This PR implements:

1. Hide Delete button in the new conversation screen and show it only when conversation avatar is set.
2. Single line textfield for conversation name.
3. Make conversation avatar sustain configuration changes.

### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)