### PR TITLE
remove hilt dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,7 +26,6 @@ apply plugin: 'com.github.spotbugs'
 apply plugin: 'io.gitlab.arturbosch.detekt'
 apply plugin: "org.jlleitschuh.gradle.ktlint"
 apply plugin: 'kotlinx-serialization'
-apply plugin: 'dagger.hilt.android.plugin'
 
 android {
     compileSdk 34
@@ -46,7 +45,6 @@ android {
         flavorDimensions "default"
         renderscriptTargetApi 19
         renderscriptSupportModeEnabled true
-        javaCompileOptions.annotationProcessorOptions.arguments['dagger.hilt.disableModulesHaveInstallInCheck'] = 'true'
 
         productFlavors {
             // used for f-droid
@@ -354,9 +352,6 @@ dependencies {
 
     implementation 'com.github.nextcloud-deps:android-talk-webrtc:121.6167.0'
     implementation("io.coil-kt:coil-compose:2.7.0")
-
-    implementation "com.google.dagger:hilt-android:$hilt_version"
-    kapt "com.google.dagger:hilt-android-compiler:$hilt_version"
 
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
     androidTestImplementation(platform("androidx.compose:compose-bom:2024.11.00"))

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ buildscript {
 
     ext {
       kotlinVersion = '2.1.0'
-        hilt_version = '2.44'
     }
 
     repositories {
@@ -28,8 +27,6 @@ buildscript {
         classpath 'com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.26'
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.7"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:12.1.2"
-        classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
-
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
This PR removes unused hilt dependency. 

Renovate failed to update the Hilt dependency due to a conflict between Hilt and KSP plugins  https://github.com/nextcloud/talk-android/pull/4019 . The Hilt plugin is applied in the root project, while KSP is applied in a sub-project, which causes compatibility issues. To avoid complexity, the unused hilt plugin has been removed.


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)