### PR TITLE
Set empty status message 

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/models/json/conversations/Conversation.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/conversations/Conversation.kt
@@ -58,7 +58,7 @@ data class Conversation(
     @JsonField(name = ["actorType"])
     var actorType: String = "",
 
-    var password: String? = null, //check if this can be removed.Does not belong to api response but is used internally?
+    var password: String? = null, // check if this can be removed.Does not belong to api response but is used internally?
 
     @JsonField(name = ["isFavorite"])
     var favorite: Boolean = false,

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/SetStatusDialogFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/SetStatusDialogFragment.kt
@@ -176,7 +176,9 @@ class SetStatusDialogFragment :
 
         setupGeneralStatusOptions()
 
-        binding.emoji.setText(getString(R.string.default_emoji))
+        if (currentStatus?.icon == null) {
+            binding.emoji.setText(getString(R.string.default_emoji))
+        }
 
         binding.clearStatus.setOnClickListener { clearStatus() }
         binding.setStatus.setOnClickListener { setStatusMessage() }

--- a/app/src/test/java/com/nextcloud/talk/json/ConversationConversionTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/json/ConversationConversionTest.kt
@@ -51,7 +51,7 @@ class ConversationConversionTest(
         val conversationEntity = conversationJson.asEntity(1)
         assertNotNull(conversationEntity)
 
-        val apiVersion : Int = jsonFileName.substringAfterLast("APIv").first().digitToInt()
+        val apiVersion: Int = jsonFileName.substringAfterLast("APIv").first().digitToInt()
 
         checkConversationEntity(conversationEntity, apiVersion)
 
@@ -61,10 +61,7 @@ class ConversationConversionTest(
         checkConversationEntity(conversationEntityConvertedBack, apiVersion)
     }
 
-    private fun checkConversationEntity(
-        conversationEntity: ConversationEntity,
-        apiVersion: Int
-    ) {
+    private fun checkConversationEntity(conversationEntity: ConversationEntity, apiVersion: Int) {
         assertEquals("1@juwd77g6", conversationEntity.internalId)
         assertEquals(1, conversationEntity.accountId)
 


### PR DESCRIPTION
Fix  #1863

![status_dialog](https://github.com/user-attachments/assets/6c77c165-df36-4f6f-85d8-4275b03d5048)


Also set a default emoji for user status


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)