### PR TITLE
Remove dead code to set the call state

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -393,11 +393,9 @@ class CallActivity : CallBaseActivity() {
             baseUrl = conversationUser!!.baseUrl
         }
         powerManagerUtils = PowerManagerUtils()
-        if ("resume".equals(extras.getString("state", ""), ignoreCase = true)) {
-            setCallState(CallStatus.IN_CONVERSATION)
-        } else {
-            setCallState(CallStatus.CONNECTING)
-        }
+
+        setCallState(CallStatus.CONNECTING)
+
         raiseHandViewModel = ViewModelProvider(this, viewModelFactory).get(RaiseHandViewModel::class.java)
         raiseHandViewModel!!.setData(roomToken!!, isBreakoutRoom)
         raiseHandViewModel!!.viewState.observe(this) { viewState: RaiseHandViewModel.ViewState? ->


### PR DESCRIPTION
This change was part of another fix, but I have extracted it to its own pull request for better reviewing, as it is related to the Android activity lifecycle and I am a bit worried to be missing something.

`IN_CONVERSATION` was set when the activity was created and `state` in the intent extras has the value `resume`. As far as I know there is no `state` extra set by default in Android intents, it should be explicitly set, but it is not set anywhere in Talk Android code, so that would make it dead code and safe to remove.

Moreover, [it was added when switching between call view and chat during a call was introduced](https://github.com/nextcloud/talk-android/commit/f7d92908716c22a6218da92578e0344a2aae7faf#diff-ecc1f9971f93c8bb9f1c42a1a78335116efa9b32ac8ca0fa44d92403ad637d03R300). At that time the check was done on a BlueLine Labs Controller rather than on an Android Activity, so maybe back then the controller received the `resume` state when switching between controllers in the same activity, but that would be no longer the case after dropping the controllers in favour of standard activities.

And even if resuming an activity provided a `resume` state, if I am not mistaken `onCreate` is called when the activity is initially created (so it would not make sense to receive a `resume` state) or after it was destroyed while in the background and recreated again when moving it to the foregroud again, which I guess would have caused the call to be interrupted anyway, and thus it should start the connection again rather than being marked as `IN_CONVERSATION`.

But as mentioned I am a bit worried to be missing something in all of the above, so please verify it :-) Thanks!
