### PR TITLE
fix to provide all call emojis

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/MoreCallActionsDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/MoreCallActionsDialog.kt
@@ -96,9 +96,8 @@ class MoreCallActionsDialog(private val callActivity: CallActivity) : BottomShee
                 capabilities?.spreedCapability?.config!!["call"]!!["supported-reactions"] as ArrayList<*>
 
             val param = LinearLayout.LayoutParams(
-                LinearLayout.LayoutParams.MATCH_PARENT,
-                LinearLayout.LayoutParams.MATCH_PARENT,
-                1.0f
+                EMOJI_WIDTH,
+                LinearLayout.LayoutParams.MATCH_PARENT
             )
 
             availableReactions.forEach {
@@ -185,5 +184,6 @@ class MoreCallActionsDialog(private val callActivity: CallActivity) : BottomShee
     companion object {
         private const val TAG = "MoreCallActionsDialog"
         private const val TEXT_SIZE = 20f
+        private const val EMOJI_WIDTH = 80
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/MoreCallActionsDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/MoreCallActionsDialog.kt
@@ -22,6 +22,7 @@ import com.nextcloud.talk.databinding.DialogMoreCallActionsBinding
 import com.nextcloud.talk.raisehand.viewmodel.RaiseHandViewModel
 import com.nextcloud.talk.ui.theme.ViewThemeUtils
 import com.nextcloud.talk.utils.CapabilitiesUtil
+import com.nextcloud.talk.utils.DisplayUtils
 import com.nextcloud.talk.viewmodels.CallRecordingViewModel
 import com.vanniktech.emoji.EmojiTextView
 import javax.inject.Inject
@@ -96,7 +97,7 @@ class MoreCallActionsDialog(private val callActivity: CallActivity) : BottomShee
                 capabilities?.spreedCapability?.config!!["call"]!!["supported-reactions"] as ArrayList<*>
 
             val param = LinearLayout.LayoutParams(
-                EMOJI_WIDTH,
+                DisplayUtils.convertDpToPixel(EMOJI_WIDTH.toFloat(), callActivity).toInt(),
                 LinearLayout.LayoutParams.MATCH_PARENT
             )
 
@@ -184,6 +185,6 @@ class MoreCallActionsDialog(private val callActivity: CallActivity) : BottomShee
     companion object {
         private const val TAG = "MoreCallActionsDialog"
         private const val TEXT_SIZE = 20f
-        private const val EMOJI_WIDTH = 80
+        private const val EMOJI_WIDTH = 40
     }
 }

--- a/app/src/main/res/layout/dialog_more_call_actions.xml
+++ b/app/src/main/res/layout/dialog_more_call_actions.xml
@@ -18,18 +18,26 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
-    <LinearLayout
-        android:id="@+id/call_emoji_bar"
+    <HorizontalScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
+        android:fadingEdgeLength="30dp"
         android:layout_marginStart="@dimen/standard_margin"
-        android:layout_marginTop="@dimen/standard_half_margin"
         android:layout_marginEnd="@dimen/standard_margin"
-        android:layout_marginBottom="@dimen/standard_half_margin"
-        android:gravity="center_vertical"
-        android:orientation="horizontal"
-        android:weightSum="10">
-    </LinearLayout>
+        android:requiresFadingEdge="horizontal"
+        android:scrollbars="none">
+
+        <LinearLayout
+            android:id="@+id/call_emoji_bar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/standard_half_margin"
+            android:layout_marginBottom="@dimen/standard_half_margin"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+        </LinearLayout>
+
+    </HorizontalScrollView>
 
     <TextView
         android:id="@+id/advanced_call_options_title"


### PR DESCRIPTION
As the number of provided emojis grew (from 10 to 12), there was a bug that only one emoji was shown.

Putting all 12 emojis in one fixed row would have been too close, so it's implemented to scroll them horizontally

🏚️ Before 

![grafik](https://github.com/user-attachments/assets/e26c37b7-429f-4ba4-804f-537eb453f0f6)

🏡 After

[A](https://github.com/user-attachments/assets/6dac5349-cbbb-47d1-b0e8-b1d1ed5468c7)



### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)