### PR TITLE
Fix handling of end call for everyone with external signaling

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/signaling/SignalingMessageReceiver.java
+++ b/app/src/main/java/com/nextcloud/talk/signaling/SignalingMessageReceiver.java
@@ -370,6 +370,9 @@ public abstract class SignalingMessageReceiver {
         //         },
         //     },
         // }
+        //
+        // Note that "incall" in participants->update is all in lower case when the message applies to all participants,
+        // even if it is "inCall" when the message provides separate properties for each participant.
 
         long inCall;
         try {

--- a/app/src/main/java/com/nextcloud/talk/signaling/SignalingMessageReceiver.java
+++ b/app/src/main/java/com/nextcloud/talk/signaling/SignalingMessageReceiver.java
@@ -373,7 +373,7 @@ public abstract class SignalingMessageReceiver {
 
         long inCall;
         try {
-            inCall = Long.parseLong(updateMap.get("inCall").toString());
+            inCall = Long.parseLong(updateMap.get("incall").toString());
         } catch (RuntimeException e) {
             // Broken message, this should not happen.
             return;

--- a/app/src/test/java/com/nextcloud/talk/signaling/SignalingMessageReceiverParticipantListTest.java
+++ b/app/src/test/java/com/nextcloud/talk/signaling/SignalingMessageReceiverParticipantListTest.java
@@ -322,7 +322,7 @@ public class SignalingMessageReceiverParticipantListTest {
         Map<String, Object> updateMap = new HashMap<>();
         updateMap.put("roomId", 108);
         updateMap.put("all", true);
-        updateMap.put("inCall", 0);
+        updateMap.put("incall", 0);
         eventMap.put("update", updateMap);
         signalingMessageReceiver.processEvent(eventMap);
 
@@ -343,7 +343,7 @@ public class SignalingMessageReceiverParticipantListTest {
         HashMap<String, Object> updateMap = new HashMap<>();
         updateMap.put("roomId", 108);
         updateMap.put("all", true);
-        updateMap.put("inCall", 0);
+        updateMap.put("incall", 0);
         eventMap.put("update", updateMap);
         signalingMessageReceiver.processEvent(eventMap);
 
@@ -370,7 +370,7 @@ public class SignalingMessageReceiverParticipantListTest {
         HashMap<String, Object> updateMap = new HashMap<>();
         updateMap.put("roomId", 108);
         updateMap.put("all", true);
-        updateMap.put("inCall", 0);
+        updateMap.put("incall", 0);
         eventMap.put("update", updateMap);
         signalingMessageReceiver.processEvent(eventMap);
 
@@ -393,7 +393,7 @@ public class SignalingMessageReceiverParticipantListTest {
         HashMap<String, Object> updateMap = new HashMap<>();
         updateMap.put("roomId", 108);
         updateMap.put("all", true);
-        updateMap.put("inCall", 0);
+        updateMap.put("incall", 0);
         eventMap.put("update", updateMap);
         signalingMessageReceiver.processEvent(eventMap);
 
@@ -420,7 +420,7 @@ public class SignalingMessageReceiverParticipantListTest {
         HashMap<String, Object> updateMap = new HashMap<>();
         updateMap.put("roomId", 108);
         updateMap.put("all", true);
-        updateMap.put("inCall", 0);
+        updateMap.put("incall", 0);
         eventMap.put("update", updateMap);
         signalingMessageReceiver.processEvent(eventMap);
 
@@ -449,7 +449,7 @@ public class SignalingMessageReceiverParticipantListTest {
         HashMap<String, Object> updateMap = new HashMap<>();
         updateMap.put("roomId", 108);
         updateMap.put("all", true);
-        updateMap.put("inCall", 0);
+        updateMap.put("incall", 0);
         eventMap.put("update", updateMap);
         signalingMessageReceiver.processEvent(eventMap);
 


### PR DESCRIPTION
When the message applies to all participants [the property is all in lower case](https://github.com/nextcloud/spreed/blob/956a1ab00ffb25d87c0f5192333c9b66e56a63fe/lib/Signaling/BackendNotifier.php#L402-L406). The comparison is case sensitive, so the message was ignored and the call was not left by the Talk Android app.

That message is sent only when the external signaling is used. If the internal signaling is used the call is left as expected when the call is ended for everyone; in that case the normal `usersInRoom` message is sent with `inCall` set to disconnected for every participant, and the Android app [leaves the call if the local participant is marked as disconnected](https://github.com/nextcloud/talk-android/blob/fdb8692b59aae8563e680c1a593ce73f48e82848/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt#L2120-L2127).

## How to test

- Setup the HPB
- Create a conversation in the WebUI
- Add a user
- Start a call
- In the Android app, log in as the user that was added to the conversation
- Join the conversation
- Join the call
- In the WebUI, end the call for all

### Expected result

The call is left in the Android app

### Actual result

The call is not left in the Android app, and it may be rejoined
