### PR TITLE
fix position and animation of typing indicator

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -1307,16 +1307,16 @@ class ChatActivity :
         runOnUiThread {
             binding.typingIndicator.text = typingString
 
-            if (participantNames.size > 0) {
-                binding.typingIndicatorWrapper.visibility = View.VISIBLE
-                binding.typingIndicatorWrapper.animate()
-                    .translationYBy(DisplayUtils.convertDpToPixel(-18f, context))
-                    .setInterpolator(AccelerateDecelerateInterpolator())
-                    .duration = TYPING_INDICATOR_ANIMATION_DURATION
+            val typingIndicatorPositionY = if (participantNames.size > 0) {
+                TYPING_INDICATOR_POSITION_VISIBLE
             } else {
-                binding.typingIndicatorWrapper.visibility = View.INVISIBLE
-                binding.typingIndicatorWrapper.y += DisplayUtils.convertDpToPixel(18f, context)
+                TYPING_INDICATOR_POSITION_HIDDEN
             }
+
+            binding.typingIndicatorWrapper.animate()
+                .translationY(DisplayUtils.convertDpToPixel(typingIndicatorPositionY, context))
+                .setInterpolator(AccelerateDecelerateInterpolator())
+                .duration = TYPING_INDICATOR_ANIMATION_DURATION
         }
     }
 
@@ -3696,6 +3696,8 @@ class ChatActivity :
         private const val COMMA = ", "
         private const val TYPING_INDICATOR_ANIMATION_DURATION = 200L
         private const val TYPING_INDICATOR_MAX_NAME_LENGTH = 14
+        private const val TYPING_INDICATOR_POSITION_VISIBLE = -18f
+        private const val TYPING_INDICATOR_POSITION_HIDDEN = -1f
         private const val TYPING_DURATION_TO_SEND_NEXT_TYPING_MESSAGE = 10000L
         private const val TYPING_INTERVAL_TO_SEND_NEXT_TYPING_MESSAGE = 1000L
         private const val TYPING_STARTED_SIGNALING_MESSAGE_TYPE = "startedTyping"


### PR DESCRIPTION
fix #4288 which was broken by https://github.com/nextcloud/talk-android/pull/3792 
The fix https://github.com/nextcloud/talk-android/pull/4041introduced the bug https://github.com/nextcloud/talk-android/issues/4288
Now the implementation is even simpler than the initial (too complex) implementation https://github.com/nextcloud/talk-android/pull/3029

### 🖼️ Videos

🏚️ Before

https://github.com/user-attachments/assets/0bd835c7-b8dc-4009-ad3d-19652130b9f6

🏡 After

https://github.com/user-attachments/assets/95d053ce-7a46-45c4-96d3-0db627699817

(usernames were a bit faked with adding "x" so it's two lines...)



### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)