### PR TITLE
Fix Codacy Warnings -  Ensure Composable Function Names Start with a Capital Letter

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -278,7 +278,7 @@ naming:
     minimumFunctionNameLength: 3
   FunctionNaming:
     active: true
-    functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
+    functionPattern: '^([a-z$A-Z][a-zA-Z$0-9]*)|(`.*`)$'
     excludeClassPattern: '$^'
     ignoreOverridden: true
     excludes:


### PR DESCRIPTION
Resolve #4014

solve codacy lint warning for composables.

The static code analysis gives a warning when composable functions name start with a capital letter. The functionPattern should be modified to write a composable function name with a capital letter.


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)