### PR TITLE
Add permanent warning when notifications are not set up correctly

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -110,6 +110,7 @@ import com.nextcloud.talk.utils.ClosedInterfaceImpl
 import com.nextcloud.talk.utils.ConversationUtils
 import com.nextcloud.talk.utils.FileUtils
 import com.nextcloud.talk.utils.Mimetype
+import com.nextcloud.talk.utils.NotificationUtils
 import com.nextcloud.talk.utils.ParticipantPermissions
 import com.nextcloud.talk.utils.SpreedFeatures
 import com.nextcloud.talk.utils.UserIdUtils
@@ -1518,7 +1519,12 @@ class ConversationsListActivity :
             !platformPermissionUtil.isPostNotificationsPermissionGranted()
         val batteryOptimizationNotIgnored = !PowerManagerUtils().isIgnoringBatteryOptimizations()
 
-        val settingsOfUserAreWrong = notificationPermissionNotGranted || batteryOptimizationNotIgnored
+        val messagesChannelNotEnabled = !NotificationUtils.isMessagesNotificationChannelEnabled(this)
+        val callsChannelNotEnabled = !NotificationUtils.isCallsNotificationChannelEnabled(this)
+
+        val settingsOfUserAreWrong = notificationPermissionNotGranted || batteryOptimizationNotIgnored ||
+                messagesChannelNotEnabled || callsChannelNotEnabled
+
         val userWantsToBeNotifiedAboutWrongSettings = appPreferences.getShowNotificationWarning()
 
         return settingsOfUserAreWrong &&

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -775,9 +775,8 @@ class ConversationsListActivity :
         )
     }
 
-    private fun hasActivityActionSendIntent(): Boolean {
-        return Intent.ACTION_SEND == intent.action || Intent.ACTION_SEND_MULTIPLE == intent.action
-    }
+    private fun hasActivityActionSendIntent(): Boolean =
+        Intent.ACTION_SEND == intent.action || Intent.ACTION_SEND_MULTIPLE == intent.action
 
     private fun showSearchView(searchView: SearchView?, searchItem: MenuItem?) {
         binding.conversationListAppbar.stateListAnimator = AnimatorInflater.loadStateListAnimator(
@@ -1286,10 +1285,9 @@ class ConversationsListActivity :
             !participantPermissions.canIgnoreLobby()
     }
 
-    private fun isReadOnlyConversation(conversation: ConversationModel): Boolean {
-        return conversation.conversationReadOnlyState ===
+    private fun isReadOnlyConversation(conversation: ConversationModel): Boolean =
+        conversation.conversationReadOnlyState ===
             ConversationEnums.ConversationReadOnlyState.CONVERSATION_READ_ONLY
-    }
 
     private fun handleSharedData() {
         collectDataFromIntent()
@@ -1514,7 +1512,7 @@ class ConversationsListActivity :
         }
     }
 
-    private fun shouldShowNotificationWarning() : Boolean {
+    private fun shouldShowNotificationWarning(): Boolean {
         val notificationPermissionNotGranted = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
             !platformPermissionUtil.isPostNotificationsPermissionGranted()
         val batteryOptimizationNotIgnored = !PowerManagerUtils().isIgnoringBatteryOptimizations()
@@ -1525,8 +1523,11 @@ class ConversationsListActivity :
         val serverNotificationAppInstalled =
             userManager.currentUser.blockingGet().capabilities?.notificationsCapability?.features?.isNotEmpty() ?: false
 
-        val settingsOfUserAreWrong = notificationPermissionNotGranted || batteryOptimizationNotIgnored ||
-                messagesChannelNotEnabled || callsChannelNotEnabled || !serverNotificationAppInstalled
+        val settingsOfUserAreWrong = notificationPermissionNotGranted ||
+            batteryOptimizationNotIgnored ||
+            messagesChannelNotEnabled ||
+            callsChannelNotEnabled ||
+            !serverNotificationAppInstalled
 
         val userWantsToBeNotifiedAboutWrongSettings = appPreferences.getShowNotificationWarning()
 

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -121,6 +121,7 @@ import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_FORWARD_MSG_TEXT
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_INTERNAL_USER_ID
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_NEW_CONVERSATION
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_ROOM_TOKEN
+import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_SCROLL_TO_NOTIFICATION_CATEGORY
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_SHARED_TEXT
 import com.nextcloud.talk.utils.permissions.PlatformPermissionUtil
 import com.nextcloud.talk.utils.power.PowerManagerUtils
@@ -273,11 +274,7 @@ class ConversationsListActivity :
         adapter!!.addListener(this)
         prepareViews()
 
-        if (shouldShowIgnoreBatteryOptimizationHint()) {
-            showIgnoreBatteryOptimizationHint()
-        } else {
-            binding.chatListBatteryOptimizationIgnoredHint.visibility = View.GONE
-        }
+        updateNotificationWarning()
 
         showShareToScreen = hasActivityActionSendIntent()
 
@@ -307,6 +304,14 @@ class ConversationsListActivity :
         }
 
         showSearchOrToolbar()
+    }
+
+    private fun updateNotificationWarning() {
+        if (shouldShowNotificationWarning()) {
+            showNotificationWarning()
+        } else {
+            binding.chatListNotificationWarning.visibility = View.GONE
+        }
     }
 
     private fun initObservers() {
@@ -1461,6 +1466,31 @@ class ConversationsListActivity :
             REQUEST_POST_NOTIFICATIONS_PERMISSION -> {
                 if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     Log.d(TAG, "Notification permission was granted")
+
+                    if (!PowerManagerUtils().isIgnoringBatteryOptimizations() &&
+                        ClosedInterfaceImpl().isGooglePlayServicesAvailable
+                    ) {
+                        val dialogText = String.format(
+                            context.resources.getString(R.string.nc_ignore_battery_optimization_dialog_text),
+                            context.resources.getString(R.string.nc_app_name)
+                        )
+
+                        val dialogBuilder = MaterialAlertDialogBuilder(this)
+                            .setTitle(R.string.nc_ignore_battery_optimization_dialog_title)
+                            .setMessage(dialogText)
+                            .setPositiveButton(R.string.nc_ok) { _, _ ->
+                                startActivity(
+                                    Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
+                                )
+                            }
+                            .setNegativeButton(R.string.nc_common_dismiss, null)
+                        viewThemeUtils.dialog.colorMaterialAlertDialogBackground(this, dialogBuilder)
+                        val dialog = dialogBuilder.show()
+                        viewThemeUtils.platform.colorTextButtons(
+                            dialog.getButton(AlertDialog.BUTTON_POSITIVE),
+                            dialog.getButton(AlertDialog.BUTTON_NEGATIVE)
+                        )
+                    }
                 } else {
                     Log.d(
                         TAG,
@@ -1472,39 +1502,28 @@ class ConversationsListActivity :
         }
     }
 
-    @SuppressLint("StringFormatInvalid")
-    private fun showIgnoreBatteryOptimizationHint() {
-        binding.chatListBatteryOptimizationIgnoredHint.visibility = View.VISIBLE
-
-        val dialogText = String.format(
-            context.resources.getString(R.string.nc_ignore_battery_optimization_dialog_text),
-            context.resources.getString(R.string.nc_app_name)
-        )
-
-        val dialogBuilder = MaterialAlertDialogBuilder(this)
-            .setTitle(R.string.nc_ignore_battery_optimization_dialog_title)
-            .setMessage(dialogText)
-            .setPositiveButton(R.string.nc_ok) { _, _ ->
-                startActivity(
-                    Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
-                )
-            }
-            .setNegativeButton(R.string.nc_common_dismiss, null)
-        viewThemeUtils.dialog.colorMaterialAlertDialogBackground(this, dialogBuilder)
-
-        binding.chatListBatteryOptimizationIgnoredHint.setOnClickListener {
-            val dialog = dialogBuilder.show()
-            viewThemeUtils.platform.colorTextButtons(
-                dialog.getButton(AlertDialog.BUTTON_POSITIVE),
-                dialog.getButton(AlertDialog.BUTTON_NEGATIVE)
-            )
+    private fun showNotificationWarning() {
+        binding.chatListNotificationWarning.visibility = View.VISIBLE
+        binding.chatListNotificationWarning.setOnClickListener {
+            val bundle = Bundle()
+            bundle.putBoolean(KEY_SCROLL_TO_NOTIFICATION_CATEGORY, true)
+            val settingsIntent = Intent(context, SettingsActivity::class.java)
+            settingsIntent.putExtras(bundle)
+            startActivity(settingsIntent)
         }
     }
 
-    private fun shouldShowIgnoreBatteryOptimizationHint() : Boolean {
-        return !PowerManagerUtils().isIgnoringBatteryOptimizations() &&
-            ClosedInterfaceImpl().isGooglePlayServicesAvailable &&
-            appPreferences.getShowIgnoreBatteryOptimizationHint()
+    private fun shouldShowNotificationWarning() : Boolean {
+        val notificationPermissionNotGranted = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            !platformPermissionUtil.isPostNotificationsPermissionGranted()
+        val batteryOptimizationNotIgnored = !PowerManagerUtils().isIgnoringBatteryOptimizations()
+
+        val settingsOfUserAreWrong = notificationPermissionNotGranted || batteryOptimizationNotIgnored
+        val userWantsToBeNotifiedAboutWrongSettings = appPreferences.getShowNotificationWarning()
+
+        return settingsOfUserAreWrong &&
+            userWantsToBeNotifiedAboutWrongSettings &&
+            ClosedInterfaceImpl().isGooglePlayServicesAvailable
     }
 
     private fun openConversation(textToPaste: String? = "") {

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -1522,8 +1522,11 @@ class ConversationsListActivity :
         val messagesChannelNotEnabled = !NotificationUtils.isMessagesNotificationChannelEnabled(this)
         val callsChannelNotEnabled = !NotificationUtils.isCallsNotificationChannelEnabled(this)
 
+        val serverNotificationAppInstalled =
+            userManager.currentUser.blockingGet().capabilities?.notificationsCapability?.features?.isNotEmpty() ?: false
+
         val settingsOfUserAreWrong = notificationPermissionNotGranted || batteryOptimizationNotIgnored ||
-                messagesChannelNotEnabled || callsChannelNotEnabled
+                messagesChannelNotEnabled || callsChannelNotEnabled || !serverNotificationAppInstalled
 
         val userWantsToBeNotifiedAboutWrongSettings = appPreferences.getShowNotificationWarning()
 

--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -77,6 +77,7 @@ import com.nextcloud.talk.utils.NotificationUtils.getCallRingtoneUri
 import com.nextcloud.talk.utils.NotificationUtils.getMessageRingtoneUri
 import com.nextcloud.talk.utils.SecurityUtils
 import com.nextcloud.talk.utils.SpreedFeatures
+import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_SCROLL_TO_NOTIFICATION_CATEGORY
 import com.nextcloud.talk.utils.permissions.PlatformPermissionUtil
 import com.nextcloud.talk.utils.power.PowerManagerUtils
 import com.nextcloud.talk.utils.preferences.AppPreferencesImpl
@@ -129,6 +130,7 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
     private lateinit var phoneBookIntegrationFlow: Flow<Boolean>
     private var profileQueryDisposable: Disposable? = null
     private var dbQueryDisposable: Disposable? = null
+    private var scrollToNotificationCategory: Boolean? = false
 
     @SuppressLint("StringFormatInvalid")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -143,6 +145,7 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
         binding.avatarImage.let { ViewCompat.setTransitionName(it, "userAvatar.transitionTag") }
 
         getCurrentUser()
+        handleIntent(intent)
 
         setupLicenceSetting()
 
@@ -160,6 +163,11 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
         setupPhoneBookIntegration()
 
         setupClientCertView()
+    }
+
+    private fun handleIntent(intent: Intent) {
+        val extras: Bundle? = intent.extras
+        scrollToNotificationCategory = extras?.getBoolean(KEY_SCROLL_TO_NOTIFICATION_CATEGORY)
     }
 
     override fun onResume() {
@@ -210,6 +218,21 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
 
         themeTitles()
         themeSwitchPreferences()
+
+        if (scrollToNotificationCategory == true) {
+            scrollToNotificationCategory()
+        }
+    }
+
+    private fun scrollToNotificationCategory() {
+        binding.scrollView.post {
+            val scrollViewLocation = IntArray(2)
+            val targetLocation = IntArray(2)
+            binding.scrollView.getLocationOnScreen(scrollViewLocation)
+            binding.settingsNotificationsCategory.getLocationOnScreen(targetLocation)
+            val offset = targetLocation[1] - scrollViewLocation[1]
+            binding.scrollView.smoothScrollBy(0, offset)
+        }
     }
 
     private fun loadCapabilitiesAndUpdateSettings() {
@@ -255,9 +278,6 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
     }
 
     private fun setupNotificationSettings() {
-        binding.settingsNotificationsTitle.text = resources!!.getString(
-            R.string.nc_settings_notification_sounds_post_oreo
-        )
         setupNotificationSoundsSettings()
         setupNotificationPermissionSettings()
     }
@@ -662,7 +682,7 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
     private fun themeSwitchPreferences() {
         binding.run {
             listOf(
-                settingsShowIgnoreBatteryOptimizationHintSwitch,
+                settingsShowNotificationWarningSwitch,
                 settingsScreenLockSwitch,
                 settingsScreenSecuritySwitch,
                 settingsIncognitoKeyboardSwitch,
@@ -858,17 +878,17 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
     }
 
     private fun setupCheckables() {
-        binding.settingsShowIgnoreBatteryOptimizationHintSwitch.isChecked =
-            appPreferences.showIgnoreBatteryOptimizationHint
+        binding.settingsShowNotificationWarningSwitch.isChecked =
+            appPreferences.showNotificationWarning
 
         if (ClosedInterfaceImpl().isGooglePlayServicesAvailable) {
-            binding.settingsShowIgnoreBatteryOptimizationHint.setOnClickListener {
-                val isChecked = binding.settingsShowIgnoreBatteryOptimizationHintSwitch.isChecked
-                binding.settingsShowIgnoreBatteryOptimizationHintSwitch.isChecked = !isChecked
-                appPreferences.setShowIgnoreBatteryOptimizationHint(!isChecked)
+            binding.settingsShowNotificationWarning.setOnClickListener {
+                val isChecked = binding.settingsShowNotificationWarningSwitch.isChecked
+                binding.settingsShowNotificationWarningSwitch.isChecked = !isChecked
+                appPreferences.setShowNotificationWarning(!isChecked)
             }
         } else {
-            binding.settingsShowIgnoreBatteryOptimizationHint.visibility = View.GONE
+            binding.settingsShowNotificationWarning.visibility = View.GONE
         }
 
         binding.settingsScreenSecuritySwitch.isChecked = appPreferences.isScreenSecured

--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -21,6 +21,8 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.PorterDuff
 import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.RippleDrawable
 import android.media.RingtoneManager
 import android.net.Uri
 import android.os.Build
@@ -89,6 +91,7 @@ import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -130,7 +133,7 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
     private lateinit var phoneBookIntegrationFlow: Flow<Boolean>
     private var profileQueryDisposable: Disposable? = null
     private var dbQueryDisposable: Disposable? = null
-    private var scrollToNotificationCategory: Boolean? = false
+    private var openedByNotificationWarning: Boolean = false
 
     @SuppressLint("StringFormatInvalid")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -167,7 +170,7 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
 
     private fun handleIntent(intent: Intent) {
         val extras: Bundle? = intent.extras
-        scrollToNotificationCategory = extras?.getBoolean(KEY_SCROLL_TO_NOTIFICATION_CATEGORY)
+        openedByNotificationWarning = extras?.getBoolean(KEY_SCROLL_TO_NOTIFICATION_CATEGORY) ?: false
     }
 
     override fun onResume() {
@@ -219,11 +222,12 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
         themeTitles()
         themeSwitchPreferences()
 
-        if (scrollToNotificationCategory == true) {
+        if (openedByNotificationWarning) {
             scrollToNotificationCategory()
         }
     }
 
+    @Suppress("MagicNumber")
     private fun scrollToNotificationCategory() {
         binding.scrollView.post {
             val scrollViewLocation = IntArray(2)
@@ -231,7 +235,7 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
             binding.scrollView.getLocationOnScreen(scrollViewLocation)
             binding.settingsNotificationsCategory.getLocationOnScreen(targetLocation)
             val offset = targetLocation[1] - scrollViewLocation[1]
-            binding.scrollView.smoothScrollBy(0, offset)
+            binding.scrollView.scrollBy(0, offset)
         }
     }
 
@@ -301,6 +305,10 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
                     resources!!.getString(R.string.nc_diagnose_battery_optimization_not_ignored)
                 binding.batteryOptimizationIgnored.setTextColor(resources.getColor(R.color.nc_darkRed, null))
 
+                if (openedByNotificationWarning){
+                    blinkRipple(binding.settingsBatteryOptimizationWrapper.background)
+                }
+
                 binding.settingsBatteryOptimizationWrapper.setOnClickListener {
                     val dialogText = String.format(
                         context.resources.getString(R.string.nc_ignore_battery_optimization_dialog_text),
@@ -343,6 +351,10 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
                     binding.ncDiagnoseNotificationPermissionSubtitle.setTextColor(
                         resources.getColor(R.color.nc_darkRed, null)
                     )
+
+                    if (openedByNotificationWarning){
+                        blinkRipple(binding.settingsNotificationsPermissionWrapper.background)
+                    }
 
                     binding.settingsCallSound.isEnabled = false
                     binding.settingsCallSound.alpha = DISABLED_ALPHA
@@ -1375,6 +1387,21 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
                             }
                         }
                     }
+                }
+            }
+        }
+    }
+
+    @Suppress("MagicNumber")
+    private fun blinkRipple(rippleView: Drawable) {
+        (rippleView as RippleDrawable).let { rippleDrawable ->
+            CoroutineScope(Dispatchers.Main).launch {
+                delay(1000L) // Wait 2 seconds before starting
+                repeat(3) {
+                    rippleDrawable.state = intArrayOf(android.R.attr.state_pressed, android.R.attr.state_enabled)
+                    delay(250L) // Ripple active duration
+                    rippleDrawable.state = intArrayOf() // Reset state
+                    delay(250L) // Time between blinks
                 }
             }
         }

--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -284,6 +284,7 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
     private fun setupNotificationSettings() {
         setupNotificationSoundsSettings()
         setupNotificationPermissionSettings()
+        setupServerNotificationAppCheck()
     }
 
     @SuppressLint("StringFormatInvalid")
@@ -473,6 +474,24 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
             }
         } else if (PowerManagerUtils().isIgnoringBatteryOptimizations()) {
             binding.settingsBatteryOptimizationWrapper.setOnClickListener { click() }
+        }
+    }
+
+    private fun setupServerNotificationAppCheck() {
+        val serverNotificationAppInstalled =
+            userManager.currentUser.blockingGet().capabilities?.notificationsCapability?.features?.isNotEmpty() ?: false
+        if (!serverNotificationAppInstalled) {
+            binding.settingsServerNotificationAppWrapper.visibility = View.VISIBLE
+
+            val description = context.getString(R.string.nc_settings_contact_admin_of) + LINEBREAK +
+                userManager.currentUser.blockingGet().baseUrl!!
+
+            binding.settingsServerNotificationAppDescription.text = description
+            if (openedByNotificationWarning) {
+                blinkRipple(binding.settingsServerNotificationAppWrapper.background)
+            }
+        } else {
+            binding.settingsServerNotificationAppWrapper.visibility = View.GONE
         }
     }
 
@@ -1421,6 +1440,7 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
         private const val START_DELAY: Long = 5000
         private const val DISABLED_ALPHA: Float = 0.38f
         private const val ENABLED_ALPHA: Float = 1.0f
+        private const val LINEBREAK = "\n"
         const val HTTP_CODE_OK: Int = 200
         const val HTTP_ERROR_CODE_BAD_REQUEST: Int = 400
     }

--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -333,12 +333,22 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
                     binding.ncDiagnoseNotificationPermissionSubtitle.setTextColor(
                         resources.getColor(R.color.high_emphasis_text, null)
                     )
+                    binding.settingsCallSound.isEnabled = true
+                    binding.settingsCallSound.alpha = ENABLED_ALPHA
+                    binding.settingsMessageSound.isEnabled = true
+                    binding.settingsMessageSound.alpha = ENABLED_ALPHA
                 } else {
                     binding.ncDiagnoseNotificationPermissionSubtitle.text =
                         resources.getString(R.string.nc_settings_notifications_declined)
                     binding.ncDiagnoseNotificationPermissionSubtitle.setTextColor(
                         resources.getColor(R.color.nc_darkRed, null)
                     )
+
+                    binding.settingsCallSound.isEnabled = false
+                    binding.settingsCallSound.alpha = DISABLED_ALPHA
+                    binding.settingsMessageSound.isEnabled = false
+                    binding.settingsMessageSound.alpha = DISABLED_ALPHA
+
                     binding.settingsNotificationsPermissionWrapper.setOnClickListener {
                         requestPermissions(
                             arrayOf(Manifest.permission.POST_NOTIFICATIONS),

--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -662,6 +662,7 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
     private fun themeSwitchPreferences() {
         binding.run {
             listOf(
+                settingsShowIgnoreBatteryOptimizationHintSwitch,
                 settingsScreenLockSwitch,
                 settingsScreenSecuritySwitch,
                 settingsIncognitoKeyboardSwitch,
@@ -857,6 +858,19 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
     }
 
     private fun setupCheckables() {
+        binding.settingsShowIgnoreBatteryOptimizationHintSwitch.isChecked =
+            appPreferences.showIgnoreBatteryOptimizationHint
+
+        if (ClosedInterfaceImpl().isGooglePlayServicesAvailable) {
+            binding.settingsShowIgnoreBatteryOptimizationHint.setOnClickListener {
+                val isChecked = binding.settingsShowIgnoreBatteryOptimizationHintSwitch.isChecked
+                binding.settingsShowIgnoreBatteryOptimizationHintSwitch.isChecked = !isChecked
+                appPreferences.setShowIgnoreBatteryOptimizationHint(!isChecked)
+            }
+        } else {
+            binding.settingsShowIgnoreBatteryOptimizationHint.visibility = View.GONE
+        }
+
         binding.settingsScreenSecuritySwitch.isChecked = appPreferences.isScreenSecured
 
         binding.settingsIncognitoKeyboardSwitch.isChecked = appPreferences.isKeyboardIncognito

--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -21,8 +21,6 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.PorterDuff
 import android.graphics.drawable.ColorDrawable
-import android.graphics.drawable.Drawable
-import android.graphics.drawable.RippleDrawable
 import android.media.RingtoneManager
 import android.net.Uri
 import android.os.Build
@@ -73,6 +71,7 @@ import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.CapabilitiesUtil
 import com.nextcloud.talk.utils.ClosedInterfaceImpl
 import com.nextcloud.talk.utils.DisplayUtils
+import com.nextcloud.talk.utils.DrawableUtils
 import com.nextcloud.talk.utils.LoggingUtils.sendMailWithAttachment
 import com.nextcloud.talk.utils.NotificationUtils
 import com.nextcloud.talk.utils.NotificationUtils.getCallRingtoneUri
@@ -91,7 +90,6 @@ import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -306,8 +304,8 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
                     resources!!.getString(R.string.nc_diagnose_battery_optimization_not_ignored)
                 binding.batteryOptimizationIgnored.setTextColor(resources.getColor(R.color.nc_darkRed, null))
 
-                if (openedByNotificationWarning){
-                    blinkRipple(binding.settingsBatteryOptimizationWrapper.background)
+                if (openedByNotificationWarning) {
+                    DrawableUtils.blinkDrawable(binding.settingsBatteryOptimizationWrapper.background)
                 }
 
                 binding.settingsBatteryOptimizationWrapper.setOnClickListener {
@@ -354,7 +352,7 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
                     )
 
                     if (openedByNotificationWarning){
-                        blinkRipple(binding.settingsNotificationsPermissionWrapper.background)
+                        DrawableUtils.blinkDrawable(binding.settingsNotificationsPermissionWrapper.background)
                     }
 
                     binding.settingsCallSound.isEnabled = false
@@ -391,7 +389,7 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
             binding.callsRingtone.text = resources!!.getString(R.string.nc_common_disabled)
 
             if (openedByNotificationWarning){
-                blinkRipple(binding.settingsCallSound.background)
+                DrawableUtils.blinkDrawable(binding.settingsCallSound.background)
             }
         }
 
@@ -406,7 +404,7 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
             binding.messagesRingtone.text = resources!!.getString(R.string.nc_common_disabled)
 
             if (openedByNotificationWarning){
-                blinkRipple(binding.settingsMessageSound.background)
+                DrawableUtils.blinkDrawable(binding.settingsMessageSound.background)
             }
         }
 
@@ -488,7 +486,7 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
 
             binding.settingsServerNotificationAppDescription.text = description
             if (openedByNotificationWarning) {
-                blinkRipple(binding.settingsServerNotificationAppWrapper.background)
+                DrawableUtils.blinkDrawable(binding.settingsServerNotificationAppWrapper.background)
             }
         } else {
             binding.settingsServerNotificationAppWrapper.visibility = View.GONE
@@ -1414,21 +1412,6 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
                             }
                         }
                     }
-                }
-            }
-        }
-    }
-
-    @Suppress("MagicNumber")
-    private fun blinkRipple(rippleView: Drawable) {
-        (rippleView as RippleDrawable).let { rippleDrawable ->
-            CoroutineScope(Dispatchers.Main).launch {
-                delay(1000L) // Wait 2 seconds before starting
-                repeat(3) {
-                    rippleDrawable.state = intArrayOf(android.R.attr.state_pressed, android.R.attr.state_enabled)
-                    delay(250L) // Ripple active duration
-                    rippleDrawable.state = intArrayOf() // Reset state
-                    delay(250L) // Time between blinks
                 }
             }
         }

--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -1101,16 +1101,14 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
 
             ConversationsListActivity.REQUEST_POST_NOTIFICATIONS_PERMISSION -> {
                 if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_DENIED) {
-                    Snackbar.make(
-                        binding.root,
-                        context.resources.getString(R.string.nc_settings_notifications_declined_hint),
-                        Snackbar.LENGTH_LONG
-                    ).show()
-                    Log.d(
-                        TAG,
-                        "Notification permission is denied. Either because user denied it when being asked. " +
-                            "Or permission is already denied and android decided to not offer the dialog."
-                    )
+                    try {
+                        val intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+                        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        intent.putExtra(Settings.EXTRA_APP_PACKAGE, BuildConfig.APPLICATION_ID)
+                        startActivity(intent)
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Failed to open notification settings as fallback", e)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -388,6 +388,10 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
                 ResourcesCompat.getColor(context.resources, R.color.nc_darkRed, null)
             )
             binding.callsRingtone.text = resources!!.getString(R.string.nc_common_disabled)
+
+            if (openedByNotificationWarning){
+                blinkRipple(binding.settingsCallSound.background)
+            }
         }
 
         if (NotificationUtils.isMessagesNotificationChannelEnabled(this)) {
@@ -399,6 +403,10 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
                 ResourcesCompat.getColor(context.resources, R.color.nc_darkRed, null)
             )
             binding.messagesRingtone.text = resources!!.getString(R.string.nc_common_disabled)
+
+            if (openedByNotificationWarning){
+                blinkRipple(binding.settingsMessageSound.background)
+            }
         }
 
         binding.settingsCallSound.setOnClickListener {

--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -103,7 +103,9 @@ import javax.inject.Inject
 
 @Suppress("LargeClass", "TooManyFunctions")
 @AutoInjector(NextcloudTalkApplication::class)
-class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNumberDialogClickListener {
+class SettingsActivity :
+    BaseActivity(),
+    SetPhoneNumberDialogFragment.SetPhoneNumberDialogClickListener {
     private lateinit var binding: ActivitySettingsBinding
 
     @Inject
@@ -351,7 +353,7 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
                         resources.getColor(R.color.nc_darkRed, null)
                     )
 
-                    if (openedByNotificationWarning){
+                    if (openedByNotificationWarning) {
                         DrawableUtils.blinkDrawable(binding.settingsNotificationsPermissionWrapper.background)
                     }
 
@@ -388,7 +390,7 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
             )
             binding.callsRingtone.text = resources!!.getString(R.string.nc_common_disabled)
 
-            if (openedByNotificationWarning){
+            if (openedByNotificationWarning) {
                 DrawableUtils.blinkDrawable(binding.settingsCallSound.background)
             }
         }
@@ -403,7 +405,7 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
             )
             binding.messagesRingtone.text = resources!!.getString(R.string.nc_common_disabled)
 
-            if (openedByNotificationWarning){
+            if (openedByNotificationWarning) {
                 DrawableUtils.blinkDrawable(binding.settingsMessageSound.background)
             }
         }
@@ -713,8 +715,8 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
         startActivity(intent)
     }
 
-    private fun getRingtoneName(context: Context, ringtoneUri: Uri?): String {
-        return if (ringtoneUri == null) {
+    private fun getRingtoneName(context: Context, ringtoneUri: Uri?): String =
+        if (ringtoneUri == null) {
             resources!!.getString(R.string.nc_settings_no_ringtone)
         } else if ((NotificationUtils.DEFAULT_CALL_RINGTONE_URI == ringtoneUri.toString()) ||
             (NotificationUtils.DEFAULT_MESSAGE_RINGTONE_URI == ringtoneUri.toString())
@@ -724,7 +726,6 @@ class SettingsActivity : BaseActivity(), SetPhoneNumberDialogFragment.SetPhoneNu
             val r = RingtoneManager.getRingtone(context, ringtoneUri)
             r.getTitle(context)
         }
-    }
 
     private fun themeSwitchPreferences() {
         binding.run {

--- a/app/src/main/java/com/nextcloud/talk/utils/DrawableUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/DrawableUtils.kt
@@ -6,14 +6,22 @@
  */
 package com.nextcloud.talk.utils
 
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.RippleDrawable
+import android.util.Log
 import com.nextcloud.talk.R
 import com.nextcloud.talk.utils.Mimetype.AUDIO_PREFIX
 import com.nextcloud.talk.utils.Mimetype.FOLDER
 import com.nextcloud.talk.utils.Mimetype.IMAGE_PREFIX
 import com.nextcloud.talk.utils.Mimetype.TEXT_PREFIX
 import com.nextcloud.talk.utils.Mimetype.VIDEO_PREFIX
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 object DrawableUtils {
+    private val TAG = DrawableUtils::class.java.simpleName
 
     @Suppress("Detekt.LongMethod")
     fun getDrawableResourceIdForMimeType(mimetype: String?): Int {
@@ -151,6 +159,25 @@ object DrawableUtils {
             R.drawable.ic_mimetype_audio
         } else {
             drawableMap["unknown"]!!
+        }
+    }
+
+    @Suppress("MagicNumber")
+    fun blinkDrawable(rippleView: Drawable) {
+        try {
+            (rippleView as RippleDrawable).let { rippleDrawable ->
+                CoroutineScope(Dispatchers.Main).launch {
+                    delay(1000L) // Wait 2 seconds before starting
+                    repeat(3) {
+                        rippleDrawable.state = intArrayOf(android.R.attr.state_pressed, android.R.attr.state_enabled)
+                        delay(250L) // Ripple active duration
+                        rippleDrawable.state = intArrayOf() // Reset state
+                        delay(250L) // Time between blinks
+                    }
+                }
+            }
+        } catch (e: Exception){
+            Log.e(TAG, "Failed to blink Drawable", e)
         }
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/utils/DrawableUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/DrawableUtils.kt
@@ -162,7 +162,7 @@ object DrawableUtils {
         }
     }
 
-    @Suppress("MagicNumber")
+    @Suppress("MagicNumber", "TooGenericExceptionCaught")
     fun blinkDrawable(rippleView: Drawable) {
         try {
             (rippleView as RippleDrawable).let { rippleDrawable ->
@@ -176,7 +176,7 @@ object DrawableUtils {
                     }
                 }
             }
-        } catch (e: Exception){
+        } catch (e: Exception) {
             Log.e(TAG, "Failed to blink Drawable", e)
         }
     }

--- a/app/src/main/java/com/nextcloud/talk/utils/bundle/BundleKeys.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/bundle/BundleKeys.kt
@@ -80,4 +80,5 @@ object BundleKeys {
     const val KEY_CREDENTIALS: String = "KEY_CREDENTIALS"
     const val KEY_FIELD_MAP: String = "KEY_FIELD_MAP"
     const val KEY_CHAT_URL: String = "KEY_CHAT_URL"
+    const val KEY_SCROLL_TO_NOTIFICATION_CATEGORY: String = "KEY_SCROLL_TO_NOTIFICATION_CATEGORY"
 }

--- a/app/src/main/java/com/nextcloud/talk/utils/preferences/AppPreferences.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/preferences/AppPreferences.java
@@ -178,6 +178,9 @@ public interface AppPreferences {
 
     void deleteAllMessageQueuesFor(String userId);
 
+    boolean getShowIgnoreBatteryOptimizationHint();
+
+    void setShowIgnoreBatteryOptimizationHint(boolean showIgnoreBatteryOptimizationHint);
 
     void clear();
 }

--- a/app/src/main/java/com/nextcloud/talk/utils/preferences/AppPreferences.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/preferences/AppPreferences.java
@@ -178,9 +178,9 @@ public interface AppPreferences {
 
     void deleteAllMessageQueuesFor(String userId);
 
-    boolean getShowIgnoreBatteryOptimizationHint();
+    boolean getShowNotificationWarning();
 
-    void setShowIgnoreBatteryOptimizationHint(boolean showIgnoreBatteryOptimizationHint);
+    void setShowNotificationWarning(boolean showNotificationWarning);
 
     void clear();
 }

--- a/app/src/main/java/com/nextcloud/talk/utils/preferences/AppPreferencesImpl.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/preferences/AppPreferencesImpl.kt
@@ -544,16 +544,16 @@ class AppPreferencesImpl(val context: Context) : AppPreferences {
         }
     }
 
-    override fun getShowIgnoreBatteryOptimizationHint(): Boolean {
+    override fun getShowNotificationWarning(): Boolean {
         return runBlocking { async {
-            readBoolean(SHOW_IGNORE_BATTERY_OPTIMIZATION_HINT, true).first()
+            readBoolean(SHOW_NOTIFICATION_WARNING, true).first()
         } }.getCompleted()
     }
 
-    override fun setShowIgnoreBatteryOptimizationHint(showIgnoreBatteryOptimizationHint: Boolean) =
+    override fun setShowNotificationWarning(showNotificationWarning: Boolean) =
         runBlocking<Unit> {
             async {
-                writeBoolean(SHOW_IGNORE_BATTERY_OPTIMIZATION_HINT, showIgnoreBatteryOptimizationHint)
+                writeBoolean(SHOW_NOTIFICATION_WARNING, showNotificationWarning)
             }
         }
 
@@ -641,7 +641,7 @@ class AppPreferencesImpl(val context: Context) : AppPreferences {
         const val PHONE_BOOK_INTEGRATION_LAST_RUN = "phone_book_integration_last_run"
         const val TYPING_STATUS = "typing_status"
         const val MESSAGE_QUEUE = "@message_queue"
-        const val SHOW_IGNORE_BATTERY_OPTIMIZATION_HINT = "show_ignore_battery_optimization_hint"
+        const val SHOW_NOTIFICATION_WARNING = "show_notification_warning"
         private fun String.convertStringToArray(): Array<Float> {
             var varString = this
             val floatList = mutableListOf<Float>()

--- a/app/src/main/java/com/nextcloud/talk/utils/preferences/AppPreferencesImpl.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/preferences/AppPreferencesImpl.kt
@@ -544,6 +544,19 @@ class AppPreferencesImpl(val context: Context) : AppPreferences {
         }
     }
 
+    override fun getShowIgnoreBatteryOptimizationHint(): Boolean {
+        return runBlocking { async {
+            readBoolean(SHOW_IGNORE_BATTERY_OPTIMIZATION_HINT, true).first()
+        } }.getCompleted()
+    }
+
+    override fun setShowIgnoreBatteryOptimizationHint(showIgnoreBatteryOptimizationHint: Boolean) =
+        runBlocking<Unit> {
+            async {
+                writeBoolean(SHOW_IGNORE_BATTERY_OPTIMIZATION_HINT, showIgnoreBatteryOptimizationHint)
+            }
+        }
+
     override fun clear() {}
 
     private suspend fun writeString(key: String, value: String) =
@@ -628,6 +641,7 @@ class AppPreferencesImpl(val context: Context) : AppPreferences {
         const val PHONE_BOOK_INTEGRATION_LAST_RUN = "phone_book_integration_last_run"
         const val TYPING_STATUS = "typing_status"
         const val MESSAGE_QUEUE = "@message_queue"
+        const val SHOW_IGNORE_BATTERY_OPTIMIZATION_HINT = "show_ignore_battery_optimization_hint"
         private fun String.convertStringToArray(): Array<Float> {
             var varString = this
             val floatList = mutableListOf<Float>()

--- a/app/src/main/res/layout/activity_conversations.xml
+++ b/app/src/main/res/layout/activity_conversations.xml
@@ -37,6 +37,18 @@
             android:visibility="gone"
             tools:visibility="visible" />
 
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/chat_list_battery_optimization_ignored_hint"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/nc_warning"
+            android:gravity="center"
+            android:minHeight="40dp"
+            android:text="@string/nc_diagnose_battery_optimization_not_ignored"
+            android:textColor="@color/white"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/search_toolbar"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_conversations.xml
+++ b/app/src/main/res/layout/activity_conversations.xml
@@ -38,13 +38,13 @@
             tools:visibility="visible" />
 
         <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/chat_list_battery_optimization_ignored_hint"
+            android:id="@+id/chat_list_notification_warning"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@color/nc_warning"
             android:gravity="center"
             android:minHeight="40dp"
-            android:text="@string/nc_diagnose_battery_optimization_not_ignored"
+            android:text="@string/nc_notification_warning"
             android:textColor="@color/white"
             android:visibility="gone"
             tools:visibility="visible" />

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -245,26 +245,49 @@
                             android:clickable="false"
                             android:gravity="center_vertical"/>
                     </LinearLayout>
-                </LinearLayout>
 
-                <LinearLayout
-                    android:id="@+id/settings_notifications_permission_wrapper"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:background="?android:attr/selectableItemBackground"
-                    android:orientation="vertical"
-                    android:padding="@dimen/standard_padding">
 
-                    <com.google.android.material.textview.MaterialTextView
-                        android:layout_width="wrap_content"
+                    <LinearLayout
+                        android:id="@+id/settings_notifications_permission_wrapper"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="@string/nc_diagnose_notification_permission"
-                        android:textSize="@dimen/headline_text_size" />
+                        android:background="?android:attr/selectableItemBackground"
+                        android:orientation="vertical"
+                        android:padding="@dimen/standard_padding">
 
-                    <com.google.android.material.textview.MaterialTextView
-                        android:id="@+id/nc_diagnose_notification_permission_subtitle"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content" />
+                        <com.google.android.material.textview.MaterialTextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/nc_diagnose_notification_permission"
+                            android:textSize="@dimen/headline_text_size" />
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/nc_diagnose_notification_permission_subtitle"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:id="@+id/settings_battery_optimization_wrapper"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="?android:attr/selectableItemBackground"
+                        android:orientation="vertical"
+                        android:padding="@dimen/standard_padding">
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/nc_diagnose_battery_optimization_title"
+                            android:textSize="@dimen/headline_text_size" />
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/battery_optimization_ignored"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            tools:text="@string/nc_diagnose_battery_optimization_ignored"/>
+                    </LinearLayout>
+
                 </LinearLayout>
 
                 <LinearLayout
@@ -328,27 +351,6 @@
                         android:layout_marginBottom="@dimen/standard_margin"
                         android:text="@string/nc_settings_default_ringtone"
                         android:textSize="@dimen/supporting_text_text_size"/>
-                </LinearLayout>
-
-                <LinearLayout
-                    android:id="@+id/settings_battery_optimization_wrapper"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:background="?android:attr/selectableItemBackground"
-                    android:orientation="vertical"
-                    android:padding="@dimen/standard_padding">
-
-                    <com.google.android.material.textview.MaterialTextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/nc_diagnose_battery_optimization_title"
-                        android:textSize="@dimen/headline_text_size" />
-
-                    <com.google.android.material.textview.MaterialTextView
-                        android:id="@+id/battery_optimization_ignored"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        tools:text="@string/nc_diagnose_battery_optimization_ignored"/>
                 </LinearLayout>
 
             </LinearLayout>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -201,7 +201,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_margin="@dimen/standard_margin"
-                    android:text="@string/nc_settings_notification_sounds"
+                    android:text="@string/nc_settings_notification_sounds_post_oreo"
                     android:textSize="@dimen/headline_text_size"
                     android:textStyle="bold"/>
 
@@ -210,6 +210,42 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical">
+
+                    <LinearLayout
+                        android:id="@+id/settings_show_notification_warning"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="?android:attr/selectableItemBackground"
+                        android:orientation="horizontal"
+                        android:padding="@dimen/standard_padding">
+
+                        <LinearLayout
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:orientation="vertical">
+
+                            <com.google.android.material.textview.MaterialTextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/nc_show_notification_warning_title"
+                                android:textSize="@dimen/headline_text_size"/>
+
+                            <com.google.android.material.textview.MaterialTextView
+                                android:id="@+id/settings_show_notification_warning_summary"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/nc_show_notification_warning_description"/>
+                        </LinearLayout>
+
+                        <com.google.android.material.materialswitch.MaterialSwitch
+                            android:id="@+id/settings_show_notification_warning_switch"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:clickable="false"
+                            android:gravity="center_vertical"/>
+                    </LinearLayout>
+                </LinearLayout>
 
                     <LinearLayout
                         android:id="@+id/settings_notifications_permission_wrapper"
@@ -251,42 +287,6 @@
                             android:layout_height="wrap_content"
                             tools:text="@string/nc_diagnose_battery_optimization_ignored"/>
                     </LinearLayout>
-
-                    <LinearLayout
-                        android:id="@+id/settings_show_ignore_battery_optimization_hint"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:background="?android:attr/selectableItemBackground"
-                        android:orientation="horizontal"
-                        android:padding="@dimen/standard_padding">
-
-                        <LinearLayout
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1"
-                            android:orientation="vertical">
-
-                            <com.google.android.material.textview.MaterialTextView
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/nc_show_ignore_battery_optimization_hint_title"
-                                android:textSize="@dimen/headline_text_size"/>
-
-                            <com.google.android.material.textview.MaterialTextView
-                                android:id="@+id/settings_show_ignore_battery_optimization_hint_summary"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/nc_show_ignore_battery_optimization_hint_description"/>
-                        </LinearLayout>
-
-                        <com.google.android.material.materialswitch.MaterialSwitch
-                            android:id="@+id/settings_show_ignore_battery_optimization_hint_switch"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:clickable="false"
-                            android:gravity="center_vertical"/>
-                    </LinearLayout>
-                </LinearLayout>
 
                 <LinearLayout
                     android:id="@+id/settings_gplay_not_available"

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -310,6 +310,7 @@
                     android:id="@+id/settings_call_sound"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:background="?android:attr/selectableItemBackground"
                     android:orientation="vertical">
 
                     <com.google.android.material.textview.MaterialTextView
@@ -333,8 +334,8 @@
                     android:id="@+id/settings_message_sound"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:background="?android:attr/selectableItemBackground">
+                    android:background="?android:attr/selectableItemBackground"
+                    android:orientation="vertical">
 
                     <com.google.android.material.textview.MaterialTextView
                         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -247,46 +247,25 @@
                     </LinearLayout>
                 </LinearLayout>
 
-                    <LinearLayout
-                        android:id="@+id/settings_notifications_permission_wrapper"
-                        android:layout_width="match_parent"
+                <LinearLayout
+                    android:id="@+id/settings_notifications_permission_wrapper"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?android:attr/selectableItemBackground"
+                    android:orientation="vertical"
+                    android:padding="@dimen/standard_padding">
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:orientation="vertical"
-                        android:padding="@dimen/standard_padding"
-                        android:background="?android:attr/selectableItemBackground">
+                        android:text="@string/nc_diagnose_notification_permission"
+                        android:textSize="@dimen/headline_text_size" />
 
-                        <com.google.android.material.textview.MaterialTextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:textSize="@dimen/headline_text_size"
-                            android:text="@string/nc_diagnose_notification_permission" />
-
-                        <com.google.android.material.textview.MaterialTextView
-                            android:id="@+id/nc_diagnose_notification_permission_subtitle"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content" />
-                    </LinearLayout>
-
-                    <LinearLayout
-                        android:id="@+id/settings_battery_optimization_wrapper"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical"
-                        android:padding="@dimen/standard_padding"
-                        android:background="?android:attr/selectableItemBackground">
-
-                        <com.google.android.material.textview.MaterialTextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:textSize="@dimen/headline_text_size"
-                            android:text="@string/nc_diagnose_battery_optimization_title" />
-
-                        <com.google.android.material.textview.MaterialTextView
-                            android:id="@+id/battery_optimization_ignored"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            tools:text="@string/nc_diagnose_battery_optimization_ignored"/>
-                    </LinearLayout>
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/nc_diagnose_notification_permission_subtitle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content" />
+                </LinearLayout>
 
                 <LinearLayout
                     android:id="@+id/settings_gplay_not_available"
@@ -349,7 +328,27 @@
                         android:layout_marginBottom="@dimen/standard_margin"
                         android:text="@string/nc_settings_default_ringtone"
                         android:textSize="@dimen/supporting_text_text_size"/>
+                </LinearLayout>
 
+                <LinearLayout
+                    android:id="@+id/settings_battery_optimization_wrapper"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?android:attr/selectableItemBackground"
+                    android:orientation="vertical"
+                    android:padding="@dimen/standard_padding">
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/nc_diagnose_battery_optimization_title"
+                        android:textSize="@dimen/headline_text_size" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/battery_optimization_ignored"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        tools:text="@string/nc_diagnose_battery_optimization_ignored"/>
                 </LinearLayout>
 
             </LinearLayout>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -185,7 +185,6 @@
                         android:text=""
                         tools:ignore="SpeakableTextPresentCheck" />
 
-
                 </com.google.android.material.textfield.TextInputLayout>
 
             </LinearLayout>
@@ -246,6 +245,28 @@
                             android:gravity="center_vertical"/>
                     </LinearLayout>
 
+                    <LinearLayout
+                        android:id="@+id/settings_server_notification_app_wrapper"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="?android:attr/selectableItemBackground"
+                        android:orientation="vertical"
+                        android:padding="@dimen/standard_padding">
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/nc_settings_server_notification_app_not_installed_title"
+                            android:textSize="@dimen/headline_text_size"/>
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/settings_server_notification_app_description"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:textColor="@color/nc_darkRed"
+                            android:textSize="@dimen/supporting_text_text_size"
+                            tools:text="Please contact the admin of www.example.com"/>
+                    </LinearLayout>
 
                     <LinearLayout
                         android:id="@+id/settings_notifications_permission_wrapper"
@@ -349,30 +370,6 @@
                         android:text="@string/nc_settings_default_ringtone"
                         android:textSize="@dimen/supporting_text_text_size"/>
                 </LinearLayout>
-
-                <LinearLayout
-                    android:id="@+id/settings_server_notification_app_wrapper"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:background="?android:attr/selectableItemBackground"
-                    android:orientation="vertical"
-                    android:padding="@dimen/standard_padding">
-
-                    <com.google.android.material.textview.MaterialTextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/nc_settings_server_notification_app_not_installed_title"
-                        android:textSize="@dimen/headline_text_size"/>
-
-                    <com.google.android.material.textview.MaterialTextView
-                        android:id="@+id/settings_server_notification_app_description"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:textColor="@color/nc_darkRed"
-                        android:textSize="@dimen/supporting_text_text_size"
-                        tools:text="Please contact the admin of www.example.com"/>
-                </LinearLayout>
-
             </LinearLayout>
 
             <LinearLayout

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -311,12 +311,12 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:background="?android:attr/selectableItemBackground"
-                    android:orientation="vertical">
+                    android:orientation="vertical"
+                    android:padding="@dimen/standard_padding">
 
                     <com.google.android.material.textview.MaterialTextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_margin="@dimen/standard_margin"
                         android:text="@string/nc_settings_call_ringtone"
                         android:textSize="@dimen/headline_text_size"/>
 
@@ -324,8 +324,6 @@
                         android:id="@+id/calls_ringtone"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginStart="@dimen/standard_margin"
-                        android:layout_marginBottom="@dimen/standard_margin"
                         android:text="@string/nc_settings_default_ringtone"
                         android:textSize="@dimen/supporting_text_text_size"/>
                 </LinearLayout>
@@ -335,12 +333,12 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:background="?android:attr/selectableItemBackground"
-                    android:orientation="vertical">
+                    android:orientation="vertical"
+                    android:padding="@dimen/standard_padding">
 
                     <com.google.android.material.textview.MaterialTextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_margin="@dimen/standard_margin"
                         android:text="@string/nc_settings_other_notifications_ringtone"
                         android:textSize="@dimen/headline_text_size"/>
 
@@ -348,10 +346,31 @@
                         android:id="@+id/messages_ringtone"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginStart="@dimen/standard_margin"
-                        android:layout_marginBottom="@dimen/standard_margin"
                         android:text="@string/nc_settings_default_ringtone"
                         android:textSize="@dimen/supporting_text_text_size"/>
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/settings_server_notification_app_wrapper"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?android:attr/selectableItemBackground"
+                    android:orientation="vertical"
+                    android:padding="@dimen/standard_padding">
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/nc_settings_server_notification_app_not_installed_title"
+                        android:textSize="@dimen/headline_text_size"/>
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/settings_server_notification_app_description"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/nc_darkRed"
+                        android:textSize="@dimen/supporting_text_text_size"
+                        tools:text="Please contact the admin of www.example.com"/>
                 </LinearLayout>
 
             </LinearLayout>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -251,6 +251,41 @@
                             android:layout_height="wrap_content"
                             tools:text="@string/nc_diagnose_battery_optimization_ignored"/>
                     </LinearLayout>
+
+                    <LinearLayout
+                        android:id="@+id/settings_show_ignore_battery_optimization_hint"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="?android:attr/selectableItemBackground"
+                        android:orientation="horizontal"
+                        android:padding="@dimen/standard_padding">
+
+                        <LinearLayout
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:orientation="vertical">
+
+                            <com.google.android.material.textview.MaterialTextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/nc_show_ignore_battery_optimization_hint_title"
+                                android:textSize="@dimen/headline_text_size"/>
+
+                            <com.google.android.material.textview.MaterialTextView
+                                android:id="@+id/settings_show_ignore_battery_optimization_hint_summary"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/nc_show_ignore_battery_optimization_hint_description"/>
+                        </LinearLayout>
+
+                        <com.google.android.material.materialswitch.MaterialSwitch
+                            android:id="@+id/settings_show_ignore_battery_optimization_hint_switch"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:clickable="false"
+                            android:gravity="center_vertical"/>
+                    </LinearLayout>
                 </LinearLayout>
 
                 <LinearLayout

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -92,5 +92,6 @@
     <color name="icon_on_bg_default">#99000000</color>
     <color name="badge_color">#EF3B02</color>
     <color name="secondary_button_background">#DBE2E9</color>
+    <color name="nc_warning">#FF9800</color>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,7 +101,6 @@ How to translate with transifex:
     <string name="nc_settings_no_talk_installed">Talk app is not installed on the server you tried to authenticate against</string>
     <string name="nc_settings_account_updated">Your already existing account was updated, instead of adding a new one</string>
     <string name="nc_account_scheduled_for_deletion">The account is scheduled for deletion, and cannot be changed</string>
-    <string name="nc_settings_notification_sounds">Notification sounds</string>
     <string name="nc_settings_notification_sounds_post_oreo">Notifications</string>
     <string name="nc_settings_call_ringtone">Calls</string>
     <string name="nc_settings_call_ringtone_key" translatable="false">call_ringtone</string>
@@ -181,8 +180,9 @@ How to translate with transifex:
 
     <string name="nc_ignore_battery_optimization_dialog_title">Ignore battery optimization</string>
     <string name="nc_ignore_battery_optimization_dialog_text">Battery optimization is not ignored. This should be changed to make sure that notifications work in the background! Please click OK and select \"All apps\" -> %1$s -> Do not optimize</string>
-    <string name="nc_show_ignore_battery_optimization_hint_title">Show battery optimization hint</string>
-    <string name="nc_show_ignore_battery_optimization_hint_description">When the battery optimization is not ignored, show a hint</string>
+    <string name="nc_show_notification_warning_title">Show notification warning</string>
+    <string name="nc_show_notification_warning_description">When notifications are not set up correctly, show a warning</string>
+    <string name="nc_notification_warning">Notifications are not set up correctly</string>
 
     <string name="nc_diagnose_meta_category_title">Meta information</string>
     <string name="nc_diagnose_meta_system_report_date">Generation of system report</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,6 +181,8 @@ How to translate with transifex:
 
     <string name="nc_ignore_battery_optimization_dialog_title">Ignore battery optimization</string>
     <string name="nc_ignore_battery_optimization_dialog_text">Battery optimization is not ignored. This should be changed to make sure that notifications work in the background! Please click OK and select \"All apps\" -> %1$s -> Do not optimize</string>
+    <string name="nc_show_ignore_battery_optimization_hint_title">Show battery optimization hint</string>
+    <string name="nc_show_ignore_battery_optimization_hint_description">When the battery optimization is not ignored, show a hint</string>
 
     <string name="nc_diagnose_meta_category_title">Meta information</string>
     <string name="nc_diagnose_meta_system_report_date">Generation of system report</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,7 +108,7 @@ How to translate with transifex:
     <string name="nc_settings_message_ringtone_key" translatable="false">message_ringtone</string>
     <string name="nc_settings_default_ringtone" translatable="false">Librem by feandesign</string>
     <string name="nc_settings_no_ringtone">No sound</string>
-    <string name="nc_settings_server_notification_app_not_installed_title">Server notification app not installed</string>
+    <string name="nc_settings_server_notification_app_not_installed_title">Server notifications app not installed</string>
     <string name="nc_settings_contact_admin_of">Please contact the administrator of</string>
 
     <string name="nc_settings_appearance">Appearance</string>
@@ -199,7 +199,7 @@ How to translate with transifex:
     <string name="nc_diagnose_gplay_available_yes">Google Play services are available</string>
     <string name="nc_diagnose_gplay_available_no">Google Play services are not available. Notifications are not supported</string>
     <string name="nc_diagnose_battery_optimization_title">Battery settings</string>
-    <string name="nc_diagnose_battery_optimization_not_ignored">Battery optimization is not ignored. This should be changed!</string>
+    <string name="nc_diagnose_battery_optimization_not_ignored">Battery optimization is enabled which might cause issues. You should disable battery optimization!</string>
     <string name="nc_diagnose_battery_optimization_ignored">Battery optimization is ignored, all fine</string>
     <string name="nc_diagnose_notification_permission">Notification permissions</string>
     <string name="nc_diagnose_notification_calls_channel_permission">Calls notification channel enabled?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,6 +108,8 @@ How to translate with transifex:
     <string name="nc_settings_message_ringtone_key" translatable="false">message_ringtone</string>
     <string name="nc_settings_default_ringtone" translatable="false">Librem by feandesign</string>
     <string name="nc_settings_no_ringtone">No sound</string>
+    <string name="nc_settings_server_notification_app_not_installed_title">Server notification app not installed</string>
+    <string name="nc_settings_contact_admin_of">Please contact the administrator of</string>
 
     <string name="nc_settings_appearance">Appearance</string>
     <string name="nc_settings_theme_title">Theme</string>


### PR DESCRIPTION
Show a warning whenever something regarding notifications is not set up correctly.

known bug is https://github.com/nextcloud/talk-android/issues/4484 (won't be fixed for now if no one comes up with an idea..)



### 🖼️ Screenshots/ Videos

Warning when notifications are not set up correctly

![grafik](https://github.com/user-attachments/assets/b0800e57-875a-4af3-a565-4d52cb066fb0)

- On first login, ask directly with popups for notification permission and to ignore battery optimization.
- If this is declined or any other setting is wrong, show a permanent warning. 
   - Also: When using mobile device management MDM, it may happen that some permissions are not set up while preparing the phones and users won't see any dialogs on first use. With this change, they now see the permanent warning and are guided what changes need to be made.
- When clicking on the warning, settings are opened and things that need to be changed will blink and have red subtitles.
- When any permission is revoked it will show a warning again in conversation list.
- Allow user to disable the warning in conversation list if anything is wrong.
- If a server has no notification app installed, this will be shown for the regarding account.

https://github.com/user-attachments/assets/caca4e1b-dcb7-440d-b5ba-7030d15d4e32

- When logging in and allowing all permissions, no warning is necessary.

https://github.com/user-attachments/assets/e74d7189-9dff-467d-bf24-855f0119a711





### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)