### PR TITLE
Fix crash when externalSignalingServer is empty

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -2448,7 +2448,9 @@ class ChatActivity :
                 }
 
                 override fun onNext(signalingSettingsOverall: SignalingSettingsOverall) {
-                    if (signalingSettingsOverall.ocs!!.settings!!.externalSignalingServer == null) {
+                    if (signalingSettingsOverall.ocs!!.settings!!.externalSignalingServer == null ||
+                        signalingSettingsOverall.ocs!!.settings!!.externalSignalingServer?.isEmpty() == true
+                    ) {
                         return
                     }
 


### PR DESCRIPTION
Otherwise, following crash happened, as it was tried to deal with the empty url:

2024-09-24 15:10:30.719 17765-17765 WebSocketInstance       com.nextcloud.talk2                  D  restartWebSocket: /spreed
2024-09-24 15:10:30.722 17765-17765 System.err              com.nextcloud.talk2                  W  java.lang.IllegalArgumentException: Expected URL scheme 'http' or 'https' but no scheme was found for /spree...
2024-09-24 15:10:30.723 17765-17765 System.err              com.nextcloud.talk2                  W  	at okhttp3.HttpUrl$Builder.parse$okhttp(HttpUrl.kt:1261)


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)