### PR TITLE
Add playback speed control to voice messages

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/VoiceMessageInterface.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/VoiceMessageInterface.kt
@@ -1,13 +1,16 @@
 /*
  * Nextcloud Talk - Android Client
  *
+ * SPDX-FileCopyrightText: 2024 Christian Reiner <foss@christian-reiner.info>
  * SPDX-FileCopyrightText: 2021 Marcel Hibbe <dev@mhibbe.de>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 package com.nextcloud.talk.adapters.messages
 
 import com.nextcloud.talk.chat.data.model.ChatMessage
+import com.nextcloud.talk.ui.PlaybackSpeed
 
 interface VoiceMessageInterface {
     fun updateMediaPlayerProgressBySlider(message: ChatMessage, progress: Int)
+    fun registerMessageToObservePlaybackSpeedPreferences(userId: String, listener: (speed: PlaybackSpeed) -> Unit)
 }

--- a/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
@@ -109,9 +109,9 @@ class ChatViewModel @Inject constructor(
     val getVoiceRecordingLocked: LiveData<Boolean>
         get() = _getVoiceRecordingLocked
 
-    private val _voiceMessagePlaybackSpeeds: MutableLiveData<Map<String, PlaybackSpeed>> = MutableLiveData()
+    private val _voiceMessagePlaybackSpeedPreferences: MutableLiveData<Map<String, PlaybackSpeed>> = MutableLiveData()
     val voiceMessagePlaybackSpeedPreferences: LiveData<Map<String, PlaybackSpeed>>
-        get() = _voiceMessagePlaybackSpeeds
+        get() = _voiceMessagePlaybackSpeedPreferences
 
     val getMessageFlow = chatRepository.messageFlow
         .onEach {
@@ -651,11 +651,11 @@ class ChatViewModel @Inject constructor(
         }
 
     fun applyPlaybackSpeedPreferences(speeds: Map<String, PlaybackSpeed>) {
-        _voiceMessagePlaybackSpeeds.postValue(speeds)
+        _voiceMessagePlaybackSpeedPreferences.postValue(speeds)
     }
 
     fun getPlaybackSpeedPreference(message: ChatMessage) =
-        _voiceMessagePlaybackSpeeds.value?.get(message.user.id) ?: PlaybackSpeed.NORMAL
+        _voiceMessagePlaybackSpeedPreferences.value?.get(message.user.id) ?: PlaybackSpeed.NORMAL
 
 // inner class GetRoomObserver : Observer<ConversationModel> {
 //     override fun onSubscribe(d: Disposable) {

--- a/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
@@ -1,6 +1,7 @@
 /*
  * Nextcloud Talk - Android Client
  *
+ * SPDX-FileCopyrightText: 2024 Christian Reiner <foss@christian-reiner.info>
  * SPDX-FileCopyrightText: 2023 Marcel Hibbe <dev@mhibbe.de>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
@@ -33,6 +34,7 @@ import com.nextcloud.talk.models.json.conversations.RoomsOverall
 import com.nextcloud.talk.models.json.generic.GenericOverall
 import com.nextcloud.talk.models.json.reminder.Reminder
 import com.nextcloud.talk.repositories.reactions.ReactionsRepository
+import com.nextcloud.talk.ui.PlaybackSpeed
 import com.nextcloud.talk.utils.ConversationUtils
 import com.nextcloud.talk.utils.bundle.BundleKeys
 import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
@@ -106,6 +108,10 @@ class ChatViewModel @Inject constructor(
     private val _getVoiceRecordingLocked: MutableLiveData<Boolean> = MutableLiveData()
     val getVoiceRecordingLocked: LiveData<Boolean>
         get() = _getVoiceRecordingLocked
+
+    private val _voiceMessagePlaybackSpeeds: MutableLiveData<Map<String, PlaybackSpeed>> = MutableLiveData()
+    val voiceMessagePlaybackSpeedPreferences: LiveData<Map<String, PlaybackSpeed>>
+        get() = _voiceMessagePlaybackSpeeds
 
     val getMessageFlow = chatRepository.messageFlow
         .onEach {
@@ -643,6 +649,13 @@ class ChatViewModel @Inject constructor(
             val message = chatRepository.getMessage(messageId, bundle)
             emit(message.first())
         }
+
+    fun applyPlaybackSpeedPreferences(speeds: Map<String, PlaybackSpeed>) {
+        _voiceMessagePlaybackSpeeds.postValue(speeds)
+    }
+
+    fun getPlaybackSpeedPreference(message: ChatMessage) =
+        _voiceMessagePlaybackSpeeds.value?.get(message.user.id) ?: PlaybackSpeed.NORMAL
 
 // inner class GetRoomObserver : Observer<ConversationModel> {
 //     override fun onSubscribe(d: Disposable) {

--- a/app/src/main/java/com/nextcloud/talk/chat/viewmodels/MessageInputViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/viewmodels/MessageInputViewModel.kt
@@ -38,7 +38,7 @@ class MessageInputViewModel @Inject constructor(
     private val audioRecorderManager: AudioRecorderManager,
     private val mediaPlayerManager: MediaPlayerManager,
     private val audioFocusRequestManager: AudioFocusRequestManager,
-    private val dataStore: AppPreferences
+    private val appPreferences: AppPreferences
 ) : ViewModel(), DefaultLifecycleObserver {
     enum class LifeCycleFlag {
         PAUSED,
@@ -147,9 +147,9 @@ class MessageInputViewModel @Inject constructor(
         if (isQueueing) {
             val tempID = System.currentTimeMillis().toInt()
             val qMsg = QueuedMessage(tempID, message, displayName, replyTo, sendWithoutNotification)
-            messageQueue = dataStore.getMessageQueue(internalId)
+            messageQueue = appPreferences.getMessageQueue(internalId)
             messageQueue.add(qMsg)
-            dataStore.saveMessageQueue(internalId, messageQueue)
+            appPreferences.saveMessageQueue(internalId, messageQueue)
             _messageQueueSizeFlow.update { messageQueue.size }
             _messageQueueFlow.postValue(listOf(qMsg))
             return
@@ -260,8 +260,8 @@ class MessageInputViewModel @Inject constructor(
         if (isQueueing) return
         messageQueue.clear()
 
-        val queue = dataStore.getMessageQueue(internalId)
-        dataStore.saveMessageQueue(internalId, null) // empties the queue
+        val queue = appPreferences.getMessageQueue(internalId)
+        appPreferences.saveMessageQueue(internalId, null) // empties the queue
         while (queue.size > 0) {
             val msg = queue.removeAt(0)
             sendChatMessage(
@@ -279,7 +279,7 @@ class MessageInputViewModel @Inject constructor(
     }
 
     fun getTempMessagesFromMessageQueue(internalId: String) {
-        val queue = dataStore.getMessageQueue(internalId)
+        val queue = appPreferences.getMessageQueue(internalId)
         val list = mutableListOf<QueuedMessage>()
         for (msg in queue) {
             list.add(msg)
@@ -292,31 +292,31 @@ class MessageInputViewModel @Inject constructor(
     }
 
     fun restoreMessageQueue(internalId: String) {
-        messageQueue = dataStore.getMessageQueue(internalId)
+        messageQueue = appPreferences.getMessageQueue(internalId)
         _messageQueueSizeFlow.tryEmit(messageQueue.size)
     }
 
     fun removeFromQueue(internalId: String, id: Int) {
-        val queue = dataStore.getMessageQueue(internalId)
+        val queue = appPreferences.getMessageQueue(internalId)
         for (qMsg in queue) {
             if (qMsg.id == id) {
                 queue.remove(qMsg)
                 break
             }
         }
-        dataStore.saveMessageQueue(internalId, queue)
+        appPreferences.saveMessageQueue(internalId, queue)
         _messageQueueSizeFlow.tryEmit(queue.size)
     }
 
     fun editQueuedMessage(internalId: String, id: Int, newMessage: String) {
-        val queue = dataStore.getMessageQueue(internalId)
+        val queue = appPreferences.getMessageQueue(internalId)
         for (qMsg in queue) {
             if (qMsg.id == id) {
                 qMsg.message = newMessage
                 break
             }
         }
-        dataStore.saveMessageQueue(internalId, queue)
+        appPreferences.saveMessageQueue(internalId, queue)
     }
 
     fun showCallStartedIndicator(recent: ChatMessage, show: Boolean) {

--- a/app/src/main/java/com/nextcloud/talk/ui/PlaybackSpeedControl.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/PlaybackSpeedControl.kt
@@ -1,0 +1,75 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Christian Reiner <foss@christian-reiner.info>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.nextcloud.talk.ui
+
+import android.content.Context
+import android.util.AttributeSet
+import autodagger.AutoInjector
+import com.google.android.material.button.MaterialButton
+import java.util.Locale
+import com.nextcloud.talk.application.NextcloudTalkApplication
+import com.nextcloud.talk.ui.theme.ViewThemeUtils
+import javax.inject.Inject
+
+internal const val SPEED_FACTOR_SLOW = 0.8f
+internal const val SPEED_FACTOR_NORMAL = 1.0f
+internal const val SPEED_FACTOR_FASTER = 1.5f
+internal const val SPEED_FACTOR_FASTEST = 2.0f
+
+@AutoInjector(NextcloudTalkApplication::class)
+class PlaybackSpeedControl @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : MaterialButton(context, attrs, defStyleAttr) {
+
+    @Inject
+    lateinit var viewThemeUtils: ViewThemeUtils
+
+    private var currentSpeed = PlaybackSpeed.NORMAL
+
+    init {
+        NextcloudTalkApplication.sharedApplication?.componentApplication?.inject(this)
+        text = currentSpeed.label
+        viewThemeUtils.material.colorMaterialButtonText(this)
+    }
+
+    fun setSpeed(newSpeed: PlaybackSpeed) {
+        currentSpeed = newSpeed
+        text = currentSpeed.label
+    }
+
+    fun getSpeed(): PlaybackSpeed {
+        return currentSpeed
+    }
+}
+
+enum class PlaybackSpeed(val value: Float) {
+    SLOW(SPEED_FACTOR_SLOW),
+    NORMAL(SPEED_FACTOR_NORMAL),
+    FASTER(SPEED_FACTOR_FASTER),
+    FASTEST(SPEED_FACTOR_FASTEST);
+
+    // no fixed, literal labels, since we want to obey numeric interpunctuation for different locales
+    val label: String = String.format(Locale.getDefault(), "%01.1fx", value)
+
+    fun next(): PlaybackSpeed {
+        return entries[(ordinal + 1) % entries.size]
+    }
+
+    companion object {
+        fun byName(name: String): PlaybackSpeed {
+            for (speed in entries) {
+                if (speed.name.equals(name, ignoreCase = true)) {
+                    return speed
+                }
+            }
+            return NORMAL
+        }
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/utils/preferences/AppPreferences.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/preferences/AppPreferences.java
@@ -1,6 +1,7 @@
 /*
  * Nextcloud Talk - Android Client
  *
+ * SPDX-FileCopyrightText: 2024 Christian Reiner <foss@christian-reiner.info>
  * SPDX-FileCopyrightText: 2021 Andy Scherzinger <info@andy-scherzinger.de>
  * SPDX-FileCopyrightText: 2021 Tim Krüger <t@timkrueger.me>
  * SPDX-FileCopyrightText: 2017 Mario Danic <mario@lovelyhq.com>
@@ -11,8 +12,10 @@ package com.nextcloud.talk.utils.preferences;
 import android.annotation.SuppressLint;
 
 import com.nextcloud.talk.chat.viewmodels.MessageInputViewModel;
+import com.nextcloud.talk.ui.PlaybackSpeed;
 
 import java.util.List;
+import java.util.Map;
 
 @SuppressLint("NonConstantResourceId")
 public interface AppPreferences {
@@ -177,6 +180,10 @@ public interface AppPreferences {
     List<MessageInputViewModel.QueuedMessage> getMessageQueue(String internalConversationId);
 
     void deleteAllMessageQueuesFor(String userId);
+
+    void saveVoiceMessagePlaybackSpeedPreferences(Map<String, PlaybackSpeed> speeds);
+
+    Map<String, PlaybackSpeed> readVoiceMessagePlaybackSpeedPreferences();
 
     Long getNotificationWarningLastPostponedDate();
 

--- a/app/src/main/res/layout/fragment_message_input_voice_recording.xml
+++ b/app/src/main/res/layout/fragment_message_input_voice_recording.xml
@@ -50,6 +50,7 @@
             tools:progress="50"
             tools:progressTint="@color/hwSecurityRed"
             tools:progressBackgroundTint="@color/blue"/>
+
     </LinearLayout>
 
     <Chronometer

--- a/app/src/main/res/layout/item_custom_incoming_voice_message.xml
+++ b/app/src/main/res/layout/item_custom_incoming_voice_message.xml
@@ -2,6 +2,7 @@
 <!--
   ~ Nextcloud Talk - Android Client
   ~
+  ~ SPDX-FileCopyrightText: 2024 Christian Reiner <foss@christian-reiner.info>
   ~ SPDX-FileCopyrightText: 2021 Andy Scherzinger <info@andy-scherzinger.de>
   ~ SPDX-FileCopyrightText: 2021 Marcel Hibbe <dev@mhibbe.de>
   ~ SPDX-FileCopyrightText: 2017-2018 Mario Danic <mario@lovelyhq.com>
@@ -76,7 +77,6 @@
                 app:iconSize="40dp"
                 app:iconTint="@color/nc_incoming_text_default" />
 
-
             <com.nextcloud.talk.ui.WaveformSeekBar
                 android:id="@+id/seekbar"
                 android:layout_width="0dp"
@@ -85,6 +85,16 @@
                 tools:progress="50"
                 android:layout_weight="1" />
 
+            <com.nextcloud.talk.ui.PlaybackSpeedControl
+                android:id="@+id/playbackSpeedControlBtn"
+                style="@style/Widget.AppTheme.Button.IconButton"
+                android:layout_width="wrap_content"
+                android:layout_height="48dp"
+                android:layout_marginEnd="@dimen/standard_margin"
+                android:contentDescription="@string/playback_speed_control"
+                android:textColor="@color/black"
+                app:cornerRadius="@dimen/button_corner_radius"
+                app:rippleColor="#1FFFFFFF" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/item_custom_outcoming_voice_message.xml
+++ b/app/src/main/res/layout/item_custom_outcoming_voice_message.xml
@@ -2,6 +2,7 @@
 <!--
   ~ Nextcloud Talk - Android Client
   ~
+  ~ SPDX-FileCopyrightText: 2024 Christian Reiner <foss@christian-reiner.info>
   ~ SPDX-FileCopyrightText: 2021 Andy Scherzinger <info@andy-scherzinger.de>
   ~ SPDX-FileCopyrightText: 2021 Marcel Hibbe <dev@mhibbe.de>
   ~ SPDX-FileCopyrightText: 2017-2018 Mario Danic <mario@lovelyhq.com>
@@ -69,6 +70,17 @@
                 android:thumb="@drawable/voice_message_outgoing_seek_bar_slider"
                 tools:progress="50"
                 android:layout_weight="1" />
+
+            <com.nextcloud.talk.ui.PlaybackSpeedControl
+                android:id="@+id/playbackSpeedControlBtn"
+                style="@style/Widget.AppTheme.Button.IconButton"
+                android:layout_width="wrap_content"
+                android:layout_height="48dp"
+                android:layout_marginEnd="@dimen/standard_margin"
+                android:contentDescription="@string/playback_speed_control"
+                android:textColor="@color/black"
+                app:cornerRadius="@dimen/button_corner_radius"
+                app:rippleColor="#1FFFFFFF" />
 
         </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -572,6 +572,7 @@ How to translate with transifex:
     <string name="nc_voice_message_slide_to_cancel">« Slide to cancel</string>
     <string name="play_pause_voice_message">Play/pause voice message</string>
     <string name="nc_voice_message_missing_audio_permission">Permission for audio recording is required</string>
+    <string name="playback_speed_control">Playback speed control</string>
 
     <!-- Phonebook Integration -->
     <string name="nc_settings_phone_book_integration_desc">Match contacts based on phone number to integrate Talk shortcut into system contacts app</string>

--- a/app/src/test/java/com/nextcloud/talk/utils/ParticipantPermissionsTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/utils/ParticipantPermissionsTest.kt
@@ -21,7 +21,34 @@ class ParticipantPermissionsTest : TestCase() {
     @Test
     fun test_areFlagsSet() {
         val spreedCapability = SpreedCapability()
-        val conversation = Conversation(
+        val conversation = createConversation()
+
+        conversation.permissions = ParticipantPermissions.PUBLISH_SCREEN or
+            ParticipantPermissions.JOIN_CALL or
+            ParticipantPermissions.DEFAULT
+
+        val user = User()
+        user.id = 1
+
+        val attendeePermissions =
+            ParticipantPermissions(
+                spreedCapability,
+                ConversationModel.mapToConversationModel(conversation, user)
+            )
+
+        assert(attendeePermissions.canPublishScreen)
+        assert(attendeePermissions.canJoinCall)
+        assert(attendeePermissions.isDefault)
+
+        assertFalse(attendeePermissions.isCustom)
+        assertFalse(attendeePermissions.canStartCall())
+        assertFalse(attendeePermissions.canIgnoreLobby())
+        assertTrue(attendeePermissions.canPublishAudio())
+        assertTrue(attendeePermissions.canPublishVideo())
+    }
+
+    private fun createConversation(): Conversation {
+        return Conversation(
             token = "test",
             name = "test",
             displayName = "test",
@@ -67,28 +94,5 @@ class ParticipantPermissionsTest : TestCase() {
             remoteServer = "",
             remoteToken = ""
         )
-
-        conversation.permissions = ParticipantPermissions.PUBLISH_SCREEN or
-            ParticipantPermissions.JOIN_CALL or
-            ParticipantPermissions.DEFAULT
-
-        val user = User()
-        user.id = 1
-
-        val attendeePermissions =
-            ParticipantPermissions(
-                spreedCapability,
-                ConversationModel.mapToConversationModel(conversation, user)
-            )
-
-        assert(attendeePermissions.canPublishScreen)
-        assert(attendeePermissions.canJoinCall)
-        assert(attendeePermissions.isDefault)
-
-        assertFalse(attendeePermissions.isCustom)
-        assertFalse(attendeePermissions.canStartCall())
-        assertFalse(attendeePermissions.canIgnoreLobby())
-        assertTrue(attendeePermissions.canPublishAudio())
-        assertTrue(attendeePermissions.canPublishVideo())
     }
 }


### PR DESCRIPTION
This is an implementation of the feature request in issue 3786: 
"Allow voice messages to be played at different speeds"

This PR should not be considered final. There are a few questions to be answered first, I cannot do that myself, however. I need someone from inside the project for that. So this is more a "request for comment" than a PR ;-)

The current implementation does not at all offer a fancy design. The UI is as simplistic as possible. 
I could very well imagine a button that extends when clicked and offers the options in parallel instead of cycling through the offered options as it is currently implemented. But that certainly is something a design expert has to decide. 

The current implementation has 4 speeds it offers (opposed to WhatsApp offering 3): 0.8x, 1.0x, 1.5x, 2.0x. I added the slow variant since that could sometimes help to understand messages with bad acoustics. 
The chosen speed is persisted on a per-user base. This appeared intuitive to me, since usually individual users keep their typical talking speed. Which means that if there is a need to change the playback speed that change probably makes sense for all voice messages of that user. 

I would need some advice about the testing strategy in this project ... When trying to implement tests I found that next to no tests and test structure exist. I assume I miss something here ...

Seems I found a bug in how the message view holders are handled: their onBind() method is called over and over again when a voice message is played. That might be triggered by updating the progress slider. This behaviour repaints the view holder millions of times which actually creates quite a load on the system ...

I am thankful for any feedback on this! 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![screenshot_nextcloud-andoird-talk-voice-message-before](https://github.com/user-attachments/assets/8585148c-9d77-471c-b15f-4f0de04b63e2) | ![screenshot_nextcloud-andoird-talk-voice-message-after](https://github.com/user-attachments/assets/460cb279-83b8-4bf4-93f3-5b24e15d68c7)

### 🚧 TODO

- [x] decide about design requirements or requests for the new button
- [x] clearify state of unit and instrumented tests
- [x] decide what to do with pre existing onBind() bug in message holders
- [x] Translations

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)