### PR TITLE
open .webm video files with internal player

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/utils/FileViewerUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/FileViewerUtils.kt
@@ -42,6 +42,7 @@ import com.nextcloud.talk.utils.Mimetype.TEXT_PLAIN
 import com.nextcloud.talk.utils.Mimetype.VIDEO_MP4
 import com.nextcloud.talk.utils.Mimetype.VIDEO_OGG
 import com.nextcloud.talk.utils.Mimetype.VIDEO_QUICKTIME
+import com.nextcloud.talk.utils.Mimetype.VIDEO_WEBM
 import com.nextcloud.talk.utils.MimetypeUtils.isAudioOnly
 import com.nextcloud.talk.utils.MimetypeUtils.isGif
 import com.nextcloud.talk.utils.MimetypeUtils.isMarkdown
@@ -148,7 +149,8 @@ class FileViewerUtils(private val context: Context, private val user: User) {
                 AUDIO_OGG,
                 VIDEO_MP4,
                 VIDEO_QUICKTIME,
-                VIDEO_OGG
+                VIDEO_OGG,
+                VIDEO_WEBM
                 -> openMediaView(filename, mimetype)
                 IMAGE_PNG,
                 IMAGE_JPEG,
@@ -252,6 +254,7 @@ class FileViewerUtils(private val context: Context, private val user: User) {
             VIDEO_MP4,
             VIDEO_QUICKTIME,
             VIDEO_OGG,
+            VIDEO_WEBM,
             TEXT_MARKDOWN,
             TEXT_PLAIN -> true
             else -> false

--- a/app/src/main/java/com/nextcloud/talk/utils/Mimetype.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/Mimetype.kt
@@ -26,6 +26,7 @@ object Mimetype {
     const val VIDEO_MP4 = "video/mp4"
     const val VIDEO_QUICKTIME = "video/quicktime"
     const val VIDEO_OGG = "video/ogg"
+    const val VIDEO_WEBM = "video/webm"
 
     const val TEXT_MARKDOWN = "text/markdown"
     const val TEXT_PLAIN = "text/plain"


### PR DESCRIPTION
Resolve #4537

webm videos can be played with the internal player for Android 8.0 and above and it was added to the supported formats.


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)