### PR TITLE
Fixes partial path traversal on >= API 26

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/utils/FileUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/FileUtils.kt
@@ -110,9 +110,9 @@ object FileUtils {
         val isOutsideCacheDir = aboveOrEqualAPI26Check || belowAPI26Check
 
         if (isOutsideCacheDir) {
-            Log.w(TAG, "cachedFile was not created in cacheDir. Aborting for security reasons.");
-            cachedFile.delete();
-            return null;
+            Log.w(TAG, "cachedFile was not created in cacheDir. Aborting for security reasons.")
+            cachedFile.delete()
+            return null
         }
 
         if (cachedFile.exists()) {


### PR DESCRIPTION
Was following [fix](https://codeql.github.com/codeql-query-help/java/java-partial-path-traversal/) , unfortunately `toPath` and `normalize` require API level 26, and our current min is API level 24.

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)