### PR TITLE
bump minSdkVersion to 26 and remove old checks

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,7 +34,7 @@ android {
     namespace 'com.nextcloud.talk'
 
     defaultConfig {
-        minSdkVersion 24
+        minSdkVersion 26
         targetSdkVersion 34
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/androidTest/java/com/nextcloud/talk/utils/VibrationUtilsTest.kt
+++ b/app/src/androidTest/java/com/nextcloud/talk/utils/VibrationUtilsTest.kt
@@ -7,7 +7,6 @@
 package com.nextcloud.talk.utils
 
 import android.content.Context
-import android.os.Build
 import android.os.VibrationEffect
 import android.os.Vibrator
 import org.junit.Before
@@ -34,8 +33,6 @@ class VibrationUtilsTest {
     @Test
     fun testVibrateShort() {
         VibrationUtils.vibrateShort(mockContext)
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             Mockito.verify(mockVibrator)
                 .vibrate(
                     VibrationEffect
@@ -44,8 +41,5 @@ class VibrationUtilsTest {
                             VibrationEffect.DEFAULT_AMPLITUDE
                         )
                 )
-        } else {
-            Mockito.verify(mockVibrator).vibrate(VibrationUtils.SHORT_VIBRATE)
-        }
     }
 }

--- a/app/src/androidTest/java/com/nextcloud/talk/utils/VibrationUtilsTest.kt
+++ b/app/src/androidTest/java/com/nextcloud/talk/utils/VibrationUtilsTest.kt
@@ -33,13 +33,13 @@ class VibrationUtilsTest {
     @Test
     fun testVibrateShort() {
         VibrationUtils.vibrateShort(mockContext)
-            Mockito.verify(mockVibrator)
-                .vibrate(
-                    VibrationEffect
-                        .createOneShot(
-                            VibrationUtils.SHORT_VIBRATE,
-                            VibrationEffect.DEFAULT_AMPLITUDE
-                        )
-                )
+        Mockito.verify(mockVibrator)
+            .vibrate(
+                VibrationEffect
+                    .createOneShot(
+                        VibrationUtils.SHORT_VIBRATE,
+                        VibrationEffect.DEFAULT_AMPLITUDE
+                    )
+            )
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/activities/BaseActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/BaseActivity.kt
@@ -11,7 +11,6 @@ package com.nextcloud.talk.activities
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
-import android.os.Build
 import android.os.Bundle
 import android.text.TextUtils
 import android.util.Log
@@ -21,7 +20,6 @@ import android.view.WindowManager
 import android.view.inputmethod.EditorInfo
 import android.webkit.SslErrorHandler
 import android.widget.EditText
-import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.res.ResourcesCompat
@@ -96,7 +94,7 @@ open class BaseActivity : AppCompatActivity() {
     public override fun onResume() {
         super.onResume()
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && appPreferences.isKeyboardIncognito) {
+        if (appPreferences.isKeyboardIncognito) {
             val viewGroup = (findViewById<View>(android.R.id.content) as ViewGroup).getChildAt(0) as ViewGroup
             disableKeyboardPersonalisedLearning(viewGroup)
         }
@@ -137,7 +135,6 @@ open class BaseActivity : AppCompatActivity() {
         }
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
     private fun disableKeyboardPersonalisedLearning(viewGroup: ViewGroup) {
         var view: View?
         var editText: EditText

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -47,7 +47,6 @@ import android.widget.FrameLayout
 import android.widget.RelativeLayout
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.DrawableRes
-import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AlertDialog
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.lifecycle.ViewModelProvider
@@ -3054,7 +3053,6 @@ class CallActivity : CallBaseActivity() {
         }
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
     override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: Configuration) {
         super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
         Log.d(TAG, "onPictureInPictureModeChanged")
@@ -3087,7 +3085,7 @@ class CallActivity : CallBaseActivity() {
     }
 
     private fun updatePictureInPictureActions(@DrawableRes iconId: Int, title: String?, requestCode: Int) {
-        if (isGreaterEqualOreo && isPipModePossible) {
+        if (isPipModePossible) {
             val actions = ArrayList<RemoteAction>()
             val icon = Icon.createWithResource(this, iconId)
             val intentFlag: Int = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {

--- a/app/src/main/java/com/nextcloud/talk/activities/CallBaseActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallBaseActivity.java
@@ -54,7 +54,7 @@ public abstract class CallBaseActivity extends BaseActivity {
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 
-        if (isGreaterEqualOreo() && isPipModePossible()) {
+        if (isPipModePossible()) {
             mPictureInPictureParamsBuilder = new PictureInPictureParams.Builder();
         }
 
@@ -118,7 +118,7 @@ public abstract class CallBaseActivity extends BaseActivity {
 
     void enterPipMode() {
         enableKeyguard();
-        if (isGreaterEqualOreo() && isPipModePossible()) {
+        if (isPipModePossible()) {
             Rational pipRatio = new Rational(300, 500);
             mPictureInPictureParamsBuilder.setAspectRatio(pipRatio);
             enterPictureInPictureMode(mPictureInPictureParamsBuilder.build());
@@ -131,7 +131,6 @@ public abstract class CallBaseActivity extends BaseActivity {
     }
 
     boolean isPipModePossible() {
-        if (isGreaterEqualOreo()) {
             boolean deviceHasPipFeature = getPackageManager().hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE);
 
             AppOpsManager appOpsManager = (AppOpsManager) getSystemService(Context.APP_OPS_SERVICE);
@@ -140,12 +139,6 @@ public abstract class CallBaseActivity extends BaseActivity {
                 android.os.Process.myUid(),
                 BuildConfig.APPLICATION_ID) == AppOpsManager.MODE_ALLOWED;
             return deviceHasPipFeature && isPipFeatureGranted;
-        }
-        return false;
-    }
-
-    boolean isGreaterEqualOreo(){
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O;
     }
 
     public abstract void updateUiForPipMode();

--- a/app/src/main/java/com/nextcloud/talk/adapters/items/ContactItem.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/ContactItem.kt
@@ -166,10 +166,7 @@ class ContactItem(
         }
     }
 
-    private fun setGenericAvatar(
-        holder: ContactItemViewHolder,
-        roundPlaceholderDrawable: Int
-    ) {
+    private fun setGenericAvatar(holder: ContactItemViewHolder, roundPlaceholderDrawable: Int) {
         val avatar =
             viewThemeUtils.talk.themePlaceholderAvatar(
                 holder.binding.avatarView,

--- a/app/src/main/java/com/nextcloud/talk/adapters/items/ContactItem.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/ContactItem.kt
@@ -8,7 +8,6 @@
  */
 package com.nextcloud.talk.adapters.items
 
-import android.os.Build
 import android.text.TextUtils
 import android.view.View
 import androidx.core.content.res.ResourcesCompat
@@ -136,9 +135,9 @@ class ContactItem(
         if (model.calculatedActorType == Participant.ActorType.GROUPS ||
             model.calculatedActorType == Participant.ActorType.CIRCLES
         ) {
-            setGenericAvatar(holder!!, R.drawable.ic_avatar_group, R.drawable.ic_circular_group)
+            setGenericAvatar(holder!!, R.drawable.ic_avatar_group)
         } else if (model.calculatedActorType == Participant.ActorType.EMAILS) {
-            setGenericAvatar(holder!!, R.drawable.ic_avatar_mail, R.drawable.ic_circular_mail)
+            setGenericAvatar(holder!!, R.drawable.ic_avatar_mail)
         } else if (model.calculatedActorType == Participant.ActorType.GUESTS ||
             model.type == Participant.ParticipantType.GUEST || model.type == Participant.ParticipantType.GUEST_MODERATOR
         ) {
@@ -169,17 +168,13 @@ class ContactItem(
 
     private fun setGenericAvatar(
         holder: ContactItemViewHolder,
-        roundPlaceholderDrawable: Int,
-        fallbackImageResource: Int
+        roundPlaceholderDrawable: Int
     ) {
-        val avatar = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        val avatar =
             viewThemeUtils.talk.themePlaceholderAvatar(
                 holder.binding.avatarView,
                 roundPlaceholderDrawable
             )
-        } else {
-            fallbackImageResource
-        }
 
         holder.binding.avatarView.loadUserAvatar(avatar)
     }

--- a/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.kt
@@ -194,12 +194,12 @@ class ConversationItem(
             }
 
             ConversationEnums.ObjectType.FILE -> {
-                    holder.binding.dialogAvatar.loadUserAvatar(
-                        viewThemeUtils.talk.themePlaceholderAvatar(
-                            holder.binding.dialogAvatar,
-                            R.drawable.ic_avatar_document
-                        )
+                holder.binding.dialogAvatar.loadUserAvatar(
+                    viewThemeUtils.talk.themePlaceholderAvatar(
+                        holder.binding.dialogAvatar,
+                        R.drawable.ic_avatar_document
                     )
+                )
 
                 false
             }

--- a/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.kt
@@ -13,7 +13,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.Typeface
-import android.os.Build
 import android.text.TextUtils
 import android.text.format.DateUtils
 import android.view.View
@@ -195,18 +194,13 @@ class ConversationItem(
             }
 
             ConversationEnums.ObjectType.FILE -> {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                     holder.binding.dialogAvatar.loadUserAvatar(
                         viewThemeUtils.talk.themePlaceholderAvatar(
                             holder.binding.dialogAvatar,
                             R.drawable.ic_avatar_document
                         )
                     )
-                } else {
-                    holder.binding.dialogAvatar.loadUserAvatar(
-                        R.drawable.ic_circular_document
-                    )
-                }
+
                 false
             }
 

--- a/app/src/main/java/com/nextcloud/talk/adapters/items/MentionAutocompleteItem.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/MentionAutocompleteItem.kt
@@ -10,7 +10,6 @@ package com.nextcloud.talk.adapters.items
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.os.Build
 import android.view.View
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.res.ResourcesCompat
@@ -117,30 +116,22 @@ class MentionAutocompleteItem(
             SOURCE_CALLS -> {
                 run {}
                 run {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                         holder.binding.avatarView.loadUserAvatar(
                             viewThemeUtils.talk.themePlaceholderAvatar(
                                 holder.binding.avatarView,
                                 R.drawable.ic_avatar_group
                             )
                         )
-                    } else {
-                        holder.binding.avatarView.loadUserAvatar(R.drawable.ic_circular_group)
-                    }
                 }
             }
 
             SOURCE_GROUPS -> {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                     holder.binding.avatarView.loadUserAvatar(
                         viewThemeUtils.talk.themePlaceholderAvatar(
                             holder.binding.avatarView,
                             R.drawable.ic_avatar_group
                         )
                     )
-                } else {
-                    holder.binding.avatarView.loadUserAvatar(R.drawable.ic_circular_group)
-                }
             }
 
             SOURCE_FEDERATION -> {

--- a/app/src/main/java/com/nextcloud/talk/adapters/items/MentionAutocompleteItem.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/MentionAutocompleteItem.kt
@@ -116,22 +116,22 @@ class MentionAutocompleteItem(
             SOURCE_CALLS -> {
                 run {}
                 run {
-                        holder.binding.avatarView.loadUserAvatar(
-                            viewThemeUtils.talk.themePlaceholderAvatar(
-                                holder.binding.avatarView,
-                                R.drawable.ic_avatar_group
-                            )
-                        )
-                }
-            }
-
-            SOURCE_GROUPS -> {
                     holder.binding.avatarView.loadUserAvatar(
                         viewThemeUtils.talk.themePlaceholderAvatar(
                             holder.binding.avatarView,
                             R.drawable.ic_avatar_group
                         )
                     )
+                }
+            }
+
+            SOURCE_GROUPS -> {
+                holder.binding.avatarView.loadUserAvatar(
+                    viewThemeUtils.talk.themePlaceholderAvatar(
+                        holder.binding.avatarView,
+                        R.drawable.ic_avatar_group
+                    )
+                )
             }
 
             SOURCE_FEDERATION -> {

--- a/app/src/main/java/com/nextcloud/talk/callnotification/CallNotificationActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/callnotification/CallNotificationActivity.kt
@@ -10,13 +10,11 @@ package com.nextcloud.talk.callnotification
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.content.res.Configuration
-import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import android.view.View
-import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationManagerCompat
 import autodagger.AutoInjector
 import com.nextcloud.talk.R
@@ -215,7 +213,6 @@ class CallNotificationActivity : CallBaseActivity() {
         super.onDestroy()
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
     override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: Configuration) {
         super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
         isInPipMode = isInPictureInPictureMode

--- a/app/src/main/java/com/nextcloud/talk/chat/data/io/AudioFocusRequestManager.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/io/AudioFocusRequestManager.kt
@@ -13,8 +13,6 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.media.AudioFocusRequest
 import android.media.AudioManager
-import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 
@@ -61,7 +59,6 @@ class AudioFocusRequestManager(private val context: Context) {
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.O)
     private val focusRequest = AudioFocusRequest.Builder(duration)
         .setOnAudioFocusChangeListener(audioFocusChangeListener)
         .build()
@@ -75,19 +72,13 @@ class AudioFocusRequestManager(private val context: Context) {
             return
         }
 
-        val isGranted: Int = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        val isGranted: Int =
             if (shouldRequestFocus) {
                 audioManager.requestAudioFocus(focusRequest)
             } else {
                 audioManager.abandonAudioFocusRequest(focusRequest)
             }
-        } else {
-            if (shouldRequestFocus) {
-                audioManager.requestAudioFocus(audioFocusChangeListener, AudioManager.STREAM_MUSIC, duration)
-            } else {
-                audioManager.abandonAudioFocus(audioFocusChangeListener)
-            }
-        }
+
         if (isGranted == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
             onGranted()
             handleBecomingNoisyBroadcast(shouldRequestFocus)

--- a/app/src/main/java/com/nextcloud/talk/contacts/ContactsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/contacts/ContactsActivity.kt
@@ -13,7 +13,6 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.PorterDuff
 import android.graphics.drawable.ColorDrawable
-import android.os.Build
 import android.os.Bundle
 import android.text.InputType
 import android.util.Log
@@ -414,9 +413,7 @@ class ContactsActivity :
             searchView!!.maxWidth = Int.MAX_VALUE
             searchView!!.inputType = InputType.TYPE_TEXT_VARIATION_FILTER
             var imeOptions: Int = EditorInfo.IME_ACTION_DONE or EditorInfo.IME_FLAG_NO_FULLSCREEN
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
-                appPreferences.isKeyboardIncognito == true
-            ) {
+            if (appPreferences.isKeyboardIncognito == true) {
                 imeOptions = imeOptions or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
             }
             searchView!!.imeOptions = imeOptions

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -551,7 +551,7 @@ class ConversationsListActivity :
             searchView!!.maxWidth = Int.MAX_VALUE
             searchView!!.inputType = InputType.TYPE_TEXT_VARIATION_FILTER
             var imeOptions = EditorInfo.IME_ACTION_DONE or EditorInfo.IME_FLAG_NO_FULLSCREEN
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && appPreferences.isKeyboardIncognito) {
+            if (appPreferences.isKeyboardIncognito) {
                 imeOptions = imeOptions or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
             }
             searchView!!.imeOptions = imeOptions

--- a/app/src/main/java/com/nextcloud/talk/extensions/ImageViewExtensions.kt
+++ b/app/src/main/java/com/nextcloud/talk/extensions/ImageViewExtensions.kt
@@ -206,11 +206,10 @@ fun ImageView.loadThumbnail(url: String, user: User): io.reactivex.disposables.D
         .target(this)
         .transformations(CircleCropTransformation())
 
-
-        val layers = arrayOfNulls<Drawable>(2)
-        layers[0] = ContextCompat.getDrawable(context, R.drawable.ic_launcher_background)
-        layers[1] = ContextCompat.getDrawable(context, R.drawable.ic_launcher_foreground)
-        requestBuilder.placeholder(LayerDrawable(layers))
+    val layers = arrayOfNulls<Drawable>(2)
+    layers[0] = ContextCompat.getDrawable(context, R.drawable.ic_launcher_background)
+    layers[1] = ContextCompat.getDrawable(context, R.drawable.ic_launcher_foreground)
+    requestBuilder.placeholder(LayerDrawable(layers))
 
     if (url.startsWith(user.baseUrl!!) &&
         (url.contains("index.php/core/preview") || url.contains("/avatar/"))
@@ -271,12 +270,11 @@ fun ImageView.loadUserAvatar(any: Any?): io.reactivex.disposables.Disposable {
 }
 
 fun ImageView.loadSystemAvatar(): io.reactivex.disposables.Disposable {
-
-        val layers = arrayOfNulls<Drawable>(2)
-        layers[0] = ContextCompat.getDrawable(context, R.drawable.ic_launcher_background)
-        layers[1] = ContextCompat.getDrawable(context, R.drawable.ic_launcher_foreground)
-        val layerDrawable = LayerDrawable(layers)
-        val data: Any  = layerDrawable
+    val layers = arrayOfNulls<Drawable>(2)
+    layers[0] = ContextCompat.getDrawable(context, R.drawable.ic_launcher_background)
+    layers[1] = ContextCompat.getDrawable(context, R.drawable.ic_launcher_foreground)
+    val layerDrawable = LayerDrawable(layers)
+    val data: Any = layerDrawable
 
     return DisposableWrapper(
         load(data) {
@@ -286,13 +284,11 @@ fun ImageView.loadSystemAvatar(): io.reactivex.disposables.Disposable {
 }
 
 fun ImageView.loadNoteToSelfAvatar(): io.reactivex.disposables.Disposable {
-
-        val layers = arrayOfNulls<Drawable>(2)
-        layers[0] = ContextCompat.getDrawable(context, R.drawable.ic_launcher_background)
-        layers[1] = ContextCompat.getDrawable(context, R.drawable.ic_note_to_self)
-        val layerDrawable = LayerDrawable(layers)
-         val data: Any = layerDrawable
-
+    val layers = arrayOfNulls<Drawable>(2)
+    layers[0] = ContextCompat.getDrawable(context, R.drawable.ic_launcher_background)
+    layers[1] = ContextCompat.getDrawable(context, R.drawable.ic_note_to_self)
+    val layerDrawable = LayerDrawable(layers)
+    val data: Any = layerDrawable
 
     return DisposableWrapper(
         load(data) {
@@ -306,12 +302,11 @@ fun ImageView.loadChangelogBotAvatar(): io.reactivex.disposables.Disposable {
 }
 
 fun ImageView.loadBotsAvatar(): io.reactivex.disposables.Disposable {
-
-        val layers = arrayOfNulls<Drawable>(2)
-        layers[0] = ColorDrawable(context.getColor(R.color.black))
-        layers[1] = TextDrawable(context, ">")
-        val layerDrawable = LayerDrawable(layers)
-        val data: Any  = layerDrawable
+    val layers = arrayOfNulls<Drawable>(2)
+    layers[0] = ColorDrawable(context.getColor(R.color.black))
+    layers[1] = TextDrawable(context, ">")
+    val layerDrawable = LayerDrawable(layers)
+    val data: Any = layerDrawable
 
     return DisposableWrapper(
         load(data) {

--- a/app/src/main/java/com/nextcloud/talk/extensions/ImageViewExtensions.kt
+++ b/app/src/main/java/com/nextcloud/talk/extensions/ImageViewExtensions.kt
@@ -13,7 +13,6 @@ package com.nextcloud.talk.extensions
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.LayerDrawable
-import android.os.Build
 import android.util.Log
 import android.widget.ImageView
 import androidx.core.content.ContextCompat
@@ -27,9 +26,9 @@ import coil.result
 import coil.transform.CircleCropTransformation
 import coil.transform.RoundedCornersTransformation
 import com.nextcloud.talk.R
+import com.nextcloud.talk.chat.data.model.ChatMessage
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.models.domain.ConversationModel
-import com.nextcloud.talk.chat.data.model.ChatMessage
 import com.nextcloud.talk.models.json.conversations.Conversation
 import com.nextcloud.talk.models.json.conversations.ConversationEnums
 import com.nextcloud.talk.ui.theme.ViewThemeUtils
@@ -207,14 +206,11 @@ fun ImageView.loadThumbnail(url: String, user: User): io.reactivex.disposables.D
         .target(this)
         .transformations(CircleCropTransformation())
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+
         val layers = arrayOfNulls<Drawable>(2)
         layers[0] = ContextCompat.getDrawable(context, R.drawable.ic_launcher_background)
         layers[1] = ContextCompat.getDrawable(context, R.drawable.ic_launcher_foreground)
         requestBuilder.placeholder(LayerDrawable(layers))
-    } else {
-        requestBuilder.placeholder(R.mipmap.ic_launcher)
-    }
 
     if (url.startsWith(user.baseUrl!!) &&
         (url.contains("index.php/core/preview") || url.contains("/avatar/"))
@@ -275,15 +271,12 @@ fun ImageView.loadUserAvatar(any: Any?): io.reactivex.disposables.Disposable {
 }
 
 fun ImageView.loadSystemAvatar(): io.reactivex.disposables.Disposable {
-    val data: Any = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+
         val layers = arrayOfNulls<Drawable>(2)
         layers[0] = ContextCompat.getDrawable(context, R.drawable.ic_launcher_background)
         layers[1] = ContextCompat.getDrawable(context, R.drawable.ic_launcher_foreground)
         val layerDrawable = LayerDrawable(layers)
-        layerDrawable
-    } else {
-        R.mipmap.ic_launcher
-    }
+        val data: Any  = layerDrawable
 
     return DisposableWrapper(
         load(data) {
@@ -293,15 +286,13 @@ fun ImageView.loadSystemAvatar(): io.reactivex.disposables.Disposable {
 }
 
 fun ImageView.loadNoteToSelfAvatar(): io.reactivex.disposables.Disposable {
-    val data: Any = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+
         val layers = arrayOfNulls<Drawable>(2)
         layers[0] = ContextCompat.getDrawable(context, R.drawable.ic_launcher_background)
         layers[1] = ContextCompat.getDrawable(context, R.drawable.ic_note_to_self)
         val layerDrawable = LayerDrawable(layers)
-        layerDrawable
-    } else {
-        R.mipmap.ic_launcher
-    }
+         val data: Any = layerDrawable
+
 
     return DisposableWrapper(
         load(data) {
@@ -315,15 +306,12 @@ fun ImageView.loadChangelogBotAvatar(): io.reactivex.disposables.Disposable {
 }
 
 fun ImageView.loadBotsAvatar(): io.reactivex.disposables.Disposable {
-    val data: Any = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+
         val layers = arrayOfNulls<Drawable>(2)
         layers[0] = ColorDrawable(context.getColor(R.color.black))
         layers[1] = TextDrawable(context, ">")
         val layerDrawable = LayerDrawable(layers)
-        layerDrawable
-    } else {
-        R.mipmap.ic_launcher
-    }
+        val data: Any  = layerDrawable
 
     return DisposableWrapper(
         load(data) {
@@ -333,29 +321,17 @@ fun ImageView.loadBotsAvatar(): io.reactivex.disposables.Disposable {
 }
 
 fun ImageView.loadDefaultGroupCallAvatar(viewThemeUtils: ViewThemeUtils): io.reactivex.disposables.Disposable {
-    val data: Any = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        viewThemeUtils.talk.themePlaceholderAvatar(this, R.drawable.ic_avatar_group) as Any
-    } else {
-        R.drawable.ic_circular_group
-    }
+    val data: Any = viewThemeUtils.talk.themePlaceholderAvatar(this, R.drawable.ic_avatar_group) as Any
     return loadUserAvatar(data)
 }
 
 fun ImageView.loadDefaultPublicCallAvatar(viewThemeUtils: ViewThemeUtils): io.reactivex.disposables.Disposable {
-    val data: Any = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        viewThemeUtils.talk.themePlaceholderAvatar(this, R.drawable.ic_avatar_link) as Any
-    } else {
-        R.drawable.ic_circular_link
-    }
+    val data: Any = viewThemeUtils.talk.themePlaceholderAvatar(this, R.drawable.ic_avatar_link) as Any
     return loadUserAvatar(data)
 }
 
 fun ImageView.loadMailAvatar(viewThemeUtils: ViewThemeUtils): io.reactivex.disposables.Disposable {
-    val data: Any = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        viewThemeUtils.talk.themePlaceholderAvatar(this, R.drawable.ic_avatar_mail) as Any
-    } else {
-        R.drawable.ic_circular_mail
-    }
+    val data: Any = viewThemeUtils.talk.themePlaceholderAvatar(this, R.drawable.ic_avatar_mail) as Any
     return loadUserAvatar(data)
 }
 

--- a/app/src/main/java/com/nextcloud/talk/jobs/AccountRemovalWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/AccountRemovalWorker.java
@@ -9,9 +9,7 @@ package com.nextcloud.talk.jobs;
 
 import android.app.NotificationManager;
 import android.content.Context;
-import android.os.Build;
 import android.util.Log;
-
 import com.nextcloud.talk.R;
 import com.nextcloud.talk.api.NcApi;
 import com.nextcloud.talk.application.NextcloudTalkApplication;
@@ -146,7 +144,6 @@ public class AccountRemovalWorker extends Worker {
 
                     @Override
                     public void onNext(Void aVoid) {
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                             String groupName = String.format(
                                 getApplicationContext()
                                     .getResources()
@@ -161,7 +158,6 @@ public class AccountRemovalWorker extends Worker {
                                 notificationManager.deleteNotificationChannelGroup(
                                     Long.toString(crc32.getValue()));
                             }
-                        }
 
                         initiateUserDeletion(user);
                     }

--- a/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.kt
@@ -535,18 +535,18 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
 
         notificationBuilder.setExtras(notificationInfoBundle)
 
-            when (pushMessage.type) {
-                TYPE_CHAT,
-                TYPE_ROOM,
-                TYPE_RECORDING,
-                TYPE_REMINDER,
-                TYPE_ADMIN_NOTIFICATIONS,
-                TYPE_REMOTE_TALK_SHARE -> {
-                    notificationBuilder.setChannelId(
-                        NotificationUtils.NotificationChannels.NOTIFICATION_CHANNEL_MESSAGES_V4.name
-                    )
-                }
+        when (pushMessage.type) {
+            TYPE_CHAT,
+            TYPE_ROOM,
+            TYPE_RECORDING,
+            TYPE_REMINDER,
+            TYPE_ADMIN_NOTIFICATIONS,
+            TYPE_REMOTE_TALK_SHARE -> {
+                notificationBuilder.setChannelId(
+                    NotificationUtils.NotificationChannels.NOTIFICATION_CHANNEL_MESSAGES_V4.name
+                )
             }
+        }
 
         notificationBuilder.setContentIntent(pendingIntent)
         val groupName = signatureVerification.user!!.id.toString() + "@" + pushMessage.id

--- a/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.kt
@@ -836,8 +836,6 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
         }
         notificationManager.notify(notificationId, notification)
 
-        // On devices with Android 8.0 (Oreo) or later, notification sound will be handled by the system
-        // if notifications have not been disabled by the user.
         return
     }
 

--- a/app/src/main/java/com/nextcloud/talk/location/GeocodingActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/location/GeocodingActivity.kt
@@ -10,7 +10,6 @@ import android.app.SearchManager
 import android.content.Context
 import android.content.Intent
 import android.graphics.drawable.ColorDrawable
-import android.os.Build
 import android.os.Bundle
 import android.text.InputType
 import android.util.Log
@@ -174,7 +173,7 @@ class GeocodingActivity :
             searchView?.maxWidth = Int.MAX_VALUE
             searchView?.inputType = InputType.TYPE_TEXT_VARIATION_FILTER
             var imeOptions = EditorInfo.IME_ACTION_DONE or EditorInfo.IME_FLAG_NO_FULLSCREEN
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && appPreferences.isKeyboardIncognito) {
+            if (appPreferences.isKeyboardIncognito) {
                 imeOptions = imeOptions or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
             }
             searchView?.imeOptions = imeOptions

--- a/app/src/main/java/com/nextcloud/talk/location/LocationPickerActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/location/LocationPickerActivity.kt
@@ -17,7 +17,6 @@ import android.graphics.drawable.ColorDrawable
 import android.location.Location
 import android.location.LocationListener
 import android.location.LocationManager
-import android.os.Build
 import android.os.Bundle
 import android.text.InputType
 import android.util.Log
@@ -217,7 +216,7 @@ class LocationPickerActivity :
             searchView?.maxWidth = Int.MAX_VALUE
             searchView?.inputType = InputType.TYPE_TEXT_VARIATION_FILTER
             var imeOptions = EditorInfo.IME_ACTION_DONE or EditorInfo.IME_FLAG_NO_FULLSCREEN
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && appPreferences!!.isKeyboardIncognito) {
+            if (appPreferences!!.isKeyboardIncognito) {
                 imeOptions = imeOptions or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
             }
             searchView?.imeOptions = imeOptions

--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -256,8 +256,8 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
 
     private fun setupNotificationSettings() {
         binding.settingsNotificationsTitle.text = resources!!.getString(
-                R.string.nc_settings_notification_sounds_post_oreo
-            )
+            R.string.nc_settings_notification_sounds_post_oreo
+        )
         setupNotificationSoundsSettings()
         setupNotificationPermissionSettings()
     }
@@ -359,26 +359,25 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
             binding.messagesRingtone.text = resources!!.getString(R.string.nc_common_disabled)
         }
 
-            binding.settingsCallSound.setOnClickListener {
-                val intent = Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS)
-                intent.putExtra(Settings.EXTRA_APP_PACKAGE, BuildConfig.APPLICATION_ID)
-                intent.putExtra(
-                    Settings.EXTRA_CHANNEL_ID,
-                    NotificationUtils.NotificationChannels.NOTIFICATION_CHANNEL_CALLS_V4.name
-                )
+        binding.settingsCallSound.setOnClickListener {
+            val intent = Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS)
+            intent.putExtra(Settings.EXTRA_APP_PACKAGE, BuildConfig.APPLICATION_ID)
+            intent.putExtra(
+                Settings.EXTRA_CHANNEL_ID,
+                NotificationUtils.NotificationChannels.NOTIFICATION_CHANNEL_CALLS_V4.name
+            )
 
-                startActivity(intent)
-            }
-            binding.settingsMessageSound.setOnClickListener {
-                val intent = Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS)
-                intent.putExtra(Settings.EXTRA_APP_PACKAGE, BuildConfig.APPLICATION_ID)
-                intent.putExtra(
-                    Settings.EXTRA_CHANNEL_ID,
-                    NotificationUtils.NotificationChannels.NOTIFICATION_CHANNEL_MESSAGES_V4.name
-                )
-                startActivity(intent)
-            }
-
+            startActivity(intent)
+        }
+        binding.settingsMessageSound.setOnClickListener {
+            val intent = Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS)
+            intent.putExtra(Settings.EXTRA_APP_PACKAGE, BuildConfig.APPLICATION_ID)
+            intent.putExtra(
+                Settings.EXTRA_CHANNEL_ID,
+                NotificationUtils.NotificationChannels.NOTIFICATION_CHANNEL_MESSAGES_V4.name
+            )
+            startActivity(intent)
+        }
     }
 
     private fun setTroubleshootingClickListenersIfNecessary() {
@@ -860,9 +859,7 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
     private fun setupCheckables() {
         binding.settingsScreenSecuritySwitch.isChecked = appPreferences.isScreenSecured
 
-
-            binding.settingsIncognitoKeyboardSwitch.isChecked = appPreferences.isKeyboardIncognito
-
+        binding.settingsIncognitoKeyboardSwitch.isChecked = appPreferences.isKeyboardIncognito
 
         if (CapabilitiesUtil.isReadStatusAvailable(currentUser!!.capabilities!!.spreedCapability!!)) {
             binding.settingsReadPrivacySwitch.isChecked = !CapabilitiesUtil.isReadStatusPrivate(currentUser!!)

--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -146,10 +146,6 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
 
         setupLicenceSetting()
 
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            binding.settingsIncognitoKeyboard.visibility = View.GONE
-        }
-
         binding.settingsScreenLockSummary.text = String.format(
             Locale.getDefault(),
             resources!!.getString(R.string.nc_settings_screen_lock_desc),
@@ -259,11 +255,9 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
     }
 
     private fun setupNotificationSettings() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            binding.settingsNotificationsTitle.text = resources!!.getString(
+        binding.settingsNotificationsTitle.text = resources!!.getString(
                 R.string.nc_settings_notification_sounds_post_oreo
             )
-        }
         setupNotificationSoundsSettings()
         setupNotificationPermissionSettings()
     }
@@ -365,7 +359,6 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
             binding.messagesRingtone.text = resources!!.getString(R.string.nc_common_disabled)
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             binding.settingsCallSound.setOnClickListener {
                 val intent = Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS)
                 intent.putExtra(Settings.EXTRA_APP_PACKAGE, BuildConfig.APPLICATION_ID)
@@ -385,9 +378,7 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
                 )
                 startActivity(intent)
             }
-        } else {
-            Log.w(TAG, "setupSoundSettings currently not supported for versions < Build.VERSION_CODES.O")
-        }
+
     }
 
     private fun setTroubleshootingClickListenersIfNecessary() {
@@ -869,11 +860,9 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
     private fun setupCheckables() {
         binding.settingsScreenSecuritySwitch.isChecked = appPreferences.isScreenSecured
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+
             binding.settingsIncognitoKeyboardSwitch.isChecked = appPreferences.isKeyboardIncognito
-        } else {
-            binding.settingsIncognitoKeyboardSwitch.visibility = View.GONE
-        }
+
 
         if (CapabilitiesUtil.isReadStatusAvailable(currentUser!!.capabilities!!.spreedCapability!!)) {
             binding.settingsReadPrivacySwitch.isChecked = !CapabilitiesUtil.isReadStatusPrivate(currentUser!!)

--- a/app/src/main/java/com/nextcloud/talk/ui/theme/TalkSpecificViewThemeUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/theme/TalkSpecificViewThemeUtils.kt
@@ -8,7 +8,6 @@
 package com.nextcloud.talk.ui.theme
 
 import android.annotation.SuppressLint
-import android.annotation.TargetApi
 import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.PorterDuff
@@ -16,7 +15,6 @@ import android.graphics.PorterDuffColorFilter
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.LayerDrawable
-import android.os.Build
 import android.text.Spannable
 import android.text.Spanned
 import android.text.style.ForegroundColorSpan
@@ -203,7 +201,6 @@ class TalkSpecificViewThemeUtils @Inject constructor(
         }
     }
 
-    @TargetApi(Build.VERSION_CODES.O)
     fun themePlaceholderAvatar(avatar: View, @DrawableRes foreground: Int): Drawable? {
         var drawable: LayerDrawable? = null
         withScheme(avatar) { scheme ->

--- a/app/src/main/java/com/nextcloud/talk/upload/chunked/ChunkedFileUploader.kt
+++ b/app/src/main/java/com/nextcloud/talk/upload/chunked/ChunkedFileUploader.kt
@@ -263,7 +263,6 @@ class ChunkedFileUploader(
         }
     }
 
-    // @RequiresApi(Build.VERSION_CODES.O)
     private fun initHttpClient(okHttpClient: OkHttpClient, currentUser: User) {
         val okHttpClientBuilder: OkHttpClient.Builder = okHttpClient.newBuilder()
         okHttpClientBuilder.followRedirects(false)

--- a/app/src/main/java/com/nextcloud/talk/utils/DisplayUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/DisplayUtils.kt
@@ -21,7 +21,6 @@ import android.graphics.Color
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.net.Uri
-import android.os.Build
 import android.text.Spannable
 import android.text.SpannableString
 import android.text.Spanned
@@ -346,12 +345,10 @@ object DisplayUtils {
         if (window != null) {
             val decor = window.decorView
             if (isLightTheme) {
-                val systemUiFlagLightStatusBar: Int = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val systemUiFlagLightStatusBar: Int =
                     View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR or
                         View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
-                } else {
-                    View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
-                }
+
                 decor.systemUiVisibility = systemUiFlagLightStatusBar
             } else {
                 decor.systemUiVisibility = 0

--- a/app/src/main/java/com/nextcloud/talk/utils/FileUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/FileUtils.kt
@@ -98,12 +98,7 @@ object FileUtils {
     fun copyFileToCache(context: Context, sourceFileUri: Uri, filename: String): File? {
         val cachedFile = File(context.cacheDir, filename)
 
-        val aboveOrEqualAPI26Check =
-            !cachedFile.toPath().normalize().startsWith(context.cacheDir.toPath())
-
-        val isOutsideCacheDir = aboveOrEqualAPI26Check
-
-        if (isOutsideCacheDir) {
+        if (!cachedFile.toPath().normalize().startsWith(context.cacheDir.toPath())) {
             Log.w(TAG, "cachedFile was not created in cacheDir. Aborting for security reasons.")
             cachedFile.delete()
             return null

--- a/app/src/main/java/com/nextcloud/talk/utils/FileUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/FileUtils.kt
@@ -99,8 +99,7 @@ object FileUtils {
         val cachedFile = File(context.cacheDir, filename)
 
         val aboveOrEqualAPI26Check =
-                !cachedFile.toPath().normalize().startsWith(context.cacheDir.toPath())
-
+            !cachedFile.toPath().normalize().startsWith(context.cacheDir.toPath())
 
         val isOutsideCacheDir = aboveOrEqualAPI26Check
 

--- a/app/src/main/java/com/nextcloud/talk/utils/FileUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/FileUtils.kt
@@ -13,7 +13,6 @@ import android.content.ContentResolver
 import android.content.Context
 import android.database.Cursor
 import android.net.Uri
-import android.os.Build
 import android.provider.OpenableColumns
 import android.util.Log
 import java.io.File
@@ -100,14 +99,10 @@ object FileUtils {
         val cachedFile = File(context.cacheDir, filename)
 
         val aboveOrEqualAPI26Check =
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
                 !cachedFile.toPath().normalize().startsWith(context.cacheDir.toPath())
 
-        val belowAPI26Check =
-            Build.VERSION.SDK_INT < Build.VERSION_CODES.O &&
-                !cachedFile.canonicalPath.startsWith(context.cacheDir.canonicalPath, true)
 
-        val isOutsideCacheDir = aboveOrEqualAPI26Check || belowAPI26Check
+        val isOutsideCacheDir = aboveOrEqualAPI26Check
 
         if (isOutsideCacheDir) {
             Log.w(TAG, "cachedFile was not created in cacheDir. Aborting for security reasons.")

--- a/app/src/main/java/com/nextcloud/talk/utils/ImageEmojiEditText.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/ImageEmojiEditText.kt
@@ -8,7 +8,6 @@ package com.nextcloud.talk.utils
 
 import android.content.Context
 import android.net.Uri
-import android.os.Build
 import android.util.AttributeSet
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
@@ -42,7 +41,7 @@ class ImageEmojiEditText : EmojiEditText {
             InputConnectionCompat.OnCommitContentListener { inputContentInfo, flags, _ ->
 
                 val lacksPermission = (flags and InputConnectionCompat.INPUT_CONTENT_GRANT_READ_URI_PERMISSION) != 0
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1 && lacksPermission) {
+                if (lacksPermission) {
                     try {
                         inputContentInfo.requestPermission()
                     } catch (e: Exception) {

--- a/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
@@ -54,7 +54,6 @@ object NotificationUtils {
     const val KEY_UPLOAD_GROUP = "com.nextcloud.talk.utils.KEY_UPLOAD_GROUP"
     const val GROUP_SUMMARY_NOTIFICATION_ID = -1
 
-
     private fun createNotificationChannel(
         context: Context,
         notificationChannel: Channel,
@@ -151,29 +150,26 @@ object NotificationUtils {
     }
 
     fun removeOldNotificationChannels(context: Context) {
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
-            val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        // Current version does not use notification channel groups - delete all groups
+        for (channelGroup in notificationManager.notificationChannelGroups) {
+            notificationManager.deleteNotificationChannelGroup(channelGroup.id)
+        }
 
-            // Current version does not use notification channel groups - delete all groups
-            for (channelGroup in notificationManager.notificationChannelGroups) {
-                notificationManager.deleteNotificationChannelGroup(channelGroup.id)
+        val channelsToKeep = NotificationChannels.values().map { it.name }
+
+        // Delete all notification channels created by previous versions
+        for (channel in notificationManager.notificationChannels) {
+            if (!channelsToKeep.contains(channel.id)) {
+                notificationManager.deleteNotificationChannel(channel.id)
             }
-
-            val channelsToKeep = NotificationChannels.values().map { it.name }
-
-            // Delete all notification channels created by previous versions
-            for (channel in notificationManager.notificationChannels) {
-                if (!channelsToKeep.contains(channel.id)) {
-                    notificationManager.deleteNotificationChannel(channel.id)
-                }
-            }
-
+        }
     }
 
-
     private fun getNotificationChannel(context: Context, channelId: String): NotificationChannel? {
-            val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-            return notificationManager.getNotificationChannel(channelId)
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        return notificationManager.getNotificationChannel(channelId)
     }
 
     private inline fun scanNotifications(
@@ -283,13 +279,12 @@ object NotificationUtils {
         defaultRingtoneUri: String,
         channelId: String
     ): Uri? {
-
-            val channel = getNotificationChannel(context, channelId)
-            if (channel != null) {
-                return channel.sound
-            }
-            // Notification channel will not be available when starting the application for the first time.
-            // Ringtone uris are required to register the notification channels -> get uri from preferences.
+        val channel = getNotificationChannel(context, channelId)
+        if (channel != null) {
+            return channel.sound
+        }
+        // Notification channel will not be available when starting the application for the first time.
+        // Ringtone uris are required to register the notification channels -> get uri from preferences.
 
         return if (TextUtils.isEmpty(ringtonePreferencesString)) {
             Uri.parse(defaultRingtoneUri)

--- a/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
@@ -7,7 +7,6 @@
  */
 package com.nextcloud.talk.utils
 
-import android.annotation.TargetApi
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -15,11 +14,9 @@ import android.content.Context
 import android.graphics.drawable.BitmapDrawable
 import android.media.AudioAttributes
 import android.net.Uri
-import android.os.Build
 import android.service.notification.StatusBarNotification
 import android.text.TextUtils
 import android.util.Log
-import androidx.core.app.NotificationManagerCompat
 import androidx.core.graphics.drawable.IconCompat
 import coil.executeBlocking
 import coil.imageLoader
@@ -57,7 +54,7 @@ object NotificationUtils {
     const val KEY_UPLOAD_GROUP = "com.nextcloud.talk.utils.KEY_UPLOAD_GROUP"
     const val GROUP_SUMMARY_NOTIFICATION_ID = -1
 
-    @TargetApi(Build.VERSION_CODES.O)
+
     private fun createNotificationChannel(
         context: Context,
         notificationChannel: Channel,
@@ -67,7 +64,6 @@ object NotificationUtils {
         val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
         if (
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
             notificationManager.getNotificationChannel(notificationChannel.id) == null
         ) {
             val importance = if (notificationChannel.isImportant) {
@@ -154,9 +150,8 @@ object NotificationUtils {
         createUploadsNotificationChannel(context)
     }
 
-    @TargetApi(Build.VERSION_CODES.O)
     fun removeOldNotificationChannels(context: Context) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+
             val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
             // Current version does not use notification channel groups - delete all groups
@@ -172,16 +167,13 @@ object NotificationUtils {
                     notificationManager.deleteNotificationChannel(channel.id)
                 }
             }
-        }
+
     }
 
-    @TargetApi(Build.VERSION_CODES.O)
+
     private fun getNotificationChannel(context: Context, channelId: String): NotificationChannel? {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
             return notificationManager.getNotificationChannel(channelId)
-        }
-        return null
     }
 
     private inline fun scanNotifications(
@@ -268,7 +260,7 @@ object NotificationUtils {
     fun isCallsNotificationChannelEnabled(context: Context): Boolean {
         val channel = getNotificationChannel(context, NotificationChannels.NOTIFICATION_CHANNEL_CALLS_V4.name)
         if (channel != null) {
-            return isNotificationChannelEnabled(context, channel)
+            return isNotificationChannelEnabled(channel)
         }
         return false
     }
@@ -276,17 +268,13 @@ object NotificationUtils {
     fun isMessagesNotificationChannelEnabled(context: Context): Boolean {
         val channel = getNotificationChannel(context, NotificationChannels.NOTIFICATION_CHANNEL_MESSAGES_V4.name)
         if (channel != null) {
-            return isNotificationChannelEnabled(context, channel)
+            return isNotificationChannelEnabled(channel)
         }
         return false
     }
 
-    private fun isNotificationChannelEnabled(context: Context, channel: NotificationChannel): Boolean {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            channel.importance != NotificationManager.IMPORTANCE_NONE
-        } else {
-            NotificationManagerCompat.from(context).areNotificationsEnabled()
-        }
+    private fun isNotificationChannelEnabled(channel: NotificationChannel): Boolean {
+        return channel.importance != NotificationManager.IMPORTANCE_NONE
     }
 
     private fun getRingtoneUri(
@@ -295,14 +283,14 @@ object NotificationUtils {
         defaultRingtoneUri: String,
         channelId: String
     ): Uri? {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+
             val channel = getNotificationChannel(context, channelId)
             if (channel != null) {
                 return channel.sound
             }
             // Notification channel will not be available when starting the application for the first time.
             // Ringtone uris are required to register the notification channels -> get uri from preferences.
-        }
+
         return if (TextUtils.isEmpty(ringtonePreferencesString)) {
             Uri.parse(defaultRingtoneUri)
         } else {

--- a/app/src/main/java/com/nextcloud/talk/utils/VibrationUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/VibrationUtils.kt
@@ -7,7 +7,6 @@
 package com.nextcloud.talk.utils
 
 import android.content.Context
-import android.os.Build
 import android.os.VibrationEffect
 import android.os.Vibrator
 

--- a/app/src/main/java/com/nextcloud/talk/utils/VibrationUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/VibrationUtils.kt
@@ -16,10 +16,6 @@ object VibrationUtils {
 
     fun vibrateShort(context: Context) {
         val vibrator = context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            vibrator.vibrate(VibrationEffect.createOneShot(SHORT_VIBRATE, VibrationEffect.DEFAULT_AMPLITUDE))
-        } else {
-            vibrator.vibrate(SHORT_VIBRATE)
-        }
+        vibrator.vibrate(VibrationEffect.createOneShot(SHORT_VIBRATE, VibrationEffect.DEFAULT_AMPLITUDE))
     }
 }


### PR DESCRIPTION
Resolve #4369


### 🚧 TODO

- [x] remove checks for android versions older than api level 26
- [x] bump minSdkVersion to 26
- [x] update documentation at 
  - [x] https://docs.nextcloud.com/server/latest/admin_manual/installation/system_requirements.html#mobile-apps
  - [x] https://nextcloud-talk.readthedocs.io/en/latest/user-requirements/#mobile-apps

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)