### PR TITLE
fix file name of voice recording

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/data/io/MediaRecorderManager.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/io/MediaRecorderManager.kt
@@ -13,7 +13,6 @@ import android.media.MediaRecorder
 import android.util.Log
 import com.nextcloud.talk.R
 import com.nextcloud.talk.models.domain.ConversationModel
-import com.nextcloud.talk.utils.FileUtils
 import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -32,6 +31,7 @@ class MediaRecorderManager : LifecycleAwareManager {
         private const val VOICE_MESSAGE_CHANNELS = 1
         private const val FILE_DATE_PATTERN = "yyyy-MM-dd HH-mm-ss"
         private const val VOICE_MESSAGE_FILE_SUFFIX = ".mp3"
+        private const val VOICE_MESSAGE_PREFIX_MAX_LENGTH = 146
     }
 
     var currentVoiceRecordFile: String = ""
@@ -150,8 +150,8 @@ class MediaRecorderManager : LifecycleAwareManager {
             date,
             validDisplayName
         )
-        if (fileNameWithoutSuffix.length > FileUtils.FILE_MAX_LENGTH) {
-            fileNameWithoutSuffix = fileNameWithoutSuffix.substring(0, FileUtils.FILE_MAX_LENGTH)
+        if (fileNameWithoutSuffix.length > VOICE_MESSAGE_PREFIX_MAX_LENGTH) {
+            fileNameWithoutSuffix = fileNameWithoutSuffix.substring(0, VOICE_MESSAGE_PREFIX_MAX_LENGTH)
         }
         val fileName = fileNameWithoutSuffix + VOICE_MESSAGE_FILE_SUFFIX
         currentVoiceRecordFile = "${context.cacheDir.absolutePath}/$fileName"

--- a/app/src/main/java/com/nextcloud/talk/utils/FileUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/FileUtils.kt
@@ -27,7 +27,6 @@ object FileUtils {
     private val TAG = FileUtils::class.java.simpleName
     private const val RADIX: Int = 16
     private const val MD5_LENGTH: Int = 32
-    const val FILE_MAX_LENGTH = 146
 
     /**
      * Creates a new [File]


### PR DESCRIPTION
Fix #1564

- [x] Filter out special chars which are not allowed on the filesystem, e.g. `/`, `\` and `:` and replace them with a space
- [x] Replace multiple spaces with 1 space
- [x] Make sure the full filename is not exceeding 150 chars, so trim the name to 146 chars before ammending the filesuffix


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)