### PR TITLE
Fetch messages in background

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/data/ChatMessageRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/ChatMessageRepository.kt
@@ -64,6 +64,8 @@ interface ChatMessageRepository : LifecycleAwareManager {
         withNetworkParams: Bundle
     ): Job
 
+    suspend fun updateRoomMessages(internalConversationId: String, limit: Int)
+
     /**
      * Long polls the server for any updates to the chat, if found, it synchronizes
      * the database with the server and emits the new messages to [messageFlow],

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -514,6 +514,9 @@ class ConversationsListActivity :
     }
 
     private fun setConversationList(list: List<ConversationModel>) {
+        // Refreshes conversation messages in the background asynchronously
+        conversationsListViewModel.updateRoomMessages(credentials!!, list)
+
         // Update Conversations
         conversationItems.clear()
         conversationItemsWithHeader.clear()
@@ -828,7 +831,7 @@ class ConversationsListActivity :
                     if (!hasFilterEnabled()) filterableConversationItems = searchableConversationItems
                     adapter!!.updateDataSet(filterableConversationItems, false)
                     adapter!!.showAllHeaders()
-                    binding.swipeRefreshLayoutView?.isEnabled = false
+                    binding.swipeRefreshLayoutView.isEnabled = false
                     searchBehaviorSubject.onNext(true)
                     return true
                 }
@@ -2077,7 +2080,8 @@ class ConversationsListActivity :
 
     private fun onMessageSearchError(throwable: Throwable) {
         handleHttpExceptions(throwable)
-        binding.swipeRefreshLayoutView?.isRefreshing = false
+        binding.swipeRefreshLayoutView.isRefreshing = false
+        showErrorDialog()
     }
 
     fun updateFilterState(mention: Boolean, unread: Boolean) {

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -515,7 +515,7 @@ class ConversationsListActivity :
 
     private fun setConversationList(list: List<ConversationModel>) {
         // Refreshes conversation messages in the background asynchronously
-        conversationsListViewModel.updateRoomMessages(credentials!!, list)
+        conversationsListViewModel.updateRoomMessages(list)
 
         // Update Conversations
         conversationItems.clear()

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/viewmodels/ConversationsListViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/viewmodels/ConversationsListViewModel.kt
@@ -17,7 +17,6 @@ import com.nextcloud.talk.invitation.data.InvitationsModel
 import com.nextcloud.talk.invitation.data.InvitationsRepository
 import com.nextcloud.talk.models.domain.ConversationModel
 import com.nextcloud.talk.users.UserManager
-import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import io.reactivex.Observer
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -95,28 +94,18 @@ class ConversationsListViewModel @Inject constructor(
         repository.getRooms()
     }
 
-    fun updateRoomMessages(
-        credentials: String,
-        list: List<ConversationModel>
-    ) {
+    fun updateRoomMessages(list: List<ConversationModel>) {
         val current = list.associateWith { model ->
             val unreadMessages = model.unreadMessages
             unreadMessages
         }
-        val baseUrl = userManager.currentUser.blockingGet().baseUrl!!
         viewModelScope.launch(Dispatchers.IO) {
             for ((model, unreadMessages) in current) {
                 if (unreadMessages > 0) {
-                    updateRoomMessage(model, unreadMessages, credentials, baseUrl)
+                    chatRepository.updateRoomMessages(model.internalId, unreadMessages)
                 }
             }
         }
-    }
-
-    private suspend fun updateRoomMessage(model: ConversationModel, limit: Int, credentials: String, baseUrl: String) {
-        val urlForChatting = ApiUtils.getUrlForChat(1, baseUrl, model.token) // FIXME v1?
-        chatRepository.setData(model, credentials, urlForChatting)
-        chatRepository.updateRoomMessages(model.internalId, limit)
     }
 
     inner class FederatedInvitationsObserver : Observer<InvitationsModel> {

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/viewmodels/ConversationsListViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/viewmodels/ConversationsListViewModel.kt
@@ -10,21 +10,28 @@ import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.nextcloud.talk.chat.data.ChatMessageRepository
 import com.nextcloud.talk.conversationlist.data.OfflineConversationsRepository
 import com.nextcloud.talk.invitation.data.InvitationsModel
 import com.nextcloud.talk.invitation.data.InvitationsRepository
+import com.nextcloud.talk.models.domain.ConversationModel
 import com.nextcloud.talk.users.UserManager
+import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import io.reactivex.Observer
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class ConversationsListViewModel @Inject constructor(
     private val repository: OfflineConversationsRepository,
+    private val chatRepository: ChatMessageRepository,
     var userManager: UserManager
 ) :
     ViewModel() {
@@ -86,6 +93,30 @@ class ConversationsListViewModel @Inject constructor(
         val startNanoTime = System.nanoTime()
         Log.d(TAG, "fetchData - getRooms - calling: $startNanoTime")
         repository.getRooms()
+    }
+
+    fun updateRoomMessages(
+        credentials: String,
+        list: List<ConversationModel>
+    ) {
+        val current = list.associateWith { model ->
+            val unreadMessages = model.unreadMessages
+            unreadMessages
+        }
+        val baseUrl = userManager.currentUser.blockingGet().baseUrl!!
+        viewModelScope.launch(Dispatchers.IO) {
+            for ((model, unreadMessages) in current) {
+                if (unreadMessages > 0) {
+                    updateRoomMessage(model, unreadMessages, credentials, baseUrl)
+                }
+            }
+        }
+    }
+
+    private suspend fun updateRoomMessage(model: ConversationModel, limit: Int, credentials: String, baseUrl: String) {
+        val urlForChatting = ApiUtils.getUrlForChat(1, baseUrl, model.token) // FIXME v1?
+        chatRepository.setData(model, credentials, urlForChatting)
+        chatRepository.updateRoomMessages(model.internalId, limit)
     }
 
     inner class FederatedInvitationsObserver : Observer<InvitationsModel> {

--- a/app/src/main/java/com/nextcloud/talk/utils/CapabilitiesUtil.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/CapabilitiesUtil.kt
@@ -56,7 +56,8 @@ enum class SpreedFeatures(val value: String) {
     DELETE_MESSAGES_UNLIMITED("delete-messages-unlimited"),
     BAN_V1("ban-v1"),
     EDIT_MESSAGES_NOTE_TO_SELF("edit-messages-note-to-self"),
-    ARCHIVE_CONVERSATIONS("archived-conversations-v2")
+    ARCHIVE_CONVERSATIONS("archived-conversations-v2"),
+    CHAT_KEEP_NOTIFICATIONS("chat-keep-notifications")
 }
 
 @Suppress("TooManyFunctions")


### PR DESCRIPTION
- fixes #4381 

Fetches messages and saves them when refreshing the conversation list. Only refreshes what is needed, to save battery.

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)