### PR TITLE
Improve handling of data channels

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -1174,12 +1174,12 @@ class CallActivity : CallBaseActivity() {
         if (isConnectionEstablished && othersInCall) {
             if (!hasMCU) {
                 for (peerConnectionWrapper in peerConnectionWrapperList) {
-                    peerConnectionWrapper.sendChannelData(DataChannelMessage(isSpeakingMessage))
+                    peerConnectionWrapper.send(DataChannelMessage(isSpeakingMessage))
                 }
             } else {
                 for (peerConnectionWrapper in peerConnectionWrapperList) {
                     if (peerConnectionWrapper.sessionId == webSocketClient!!.sessionId) {
-                        peerConnectionWrapper.sendChannelData(DataChannelMessage(isSpeakingMessage))
+                        peerConnectionWrapper.send(DataChannelMessage(isSpeakingMessage))
                         break
                     }
                 }
@@ -1370,12 +1370,12 @@ class CallActivity : CallBaseActivity() {
         if (isConnectionEstablished) {
             if (!hasMCU) {
                 for (peerConnectionWrapper in peerConnectionWrapperList) {
-                    peerConnectionWrapper.sendChannelData(DataChannelMessage(message))
+                    peerConnectionWrapper.send(DataChannelMessage(message))
                 }
             } else {
                 for (peerConnectionWrapper in peerConnectionWrapperList) {
                     if (peerConnectionWrapper.sessionId == webSocketClient!!.sessionId) {
-                        peerConnectionWrapper.sendChannelData(DataChannelMessage(message))
+                        peerConnectionWrapper.send(DataChannelMessage(message))
                         break
                     }
                 }
@@ -2563,7 +2563,7 @@ class CallActivity : CallBaseActivity() {
                         }
 
                         override fun onNext(aLong: Long) {
-                            peerConnectionWrapper.sendChannelData(dataChannelMessage)
+                            peerConnectionWrapper.send(dataChannelMessage)
                         }
 
                         override fun onError(e: Throwable) {

--- a/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
@@ -400,9 +400,11 @@ public class PeerConnectionWrapper {
     private class DataChannelObserver implements DataChannel.Observer {
 
         private final DataChannel dataChannel;
+        private final String dataChannelLabel;
 
         public DataChannelObserver(DataChannel dataChannel) {
             this.dataChannel = Objects.requireNonNull(dataChannel);
+            this.dataChannelLabel = dataChannel.label();
         }
 
         @Override
@@ -412,7 +414,7 @@ public class PeerConnectionWrapper {
 
         @Override
         public void onStateChange() {
-            if (dataChannel.state() == DataChannel.State.OPEN && "status".equals(dataChannel.label())) {
+            if (dataChannel.state() == DataChannel.State.OPEN && "status".equals(dataChannelLabel)) {
                 for (DataChannelMessage dataChannelMessage: pendingDataChannelMessages) {
                     send(dataChannelMessage);
                 }
@@ -427,7 +429,7 @@ public class PeerConnectionWrapper {
         @Override
         public void onMessage(DataChannel.Buffer buffer) {
             if (buffer.binary) {
-                Log.d(TAG, "Received binary data channel message over " + dataChannel.label() + " " + sessionId);
+                Log.d(TAG, "Received binary data channel message over " + dataChannelLabel + " " + sessionId);
                 return;
             }
 
@@ -435,7 +437,7 @@ public class PeerConnectionWrapper {
             final byte[] bytes = new byte[data.capacity()];
             data.get(bytes);
             String strData = new String(bytes);
-            Log.d(TAG, "Received data channel message (" + strData + ") over " + dataChannel.label() + " " + sessionId);
+            Log.d(TAG, "Received data channel message (" + strData + ") over " + dataChannelLabel + " " + sessionId);
 
             DataChannelMessage dataChannelMessage;
             try {

--- a/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
@@ -285,8 +285,12 @@ public class PeerConnectionWrapper {
      * @param dataChannelMessage the message to send
      */
     public void send(DataChannelMessage dataChannelMessage) {
+        if (dataChannelMessage == null) {
+            return;
+        }
+
         DataChannel statusDataChannel = dataChannels.get("status");
-        if (statusDataChannel == null || dataChannelMessage == null) {
+        if (statusDataChannel == null) {
             return;
         }
 

--- a/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
@@ -298,7 +298,8 @@ public class PeerConnectionWrapper {
         }
 
         DataChannel statusDataChannel = dataChannels.get("status");
-        if (statusDataChannel == null || statusDataChannel.state() != DataChannel.State.OPEN) {
+        if (statusDataChannel == null || statusDataChannel.state() != DataChannel.State.OPEN ||
+            !pendingDataChannelMessages.isEmpty()) {
             Log.d(TAG, "Queuing data channel message (" + dataChannelMessage + ") " + sessionId);
 
             pendingDataChannelMessages.add(dataChannelMessage);
@@ -306,6 +307,10 @@ public class PeerConnectionWrapper {
             return;
         }
 
+        sendWithoutQueuing(statusDataChannel, dataChannelMessage);
+    }
+
+    private void sendWithoutQueuing(DataChannel statusDataChannel, DataChannelMessage dataChannelMessage) {
         try {
             Log.d(TAG, "Sending data channel message (" + dataChannelMessage + ") " + sessionId);
 
@@ -423,7 +428,7 @@ public class PeerConnectionWrapper {
 
                 if (dataChannel.state() == DataChannel.State.OPEN && "status".equals(dataChannelLabel)) {
                     for (DataChannelMessage dataChannelMessage : pendingDataChannelMessages) {
-                        send(dataChannelMessage);
+                        sendWithoutQueuing(dataChannel, dataChannelMessage);
                     }
                     pendingDataChannelMessages.clear();
                 }

--- a/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
@@ -286,13 +286,15 @@ public class PeerConnectionWrapper {
      */
     public void send(DataChannelMessage dataChannelMessage) {
         DataChannel statusDataChannel = dataChannels.get("status");
-        if (statusDataChannel != null && dataChannelMessage != null) {
-            try {
-                ByteBuffer buffer = ByteBuffer.wrap(LoganSquare.serialize(dataChannelMessage).getBytes());
-                statusDataChannel.send(new DataChannel.Buffer(buffer, false));
-            } catch (Exception e) {
-                Log.d(TAG, "Failed to send channel data, attempting regular " + dataChannelMessage);
-            }
+        if (statusDataChannel == null || dataChannelMessage == null) {
+            return;
+        }
+
+        try {
+            ByteBuffer buffer = ByteBuffer.wrap(LoganSquare.serialize(dataChannelMessage).getBytes());
+            statusDataChannel.send(new DataChannel.Buffer(buffer, false));
+        } catch (Exception e) {
+            Log.d(TAG, "Failed to send channel data, attempting regular " + dataChannelMessage);
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
@@ -7,11 +7,9 @@
  */
 package com.nextcloud.talk.webrtc;
 
-import android.content.Context;
 import android.util.Log;
 
 import com.bluelinelabs.logansquare.LoganSquare;
-import com.nextcloud.talk.application.NextcloudTalkApplication;
 import com.nextcloud.talk.models.json.signaling.DataChannelMessage;
 import com.nextcloud.talk.models.json.signaling.NCIceCandidate;
 import com.nextcloud.talk.models.json.signaling.NCMessagePayload;
@@ -38,18 +36,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-
-import javax.inject.Inject;
 
 import androidx.annotation.Nullable;
-import autodagger.AutoInjector;
 
-@AutoInjector(NextcloudTalkApplication.class)
 public class PeerConnectionWrapper {
-
-    @Inject
-    Context context;
 
     private static final String TAG = PeerConnectionWrapper.class.getCanonicalName();
 
@@ -117,9 +107,6 @@ public class PeerConnectionWrapper {
                                  boolean isMCUPublisher, boolean hasMCU, String videoStreamType,
                                  SignalingMessageReceiver signalingMessageReceiver,
                                  SignalingMessageSender signalingMessageSender) {
-
-        Objects.requireNonNull(NextcloudTalkApplication.Companion.getSharedApplication()).getComponentApplication().inject(this);
-
         this.localStream = localStream;
         this.videoStreamType = videoStreamType;
 

--- a/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
@@ -299,16 +299,20 @@ public class PeerConnectionWrapper {
 
         DataChannel statusDataChannel = dataChannels.get("status");
         if (statusDataChannel == null || statusDataChannel.state() != DataChannel.State.OPEN) {
+            Log.d(TAG, "Queuing data channel message (" + dataChannelMessage + ") " + sessionId);
+
             pendingDataChannelMessages.add(dataChannelMessage);
 
             return;
         }
 
         try {
+            Log.d(TAG, "Sending data channel message (" + dataChannelMessage + ") " + sessionId);
+
             ByteBuffer buffer = ByteBuffer.wrap(LoganSquare.serialize(dataChannelMessage).getBytes());
             statusDataChannel.send(new DataChannel.Buffer(buffer, false));
         } catch (Exception e) {
-            Log.d(TAG, "Failed to send channel data, attempting regular " + dataChannelMessage);
+            Log.w(TAG, "Failed to send data channel message");
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
@@ -269,7 +269,7 @@ public class PeerConnectionWrapper {
         }
     }
 
-    public void sendChannelData(DataChannelMessage dataChannelMessage) {
+    public void send(DataChannelMessage dataChannelMessage) {
         ByteBuffer buffer;
         if (dataChannel != null && dataChannelMessage != null) {
             try {
@@ -292,15 +292,15 @@ public class PeerConnectionWrapper {
     private void sendInitialMediaStatus() {
         if (localStream != null) {
             if (localStream.videoTracks.size() == 1 && localStream.videoTracks.get(0).enabled()) {
-                sendChannelData(new DataChannelMessage("videoOn"));
+                send(new DataChannelMessage("videoOn"));
             } else {
-                sendChannelData(new DataChannelMessage("videoOff"));
+                send(new DataChannelMessage("videoOff"));
             }
 
             if (localStream.audioTracks.size() == 1 && localStream.audioTracks.get(0).enabled()) {
-                sendChannelData(new DataChannelMessage("audioOn"));
+                send(new DataChannelMessage("audioOn"));
             } else {
-                sendChannelData(new DataChannelMessage("audioOff"));
+                send(new DataChannelMessage("audioOff"));
             }
         }
     }

--- a/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
@@ -379,7 +379,7 @@ public class PeerConnectionWrapper {
         @Override
         public void onMessage(DataChannel.Buffer buffer) {
             if (buffer.binary) {
-                Log.d(TAG, "Received binary msg over " + TAG + " " + sessionId);
+                Log.d(TAG, "Received binary data channel message over " + TAG + " " + sessionId);
                 return;
             }
 
@@ -387,7 +387,7 @@ public class PeerConnectionWrapper {
             final byte[] bytes = new byte[data.capacity()];
             data.get(bytes);
             String strData = new String(bytes);
-            Log.d(TAG, "Got msg: " + strData + " over " + TAG + " " + sessionId);
+            Log.d(TAG, "Received data channel message (" + strData + ") over " + TAG + " " + sessionId);
 
             DataChannelMessage dataChannelMessage;
             try {

--- a/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
@@ -71,6 +71,9 @@ public class PeerConnectionWrapper {
     /**
      * Listener for data channel messages.
      * <p>
+     * Messages might have been received on any data channel, independently of its label or whether it was open by the
+     * local or the remote peer.
+     * <p>
      * The messages are bound to a specific peer connection, so each listener is expected to handle messages only for
      * a single peer connection.
      * <p>

--- a/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
@@ -285,11 +285,10 @@ public class PeerConnectionWrapper {
      * @param dataChannelMessage the message to send
      */
     public void send(DataChannelMessage dataChannelMessage) {
-        ByteBuffer buffer;
         DataChannel statusDataChannel = dataChannels.get("status");
         if (statusDataChannel != null && dataChannelMessage != null) {
             try {
-                buffer = ByteBuffer.wrap(LoganSquare.serialize(dataChannelMessage).getBytes());
+                ByteBuffer buffer = ByteBuffer.wrap(LoganSquare.serialize(dataChannelMessage).getBytes());
                 statusDataChannel.send(new DataChannel.Buffer(buffer, false));
             } catch (Exception e) {
                 Log.d(TAG, "Failed to send channel data, attempting regular " + dataChannelMessage);

--- a/app/src/test/java/android/util/Log.java
+++ b/app/src/test/java/android/util/Log.java
@@ -1,0 +1,51 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package android.util;
+
+/**
+ * Dummy implementation of android.util.Log to be used in unit tests.
+ * <p>
+ * The Android Gradle plugin provides a library with the APIs of the Android framework that throws an exception if any
+ * of them are called. This class is loaded before that library and therefore becomes the implementation used during the
+ * tests, simply printing the messages to the system console.
+ */
+public class Log {
+
+    public static int d(String tag, String msg) {
+        System.out.println("DEBUG: " + tag + ": " + msg);
+
+        return 1;
+    }
+
+    public static int e(String tag, String msg) {
+        System.out.println("ERROR: " + tag + ": " + msg);
+
+        return 1;
+    }
+
+    public static int i(String tag, String msg) {
+        System.out.println("INFO: " + tag + ": " + msg);
+
+        return 1;
+    }
+
+    public static boolean isLoggable(String tag, int level) {
+        return true;
+    }
+
+    public static int v(String tag, String msg) {
+        System.out.println("VERBOSE: " + tag + ": " + msg);
+
+        return 1;
+    }
+
+    public static int w(String tag, String msg) {
+        System.out.println("WARN: " + tag + ": " + msg);
+
+        return 1;
+    }
+}

--- a/app/src/test/java/com/nextcloud/talk/webrtc/PeerConnectionWrapperTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/webrtc/PeerConnectionWrapperTest.kt
@@ -23,6 +23,7 @@ import org.mockito.Mockito.atLeast
 import org.mockito.Mockito.atMostOnce
 import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.doNothing
+import org.mockito.Mockito.inOrder
 import org.mockito.Mockito.never
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
@@ -288,8 +289,10 @@ class PeerConnectionWrapperTest {
                 throw exceptionOnStateChange!!
             }
 
+            val inOrder = inOrder(mockedStatusDataChannel)
+
             for (j in 1..dataChannelMessageCount) {
-                Mockito.verify(mockedStatusDataChannel).send(
+                inOrder.verify(mockedStatusDataChannel).send(
                     argThat(MatchesDataChannelMessage(DataChannelMessage("the-message-type-$j")))
                 )
             }

--- a/app/src/test/java/com/nextcloud/talk/webrtc/PeerConnectionWrapperTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/webrtc/PeerConnectionWrapperTest.kt
@@ -1,0 +1,194 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.webrtc
+
+import com.bluelinelabs.logansquare.LoganSquare
+import com.nextcloud.talk.models.json.signaling.DataChannelMessage
+import com.nextcloud.talk.signaling.SignalingMessageReceiver
+import com.nextcloud.talk.signaling.SignalingMessageSender
+import com.nextcloud.talk.webrtc.PeerConnectionWrapper.DataChannelMessageListener
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito
+import org.mockito.Mockito.doNothing
+import org.webrtc.DataChannel
+import org.webrtc.MediaConstraints
+import org.webrtc.PeerConnection
+import org.webrtc.PeerConnectionFactory
+import java.nio.ByteBuffer
+import java.util.HashMap
+
+class PeerConnectionWrapperTest {
+
+    private var peerConnectionWrapper: PeerConnectionWrapper? = null
+    private var mockedPeerConnection: PeerConnection? = null
+    private var mockedPeerConnectionFactory: PeerConnectionFactory? = null
+    private var mockedSignalingMessageReceiver: SignalingMessageReceiver? = null
+    private var mockedSignalingMessageSender: SignalingMessageSender? = null
+
+    private fun dataChannelMessageToBuffer(dataChannelMessage: DataChannelMessage): DataChannel.Buffer {
+        return DataChannel.Buffer(
+            ByteBuffer.wrap(LoganSquare.serialize(dataChannelMessage).toByteArray()),
+            false
+        )
+    }
+
+    @Before
+    fun setUp() {
+        mockedPeerConnection = Mockito.mock(PeerConnection::class.java)
+        mockedPeerConnectionFactory = Mockito.mock(PeerConnectionFactory::class.java)
+        mockedSignalingMessageReceiver = Mockito.mock(SignalingMessageReceiver::class.java)
+        mockedSignalingMessageSender = Mockito.mock(SignalingMessageSender::class.java)
+    }
+
+    @Test
+    fun testReceiveDataChannelMessage() {
+        Mockito.`when`(
+            mockedPeerConnectionFactory!!.createPeerConnection(
+                any(PeerConnection.RTCConfiguration::class.java),
+                any(PeerConnection.Observer::class.java)
+            )
+        ).thenReturn(mockedPeerConnection)
+
+        val mockedStatusDataChannel = Mockito.mock(DataChannel::class.java)
+        Mockito.`when`(mockedStatusDataChannel.label()).thenReturn("status")
+        Mockito.`when`(mockedStatusDataChannel.state()).thenReturn(DataChannel.State.OPEN)
+        Mockito.`when`(mockedPeerConnection!!.createDataChannel(eq("status"), any()))
+            .thenReturn(mockedStatusDataChannel)
+
+        val statusDataChannelObserverArgumentCaptor: ArgumentCaptor<DataChannel.Observer> =
+            ArgumentCaptor.forClass(DataChannel.Observer::class.java)
+
+        doNothing().`when`(mockedStatusDataChannel).registerObserver(statusDataChannelObserverArgumentCaptor.capture())
+
+        peerConnectionWrapper = PeerConnectionWrapper(
+            mockedPeerConnectionFactory,
+            ArrayList<PeerConnection.IceServer>(),
+            MediaConstraints(),
+            "the-session-id",
+            "the-local-session-id",
+            null,
+            true,
+            true,
+            "video",
+            mockedSignalingMessageReceiver,
+            mockedSignalingMessageSender
+        )
+
+        val mockedDataChannelMessageListener = Mockito.mock(DataChannelMessageListener::class.java)
+        peerConnectionWrapper!!.addListener(mockedDataChannelMessageListener)
+
+        // The payload must be a map to be able to serialize it and, therefore, generate the data that would have been
+        // received from another participant, so it is not possible to test receiving the nick as a String payload.
+        val payloadMap = HashMap<String, String>()
+        payloadMap["name"] = "the-nick-in-map"
+
+        statusDataChannelObserverArgumentCaptor.value.onMessage(
+            dataChannelMessageToBuffer(DataChannelMessage("nickChanged", null, payloadMap))
+        )
+
+        Mockito.verify(mockedDataChannelMessageListener).onNickChanged("the-nick-in-map")
+        Mockito.verifyNoMoreInteractions(mockedDataChannelMessageListener)
+
+        statusDataChannelObserverArgumentCaptor.value.onMessage(
+            dataChannelMessageToBuffer(DataChannelMessage("audioOn"))
+        )
+
+        Mockito.verify(mockedDataChannelMessageListener).onAudioOn()
+        Mockito.verifyNoMoreInteractions(mockedDataChannelMessageListener)
+
+        statusDataChannelObserverArgumentCaptor.value.onMessage(
+            dataChannelMessageToBuffer(DataChannelMessage("audioOff"))
+        )
+
+        Mockito.verify(mockedDataChannelMessageListener).onAudioOff()
+        Mockito.verifyNoMoreInteractions(mockedDataChannelMessageListener)
+
+        statusDataChannelObserverArgumentCaptor.value.onMessage(
+            dataChannelMessageToBuffer(DataChannelMessage("videoOn"))
+        )
+
+        Mockito.verify(mockedDataChannelMessageListener).onVideoOn()
+        Mockito.verifyNoMoreInteractions(mockedDataChannelMessageListener)
+
+        statusDataChannelObserverArgumentCaptor.value.onMessage(
+            dataChannelMessageToBuffer(DataChannelMessage("videoOff"))
+        )
+
+        Mockito.verify(mockedDataChannelMessageListener).onVideoOff()
+        Mockito.verifyNoMoreInteractions(mockedDataChannelMessageListener)
+    }
+
+    @Test
+    fun testReceiveDataChannelMessageWithOpenRemoteDataChannel() {
+        val peerConnectionObserverArgumentCaptor: ArgumentCaptor<PeerConnection.Observer> =
+            ArgumentCaptor.forClass(PeerConnection.Observer::class.java)
+
+        Mockito.`when`(
+            mockedPeerConnectionFactory!!.createPeerConnection(
+                any(PeerConnection.RTCConfiguration::class.java),
+                peerConnectionObserverArgumentCaptor.capture()
+            )
+        ).thenReturn(mockedPeerConnection)
+
+        val mockedStatusDataChannel = Mockito.mock(DataChannel::class.java)
+        Mockito.`when`(mockedStatusDataChannel.label()).thenReturn("status")
+        Mockito.`when`(mockedStatusDataChannel.state()).thenReturn(DataChannel.State.OPEN)
+        Mockito.`when`(mockedPeerConnection!!.createDataChannel(eq("status"), any()))
+            .thenReturn(mockedStatusDataChannel)
+
+        val statusDataChannelObserverArgumentCaptor: ArgumentCaptor<DataChannel.Observer> =
+            ArgumentCaptor.forClass(DataChannel.Observer::class.java)
+
+        doNothing().`when`(mockedStatusDataChannel).registerObserver(statusDataChannelObserverArgumentCaptor.capture())
+
+        peerConnectionWrapper = PeerConnectionWrapper(
+            mockedPeerConnectionFactory,
+            ArrayList<PeerConnection.IceServer>(),
+            MediaConstraints(),
+            "the-session-id",
+            "the-local-session-id",
+            null,
+            true,
+            true,
+            "video",
+            mockedSignalingMessageReceiver,
+            mockedSignalingMessageSender
+        )
+
+        val randomIdDataChannelObserverArgumentCaptor: ArgumentCaptor<DataChannel.Observer> =
+            ArgumentCaptor.forClass(DataChannel.Observer::class.java)
+
+        val mockedRandomIdDataChannel = Mockito.mock(DataChannel::class.java)
+        Mockito.`when`(mockedRandomIdDataChannel.label()).thenReturn("random-id")
+        Mockito.`when`(mockedRandomIdDataChannel.state()).thenReturn(DataChannel.State.OPEN)
+        doNothing().`when`(mockedRandomIdDataChannel).registerObserver(
+            randomIdDataChannelObserverArgumentCaptor.capture()
+        )
+        peerConnectionObserverArgumentCaptor.value.onDataChannel(mockedRandomIdDataChannel)
+
+        val mockedDataChannelMessageListener = Mockito.mock(DataChannelMessageListener::class.java)
+        peerConnectionWrapper!!.addListener(mockedDataChannelMessageListener)
+
+        statusDataChannelObserverArgumentCaptor.value.onMessage(
+            dataChannelMessageToBuffer(DataChannelMessage("audioOn"))
+        )
+
+        Mockito.verify(mockedDataChannelMessageListener).onAudioOn()
+        Mockito.verifyNoMoreInteractions(mockedDataChannelMessageListener)
+
+        randomIdDataChannelObserverArgumentCaptor.value.onMessage(
+            dataChannelMessageToBuffer(DataChannelMessage("audioOff"))
+        )
+
+        Mockito.verify(mockedDataChannelMessageListener).onAudioOff()
+        Mockito.verifyNoMoreInteractions(mockedDataChannelMessageListener)
+    }
+}

--- a/app/src/test/java/com/nextcloud/talk/webrtc/PeerConnectionWrapperTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/webrtc/PeerConnectionWrapperTest.kt
@@ -19,15 +19,22 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.argThat
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito
+import org.mockito.Mockito.atLeast
+import org.mockito.Mockito.atMostOnce
+import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.never
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
 import org.webrtc.DataChannel
 import org.webrtc.MediaConstraints
 import org.webrtc.PeerConnection
 import org.webrtc.PeerConnectionFactory
 import java.nio.ByteBuffer
 import java.util.HashMap
+import kotlin.concurrent.thread
 
+@Suppress("LongMethod", "TooGenericExceptionCaught")
 class PeerConnectionWrapperTest {
 
     private var peerConnectionWrapper: PeerConnectionWrapper? = null
@@ -35,6 +42,23 @@ class PeerConnectionWrapperTest {
     private var mockedPeerConnectionFactory: PeerConnectionFactory? = null
     private var mockedSignalingMessageReceiver: SignalingMessageReceiver? = null
     private var mockedSignalingMessageSender: SignalingMessageSender? = null
+
+    /**
+     * Helper answer for DataChannel methods.
+     */
+    private class ReturnValueOrThrowIfDisposed<T>(val value: T) :
+        Answer<T> {
+        override fun answer(currentInvocation: InvocationOnMock): T {
+            if (Mockito.mockingDetails(currentInvocation.mock).invocations.find {
+                    it!!.method.name === "dispose"
+                } !== null
+            ) {
+                throw IllegalStateException("DataChannel has been disposed")
+            }
+
+            return value
+        }
+    }
 
     /**
      * Helper matcher for DataChannelMessages.
@@ -193,6 +217,83 @@ class PeerConnectionWrapperTest {
         Mockito.verify(mockedStatusDataChannel).send(
             argThat(MatchesDataChannelMessage(DataChannelMessage("another-message-type")))
         )
+    }
+
+    @Test
+    fun testSendDataChannelMessageBeforeOpeningDataChannelWithDifferentThreads() {
+        // A brute force approach is used to test race conditions between different threads just repeating the test
+        // several times. Due to this the test passing could be a false positive, as it could have been a matter of
+        // luck, but even if the test may wrongly pass sometimes it is better than nothing (although, in general, with
+        // that number of reruns, it fails when it should).
+        for (i in 1..1000) {
+            Mockito.`when`(
+                mockedPeerConnectionFactory!!.createPeerConnection(
+                    any(PeerConnection.RTCConfiguration::class.java),
+                    any(PeerConnection.Observer::class.java)
+                )
+            ).thenReturn(mockedPeerConnection)
+
+            val mockedStatusDataChannel = Mockito.mock(DataChannel::class.java)
+            Mockito.`when`(mockedStatusDataChannel.label()).thenReturn("status")
+            Mockito.`when`(mockedStatusDataChannel.state()).thenReturn(DataChannel.State.CONNECTING)
+            Mockito.`when`(mockedPeerConnection!!.createDataChannel(eq("status"), any()))
+                .thenReturn(mockedStatusDataChannel)
+
+            val statusDataChannelObserverArgumentCaptor: ArgumentCaptor<DataChannel.Observer> =
+                ArgumentCaptor.forClass(DataChannel.Observer::class.java)
+
+            doNothing().`when`(mockedStatusDataChannel)
+                .registerObserver(statusDataChannelObserverArgumentCaptor.capture())
+
+            peerConnectionWrapper = PeerConnectionWrapper(
+                mockedPeerConnectionFactory,
+                ArrayList<PeerConnection.IceServer>(),
+                MediaConstraints(),
+                "the-session-id",
+                "the-local-session-id",
+                null,
+                true,
+                true,
+                "video",
+                mockedSignalingMessageReceiver,
+                mockedSignalingMessageSender
+            )
+
+            val dataChannelMessageCount = 5
+
+            val sendThread = thread {
+                for (j in 1..dataChannelMessageCount) {
+                    peerConnectionWrapper!!.send(DataChannelMessage("the-message-type-$j"))
+                }
+            }
+
+            // Exceptions thrown in threads are not propagated to the main thread, so it needs to be explicitly done
+            // (for example, for ConcurrentModificationExceptions when iterating over the data channel messages).
+            var exceptionOnStateChange: Exception? = null
+
+            val openDataChannelThread = thread {
+                Mockito.`when`(mockedStatusDataChannel.state()).thenReturn(DataChannel.State.OPEN)
+
+                try {
+                    statusDataChannelObserverArgumentCaptor.value.onStateChange()
+                } catch (e: Exception) {
+                    exceptionOnStateChange = e
+                }
+            }
+
+            sendThread.join()
+            openDataChannelThread.join()
+
+            if (exceptionOnStateChange !== null) {
+                throw exceptionOnStateChange!!
+            }
+
+            for (j in 1..dataChannelMessageCount) {
+                Mockito.verify(mockedStatusDataChannel).send(
+                    argThat(MatchesDataChannelMessage(DataChannelMessage("the-message-type-$j")))
+                )
+            }
+        }
     }
 
     @Test
@@ -380,5 +481,280 @@ class PeerConnectionWrapperTest {
 
         Mockito.verify(mockedStatusDataChannel).dispose()
         Mockito.verify(mockedRandomIdDataChannel).dispose()
+    }
+
+    @Test
+    fun testRemovePeerConnectionWhileAddingRemoteDataChannelsWithDifferentThreads() {
+        // A brute force approach is used to test race conditions between different threads just repeating the test
+        // several times. Due to this the test passing could be a false positive, as it could have been a matter of
+        // luck, but even if the test may wrongly pass sometimes it is better than nothing (although, in general, with
+        // that number of reruns, it fails when it should).
+        for (i in 1..1000) {
+            val peerConnectionObserverArgumentCaptor: ArgumentCaptor<PeerConnection.Observer> =
+                ArgumentCaptor.forClass(PeerConnection.Observer::class.java)
+
+            Mockito.`when`(
+                mockedPeerConnectionFactory!!.createPeerConnection(
+                    any(PeerConnection.RTCConfiguration::class.java),
+                    peerConnectionObserverArgumentCaptor.capture()
+                )
+            ).thenReturn(mockedPeerConnection)
+
+            val mockedStatusDataChannel = Mockito.mock(DataChannel::class.java)
+            Mockito.`when`(mockedStatusDataChannel.label()).thenAnswer(ReturnValueOrThrowIfDisposed("status"))
+            Mockito.`when`(mockedStatusDataChannel.state()).thenAnswer(
+                ReturnValueOrThrowIfDisposed(DataChannel.State.OPEN)
+            )
+            Mockito.`when`(mockedPeerConnection!!.createDataChannel(eq("status"), any()))
+                .thenReturn(mockedStatusDataChannel)
+
+            peerConnectionWrapper = PeerConnectionWrapper(
+                mockedPeerConnectionFactory,
+                ArrayList<PeerConnection.IceServer>(),
+                MediaConstraints(),
+                "the-session-id",
+                "the-local-session-id",
+                null,
+                true,
+                true,
+                "video",
+                mockedSignalingMessageReceiver,
+                mockedSignalingMessageSender
+            )
+
+            val dataChannelCount = 5
+
+            val mockedRandomIdDataChannels: MutableList<DataChannel> = ArrayList()
+            val dataChannelObservers: MutableList<DataChannel.Observer?> = ArrayList()
+            for (j in 0..<dataChannelCount) {
+                mockedRandomIdDataChannels.add(Mockito.mock(DataChannel::class.java))
+                // Add data channels with duplicated labels (from the second data channel and onwards) to test that
+                // they are correctly disposed also in that case (which should not happen anyway, but just in case).
+                Mockito.`when`(mockedRandomIdDataChannels[j].label())
+                    .thenAnswer(ReturnValueOrThrowIfDisposed("random-id-" + ((j + 1) / 2)))
+                Mockito.`when`(mockedRandomIdDataChannels[j].state())
+                    .thenAnswer(ReturnValueOrThrowIfDisposed(DataChannel.State.OPEN))
+
+                // Store a reference to the registered observer, if any, to be called after the registration. The call
+                // is done outside the mock to better simulate the normal behaviour, as it would not be called during
+                // the registration itself.
+                dataChannelObservers.add(null)
+                doAnswer { invocation ->
+                    if (Mockito.mockingDetails(invocation.mock).invocations.find {
+                            it!!.method.name === "dispose"
+                        } !== null
+                    ) {
+                        throw IllegalStateException("DataChannel has been disposed")
+                    }
+
+                    dataChannelObservers[j] = invocation.getArgument(0, DataChannel.Observer::class.java)
+
+                    null
+                }.`when`(mockedRandomIdDataChannels[j]).registerObserver(any())
+            }
+
+            val onDataChannelThread = thread {
+                // Add again "status" data channel to test that it is correctly disposed also in that case (which
+                // should not happen anyway even if it was added by the remote peer, but just in case)
+                peerConnectionObserverArgumentCaptor.value.onDataChannel(mockedStatusDataChannel)
+
+                for (j in 0..<dataChannelCount) {
+                    peerConnectionObserverArgumentCaptor.value.onDataChannel(mockedRandomIdDataChannels[j])
+
+                    // Call "onStateChange" on the registered observer to simulate that the data channel was opened.
+                    dataChannelObservers[j]?.onStateChange()
+                }
+            }
+
+            // Exceptions thrown in threads are not propagated to the main thread, so it needs to be explicitly done
+            // (for example, for ConcurrentModificationExceptions when iterating over the data channels).
+            var exceptionRemovePeerConnection: Exception? = null
+
+            val removePeerConnectionThread = thread {
+                try {
+                    peerConnectionWrapper!!.removePeerConnection()
+                } catch (e: Exception) {
+                    exceptionRemovePeerConnection = e
+                }
+            }
+
+            onDataChannelThread.join()
+            removePeerConnectionThread.join()
+
+            if (exceptionRemovePeerConnection !== null) {
+                throw exceptionRemovePeerConnection!!
+            }
+
+            Mockito.verify(mockedStatusDataChannel).dispose()
+            for (j in 0..<dataChannelCount) {
+                Mockito.verify(mockedRandomIdDataChannels[j]).dispose()
+            }
+        }
+    }
+
+    @Test
+    fun testRemovePeerConnectionWhileSendingWithDifferentThreads() {
+        // A brute force approach is used to test race conditions between different threads just repeating the test
+        // several times. Due to this the test passing could be a false positive, as it could have been a matter of
+        // luck, but even if the test may wrongly pass sometimes it is better than nothing (although, in general, with
+        // that number of reruns, it fails when it should).
+        for (i in 1..1000) {
+            val peerConnectionObserverArgumentCaptor: ArgumentCaptor<PeerConnection.Observer> =
+                ArgumentCaptor.forClass(PeerConnection.Observer::class.java)
+
+            Mockito.`when`(
+                mockedPeerConnectionFactory!!.createPeerConnection(
+                    any(PeerConnection.RTCConfiguration::class.java),
+                    peerConnectionObserverArgumentCaptor.capture()
+                )
+            ).thenReturn(mockedPeerConnection)
+
+            val mockedStatusDataChannel = Mockito.mock(DataChannel::class.java)
+
+            Mockito.`when`(mockedStatusDataChannel.label()).thenAnswer(ReturnValueOrThrowIfDisposed("status"))
+            Mockito.`when`(mockedStatusDataChannel.state())
+                .thenAnswer(ReturnValueOrThrowIfDisposed(DataChannel.State.OPEN))
+            Mockito.`when`(mockedStatusDataChannel.send(any())).thenAnswer(ReturnValueOrThrowIfDisposed(true))
+            Mockito.`when`(mockedPeerConnection!!.createDataChannel(eq("status"), any()))
+                .thenReturn(mockedStatusDataChannel)
+
+            peerConnectionWrapper = PeerConnectionWrapper(
+                mockedPeerConnectionFactory,
+                ArrayList<PeerConnection.IceServer>(),
+                MediaConstraints(),
+                "the-session-id",
+                "the-local-session-id",
+                null,
+                true,
+                true,
+                "video",
+                mockedSignalingMessageReceiver,
+                mockedSignalingMessageSender
+            )
+
+            val dataChannelMessageCount = 5
+
+            // Exceptions thrown in threads are not propagated to the main thread, so it needs to be explicitly done
+            // (for example, for IllegalStateExceptions when using a disposed data channel).
+            var exceptionSend: Exception? = null
+
+            val sendThread = thread {
+                try {
+                    for (j in 0..<dataChannelMessageCount) {
+                        peerConnectionWrapper!!.send(DataChannelMessage("the-message-type-$j"))
+                    }
+                } catch (e: Exception) {
+                    exceptionSend = e
+                }
+            }
+
+            val removePeerConnectionThread = thread {
+                peerConnectionWrapper!!.removePeerConnection()
+            }
+
+            sendThread.join()
+            removePeerConnectionThread.join()
+
+            if (exceptionSend !== null) {
+                throw exceptionSend!!
+            }
+
+            Mockito.verify(mockedStatusDataChannel).registerObserver(any())
+            Mockito.verify(mockedStatusDataChannel).dispose()
+            Mockito.verify(mockedStatusDataChannel, atLeast(0)).label()
+            Mockito.verify(mockedStatusDataChannel, atLeast(0)).state()
+            Mockito.verify(mockedStatusDataChannel, atLeast(0)).send(any())
+            Mockito.verifyNoMoreInteractions(mockedStatusDataChannel)
+        }
+    }
+
+    @Test
+    fun testRemovePeerConnectionWhileReceivingWithDifferentThreads() {
+        // A brute force approach is used to test race conditions between different threads just repeating the test
+        // several times. Due to this the test passing could be a false positive, as it could have been a matter of
+        // luck, but even if the test may wrongly pass sometimes it is better than nothing (although, in general, with
+        // that number of reruns, it fails when it should).
+        for (i in 1..1000) {
+            val peerConnectionObserverArgumentCaptor: ArgumentCaptor<PeerConnection.Observer> =
+                ArgumentCaptor.forClass(PeerConnection.Observer::class.java)
+
+            Mockito.`when`(
+                mockedPeerConnectionFactory!!.createPeerConnection(
+                    any(PeerConnection.RTCConfiguration::class.java),
+                    peerConnectionObserverArgumentCaptor.capture()
+                )
+            ).thenReturn(mockedPeerConnection)
+
+            val mockedStatusDataChannel = Mockito.mock(DataChannel::class.java)
+            Mockito.`when`(mockedStatusDataChannel.label()).thenAnswer(ReturnValueOrThrowIfDisposed("status"))
+            Mockito.`when`(mockedStatusDataChannel.state()).thenAnswer(
+                ReturnValueOrThrowIfDisposed(DataChannel.State.OPEN)
+            )
+            Mockito.`when`(mockedPeerConnection!!.createDataChannel(eq("status"), any()))
+                .thenReturn(mockedStatusDataChannel)
+
+            val statusDataChannelObserverArgumentCaptor: ArgumentCaptor<DataChannel.Observer> =
+                ArgumentCaptor.forClass(DataChannel.Observer::class.java)
+
+            doNothing().`when`(mockedStatusDataChannel)
+                .registerObserver(statusDataChannelObserverArgumentCaptor.capture())
+
+            peerConnectionWrapper = PeerConnectionWrapper(
+                mockedPeerConnectionFactory,
+                ArrayList<PeerConnection.IceServer>(),
+                MediaConstraints(),
+                "the-session-id",
+                "the-local-session-id",
+                null,
+                true,
+                true,
+                "video",
+                mockedSignalingMessageReceiver,
+                mockedSignalingMessageSender
+            )
+
+            val mockedDataChannelMessageListener = Mockito.mock(DataChannelMessageListener::class.java)
+            peerConnectionWrapper!!.addListener(mockedDataChannelMessageListener)
+
+            // Exceptions thrown in threads are not propagated to the main thread, so it needs to be explicitly done
+            // (for example, for IllegalStateExceptions when using a disposed data channel).
+            var exceptionOnMessage: Exception? = null
+
+            val onMessageThread = thread {
+                try {
+                    // It is assumed that, even if its data channel was disposed, its buffers can be used while there
+                    // is a reference to them, so no special mock behaviour is added to throw an exception in that case.
+                    statusDataChannelObserverArgumentCaptor.value.onMessage(
+                        dataChannelMessageToBuffer(DataChannelMessage("audioOn"))
+                    )
+
+                    statusDataChannelObserverArgumentCaptor.value.onMessage(
+                        dataChannelMessageToBuffer(DataChannelMessage("audioOff"))
+                    )
+                } catch (e: Exception) {
+                    exceptionOnMessage = e
+                }
+            }
+
+            val removePeerConnectionThread = thread {
+                peerConnectionWrapper!!.removePeerConnection()
+            }
+
+            onMessageThread.join()
+            removePeerConnectionThread.join()
+
+            if (exceptionOnMessage !== null) {
+                throw exceptionOnMessage!!
+            }
+
+            Mockito.verify(mockedStatusDataChannel).registerObserver(any())
+            Mockito.verify(mockedStatusDataChannel).dispose()
+            Mockito.verify(mockedStatusDataChannel, atLeast(0)).label()
+            Mockito.verify(mockedStatusDataChannel, atLeast(0)).state()
+            Mockito.verifyNoMoreInteractions(mockedStatusDataChannel)
+            Mockito.verify(mockedDataChannelMessageListener, atMostOnce()).onAudioOn()
+            Mockito.verify(mockedDataChannelMessageListener, atMostOnce()).onAudioOff()
+            Mockito.verifyNoMoreInteractions(mockedDataChannelMessageListener)
+        }
     }
 }


### PR DESCRIPTION
Follow up to #3670

This was part of an upcoming pull request but was extracted for easier reviewing. It adjusts some data channel related code that is either needed for the other pull request (queuing messages if the data channel was not open yet), was incorrect (not disposing of all data channels, sending messages on data channels other than _status_) or could be improved (missing logs, documentation and tests). Please refer to the individual commit messages for details.

As data channels involve several threads (the events are received in the so called WebRTC signaling thread (unrelated to the thread were signaling messages are received), but the PeerConnectionWrapper can be used from RxJava executors, the main thread, the WebRTC signaling thread itself...) synchronization was needed in certain points. There are probably better ways to do the synchronization, but for simplicity I just resorted to synchronized methods/blocks and catching exceptions. Similarly the unit tests for the possible synchronization problems were done in a brute force approach, just repeating the test many times, so all this has a lot of room for improvements... In any case, thread safety should be kept in mind for future changes, as there are probably other areas of the code that might need to be adjusted :shrug:

Besides that, adding the logs unveiled a bug that seems to have been there since forever: when the HPB is used the nick is tried to be sent even after the call activity is destroyed (and the `PeerConnectionWrapper` is also leaked). There is something wrong with the use of [`interval` and `repeatUntil`](https://github.com/nextcloud/talk-android/blob/f820277779ced24c9fea877cb6df3ef853bfca2e/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt#L2552-L2553), but that will be rewritten anyway in the upcoming pull request, so for now it stays as is.

Finally, one thing that still should be implemented (but it will not be implemented either in the other pull request) is disabling data channels so they are not even negotiated when not needed (for example, screen connections). This is not a big deal, however, as the data channel will be blocked by the other end, and even if it is opened it should not cause any trouble unless the Android app sends conflicting messages :-)
