### PR TITLE
Feature/4299/improve offline support

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -1250,9 +1250,7 @@ class ChatActivity :
 
     @Suppress("MagicNumber", "LongMethod")
     private fun updateTypingIndicator() {
-        fun ellipsize(text: String): String {
-            return DisplayUtils.ellipsize(text, TYPING_INDICATOR_MAX_NAME_LENGTH)
-        }
+        fun ellipsize(text: String): String = DisplayUtils.ellipsize(text, TYPING_INDICATOR_MAX_NAME_LENGTH)
 
         val participantNames = ArrayList<String>()
 
@@ -1326,10 +1324,9 @@ class ChatActivity :
         }
     }
 
-    private fun isTypingStatusEnabled(): Boolean {
-        return webSocketInstance != null &&
+    private fun isTypingStatusEnabled(): Boolean =
+        webSocketInstance != null &&
             !CapabilitiesUtil.isTypingStatusPrivate(conversationUser!!)
-    }
 
     private fun setupSwipeToReply() {
         if (this::participantPermissions.isInitialized &&
@@ -1428,15 +1425,18 @@ class ChatActivity :
     }
 
     fun isOneToOneConversation() =
-        currentConversation != null && currentConversation?.type != null &&
+        currentConversation != null &&
+            currentConversation?.type != null &&
             currentConversation?.type == ConversationEnums.ConversationType.ROOM_TYPE_ONE_TO_ONE_CALL
 
     private fun isGroupConversation() =
-        currentConversation != null && currentConversation?.type != null &&
+        currentConversation != null &&
+            currentConversation?.type != null &&
             currentConversation?.type == ConversationEnums.ConversationType.ROOM_GROUP_CALL
 
     private fun isPublicConversation() =
-        currentConversation != null && currentConversation?.type != null &&
+        currentConversation != null &&
+            currentConversation?.type != null &&
             currentConversation?.type == ConversationEnums.ConversationType.ROOM_PUBLIC_CALL
 
     private fun updateRoomTimerHandler() {
@@ -1674,11 +1674,10 @@ class ChatActivity :
         adapter?.notifyDataSetChanged()
     }
 
-    private fun isChildOfExpandableSystemMessage(chatMessage: ChatMessage): Boolean {
-        return isSystemMessage(chatMessage) &&
+    private fun isChildOfExpandableSystemMessage(chatMessage: ChatMessage): Boolean =
+        isSystemMessage(chatMessage) &&
             !chatMessage.expandableParent &&
             chatMessage.lastItemOfExpandableGroup != 0
-    }
 
     @SuppressLint("NotifyDataSetChanged")
     override fun expandSystemMessage(chatMessageToExpand: ChatMessage) {
@@ -1764,12 +1763,11 @@ class ChatActivity :
             }
     }
 
-    fun isRecordAudioPermissionGranted(): Boolean {
-        return PermissionChecker.checkSelfPermission(
+    fun isRecordAudioPermissionGranted(): Boolean =
+        PermissionChecker.checkSelfPermission(
             context,
             Manifest.permission.RECORD_AUDIO
         ) == PERMISSION_GRANTED
-    }
 
     fun requestRecordAudioPermissions() {
         requestPermissions(
@@ -1876,11 +1874,10 @@ class ChatActivity :
         }
     }
 
-    private fun isReadOnlyConversation(): Boolean {
-        return currentConversation?.conversationReadOnlyState != null &&
+    private fun isReadOnlyConversation(): Boolean =
+        currentConversation?.conversationReadOnlyState != null &&
             currentConversation?.conversationReadOnlyState ==
             ConversationEnums.ConversationReadOnlyState.CONVERSATION_READ_ONLY
-    }
 
     private fun checkLobbyState() {
         if (currentConversation != null &&
@@ -1896,7 +1893,8 @@ class ChatActivity :
                 sb.append(resources!!.getText(R.string.nc_lobby_waiting))
                     .append("\n\n")
 
-                if (currentConversation?.lobbyTimer != null && currentConversation?.lobbyTimer !=
+                if (currentConversation?.lobbyTimer != null &&
+                    currentConversation?.lobbyTimer !=
                     0L
                 ) {
                     val timestampMS = (currentConversation?.lobbyTimer ?: 0) * DateConstants.SECOND_DIVIDER
@@ -2095,7 +2093,7 @@ class ChatActivity :
         if (position != null && position >= 0) {
             binding.messagesListView.scrollToPosition(position)
         } else {
-            // TODO show error that we don't have that message?
+            Log.d(TAG, "message $messageId that should be scrolled to was not found (scrollToMessageWithId)")
         }
     }
 
@@ -2106,6 +2104,12 @@ class ChatActivity :
                 layoutManager?.scrollToPositionWithOffset(
                     position,
                     binding.messagesListView.height / 2
+                )
+            } else {
+                Log.d(
+                    TAG,
+                    "message $messageId that should be scrolled to was not found " +
+                        "(scrollToAndCenterMessageWithId)"
                 )
             }
         }
@@ -2270,11 +2274,10 @@ class ChatActivity :
         startActivity(intent)
     }
 
-    private fun validSessionId(): Boolean {
-        return currentConversation != null &&
+    private fun validSessionId(): Boolean =
+        currentConversation != null &&
             sessionIdAfterRoomJoined?.isNotEmpty() == true &&
             sessionIdAfterRoomJoined != "0"
-    }
 
     @Suppress("Detekt.TooGenericExceptionCaught")
     private fun cancelNotificationsForCurrentConversation() {
@@ -2327,14 +2330,11 @@ class ChatActivity :
         }
     }
 
-    private fun isActivityNotChangingConfigurations(): Boolean {
-        return !isChangingConfigurations
-    }
+    private fun isActivityNotChangingConfigurations(): Boolean = !isChangingConfigurations
 
-    private fun isNotInCall(): Boolean {
-        return !ApplicationWideCurrentRoomHolder.getInstance().isInCall &&
+    private fun isNotInCall(): Boolean =
+        !ApplicationWideCurrentRoomHolder.getInstance().isInCall &&
             !ApplicationWideCurrentRoomHolder.getInstance().isDialing
-    }
 
     private fun setActionBarTitle() {
         val title = binding.chatToolbar.findViewById<TextView>(R.id.chat_toolbar_title)
@@ -2775,11 +2775,10 @@ class ChatActivity :
         }
     }
 
-    private fun isSameDayNonSystemMessages(messageLeft: ChatMessage, messageRight: ChatMessage): Boolean {
-        return TextUtils.isEmpty(messageLeft.systemMessage) &&
+    private fun isSameDayNonSystemMessages(messageLeft: ChatMessage, messageRight: ChatMessage): Boolean =
+        TextUtils.isEmpty(messageLeft.systemMessage) &&
             TextUtils.isEmpty(messageRight.systemMessage) &&
             DateFormatter.isSameDay(messageLeft.createdAt, messageRight.createdAt)
-    }
 
     override fun onLoadMore(page: Int, totalItemsCount: Int) {
         val id = (
@@ -2799,15 +2798,14 @@ class ChatActivity :
         )
     }
 
-    override fun format(date: Date): String {
-        return if (DateFormatter.isToday(date)) {
+    override fun format(date: Date): String =
+        if (DateFormatter.isToday(date)) {
             resources!!.getString(R.string.nc_date_header_today)
         } else if (DateFormatter.isYesterday(date)) {
             resources!!.getString(R.string.nc_date_header_yesterday)
         } else {
             DateFormatter.format(date, DateFormatter.Template.STRING_DAY_MONTH_YEAR)
         }
-    }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         super.onCreateOptionsMenu(menu)
@@ -2869,8 +2867,8 @@ class ChatActivity :
         return true
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
+    override fun onOptionsItemSelected(item: MenuItem): Boolean =
+        when (item.itemId) {
             R.id.conversation_video_call -> {
                 startACall(false, false)
                 true
@@ -2898,7 +2896,6 @@ class ChatActivity :
 
             else -> super.onOptionsItemSelected(item)
         }
-    }
 
     private fun showSharedItems() {
         val intent = Intent(this, SharedItemsActivity::class.java)
@@ -2960,25 +2957,23 @@ class ChatActivity :
         return chatMessageMap.values.toList()
     }
 
-    private fun isInfoMessageAboutDeletion(currentMessage: MutableMap.MutableEntry<String, ChatMessage>): Boolean {
-        return currentMessage.value.parentMessageId != null && currentMessage.value.systemMessageType == ChatMessage
-            .SystemMessageType.MESSAGE_DELETED
-    }
+    private fun isInfoMessageAboutDeletion(currentMessage: MutableMap.MutableEntry<String, ChatMessage>): Boolean =
+        currentMessage.value.parentMessageId != null &&
+            currentMessage.value.systemMessageType == ChatMessage
+                .SystemMessageType.MESSAGE_DELETED
 
-    private fun isReactionsMessage(currentMessage: MutableMap.MutableEntry<String, ChatMessage>): Boolean {
-        return currentMessage.value.systemMessageType == ChatMessage.SystemMessageType.REACTION ||
+    private fun isReactionsMessage(currentMessage: MutableMap.MutableEntry<String, ChatMessage>): Boolean =
+        currentMessage.value.systemMessageType == ChatMessage.SystemMessageType.REACTION ||
             currentMessage.value.systemMessageType == ChatMessage.SystemMessageType.REACTION_DELETED ||
             currentMessage.value.systemMessageType == ChatMessage.SystemMessageType.REACTION_REVOKED
-    }
 
-    private fun isEditMessage(currentMessage: MutableMap.MutableEntry<String, ChatMessage>): Boolean {
-        return currentMessage.value.parentMessageId != null && currentMessage.value.systemMessageType == ChatMessage
-            .SystemMessageType.MESSAGE_EDITED
-    }
+    private fun isEditMessage(currentMessage: MutableMap.MutableEntry<String, ChatMessage>): Boolean =
+        currentMessage.value.parentMessageId != null &&
+            currentMessage.value.systemMessageType == ChatMessage
+                .SystemMessageType.MESSAGE_EDITED
 
-    private fun isPollVotedMessage(currentMessage: MutableMap.MutableEntry<String, ChatMessage>): Boolean {
-        return currentMessage.value.systemMessageType == ChatMessage.SystemMessageType.POLL_VOTED
-    }
+    private fun isPollVotedMessage(currentMessage: MutableMap.MutableEntry<String, ChatMessage>): Boolean =
+        currentMessage.value.systemMessageType == ChatMessage.SystemMessageType.POLL_VOTED
 
     private fun startACall(isVoiceOnlyCall: Boolean, callWithoutNotification: Boolean) {
         currentConversation?.let {
@@ -3082,9 +3077,8 @@ class ChatActivity :
         }
     }
 
-    private fun isSystemMessage(message: ChatMessage): Boolean {
-        return ChatMessage.MessageType.SYSTEM_MESSAGE == message.getCalculateMessageType()
-    }
+    private fun isSystemMessage(message: ChatMessage): Boolean =
+        ChatMessage.MessageType.SYSTEM_MESSAGE == message.getCalculateMessageType()
 
     fun deleteMessage(message: IMessage) {
         if (!participantPermissions.hasChatPermission()) {
@@ -3327,20 +3321,26 @@ class ChatActivity :
         fileViewerUtils.openFileInFilesApp(link!!, keyID!!)
     }
 
-    private fun hasVisibleItems(message: ChatMessage): Boolean {
-        return !message.isDeleted || // copy message
-            message.replyable || // reply to
-            message.replyable && // reply privately
-            conversationUser?.userId?.isNotEmpty() == true && conversationUser!!.userId != "?" &&
+    private fun hasVisibleItems(message: ChatMessage): Boolean =
+        !message.isDeleted ||
+            // copy message
+            message.replyable ||
+            // reply to
+            message.replyable &&
+            // reply privately
+            conversationUser?.userId?.isNotEmpty() == true &&
+            conversationUser!!.userId != "?" &&
             message.user.id.startsWith("users/") &&
             message.user.id.substring(ACTOR_LENGTH) != currentConversation?.actorId &&
             currentConversation?.type != ConversationEnums.ConversationType.ROOM_TYPE_ONE_TO_ONE_CALL ||
-            isShowMessageDeletionButton(message) || // delete
-            ChatMessage.MessageType.REGULAR_TEXT_MESSAGE == message.getCalculateMessageType() || // forward
-            message.previousMessageId > NO_PREVIOUS_MESSAGE_ID && // mark as unread
+            isShowMessageDeletionButton(message) ||
+            // delete
+            ChatMessage.MessageType.REGULAR_TEXT_MESSAGE == message.getCalculateMessageType() ||
+            // forward
+            message.previousMessageId > NO_PREVIOUS_MESSAGE_ID &&
+            // mark as unread
             ChatMessage.MessageType.SYSTEM_MESSAGE != message.getCalculateMessageType() &&
             BuildConfig.DEBUG
-    }
 
     private fun setMessageAsDeleted(message: IMessage?) {
         val messageTemp = message as ChatMessage
@@ -3458,8 +3458,8 @@ class ChatActivity :
         return isUserAllowedByPrivileges
     }
 
-    override fun hasContentFor(message: ChatMessage, type: Byte): Boolean {
-        return when (type) {
+    override fun hasContentFor(message: ChatMessage, type: Byte): Boolean =
+        when (type) {
             CONTENT_TYPE_LOCATION -> message.hasGeoLocation()
             CONTENT_TYPE_VOICE_MESSAGE -> message.isVoiceMessage
             CONTENT_TYPE_POLL -> message.isPoll()
@@ -3470,7 +3470,6 @@ class ChatActivity :
 
             else -> false
         }
-    }
 
     private fun processMostRecentMessage(recent: ChatMessage, chatMessageList: List<ChatMessage>) {
         when (recent.systemMessageType) {

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -183,6 +183,7 @@ import io.reactivex.Observer
 import io.reactivex.disposables.Disposable
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -416,7 +417,12 @@ class ChatActivity :
 
         messageInputViewModel = ViewModelProvider(this, viewModelFactory)[MessageInputViewModel::class.java]
 
-        binding.progressBar.visibility = View.VISIBLE
+        this.lifecycleScope.launch {
+            delay(DELAY_TO_SHOW_PROGRESS_BAR)
+            if (adapter?.isEmpty == true) {
+                binding.progressBar.visibility = View.VISIBLE
+            }
+        }
 
         onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
 
@@ -3712,5 +3718,6 @@ class ChatActivity :
         private const val CURRENT_AUDIO_POSITION_KEY = "CURRENT_AUDIO_POSITION"
         private const val CURRENT_AUDIO_WAS_PLAYING_KEY = "CURRENT_AUDIO_PLAYING"
         private const val RESUME_AUDIO_TAG = "RESUME_AUDIO_TAG"
+        private const val DELAY_TO_SHOW_PROGRESS_BAR = 1000L
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/chat/data/ChatMessageRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/ChatMessageRepository.kt
@@ -56,10 +56,8 @@ interface ChatMessageRepository : LifecycleAwareManager {
      * Long polls the server for any updates to the chat, if found, it synchronizes
      * the database with the server and emits the new messages to [messageFlow],
      * else it simply retries after timeout.
-     *
-     * [withNetworkParams] credentials and url.
      */
-    fun initMessagePolling(): Job
+    fun initMessagePolling(initialMessageId: Long): Job
 
     /**
      * Gets a individual message.

--- a/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
@@ -158,6 +158,8 @@ class OfflineFirstChatRepository @Inject constructor(
                 Log.d(TAG, "newestMessageId after sync: $newestMessageIdFromDb")
             } else {
                 Log.d(TAG, "Initial online request is skipped because offline messages are up to date")
+                // if conversationModel was not up to date and there are new messages, they will just get pulled with
+                // look into future.. Old messages will be displayed immediately beforehand.
             }
 
             val limit = getCappedMessagesAmountOfChatBlock(newestMessageIdFromDb)
@@ -175,7 +177,7 @@ class OfflineFirstChatRepository @Inject constructor(
             updateUiForLastCommonRead()
             updateUiForLastReadMessage(newestMessageIdFromDb)
 
-            initMessagePolling()
+            initMessagePolling(newestMessageIdFromDb)
         }
 
     private suspend fun getCappedMessagesAmountOfChatBlock(messageId: Long): Int {
@@ -240,18 +242,17 @@ class OfflineFirstChatRepository @Inject constructor(
             updateUiForLastCommonRead()
         }
 
-    override fun initMessagePolling(): Job =
+    override fun initMessagePolling(initialMessageId: Long): Job =
         scope.launch {
             Log.d(TAG, "---- initMessagePolling ------------")
 
-            val initialMessageId = chatDao.getNewestMessageId(internalConversationId).toInt()
             Log.d(TAG, "newestMessage: $initialMessageId")
 
             var fieldMap = getFieldMap(
                 lookIntoFuture = true,
                 includeLastKnown = false,
                 setReadMarker = true,
-                lastKnown = initialMessageId
+                lastKnown = initialMessageId.toInt()
             )
 
             val networkParams = Bundle()

--- a/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
@@ -108,26 +108,63 @@ class OfflineFirstChatRepository @Inject constructor(
     override fun loadInitialMessages(withNetworkParams: Bundle): Job =
         scope.launch {
             Log.d(TAG, "---- loadInitialMessages ------------")
+            Log.d(TAG, "conversationModel.internalId: " + conversationModel.internalId)
 
             newXChatLastCommonRead = conversationModel.lastCommonReadMessage
 
-            val fieldMap = getFieldMap(
-                lookIntoFuture = false,
-                includeLastKnown = true,
-                setReadMarker = true,
-                lastKnown = null
-            )
-            withNetworkParams.putSerializable(BundleKeys.KEY_FIELD_MAP, fieldMap)
-            withNetworkParams.putString(BundleKeys.KEY_ROOM_TOKEN, conversationModel.token)
+            Log.d(TAG, "conversationModel.lastReadMessage:" + conversationModel.lastReadMessage)
 
-            sync(withNetworkParams)
+            var newestMessageId = chatDao.getNewestMessageId(internalConversationId)
+            Log.d(TAG, "newestMessageId: $newestMessageId")
+            if (newestMessageId.toInt() == 0) {
+                Log.d(TAG, "newestMessageId from db was 0. Must only happen when chat is loaded for the first time")
+            }
 
-            val newestMessageId = chatDao.getNewestMessageId(internalConversationId)
-            Log.d(TAG, "newestMessageId after sync: $newestMessageId")
+            if (conversationModel.lastReadMessage.toLong() != newestMessageId) {
+                Log.d(TAG, "An online request is made because chat is not up to date")
 
-            showLast100MessagesBeforeAndEqual(
+                // set up field map to load the newest messages
+                val fieldMap = getFieldMap(
+                    lookIntoFuture = false,
+                    includeLastKnown = true,
+                    setReadMarker = true,
+                    lastKnown = null
+                )
+                withNetworkParams.putSerializable(BundleKeys.KEY_FIELD_MAP, fieldMap)
+                withNetworkParams.putString(BundleKeys.KEY_ROOM_TOKEN, conversationModel.token)
+
+                Log.d(TAG, "Starting online request for initial loading")
+                val chatMessageEntities = sync(withNetworkParams)
+                if (chatMessageEntities == null) {
+                    Log.e(TAG, "initial loading of messages failed")
+                }
+
+                newestMessageId = chatDao.getNewestMessageId(internalConversationId)
+                Log.d(TAG, "newestMessageId after sync: $newestMessageId")
+            } else {
+                Log.d(TAG, "Initial online request is skipped because offline messages are up to date")
+            }
+
+            val chatBlock = getBlockOfMessage(newestMessageId.toInt())
+
+            val amountBetween = chatDao.getCountBetweenMessageIds(
                 internalConversationId,
-                chatDao.getNewestMessageId(internalConversationId)
+                newestMessageId,
+                chatBlock!!.oldestMessageId
+            )
+
+            Log.d(TAG, "amount of messages between newestMessageId and oldest message of same ChatBlock:$amountBetween")
+            val limit = if (amountBetween > DEFAULT_MESSAGES_LIMIT) {
+                DEFAULT_MESSAGES_LIMIT
+            } else {
+                amountBetween
+            }
+            Log.d(TAG, "limit of messages to load for UI (max 100 to ensure performance is okay):$limit")
+
+            showMessagesBeforeAndEqual(
+                internalConversationId,
+                newestMessageId,
+                limit
             )
 
             // delay is a dirty workaround to make sure messages are added to adapter on initial load before dealing
@@ -175,10 +212,11 @@ class OfflineFirstChatRepository @Inject constructor(
             val loadFromServer = hasToLoadPreviousMessagesFromServer(beforeMessageId)
 
             if (loadFromServer) {
+                Log.d(TAG, "Starting online request for loadMoreMessages")
                 sync(withNetworkParams)
             }
 
-            showLast100MessagesBefore(internalConversationId, beforeMessageId)
+            showMessagesBefore(internalConversationId, beforeMessageId, DEFAULT_MESSAGES_LIMIT)
             updateUiForLastCommonRead()
         }
 
@@ -205,6 +243,7 @@ class OfflineFirstChatRepository @Inject constructor(
                     // sync database with server (This is a long blocking call because long polling (lookIntoFuture) is set)
                     networkParams.putSerializable(BundleKeys.KEY_FIELD_MAP, fieldMap)
 
+                    Log.d(TAG, "Starting online request for long polling")
                     val resultsFromSync = sync(networkParams)
                     if (!resultsFromSync.isNullOrEmpty()) {
                         val chatMessages = resultsFromSync.map(ChatMessageEntity::asModel)
@@ -240,15 +279,15 @@ class OfflineFirstChatRepository @Inject constructor(
             loadFromServer = false
         } else {
             // we know that beforeMessageId and blockForMessage.oldestMessageId are in the same block.
-            // As we want the last 100 entries before beforeMessageId, we calculate if these messages are 100
-            // entries apart from each other
+            // As we want the last DEFAULT_MESSAGES_LIMIT entries before beforeMessageId, we calculate if these
+            // messages are DEFAULT_MESSAGES_LIMIT entries apart from each other
 
             val amountBetween = chatDao.getCountBetweenMessageIds(
                 internalConversationId,
                 beforeMessageId,
                 blockForMessage.oldestMessageId
             )
-            loadFromServer = amountBetween < 100
+            loadFromServer = amountBetween < DEFAULT_MESSAGES_LIMIT
 
             Log.d(
                 TAG,
@@ -263,7 +302,8 @@ class OfflineFirstChatRepository @Inject constructor(
         lookIntoFuture: Boolean,
         includeLastKnown: Boolean,
         setReadMarker: Boolean,
-        lastKnown: Int?
+        lastKnown: Int?,
+        limit: Int = DEFAULT_MESSAGES_LIMIT
     ): HashMap<String, Int> {
         val fieldMap = HashMap<String, Int>()
 
@@ -278,7 +318,7 @@ class OfflineFirstChatRepository @Inject constructor(
         }
 
         fieldMap["timeout"] = if (lookIntoFuture) 30 else 0
-        fieldMap["limit"] = 100
+        fieldMap["limit"] = limit
         fieldMap["lookIntoFuture"] = if (lookIntoFuture) 1 else 0
         fieldMap["setReadMarker"] = if (setReadMarker) 1 else 0
 
@@ -294,12 +334,12 @@ class OfflineFirstChatRepository @Inject constructor(
                 lookIntoFuture = false,
                 includeLastKnown = true,
                 setReadMarker = false,
-                lastKnown = messageId.toInt()
+                lastKnown = messageId.toInt(),
+                limit = 1
             )
             bundle.putSerializable(BundleKeys.KEY_FIELD_MAP, fieldMap)
 
-            // Although only the single message will be returned, a server request will load 100 messages.
-            // If this turns out to be confusion for debugging we could load set the limit to 1 for this request.
+            Log.d(TAG, "Starting online request for single message (e.g. a reply)")
             sync(bundle)
         }
         return chatDao.getChatMessageForConversation(internalConversationId, messageId)
@@ -308,59 +348,70 @@ class OfflineFirstChatRepository @Inject constructor(
 
     @Suppress("UNCHECKED_CAST")
     private fun getMessagesFromServer(bundle: Bundle): Pair<Int, List<ChatMessageJson>>? {
-        Log.d(TAG, "An online request is made!!!!!!!!!!!!!!!!!!!!")
         val fieldMap = bundle.getSerializable(BundleKeys.KEY_FIELD_MAP) as HashMap<String, Int>
 
-        try {
-            val result = network.pullChatMessages(credentials, urlForChatting, fieldMap)
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                // .timeout(3, TimeUnit.SECONDS)
-                .map { it ->
-                    when (it.code()) {
-                        HTTP_CODE_OK -> {
-                            Log.d(TAG, "getMessagesFromServer HTTP_CODE_OK")
-                            newXChatLastCommonRead = it.headers()["X-Chat-Last-Common-Read"]?.let {
-                                Integer.parseInt(it)
+        var attempts = 1
+        while (attempts < 5) {
+            Log.d(TAG, "message limit: " + fieldMap["limit"])
+            try {
+                val result = network.pullChatMessages(credentials, urlForChatting, fieldMap)
+                    .subscribeOn(Schedulers.io())
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .map { it ->
+                        when (it.code()) {
+                            HTTP_CODE_OK -> {
+                                Log.d(TAG, "getMessagesFromServer HTTP_CODE_OK")
+                                newXChatLastCommonRead = it.headers()["X-Chat-Last-Common-Read"]?.let {
+                                    Integer.parseInt(it)
+                                }
+
+                                return@map Pair(
+                                    HTTP_CODE_OK,
+                                    (it.body() as ChatOverall).ocs!!.data!!
+                                )
                             }
 
-                            return@map Pair(
-                                HTTP_CODE_OK,
-                                (it.body() as ChatOverall).ocs!!.data!!
-                            )
-                        }
+                            HTTP_CODE_NOT_MODIFIED -> {
+                                Log.d(TAG, "getMessagesFromServer HTTP_CODE_NOT_MODIFIED")
 
-                        HTTP_CODE_NOT_MODIFIED -> {
-                            Log.d(TAG, "getMessagesFromServer HTTP_CODE_NOT_MODIFIED")
+                                return@map Pair(
+                                    HTTP_CODE_NOT_MODIFIED,
+                                    listOf<ChatMessageJson>()
+                                )
+                            }
 
-                            return@map Pair(
-                                HTTP_CODE_NOT_MODIFIED,
-                                listOf<ChatMessageJson>()
-                            )
-                        }
+                            HTTP_CODE_PRECONDITION_FAILED -> {
+                                Log.d(TAG, "getMessagesFromServer HTTP_CODE_PRECONDITION_FAILED")
 
-                        HTTP_CODE_PRECONDITION_FAILED -> {
-                            Log.d(TAG, "getMessagesFromServer HTTP_CODE_PRECONDITION_FAILED")
+                                return@map Pair(
+                                    HTTP_CODE_PRECONDITION_FAILED,
+                                    listOf<ChatMessageJson>()
+                                )
+                            }
 
-                            return@map Pair(
-                                HTTP_CODE_PRECONDITION_FAILED,
-                                listOf<ChatMessageJson>()
-                            )
-                        }
-
-                        else -> {
-                            return@map Pair(
-                                HTTP_CODE_PRECONDITION_FAILED,
-                                listOf<ChatMessageJson>()
-                            )
+                            else -> {
+                                return@map Pair(
+                                    HTTP_CODE_PRECONDITION_FAILED,
+                                    listOf<ChatMessageJson>()
+                                )
+                            }
                         }
                     }
+                    .blockingSingle()
+                return result
+            } catch (e: Exception) {
+                Log.e(TAG, "Something went wrong when pulling chat messages (attempt: $attempts)", e)
+                attempts++
+
+                val newMessageLimit = when (attempts) {
+                    2 -> 50
+                    3 -> 10
+                    else -> 5
                 }
-                .blockingSingle()
-            return result
-        } catch (e: Exception) {
-            Log.e(TAG, "Something went wrong when pulling chat messages", e)
+                fieldMap["limit"] = newMessageLimit
+            }
         }
+        Log.e(TAG, "All attempts to get messages from server failed")
         return null
     }
 
@@ -370,7 +421,12 @@ class OfflineFirstChatRepository @Inject constructor(
             return null
         }
 
-        val result = getMessagesFromServer(bundle) ?: return listOf()
+        val result = getMessagesFromServer(bundle)
+        if (result == null) {
+            Log.d(TAG, "No result from server")
+            return null
+        }
+
         var chatMessagesFromSync: List<ChatMessageEntity>? = null
 
         val fieldMap = bundle.getSerializable(BundleKeys.KEY_FIELD_MAP) as HashMap<String, Int>
@@ -471,7 +527,7 @@ class OfflineFirstChatRepository @Inject constructor(
                 ChatMessage.SystemMessageType.CLEARED_CHAT -> {
                     // for lookIntoFuture just deleting everything would be fine.
                     // But lets say we did not open the chat for a while and in between it was cleared.
-                    // We just load the last 100 messages but this don't contain the system message.
+                    // We just load the last messages but this don't contain the system message.
                     // We scroll up and load the system message. Deleting everything is not an option as we
                     // would loose the messages that we want to keep. We only want to
                     // delete the messages and chatBlocks older than the system message.
@@ -488,13 +544,12 @@ class OfflineFirstChatRepository @Inject constructor(
      *  304 is returned when oldest message of chat was queried or when long polling request returned with no
      *  modification. hasHistory is only set to false, when 304 was returned for the the oldest message
      */
-    private fun getHasHistory(statusCode: Int, lookIntoFuture: Boolean): Boolean {
-        return if (statusCode == HTTP_CODE_NOT_MODIFIED) {
+    private fun getHasHistory(statusCode: Int, lookIntoFuture: Boolean): Boolean =
+        if (statusCode == HTTP_CODE_NOT_MODIFIED) {
             lookIntoFuture
         } else {
             true
         }
-    }
 
     private suspend fun getBlockOfMessage(queriedMessageId: Int?): ChatBlockEntity? {
         var blockContainingQueriedMessage: ChatBlockEntity? = null
@@ -563,7 +618,7 @@ class OfflineFirstChatRepository @Inject constructor(
         }
     }
 
-    private suspend fun showLast100MessagesBeforeAndEqual(internalConversationId: String, messageId: Long) {
+    private suspend fun showMessagesBeforeAndEqual(internalConversationId: String, messageId: Long, limit: Int) {
         suspend fun getMessagesBeforeAndEqual(
             messageId: Long,
             internalConversationId: String,
@@ -580,7 +635,7 @@ class OfflineFirstChatRepository @Inject constructor(
         val list = getMessagesBeforeAndEqual(
             messageId,
             internalConversationId,
-            100
+            limit
         )
 
         if (list.isNotEmpty()) {
@@ -589,7 +644,7 @@ class OfflineFirstChatRepository @Inject constructor(
         }
     }
 
-    private suspend fun showLast100MessagesBefore(internalConversationId: String, messageId: Long) {
+    private suspend fun showMessagesBefore(internalConversationId: String, messageId: Long, limit: Int) {
         suspend fun getMessagesBefore(
             messageId: Long,
             internalConversationId: String,
@@ -606,7 +661,7 @@ class OfflineFirstChatRepository @Inject constructor(
         val list = getMessagesBefore(
             messageId,
             internalConversationId,
-            100
+            limit
         )
 
         if (list.isNotEmpty()) {
@@ -638,5 +693,6 @@ class OfflineFirstChatRepository @Inject constructor(
         private const val HTTP_CODE_PRECONDITION_FAILED = 412
         private const val HALF_SECOND = 500L
         private const val DELAY_TO_ENSURE_MESSAGES_ARE_ADDED: Long = 100
+        private const val DEFAULT_MESSAGES_LIMIT = 100
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
@@ -225,7 +225,7 @@ class ChatViewModel @Inject constructor(
 
     fun getRoom(user: User, token: String) {
         _getRoomViewState.value = GetRoomStartState
-        conversationRepository.getConversationSettings(token)
+        conversationRepository.getRoom(token)
 
         // chatNetworkDataSource.getRoom(user, token)
         //     .subscribeOn(Schedulers.io())

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/data/OfflineConversationsRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/data/OfflineConversationsRepository.kt
@@ -35,5 +35,5 @@ interface OfflineConversationsRepository {
      * Called once onStart to emit a conversation to [conversationFlow]
      * to be handled asynchronously.
      */
-    fun getConversationSettings(roomToken: String): Job
+    fun getRoom(roomToken: String): Job
 }

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/data/network/OfflineFirstConversationsRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/data/network/OfflineFirstConversationsRepository.kt
@@ -56,17 +56,19 @@ class OfflineFirstConversationsRepository @Inject constructor(
 
     override fun getRooms(): Job =
         scope.launch {
-            val resultsFromSync = sync()
-            if (!resultsFromSync.isNullOrEmpty()) {
-                val conversations = resultsFromSync.map(ConversationEntity::asModel)
-                _roomListFlow.emit(conversations)
-            } else {
-                val conversationsFromDb = getListOfConversations(user.id!!)
-                _roomListFlow.emit(conversationsFromDb)
+            val initialConversationModels = getListOfConversations(user.id!!)
+            _roomListFlow.emit(initialConversationModels)
+
+            if (monitor.isOnline.first()) {
+                val conversationEntitiesFromSync = getRoomsFromServer()
+                if (!conversationEntitiesFromSync.isNullOrEmpty()) {
+                    val conversationModelsFromSync = conversationEntitiesFromSync.map(ConversationEntity::asModel)
+                    _roomListFlow.emit(conversationModelsFromSync)
+                }
             }
         }
 
-    override fun getConversationSettings(roomToken: String): Job =
+    override fun getRoom(roomToken: String): Job =
         scope.launch {
             val id = user.id!!
             val model = getConversation(id, roomToken)
@@ -100,7 +102,7 @@ class OfflineFirstConversationsRepository @Inject constructor(
             }
         }
 
-    private suspend fun sync(): List<ConversationEntity>? {
+    private suspend fun getRoomsFromServer(): List<ConversationEntity>? {
         var conversationsFromSync: List<ConversationEntity>? = null
 
         if (!monitor.isOnline.first()) {

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/data/network/OfflineFirstConversationsRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/data/network/OfflineFirstConversationsRepository.kt
@@ -131,10 +131,12 @@ class OfflineFirstConversationsRepository @Inject constructor(
     }
 
     private suspend fun deleteLeftConversations(conversationsFromSync: List<ConversationEntity>) {
+        val conversationsFromSyncIds = conversationsFromSync.map { it.internalId }.toSet()
         val oldConversationsFromDb = dao.getConversationsForUser(user.id!!).first()
 
-        val conversationsToDelete = oldConversationsFromDb.filterNot { conversationsFromSync.contains(it) }
-        val conversationIdsToDelete = conversationsToDelete.map { it.internalId }
+        val conversationIdsToDelete = oldConversationsFromDb
+            .map { it.internalId }
+            .filterNot { it in conversationsFromSyncIds }
 
         dao.deleteConversations(conversationIdsToDelete)
     }


### PR DESCRIPTION
resolve #4299

besides real "offline first" behavior and performance improvements for slow connections, commit adf18020c1750095a6490aadb96034dc353eb04c fixes a bug that conversations are not deleted sometimes (e.g. when a user status was changed)

### 🚧 TODO

- [x] analyze bug: sometimes chat messages are dropped from DB when navigating back to Conversation list. Check if this is caused by this PR or if it also happens on master or 20.0.2
- [x] check if lastReadMessageId or lastMessage.id should be used to compare with newest message from DB


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)