### PR TITLE
Fix sending local state to other participants

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -1590,6 +1590,8 @@ class CallActivity : CallBaseActivity() {
                         hasMCU = false
 
                         messageSender = MessageSenderNoMcu(
+                            signalingMessageSender,
+                            callParticipants.keys,
                             peerConnectionWrapperList
                         )
 
@@ -1895,11 +1897,15 @@ class CallActivity : CallBaseActivity() {
 
             if (hasMCU) {
                 messageSender = MessageSenderMcu(
+                    signalingMessageSender,
+                    callParticipants.keys,
                     peerConnectionWrapperList,
                     webSocketClient!!.sessionId
                 )
             } else {
                 messageSender = MessageSenderNoMcu(
+                    signalingMessageSender,
+                    callParticipants.keys,
                     peerConnectionWrapperList
                 )
             }
@@ -1934,11 +1940,15 @@ class CallActivity : CallBaseActivity() {
 
                     if (hasMCU) {
                         messageSender = MessageSenderMcu(
+                            signalingMessageSender,
+                            callParticipants.keys,
                             peerConnectionWrapperList,
                             webSocketClient!!.sessionId
                         )
                     } else {
                         messageSender = MessageSenderNoMcu(
+                            signalingMessageSender,
+                            callParticipants.keys,
                             peerConnectionWrapperList
                         )
                     }

--- a/app/src/main/java/com/nextcloud/talk/call/LocalCallParticipantModel.java
+++ b/app/src/main/java/com/nextcloud/talk/call/LocalCallParticipantModel.java
@@ -1,0 +1,114 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.call;
+
+import android.os.Handler;
+
+import java.util.Objects;
+
+/**
+ * Read-only data model for local call participants.
+ * <p>
+ * Clients of the model can observe it with LocalCallParticipantModel.Observer to be notified when any value changes.
+ * Getters called after receiving a notification are guaranteed to provide at least the value that triggered the
+ * notification, but it may return even a more up to date one (so getting the value again on the following notification
+ * may return the same value as before).
+ */
+public class LocalCallParticipantModel {
+
+    protected final LocalCallParticipantModelNotifier localCallParticipantModelNotifier =
+        new LocalCallParticipantModelNotifier();
+
+    protected Data<Boolean> audioEnabled;
+    protected Data<Boolean> speaking;
+    protected Data<Boolean> speakingWhileMuted;
+    protected Data<Boolean> videoEnabled;
+
+    public interface Observer {
+        void onChange();
+    }
+
+    protected class Data<T> {
+
+        private T value;
+
+        public Data() {
+        }
+
+        public Data(T value) {
+            this.value = value;
+        }
+
+        public T getValue() {
+            return value;
+        }
+
+        public void setValue(T value) {
+            if (Objects.equals(this.value, value)) {
+                return;
+            }
+
+            this.value = value;
+
+            localCallParticipantModelNotifier.notifyChange();
+        }
+    }
+
+    public LocalCallParticipantModel() {
+        this.audioEnabled = new Data<>(Boolean.FALSE);
+        this.speaking = new Data<>(Boolean.FALSE);
+        this.speakingWhileMuted = new Data<>(Boolean.FALSE);
+        this.videoEnabled = new Data<>(Boolean.FALSE);
+    }
+
+    public Boolean isAudioEnabled() {
+        return audioEnabled.getValue();
+    }
+
+    public Boolean isSpeaking() {
+        return speaking.getValue();
+    }
+
+    public Boolean isSpeakingWhileMuted() {
+        return speakingWhileMuted.getValue();
+    }
+
+    public Boolean isVideoEnabled() {
+        return videoEnabled.getValue();
+    }
+
+    /**
+     * Adds an Observer to be notified when any value changes.
+     *
+     * @param observer the Observer
+     * @see LocalCallParticipantModel#addObserver(Observer, Handler)
+     */
+    public void addObserver(Observer observer) {
+        addObserver(observer, null);
+    }
+
+    /**
+     * Adds an observer to be notified when any value changes.
+     * <p>
+     * The observer will be notified on the thread associated to the given handler. If no handler is given the
+     * observer will be immediately notified on the same thread that changed the value; the observer will be
+     * immediately notified too if the thread of the handler is the same thread that changed the value.
+     * <p>
+     * An observer is expected to be added only once. If the same observer is added again it will be notified just
+     * once on the thread of the last handler.
+     *
+     * @param observer the Observer
+     * @param handler a Handler for the thread to be notified on
+     */
+    public void addObserver(Observer observer, Handler handler) {
+        localCallParticipantModelNotifier.addObserver(observer, handler);
+    }
+
+    public void removeObserver(Observer observer) {
+        localCallParticipantModelNotifier.removeObserver(observer);
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/call/LocalCallParticipantModelNotifier.java
+++ b/app/src/main/java/com/nextcloud/talk/call/LocalCallParticipantModelNotifier.java
@@ -1,0 +1,73 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.call;
+
+import android.os.Handler;
+import android.os.Looper;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Helper class to register and notify LocalCallParticipantModel.Observers.
+ * <p>
+ * This class is only meant for internal use by LocalCallParticipantModel; observers must register themselves against a
+ * LocalCallParticipantModel rather than against a LocalCallParticipantModelNotifier.
+ */
+class LocalCallParticipantModelNotifier {
+
+    private final List<LocalCallParticipantModelObserverOn> localCallParticipantModelObserversOn = new ArrayList<>();
+
+    /**
+     * Helper class to associate a LocalCallParticipantModel.Observer with a Handler.
+     */
+    private static class LocalCallParticipantModelObserverOn {
+        public final LocalCallParticipantModel.Observer observer;
+        public final Handler handler;
+
+        private LocalCallParticipantModelObserverOn(LocalCallParticipantModel.Observer observer, Handler handler) {
+            this.observer = observer;
+            this.handler = handler;
+        }
+    }
+
+    public synchronized void addObserver(LocalCallParticipantModel.Observer observer, Handler handler) {
+        if (observer == null) {
+            throw new IllegalArgumentException("LocalCallParticipantModel.Observer can not be null");
+        }
+
+        removeObserver(observer);
+
+        localCallParticipantModelObserversOn.add(new LocalCallParticipantModelObserverOn(observer, handler));
+    }
+
+    public synchronized void removeObserver(LocalCallParticipantModel.Observer observer) {
+        Iterator<LocalCallParticipantModelObserverOn> it = localCallParticipantModelObserversOn.iterator();
+        while (it.hasNext()) {
+            LocalCallParticipantModelObserverOn observerOn = it.next();
+
+            if (observerOn.observer == observer) {
+                it.remove();
+
+                return;
+            }
+        }
+    }
+
+    public synchronized void notifyChange() {
+        for (LocalCallParticipantModelObserverOn observerOn : new ArrayList<>(localCallParticipantModelObserversOn)) {
+            if (observerOn.handler == null || observerOn.handler.getLooper() == Looper.myLooper()) {
+                observerOn.observer.onChange();
+            } else {
+                observerOn.handler.post(() -> {
+                    observerOn.observer.onChange();
+                });
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/call/LocalStateBroadcaster.java
+++ b/app/src/main/java/com/nextcloud/talk/call/LocalStateBroadcaster.java
@@ -1,0 +1,102 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.call;
+
+import com.nextcloud.talk.models.json.signaling.DataChannelMessage;
+
+import java.util.Objects;
+
+/**
+ * Helper class to send the local participant state to the other participants in the call.
+ * <p>
+ * Once created, and until destroyed, the LocalStateBroadcaster will send the changes in the local participant state to
+ * all the participants in the call. Note that the LocalStateBroadcaster does not check whether the local participant
+ * is actually in the call or not; it is expected that the LocalStateBroadcaster will be created and destroyed when the
+ * local participant joins and leaves the call.
+ */
+public class LocalStateBroadcaster {
+
+    private final LocalCallParticipantModel localCallParticipantModel;
+
+    private final LocalCallParticipantModelObserver localCallParticipantModelObserver;
+
+    private final MessageSender messageSender;
+
+    private class LocalCallParticipantModelObserver implements LocalCallParticipantModel.Observer {
+
+        private Boolean audioEnabled;
+        private Boolean speaking;
+        private Boolean videoEnabled;
+
+        public LocalCallParticipantModelObserver(LocalCallParticipantModel localCallParticipantModel) {
+            audioEnabled = localCallParticipantModel.isAudioEnabled();
+            speaking = localCallParticipantModel.isSpeaking();
+            videoEnabled = localCallParticipantModel.isVideoEnabled();
+        }
+
+        @Override
+        public void onChange() {
+            if (!Objects.equals(audioEnabled, localCallParticipantModel.isAudioEnabled())) {
+                audioEnabled = localCallParticipantModel.isAudioEnabled();
+
+                messageSender.sendToAll(getDataChannelMessageForAudioState());
+            }
+
+            if (!Objects.equals(speaking, localCallParticipantModel.isSpeaking())) {
+                speaking = localCallParticipantModel.isSpeaking();
+
+                messageSender.sendToAll(getDataChannelMessageForSpeakingState());
+            }
+
+            if (!Objects.equals(videoEnabled, localCallParticipantModel.isVideoEnabled())) {
+                videoEnabled = localCallParticipantModel.isVideoEnabled();
+
+                messageSender.sendToAll(getDataChannelMessageForVideoState());
+            }
+        }
+    }
+
+    public LocalStateBroadcaster(LocalCallParticipantModel localCallParticipantModel,
+                                 MessageSender messageSender) {
+        this.localCallParticipantModel = localCallParticipantModel;
+        this.localCallParticipantModelObserver = new LocalCallParticipantModelObserver(localCallParticipantModel);
+        this.messageSender = messageSender;
+
+        this.localCallParticipantModel.addObserver(localCallParticipantModelObserver);
+    }
+
+    public void destroy() {
+        this.localCallParticipantModel.removeObserver(localCallParticipantModelObserver);
+    }
+
+    private DataChannelMessage getDataChannelMessageForAudioState() {
+        String type = "audioOff";
+        if (localCallParticipantModel.isAudioEnabled() != null && localCallParticipantModel.isAudioEnabled()) {
+            type = "audioOn";
+        }
+
+        return new DataChannelMessage(type);
+    }
+
+    private DataChannelMessage getDataChannelMessageForSpeakingState() {
+        String type = "stoppedSpeaking";
+        if (localCallParticipantModel.isSpeaking() != null && localCallParticipantModel.isSpeaking()) {
+            type = "speaking";
+        }
+
+        return new DataChannelMessage(type);
+    }
+
+    private DataChannelMessage getDataChannelMessageForVideoState() {
+        String type = "videoOff";
+        if (localCallParticipantModel.isVideoEnabled() != null && localCallParticipantModel.isVideoEnabled()) {
+            type = "videoOn";
+        }
+
+        return new DataChannelMessage(type);
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/call/LocalStateBroadcaster.java
+++ b/app/src/main/java/com/nextcloud/talk/call/LocalStateBroadcaster.java
@@ -17,8 +17,12 @@ import java.util.Objects;
  * all the participants in the call. Note that the LocalStateBroadcaster does not check whether the local participant
  * is actually in the call or not; it is expected that the LocalStateBroadcaster will be created and destroyed when the
  * local participant joins and leaves the call.
+ * <p>
+ * The LocalStateBroadcaster also sends the current state to remote participants when they join (which implicitly
+ * sends it to all remote participants when the local participant joins the call) so they can set an initial state
+ * for the local participant.
  */
-public class LocalStateBroadcaster {
+public abstract class LocalStateBroadcaster {
 
     private final LocalCallParticipantModel localCallParticipantModel;
 
@@ -73,7 +77,10 @@ public class LocalStateBroadcaster {
         this.localCallParticipantModel.removeObserver(localCallParticipantModelObserver);
     }
 
-    private DataChannelMessage getDataChannelMessageForAudioState() {
+    public abstract void handleCallParticipantAdded(CallParticipantModel callParticipantModel);
+    public abstract void handleCallParticipantRemoved(CallParticipantModel callParticipantModel);
+
+    protected DataChannelMessage getDataChannelMessageForAudioState() {
         String type = "audioOff";
         if (localCallParticipantModel.isAudioEnabled() != null && localCallParticipantModel.isAudioEnabled()) {
             type = "audioOn";
@@ -82,7 +89,7 @@ public class LocalStateBroadcaster {
         return new DataChannelMessage(type);
     }
 
-    private DataChannelMessage getDataChannelMessageForSpeakingState() {
+    protected DataChannelMessage getDataChannelMessageForSpeakingState() {
         String type = "stoppedSpeaking";
         if (localCallParticipantModel.isSpeaking() != null && localCallParticipantModel.isSpeaking()) {
             type = "speaking";
@@ -91,7 +98,7 @@ public class LocalStateBroadcaster {
         return new DataChannelMessage(type);
     }
 
-    private DataChannelMessage getDataChannelMessageForVideoState() {
+    protected DataChannelMessage getDataChannelMessageForVideoState() {
         String type = "videoOff";
         if (localCallParticipantModel.isVideoEnabled() != null && localCallParticipantModel.isVideoEnabled()) {
             type = "videoOn";

--- a/app/src/main/java/com/nextcloud/talk/call/LocalStateBroadcasterMcu.java
+++ b/app/src/main/java/com/nextcloud/talk/call/LocalStateBroadcasterMcu.java
@@ -1,0 +1,72 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.call;
+
+import java.util.concurrent.TimeUnit;
+
+import io.reactivex.Observable;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.schedulers.Schedulers;
+
+/**
+ * Helper class to send the local participant state to the other participants in the call when an MCU is used.
+ * <p>
+ * Sending the state when it changes is handled by the base class; this subclass only handles sending the initial
+ * state when a remote participant is added.
+ * <p>
+ * When Janus is used data channel messages are sent to all remote participants (with a peer connection to receive from
+ * the local participant). Moreover, it is not possible to know when the remote participants open the data channel to
+ * receive the messages, or even when they establish the receiver connection; it is only possible to know when the
+ * data channel is open for the publisher connection of the local participant. Due to all that the state is sent
+ * several times with an increasing delay whenever a participant joins the call (which implicitly broadcasts the
+ * initial state when the local participant joins the call, as all the remote participants joined from the point of
+ * view of the local participant). If the state was already being sent the sending is restarted with each new
+ * participant that joins.
+ */
+public class LocalStateBroadcasterMcu extends LocalStateBroadcaster {
+
+    private final MessageSender messageSender;
+
+    private Disposable sendStateWithRepetition;
+
+    public LocalStateBroadcasterMcu(LocalCallParticipantModel localCallParticipantModel,
+                                    MessageSender messageSender) {
+        super(localCallParticipantModel, messageSender);
+
+        this.messageSender = messageSender;
+    }
+
+    public void destroy() {
+        super.destroy();
+
+        if (sendStateWithRepetition != null) {
+            sendStateWithRepetition.dispose();
+        }
+    }
+
+    @Override
+    public void handleCallParticipantAdded(CallParticipantModel callParticipantModel) {
+        if (sendStateWithRepetition != null) {
+            sendStateWithRepetition.dispose();
+        }
+
+        sendStateWithRepetition = Observable
+            .fromArray(new Integer[]{0, 1, 2, 4, 8, 16})
+            .concatMap(i -> Observable.just(i).delay(i, TimeUnit.SECONDS, Schedulers.io()))
+            .subscribe(value -> sendState());
+    }
+
+    @Override
+    public void handleCallParticipantRemoved(CallParticipantModel callParticipantModel) {
+    }
+
+    private void sendState() {
+        messageSender.sendToAll(getDataChannelMessageForAudioState());
+        messageSender.sendToAll(getDataChannelMessageForSpeakingState());
+        messageSender.sendToAll(getDataChannelMessageForVideoState());
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/call/LocalStateBroadcasterNoMcu.java
+++ b/app/src/main/java/com/nextcloud/talk/call/LocalStateBroadcasterNoMcu.java
@@ -1,0 +1,119 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.call;
+
+import org.webrtc.PeerConnection;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Helper class to send the local participant state to the other participants in the call when an MCU is not used.
+ * <p>
+ * Sending the state when it changes is handled by the base class; this subclass only handles sending the initial
+ * state when a remote participant is added.
+ * <p>
+ * The state is sent when a connection with another participant is first established (which implicitly broadcasts the
+ * initial state when the local participant joins the call, as a connection is established with all the remote
+ * participants). Note that, as long as that participant stays in the call, the initial state is not sent again, even
+ * after a temporary disconnection; data channels use a reliable transport by default, so even if the state changes
+ * while the connection is temporarily interrupted the normal state update messages should be received by the other
+ * participant once the connection is restored.
+ */
+public class LocalStateBroadcasterNoMcu extends LocalStateBroadcaster {
+
+    private final MessageSenderNoMcu messageSender;
+
+    private final Map<String, IceConnectionStateObserver> iceConnectionStateObservers = new HashMap<>();
+
+    private class IceConnectionStateObserver implements CallParticipantModel.Observer {
+
+        private final CallParticipantModel callParticipantModel;
+
+        private PeerConnection.IceConnectionState iceConnectionState;
+
+        public IceConnectionStateObserver(CallParticipantModel callParticipantModel) {
+            this.callParticipantModel = callParticipantModel;
+
+            callParticipantModel.addObserver(this);
+            iceConnectionStateObservers.put(callParticipantModel.getSessionId(), this);
+        }
+
+        @Override
+        public void onChange() {
+            if (Objects.equals(iceConnectionState, callParticipantModel.getIceConnectionState())) {
+                return;
+            }
+
+            iceConnectionState = callParticipantModel.getIceConnectionState();
+
+            if (iceConnectionState == PeerConnection.IceConnectionState.CONNECTED ||
+                iceConnectionState == PeerConnection.IceConnectionState.COMPLETED) {
+                remove();
+
+                sendState(callParticipantModel.getSessionId());
+            }
+        }
+
+        @Override
+        public void onReaction(String reaction) {
+        }
+
+        public void remove() {
+            callParticipantModel.removeObserver(this);
+            iceConnectionStateObservers.remove(callParticipantModel.getSessionId());
+        }
+    }
+
+    public LocalStateBroadcasterNoMcu(LocalCallParticipantModel localCallParticipantModel,
+                                      MessageSenderNoMcu messageSender) {
+        super(localCallParticipantModel, messageSender);
+
+        this.messageSender = messageSender;
+    }
+
+    public void destroy() {
+        super.destroy();
+
+        // The observers remove themselves from the map, so a copy is needed to remove them while iterating.
+        List<IceConnectionStateObserver> iceConnectionStateObserversCopy =
+            new ArrayList<>(iceConnectionStateObservers.values());
+        for (IceConnectionStateObserver iceConnectionStateObserver : iceConnectionStateObserversCopy) {
+            iceConnectionStateObserver.remove();
+        }
+    }
+
+    @Override
+    public void handleCallParticipantAdded(CallParticipantModel callParticipantModel) {
+        IceConnectionStateObserver iceConnectionStateObserver =
+            iceConnectionStateObservers.get(callParticipantModel.getSessionId());
+        if (iceConnectionStateObserver != null) {
+            iceConnectionStateObserver.remove();
+        }
+
+        iceConnectionStateObserver = new IceConnectionStateObserver(callParticipantModel);
+        iceConnectionStateObservers.put(callParticipantModel.getSessionId(), iceConnectionStateObserver);
+    }
+
+    @Override
+    public void handleCallParticipantRemoved(CallParticipantModel callParticipantModel) {
+        IceConnectionStateObserver iceConnectionStateObserver =
+            iceConnectionStateObservers.get(callParticipantModel.getSessionId());
+        if (iceConnectionStateObserver != null) {
+            iceConnectionStateObserver.remove();
+        }
+    }
+
+    private void sendState(String sessionId) {
+        messageSender.send(getDataChannelMessageForAudioState(), sessionId);
+        messageSender.send(getDataChannelMessageForSpeakingState(), sessionId);
+        messageSender.send(getDataChannelMessageForVideoState(), sessionId);
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/call/LocalStateBroadcasterNoMcu.java
+++ b/app/src/main/java/com/nextcloud/talk/call/LocalStateBroadcasterNoMcu.java
@@ -26,6 +26,12 @@ import java.util.Objects;
  * after a temporary disconnection; data channels use a reliable transport by default, so even if the state changes
  * while the connection is temporarily interrupted the normal state update messages should be received by the other
  * participant once the connection is restored.
+ * <p>
+ * Nevertheless, in case of a failed connection and an ICE restart it is unclear whether the data channel messages
+ * would be received or not (as the data channel transport may be the one that failed and needs to be restarted).
+ * However, the state (except the speaking state) is also sent through signaling messages, which need to be
+ * explicitly fetched from the internal signaling server, so even in case of a failed connection they will be
+ * eventually received once the remote participant connects again.
  */
 public class LocalStateBroadcasterNoMcu extends LocalStateBroadcaster {
 
@@ -115,5 +121,8 @@ public class LocalStateBroadcasterNoMcu extends LocalStateBroadcaster {
         messageSender.send(getDataChannelMessageForAudioState(), sessionId);
         messageSender.send(getDataChannelMessageForSpeakingState(), sessionId);
         messageSender.send(getDataChannelMessageForVideoState(), sessionId);
+
+        messageSender.send(getSignalingMessageForAudioState(), sessionId);
+        messageSender.send(getSignalingMessageForVideoState(), sessionId);
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/call/MessageSender.java
+++ b/app/src/main/java/com/nextcloud/talk/call/MessageSender.java
@@ -7,16 +7,22 @@
 package com.nextcloud.talk.call;
 
 import com.nextcloud.talk.models.json.signaling.DataChannelMessage;
+import com.nextcloud.talk.models.json.signaling.NCSignalingMessage;
+import com.nextcloud.talk.signaling.SignalingMessageSender;
 import com.nextcloud.talk.webrtc.PeerConnectionWrapper;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Helper class to send messages to participants in a call.
  * <p>
  * A specific subclass has to be created depending on whether an MCU is being used or not.
  * <p>
- * Note that, unlike signaling messages, data channel messages require a peer connection. Therefore data channel
+ * Note that recipients of signaling messages are not validated, so no error will be triggered if trying to send a
+ * message to a participant with a session ID that does not exist or is not in the call.
+ * <p>
+ * Also note that, unlike signaling messages, data channel messages require a peer connection. Therefore data channel
  * messages may not be received by a participant if there is no peer connection with that participant (for example, if
  * neither the local and remote participants have publishing rights). Moreover, data channel messages are expected to
  * be received only on peer connections with type "video", so data channel messages will not be sent on other peer
@@ -24,9 +30,17 @@ import java.util.List;
  */
 public abstract class MessageSender {
 
+    private final SignalingMessageSender signalingMessageSender;
+
+    private final Set<String> callParticipantSessionIds;
+
     protected final List<PeerConnectionWrapper> peerConnectionWrappers;
 
-    public MessageSender(List<PeerConnectionWrapper> peerConnectionWrappers) {
+    public MessageSender(SignalingMessageSender signalingMessageSender,
+                         Set<String> callParticipantSessionIds,
+                         List<PeerConnectionWrapper> peerConnectionWrappers) {
+        this.signalingMessageSender = signalingMessageSender;
+        this.callParticipantSessionIds = callParticipantSessionIds;
         this.peerConnectionWrappers = peerConnectionWrappers;
     }
 
@@ -36,6 +50,35 @@ public abstract class MessageSender {
      * @param dataChannelMessage the message to send
      */
     public abstract void sendToAll(DataChannelMessage dataChannelMessage);
+
+    /**
+     * Sends the given signaling message to the given session ID.
+     * <p>
+     * Note that the signaling message will be modified to set the recipient in the "to" field.
+     *
+     * @param ncSignalingMessage the message to send
+     * @param sessionId the signaling session ID of the participant to send the message to
+     */
+    public void send(NCSignalingMessage ncSignalingMessage, String sessionId) {
+        ncSignalingMessage.setTo(sessionId);
+
+        signalingMessageSender.send(ncSignalingMessage);
+    }
+
+    /**
+     * Sends the given signaling message to all the participants in the call.
+     * <p>
+     * Note that the signaling message will be modified to set each of the recipients in the "to" field.
+     *
+     * @param ncSignalingMessage the message to send
+     */
+    public void sendToAll(NCSignalingMessage ncSignalingMessage) {
+        for (String sessionId: callParticipantSessionIds) {
+            ncSignalingMessage.setTo(sessionId);
+
+            signalingMessageSender.send(ncSignalingMessage);
+        }
+    }
 
     protected PeerConnectionWrapper getPeerConnectionWrapper(String sessionId) {
         for (PeerConnectionWrapper peerConnectionWrapper: peerConnectionWrappers) {

--- a/app/src/main/java/com/nextcloud/talk/call/MessageSender.java
+++ b/app/src/main/java/com/nextcloud/talk/call/MessageSender.java
@@ -18,7 +18,9 @@ import java.util.List;
  * <p>
  * Note that, unlike signaling messages, data channel messages require a peer connection. Therefore data channel
  * messages may not be received by a participant if there is no peer connection with that participant (for example, if
- * neither the local and remote participants have publishing rights).
+ * neither the local and remote participants have publishing rights). Moreover, data channel messages are expected to
+ * be received only on peer connections with type "video", so data channel messages will not be sent on other peer
+ * connections.
  */
 public abstract class MessageSender {
 
@@ -37,7 +39,8 @@ public abstract class MessageSender {
 
     protected PeerConnectionWrapper getPeerConnectionWrapper(String sessionId) {
         for (PeerConnectionWrapper peerConnectionWrapper: peerConnectionWrappers) {
-            if (peerConnectionWrapper.getSessionId().equals(sessionId)) {
+            if (peerConnectionWrapper.getSessionId().equals(sessionId)
+                    && "video".equals(peerConnectionWrapper.getVideoStreamType())) {
                 return peerConnectionWrapper;
             }
         }

--- a/app/src/main/java/com/nextcloud/talk/call/MessageSender.java
+++ b/app/src/main/java/com/nextcloud/talk/call/MessageSender.java
@@ -1,0 +1,47 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.call;
+
+import com.nextcloud.talk.models.json.signaling.DataChannelMessage;
+import com.nextcloud.talk.webrtc.PeerConnectionWrapper;
+
+import java.util.List;
+
+/**
+ * Helper class to send messages to participants in a call.
+ * <p>
+ * A specific subclass has to be created depending on whether an MCU is being used or not.
+ * <p>
+ * Note that, unlike signaling messages, data channel messages require a peer connection. Therefore data channel
+ * messages may not be received by a participant if there is no peer connection with that participant (for example, if
+ * neither the local and remote participants have publishing rights).
+ */
+public abstract class MessageSender {
+
+    protected final List<PeerConnectionWrapper> peerConnectionWrappers;
+
+    public MessageSender(List<PeerConnectionWrapper> peerConnectionWrappers) {
+        this.peerConnectionWrappers = peerConnectionWrappers;
+    }
+
+    /**
+     * Sends the given data channel message to all the participants in the call.
+     *
+     * @param dataChannelMessage the message to send
+     */
+    public abstract void sendToAll(DataChannelMessage dataChannelMessage);
+
+    protected PeerConnectionWrapper getPeerConnectionWrapper(String sessionId) {
+        for (PeerConnectionWrapper peerConnectionWrapper: peerConnectionWrappers) {
+            if (peerConnectionWrapper.getSessionId().equals(sessionId)) {
+                return peerConnectionWrapper;
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/call/MessageSenderMcu.java
+++ b/app/src/main/java/com/nextcloud/talk/call/MessageSenderMcu.java
@@ -1,0 +1,34 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.call;
+
+import com.nextcloud.talk.models.json.signaling.DataChannelMessage;
+import com.nextcloud.talk.webrtc.PeerConnectionWrapper;
+
+import java.util.List;
+
+/**
+ * Helper class to send messages to participants in a call when an MCU is used.
+ */
+public class MessageSenderMcu extends MessageSender {
+
+    private final String ownSessionId;
+
+    public MessageSenderMcu(List<PeerConnectionWrapper> peerConnectionWrappers,
+                            String ownSessionId) {
+        super(peerConnectionWrappers);
+
+        this.ownSessionId = ownSessionId;
+    }
+
+    public void sendToAll(DataChannelMessage dataChannelMessage) {
+        PeerConnectionWrapper ownPeerConnectionWrapper = getPeerConnectionWrapper(ownSessionId);
+        if (ownPeerConnectionWrapper != null) {
+            ownPeerConnectionWrapper.send(dataChannelMessage);
+        }
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/call/MessageSenderMcu.java
+++ b/app/src/main/java/com/nextcloud/talk/call/MessageSenderMcu.java
@@ -13,6 +13,9 @@ import java.util.List;
 
 /**
  * Helper class to send messages to participants in a call when an MCU is used.
+ * <p>
+ * Note that when Janus is used it is not possible to send a data channel message to a specific participant. Any data
+ * channel message will be broadcast to all the subscribers of the publisher peer connection (the own peer connection).
  */
 public class MessageSenderMcu extends MessageSender {
 

--- a/app/src/main/java/com/nextcloud/talk/call/MessageSenderMcu.java
+++ b/app/src/main/java/com/nextcloud/talk/call/MessageSenderMcu.java
@@ -7,9 +7,11 @@
 package com.nextcloud.talk.call;
 
 import com.nextcloud.talk.models.json.signaling.DataChannelMessage;
+import com.nextcloud.talk.signaling.SignalingMessageSender;
 import com.nextcloud.talk.webrtc.PeerConnectionWrapper;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Helper class to send messages to participants in a call when an MCU is used.
@@ -21,9 +23,11 @@ public class MessageSenderMcu extends MessageSender {
 
     private final String ownSessionId;
 
-    public MessageSenderMcu(List<PeerConnectionWrapper> peerConnectionWrappers,
+    public MessageSenderMcu(SignalingMessageSender signalingMessageSender,
+                            Set<String> callParticipantSessionIds,
+                            List<PeerConnectionWrapper> peerConnectionWrappers,
                             String ownSessionId) {
-        super(peerConnectionWrappers);
+        super(signalingMessageSender, callParticipantSessionIds, peerConnectionWrappers);
 
         this.ownSessionId = ownSessionId;
     }

--- a/app/src/main/java/com/nextcloud/talk/call/MessageSenderNoMcu.java
+++ b/app/src/main/java/com/nextcloud/talk/call/MessageSenderNoMcu.java
@@ -1,0 +1,28 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.call;
+
+import com.nextcloud.talk.models.json.signaling.DataChannelMessage;
+import com.nextcloud.talk.webrtc.PeerConnectionWrapper;
+
+import java.util.List;
+
+/**
+ * Helper class to send messages to participants in a call when an MCU is not used.
+ */
+public class MessageSenderNoMcu extends MessageSender {
+
+    public MessageSenderNoMcu(List<PeerConnectionWrapper> peerConnectionWrappers) {
+        super(peerConnectionWrappers);
+    }
+
+    public void sendToAll(DataChannelMessage dataChannelMessage) {
+        for (PeerConnectionWrapper peerConnectionWrapper: peerConnectionWrappers) {
+            peerConnectionWrapper.send(dataChannelMessage);
+        }
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/call/MessageSenderNoMcu.java
+++ b/app/src/main/java/com/nextcloud/talk/call/MessageSenderNoMcu.java
@@ -22,7 +22,9 @@ public class MessageSenderNoMcu extends MessageSender {
 
     public void sendToAll(DataChannelMessage dataChannelMessage) {
         for (PeerConnectionWrapper peerConnectionWrapper: peerConnectionWrappers) {
-            peerConnectionWrapper.send(dataChannelMessage);
+            if ("video".equals(peerConnectionWrapper.getVideoStreamType())){
+                peerConnectionWrapper.send(dataChannelMessage);
+            }
         }
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/call/MessageSenderNoMcu.java
+++ b/app/src/main/java/com/nextcloud/talk/call/MessageSenderNoMcu.java
@@ -7,17 +7,21 @@
 package com.nextcloud.talk.call;
 
 import com.nextcloud.talk.models.json.signaling.DataChannelMessage;
+import com.nextcloud.talk.signaling.SignalingMessageSender;
 import com.nextcloud.talk.webrtc.PeerConnectionWrapper;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Helper class to send messages to participants in a call when an MCU is not used.
  */
 public class MessageSenderNoMcu extends MessageSender {
 
-    public MessageSenderNoMcu(List<PeerConnectionWrapper> peerConnectionWrappers) {
-        super(peerConnectionWrappers);
+    public MessageSenderNoMcu(SignalingMessageSender signalingMessageSender,
+                              Set<String> callParticipantSessionIds,
+                              List<PeerConnectionWrapper> peerConnectionWrappers) {
+        super(signalingMessageSender, callParticipantSessionIds, peerConnectionWrappers);
     }
 
     /**

--- a/app/src/main/java/com/nextcloud/talk/call/MessageSenderNoMcu.java
+++ b/app/src/main/java/com/nextcloud/talk/call/MessageSenderNoMcu.java
@@ -20,6 +20,19 @@ public class MessageSenderNoMcu extends MessageSender {
         super(peerConnectionWrappers);
     }
 
+    /**
+     * Sends the given data channel message to the given signaling session ID.
+     *
+     * @param dataChannelMessage the message to send
+     * @param sessionId the signaling session ID of the participant to send the message to
+     */
+    public void send(DataChannelMessage dataChannelMessage, String sessionId) {
+        PeerConnectionWrapper peerConnectionWrapper = getPeerConnectionWrapper(sessionId);
+        if (peerConnectionWrapper != null) {
+            peerConnectionWrapper.send(dataChannelMessage);
+        }
+    }
+
     public void sendToAll(DataChannelMessage dataChannelMessage) {
         for (PeerConnectionWrapper peerConnectionWrapper: peerConnectionWrappers) {
             if ("video".equals(peerConnectionWrapper.getVideoStreamType())){

--- a/app/src/main/java/com/nextcloud/talk/call/MutableLocalCallParticipantModel.java
+++ b/app/src/main/java/com/nextcloud/talk/call/MutableLocalCallParticipantModel.java
@@ -1,0 +1,51 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.call;
+
+import java.util.Objects;
+
+/**
+ * Mutable data model for local call participants.
+ * <p>
+ * Setting "speaking" will automatically set "speaking" or "speakingWhileMuted" as needed, depending on whether audio is
+ * enabled or not. Similarly, setting whether the audio is enabled or disabled will automatically switch between
+ * "speaking" and "speakingWhileMuted" as needed.
+ * <p>
+ * There is no synchronization when setting the values; if needed, it should be handled by the clients of the model.
+ */
+public class MutableLocalCallParticipantModel extends LocalCallParticipantModel {
+
+    public void setAudioEnabled(Boolean audioEnabled) {
+        if (Objects.equals(this.audioEnabled.getValue(), audioEnabled)) {
+            return;
+        }
+
+        if (audioEnabled == null || !audioEnabled) {
+            this.speakingWhileMuted.setValue(this.speaking.getValue());
+            this.speaking.setValue(Boolean.FALSE);
+        }
+
+        this.audioEnabled.setValue(audioEnabled);
+
+        if (audioEnabled != null && audioEnabled) {
+            this.speaking.setValue(this.speakingWhileMuted.getValue());
+            this.speakingWhileMuted.setValue(Boolean.FALSE);
+        }
+    }
+
+    public void setSpeaking(Boolean speaking) {
+        if (this.audioEnabled.getValue() != null && this.audioEnabled.getValue()) {
+            this.speaking.setValue(speaking);
+        } else {
+            this.speakingWhileMuted.setValue(speaking);
+        }
+    }
+
+    public void setVideoEnabled(Boolean videoEnabled) {
+        this.videoEnabled.setValue(videoEnabled);
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
@@ -329,22 +329,6 @@ public class PeerConnectionWrapper {
         return sessionId;
     }
 
-    private void sendInitialMediaStatus() {
-        if (localStream != null) {
-            if (localStream.videoTracks.size() == 1 && localStream.videoTracks.get(0).enabled()) {
-                send(new DataChannelMessage("videoOn"));
-            } else {
-                send(new DataChannelMessage("videoOff"));
-            }
-
-            if (localStream.audioTracks.size() == 1 && localStream.audioTracks.get(0).enabled()) {
-                send(new DataChannelMessage("audioOn"));
-            } else {
-                send(new DataChannelMessage("audioOff"));
-            }
-        }
-    }
-
     public boolean isMCUPublisher() {
         return isMCUPublisher;
     }
@@ -431,10 +415,6 @@ public class PeerConnectionWrapper {
                         sendWithoutQueuing(dataChannel, dataChannelMessage);
                     }
                     pendingDataChannelMessages.clear();
-                }
-
-                if (dataChannel.state() == DataChannel.State.OPEN) {
-                    sendInitialMediaStatus();
                 }
             }
         }
@@ -523,11 +503,6 @@ public class PeerConnectionWrapper {
         public void onIceConnectionChange(PeerConnection.IceConnectionState iceConnectionState) {
 
             Log.d("iceConnectionChangeTo: ", iceConnectionState.name() + " over " + peerConnection.hashCode() + " " + sessionId);
-            if (iceConnectionState == PeerConnection.IceConnectionState.CONNECTED) {
-                if (hasInitiated) {
-                    sendInitialMediaStatus();
-                }
-            }
 
             peerConnectionNotifier.notifyIceConnectionStateChanged(iceConnectionState);
         }

--- a/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java
@@ -62,9 +62,6 @@ public class PeerConnectionWrapper {
     private final List<DataChannelMessage> pendingDataChannelMessages = new ArrayList<>();
     private final SdpObserver sdpObserver;
 
-    private final boolean hasInitiated;
-
-    private final MediaStream localStream;
     private final boolean isMCUPublisher;
     private final String videoStreamType;
 
@@ -113,14 +110,13 @@ public class PeerConnectionWrapper {
                                  boolean isMCUPublisher, boolean hasMCU, String videoStreamType,
                                  SignalingMessageReceiver signalingMessageReceiver,
                                  SignalingMessageSender signalingMessageSender) {
-        this.localStream = localStream;
         this.videoStreamType = videoStreamType;
 
         this.sessionId = sessionId;
         this.mediaConstraints = mediaConstraints;
 
         sdpObserver = new SdpObserver();
-        hasInitiated = sessionId.compareTo(localSession) < 0;
+        boolean hasInitiated = sessionId.compareTo(localSession) < 0;
         this.isMCUPublisher = isMCUPublisher;
 
         PeerConnection.RTCConfiguration configuration = new PeerConnection.RTCConfiguration(iceServerList);
@@ -133,12 +129,12 @@ public class PeerConnectionWrapper {
         this.signalingMessageSender = signalingMessageSender;
 
         if (peerConnection != null) {
-            if (this.localStream != null) {
-                List<String> localStreamIds = Collections.singletonList(this.localStream.getId());
-                for(AudioTrack track : this.localStream.audioTracks) {
+            if (localStream != null) {
+                List<String> localStreamIds = Collections.singletonList(localStream.getId());
+                for(AudioTrack track : localStream.audioTracks) {
                     peerConnection.addTrack(track, localStreamIds);
                 }
-                for(VideoTrack track : this.localStream.videoTracks) {
+                for(VideoTrack track : localStream.videoTracks) {
                     peerConnection.addTrack(track, localStreamIds);
                 }
             }

--- a/app/src/test/java/com/nextcloud/talk/call/LocalCallParticipantModelTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/call/LocalCallParticipantModelTest.kt
@@ -1,0 +1,168 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.call
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+
+class LocalCallParticipantModelTest {
+    private var localCallParticipantModel: MutableLocalCallParticipantModel? = null
+    private var mockedLocalCallParticipantModelObserver: LocalCallParticipantModel.Observer? = null
+
+    @Before
+    fun setUp() {
+        localCallParticipantModel = MutableLocalCallParticipantModel()
+        mockedLocalCallParticipantModelObserver = Mockito.mock(LocalCallParticipantModel.Observer::class.java)
+    }
+
+    @Test
+    fun testSetAudioEnabled() {
+        localCallParticipantModel!!.addObserver(mockedLocalCallParticipantModelObserver)
+
+        localCallParticipantModel!!.isAudioEnabled = true
+
+        assertTrue(localCallParticipantModel!!.isAudioEnabled)
+        assertFalse(localCallParticipantModel!!.isSpeaking)
+        assertFalse(localCallParticipantModel!!.isSpeakingWhileMuted)
+        Mockito.verify(mockedLocalCallParticipantModelObserver, Mockito.only())?.onChange()
+    }
+
+    @Test
+    fun testSetAudioEnabledWhileSpeakingWhileMuted() {
+        localCallParticipantModel!!.isSpeaking = true
+
+        localCallParticipantModel!!.addObserver(mockedLocalCallParticipantModelObserver)
+
+        localCallParticipantModel!!.isAudioEnabled = true
+
+        assertTrue(localCallParticipantModel!!.isAudioEnabled)
+        assertTrue(localCallParticipantModel!!.isSpeaking)
+        assertFalse(localCallParticipantModel!!.isSpeakingWhileMuted)
+        Mockito.verify(mockedLocalCallParticipantModelObserver, Mockito.times(3))?.onChange()
+    }
+
+    @Test
+    fun testSetAudioEnabledTwiceWhileSpeakingWhileMuted() {
+        localCallParticipantModel!!.isSpeaking = true
+
+        localCallParticipantModel!!.addObserver(mockedLocalCallParticipantModelObserver)
+
+        localCallParticipantModel!!.isAudioEnabled = true
+        localCallParticipantModel!!.isAudioEnabled = true
+
+        assertTrue(localCallParticipantModel!!.isAudioEnabled)
+        assertTrue(localCallParticipantModel!!.isSpeaking)
+        assertFalse(localCallParticipantModel!!.isSpeakingWhileMuted)
+        Mockito.verify(mockedLocalCallParticipantModelObserver, Mockito.times(3))?.onChange()
+    }
+
+    @Test
+    fun testSetAudioDisabled() {
+        localCallParticipantModel!!.isAudioEnabled = true
+
+        localCallParticipantModel!!.addObserver(mockedLocalCallParticipantModelObserver)
+
+        localCallParticipantModel!!.isAudioEnabled = false
+
+        assertFalse(localCallParticipantModel!!.isAudioEnabled)
+        assertFalse(localCallParticipantModel!!.isSpeaking)
+        assertFalse(localCallParticipantModel!!.isSpeakingWhileMuted)
+        Mockito.verify(mockedLocalCallParticipantModelObserver, Mockito.only())?.onChange()
+    }
+
+    @Test
+    fun testSetAudioDisabledWhileSpeaking() {
+        localCallParticipantModel!!.isAudioEnabled = true
+        localCallParticipantModel!!.isSpeaking = true
+
+        localCallParticipantModel!!.addObserver(mockedLocalCallParticipantModelObserver)
+
+        localCallParticipantModel!!.isAudioEnabled = false
+
+        assertFalse(localCallParticipantModel!!.isAudioEnabled)
+        assertFalse(localCallParticipantModel!!.isSpeaking)
+        assertTrue(localCallParticipantModel!!.isSpeakingWhileMuted)
+        Mockito.verify(mockedLocalCallParticipantModelObserver, Mockito.times(3))?.onChange()
+    }
+
+    @Test
+    fun testSetAudioDisabledTwiceWhileSpeaking() {
+        localCallParticipantModel!!.isAudioEnabled = true
+        localCallParticipantModel!!.isSpeaking = true
+
+        localCallParticipantModel!!.addObserver(mockedLocalCallParticipantModelObserver)
+
+        localCallParticipantModel!!.isAudioEnabled = false
+        localCallParticipantModel!!.isAudioEnabled = false
+
+        assertFalse(localCallParticipantModel!!.isAudioEnabled)
+        assertFalse(localCallParticipantModel!!.isSpeaking)
+        assertTrue(localCallParticipantModel!!.isSpeakingWhileMuted)
+        Mockito.verify(mockedLocalCallParticipantModelObserver, Mockito.times(3))?.onChange()
+    }
+
+    @Test
+    fun testSetSpeakingWhileAudioEnabled() {
+        localCallParticipantModel!!.isAudioEnabled = true
+
+        localCallParticipantModel!!.addObserver(mockedLocalCallParticipantModelObserver)
+
+        localCallParticipantModel!!.isSpeaking = true
+
+        assertTrue(localCallParticipantModel!!.isAudioEnabled)
+        assertTrue(localCallParticipantModel!!.isSpeaking)
+        assertFalse(localCallParticipantModel!!.isSpeakingWhileMuted)
+        Mockito.verify(mockedLocalCallParticipantModelObserver, Mockito.only())?.onChange()
+    }
+
+    @Test
+    fun testSetNotSpeakingWhileAudioEnabled() {
+        localCallParticipantModel!!.isAudioEnabled = true
+        localCallParticipantModel!!.isSpeaking = true
+
+        localCallParticipantModel!!.addObserver(mockedLocalCallParticipantModelObserver)
+
+        localCallParticipantModel!!.isSpeaking = false
+
+        assertTrue(localCallParticipantModel!!.isAudioEnabled)
+        assertFalse(localCallParticipantModel!!.isSpeaking)
+        assertFalse(localCallParticipantModel!!.isSpeakingWhileMuted)
+        Mockito.verify(mockedLocalCallParticipantModelObserver, Mockito.only())?.onChange()
+    }
+
+    @Test
+    fun testSetSpeakingWhileAudioDisabled() {
+        localCallParticipantModel!!.isAudioEnabled = false
+
+        localCallParticipantModel!!.addObserver(mockedLocalCallParticipantModelObserver)
+
+        localCallParticipantModel!!.isSpeaking = true
+
+        assertFalse(localCallParticipantModel!!.isAudioEnabled)
+        assertFalse(localCallParticipantModel!!.isSpeaking)
+        assertTrue(localCallParticipantModel!!.isSpeakingWhileMuted)
+        Mockito.verify(mockedLocalCallParticipantModelObserver, Mockito.only())?.onChange()
+    }
+
+    @Test
+    fun testSetNotSpeakingWhileAudioDisabled() {
+        localCallParticipantModel!!.isAudioEnabled = false
+        localCallParticipantModel!!.isSpeaking = true
+
+        localCallParticipantModel!!.addObserver(mockedLocalCallParticipantModelObserver)
+
+        localCallParticipantModel!!.isSpeaking = false
+
+        assertFalse(localCallParticipantModel!!.isAudioEnabled)
+        assertFalse(localCallParticipantModel!!.isSpeaking)
+        assertFalse(localCallParticipantModel!!.isSpeakingWhileMuted)
+        Mockito.verify(mockedLocalCallParticipantModelObserver, Mockito.only())?.onChange()
+    }
+}

--- a/app/src/test/java/com/nextcloud/talk/call/LocalStateBroadcasterMcuTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/call/LocalStateBroadcasterMcuTest.kt
@@ -7,6 +7,8 @@
 package com.nextcloud.talk.call
 
 import com.nextcloud.talk.models.json.signaling.DataChannelMessage
+import com.nextcloud.talk.models.json.signaling.NCMessagePayload
+import com.nextcloud.talk.models.json.signaling.NCSignalingMessage
 import io.reactivex.plugins.RxJavaPlugins
 import io.reactivex.schedulers.TestScheduler
 import org.junit.Before
@@ -32,6 +34,54 @@ class LocalStateBroadcasterMcuTest {
         mockedMessageSender = Mockito.mock(MessageSender::class.java)
     }
 
+    private fun getExpectedUnmuteAudio(): NCSignalingMessage {
+        val expectedUnmuteAudio = NCSignalingMessage()
+        expectedUnmuteAudio.roomType = "video"
+        expectedUnmuteAudio.type = "unmute"
+
+        val payload = NCMessagePayload()
+        payload.name = "audio"
+        expectedUnmuteAudio.payload = payload
+
+        return expectedUnmuteAudio
+    }
+
+    private fun getExpectedMuteAudio(): NCSignalingMessage {
+        val expectedMuteAudio = NCSignalingMessage()
+        expectedMuteAudio.roomType = "video"
+        expectedMuteAudio.type = "mute"
+
+        val payload = NCMessagePayload()
+        payload.name = "audio"
+        expectedMuteAudio.payload = payload
+
+        return expectedMuteAudio
+    }
+
+    private fun getExpectedUnmuteVideo(): NCSignalingMessage {
+        val expectedUnmuteVideo = NCSignalingMessage()
+        expectedUnmuteVideo.roomType = "video"
+        expectedUnmuteVideo.type = "unmute"
+
+        val payload = NCMessagePayload()
+        payload.name = "video"
+        expectedUnmuteVideo.payload = payload
+
+        return expectedUnmuteVideo
+    }
+
+    private fun getExpectedMuteVideo(): NCSignalingMessage {
+        val expectedMuteVideo = NCSignalingMessage()
+        expectedMuteVideo.roomType = "video"
+        expectedMuteVideo.type = "mute"
+
+        val payload = NCMessagePayload()
+        payload.name = "video"
+        expectedMuteVideo.payload = payload
+
+        return expectedMuteVideo
+    }
+
     @Test
     fun testStateSentWithExponentialBackoffWhenParticipantAdded() {
         val testScheduler = TestScheduler()
@@ -54,12 +104,17 @@ class LocalStateBroadcasterMcuTest {
         val expectedSpeaking = DataChannelMessage("speaking")
         val expectedVideoOn = DataChannelMessage("videoOn")
 
+        val expectedUnmuteAudio = getExpectedUnmuteAudio()
+        val expectedUnmuteVideo = getExpectedUnmuteVideo()
+
         testScheduler.advanceTimeBy(0, TimeUnit.SECONDS)
 
         var messageCount = 1
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).send(expectedUnmuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(1, TimeUnit.SECONDS)
@@ -68,6 +123,8 @@ class LocalStateBroadcasterMcuTest {
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).send(expectedUnmuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
@@ -76,6 +133,8 @@ class LocalStateBroadcasterMcuTest {
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).send(expectedUnmuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(4, TimeUnit.SECONDS)
@@ -84,6 +143,8 @@ class LocalStateBroadcasterMcuTest {
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).send(expectedUnmuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(8, TimeUnit.SECONDS)
@@ -92,6 +153,8 @@ class LocalStateBroadcasterMcuTest {
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).send(expectedUnmuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(16, TimeUnit.SECONDS)
@@ -100,6 +163,8 @@ class LocalStateBroadcasterMcuTest {
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).send(expectedUnmuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(100, TimeUnit.SECONDS)
@@ -132,11 +197,16 @@ class LocalStateBroadcasterMcuTest {
         val expectedSpeaking = DataChannelMessage("speaking")
         val expectedVideoOn = DataChannelMessage("videoOn")
 
+        val expectedUnmuteAudio = getExpectedUnmuteAudio()
+        val expectedUnmuteVideo = getExpectedUnmuteVideo()
+
         testScheduler.advanceTimeBy(0, TimeUnit.SECONDS)
 
         Mockito.verify(mockedMessageSender!!, times(1)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(1)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(1)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(1)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(1)).send(expectedUnmuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         localCallParticipantModel!!.isSpeaking = false
@@ -151,51 +221,73 @@ class LocalStateBroadcasterMcuTest {
         Mockito.verify(mockedMessageSender!!, times(2)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(2)).sendToAll(expectedStoppedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(2)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(2)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(2)).send(expectedUnmuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         localCallParticipantModel!!.isAudioEnabled = false
 
         val expectedAudioOff = DataChannelMessage("audioOff")
+        val expectedMuteAudio = getExpectedMuteAudio()
 
         // Changing the state causes the normal state update to be sent, independently of the initial state
         Mockito.verify(mockedMessageSender!!, times(1)).sendToAll(expectedAudioOff)
+        Mockito.verify(mockedMessageSender!!, times(1)).sendToAll(expectedMuteAudio)
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
 
         Mockito.verify(mockedMessageSender!!, times(2)).sendToAll(expectedAudioOff)
         Mockito.verify(mockedMessageSender!!, times(3)).sendToAll(expectedStoppedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(3)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(1)).sendToAll(expectedMuteAudio)
+        Mockito.verify(mockedMessageSender!!, times(1)).send(expectedMuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(3)).send(expectedUnmuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         localCallParticipantModel!!.isVideoEnabled = false
 
         val expectedVideoOff = DataChannelMessage("videoOff")
+        val expectedMuteVideo = getExpectedMuteVideo()
 
         // Changing the state causes the normal state update to be sent, independently of the initial state
         Mockito.verify(mockedMessageSender!!, times(1)).sendToAll(expectedVideoOff)
+        Mockito.verify(mockedMessageSender!!, times(1)).sendToAll(expectedMuteVideo)
 
         testScheduler.advanceTimeBy(4, TimeUnit.SECONDS)
 
         Mockito.verify(mockedMessageSender!!, times(3)).sendToAll(expectedAudioOff)
         Mockito.verify(mockedMessageSender!!, times(4)).sendToAll(expectedStoppedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(2)).sendToAll(expectedVideoOff)
+        Mockito.verify(mockedMessageSender!!, times(1)).sendToAll(expectedMuteAudio)
+        Mockito.verify(mockedMessageSender!!, times(1)).sendToAll(expectedMuteVideo)
+        Mockito.verify(mockedMessageSender!!, times(2)).send(expectedMuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(1)).send(expectedMuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         localCallParticipantModel!!.isVideoEnabled = true
 
         // Changing the state causes the normal state update to be sent, independently of the initial state
         Mockito.verify(mockedMessageSender!!, times(4)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(1)).sendToAll(expectedUnmuteVideo)
 
         testScheduler.advanceTimeBy(8, TimeUnit.SECONDS)
 
         Mockito.verify(mockedMessageSender!!, times(4)).sendToAll(expectedAudioOff)
         Mockito.verify(mockedMessageSender!!, times(5)).sendToAll(expectedStoppedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(5)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(1)).sendToAll(expectedMuteAudio)
+        Mockito.verify(mockedMessageSender!!, times(1)).sendToAll(expectedMuteVideo)
+        Mockito.verify(mockedMessageSender!!, times(1)).sendToAll(expectedUnmuteVideo)
+        Mockito.verify(mockedMessageSender!!, times(3)).send(expectedMuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(4)).send(expectedUnmuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
     }
 
     @Test
-    fun testStateSentWithExponentialBackoffRestartedWhenAnotherParticipantAdded() {
+    fun testStateSentWithExponentialBackoffWhenAnotherParticipantAdded() {
+        // The state sent through data channels should be restarted, although the state sent through signaling
+        // messages should be independent for each participant.
+
         val testScheduler = TestScheduler()
         RxJavaPlugins.setIoSchedulerHandler { testScheduler }
 
@@ -216,36 +308,51 @@ class LocalStateBroadcasterMcuTest {
         val expectedSpeaking = DataChannelMessage("speaking")
         val expectedVideoOn = DataChannelMessage("videoOn")
 
+        val expectedUnmuteAudio = getExpectedUnmuteAudio()
+        val expectedUnmuteVideo = getExpectedUnmuteVideo()
+
         testScheduler.advanceTimeBy(0, TimeUnit.SECONDS)
 
         var dataChannelMessageCount = 1
+        var signalingMessageCount1 = 1
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount1)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount1)).send(expectedUnmuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(1, TimeUnit.SECONDS)
 
         dataChannelMessageCount = 2
+        signalingMessageCount1 = 2
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount1)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount1)).send(expectedUnmuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
 
         dataChannelMessageCount = 3
+        signalingMessageCount1 = 3
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount1)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount1)).send(expectedUnmuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(4, TimeUnit.SECONDS)
 
         dataChannelMessageCount = 4
+        signalingMessageCount1 = 4
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount1)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount1)).send(expectedUnmuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         val callParticipantModel2 = MutableCallParticipantModel("theSessionId2")
@@ -255,49 +362,107 @@ class LocalStateBroadcasterMcuTest {
         testScheduler.advanceTimeBy(0, TimeUnit.SECONDS)
 
         dataChannelMessageCount = 5
+        var signalingMessageCount2 = 1
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount1)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount1)).send(expectedUnmuteVideo, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount2)).send(expectedUnmuteAudio, "theSessionId2")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount2)).send(expectedUnmuteVideo, "theSessionId2")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(1, TimeUnit.SECONDS)
 
         dataChannelMessageCount = 6
+        signalingMessageCount2 = 2
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount1)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount1)).send(expectedUnmuteVideo, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount2)).send(expectedUnmuteAudio, "theSessionId2")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount2)).send(expectedUnmuteVideo, "theSessionId2")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
 
         dataChannelMessageCount = 7
+        signalingMessageCount2 = 3
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount1)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount1)).send(expectedUnmuteVideo, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount2)).send(expectedUnmuteAudio, "theSessionId2")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount2)).send(expectedUnmuteVideo, "theSessionId2")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(4, TimeUnit.SECONDS)
 
         dataChannelMessageCount = 8
+        signalingMessageCount2 = 4
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount1)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount1)).send(expectedUnmuteVideo, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount2)).send(expectedUnmuteAudio, "theSessionId2")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount2)).send(expectedUnmuteVideo, "theSessionId2")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
-        testScheduler.advanceTimeBy(8, TimeUnit.SECONDS)
+        // 0+1+2+4+1=8 seconds since last signaling messages for participant 1
+        testScheduler.advanceTimeBy(1, TimeUnit.SECONDS)
+
+        signalingMessageCount1 = 5
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount1)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount1)).send(expectedUnmuteVideo, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount2)).send(expectedUnmuteAudio, "theSessionId2")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount2)).send(expectedUnmuteVideo, "theSessionId2")
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        // 1+7=8 seconds since last data channel messages and signaling messages for participant 2
+        testScheduler.advanceTimeBy(7, TimeUnit.SECONDS)
 
         dataChannelMessageCount = 9
+        signalingMessageCount2 = 5
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount1)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount1)).send(expectedUnmuteVideo, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount2)).send(expectedUnmuteAudio, "theSessionId2")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount2)).send(expectedUnmuteVideo, "theSessionId2")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
-        testScheduler.advanceTimeBy(16, TimeUnit.SECONDS)
+        // 7+9=16 seconds since last signaling messages for participant 1
+        testScheduler.advanceTimeBy(9, TimeUnit.SECONDS)
 
-        dataChannelMessageCount = 10
+        signalingMessageCount1 = 6
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount1)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount1)).send(expectedUnmuteVideo, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount2)).send(expectedUnmuteAudio, "theSessionId2")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount2)).send(expectedUnmuteVideo, "theSessionId2")
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        // 9+7=16 seconds since last data channel messages and signaling messages for participant 2
+        testScheduler.advanceTimeBy(7, TimeUnit.SECONDS)
+
+        dataChannelMessageCount = 10
+        signalingMessageCount2 = 6
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount1)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount1)).send(expectedUnmuteVideo, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount2)).send(expectedUnmuteAudio, "theSessionId2")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount2)).send(expectedUnmuteVideo, "theSessionId2")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(100, TimeUnit.SECONDS)
@@ -306,8 +471,9 @@ class LocalStateBroadcasterMcuTest {
     }
 
     @Test
-    fun testStateStillSentWithExponentialBackoffWhenParticipantRemoved() {
+    fun testStateSentWithExponentialBackoffWhenParticipantRemoved() {
         // For simplicity the exponential backoff is not aborted when the participant that triggered it is removed.
+        // However, the signaling messages are stopped when the participant is removed.
 
         val testScheduler = TestScheduler()
         RxJavaPlugins.setIoSchedulerHandler { testScheduler }
@@ -329,36 +495,51 @@ class LocalStateBroadcasterMcuTest {
         val expectedSpeaking = DataChannelMessage("speaking")
         val expectedVideoOn = DataChannelMessage("videoOn")
 
+        val expectedUnmuteAudio = getExpectedUnmuteAudio()
+        val expectedUnmuteVideo = getExpectedUnmuteVideo()
+
         testScheduler.advanceTimeBy(0, TimeUnit.SECONDS)
 
         var dataChannelMessageCount = 1
+        var signalingMessageCount = 1
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount)).send(expectedUnmuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(1, TimeUnit.SECONDS)
 
         dataChannelMessageCount = 2
+        signalingMessageCount = 2
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount)).send(expectedUnmuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
 
         dataChannelMessageCount = 3
+        signalingMessageCount = 3
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount)).send(expectedUnmuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(4, TimeUnit.SECONDS)
 
         dataChannelMessageCount = 4
+        signalingMessageCount = 4
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount)).send(expectedUnmuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         localStateBroadcasterMcu!!.handleCallParticipantRemoved(callParticipantModel)
@@ -369,6 +550,8 @@ class LocalStateBroadcasterMcuTest {
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount)).send(expectedUnmuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(16, TimeUnit.SECONDS)
@@ -377,6 +560,8 @@ class LocalStateBroadcasterMcuTest {
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(signalingMessageCount)).send(expectedUnmuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(100, TimeUnit.SECONDS)
@@ -395,8 +580,10 @@ class LocalStateBroadcasterMcuTest {
         )
 
         val callParticipantModel = MutableCallParticipantModel("theSessionId")
+        val callParticipantModel2 = MutableCallParticipantModel("theSessionId2")
 
         localStateBroadcasterMcu!!.handleCallParticipantAdded(callParticipantModel)
+        localStateBroadcasterMcu!!.handleCallParticipantAdded(callParticipantModel2)
 
         // Sending will be done in another thread, so just adding the participant does not send anything until that
         // other thread could run.
@@ -406,12 +593,19 @@ class LocalStateBroadcasterMcuTest {
         val expectedSpeaking = DataChannelMessage("speaking")
         val expectedVideoOn = DataChannelMessage("videoOn")
 
+        val expectedUnmuteAudio = getExpectedUnmuteAudio()
+        val expectedUnmuteVideo = getExpectedUnmuteVideo()
+
         testScheduler.advanceTimeBy(0, TimeUnit.SECONDS)
 
         var messageCount = 1
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).send(expectedUnmuteVideo, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).send(expectedUnmuteAudio, "theSessionId2")
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).send(expectedUnmuteVideo, "theSessionId2")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(1, TimeUnit.SECONDS)
@@ -420,6 +614,10 @@ class LocalStateBroadcasterMcuTest {
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).send(expectedUnmuteVideo, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).send(expectedUnmuteAudio, "theSessionId2")
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).send(expectedUnmuteVideo, "theSessionId2")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
@@ -428,6 +626,10 @@ class LocalStateBroadcasterMcuTest {
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
         Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).send(expectedUnmuteVideo, "theSessionId")
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).send(expectedUnmuteAudio, "theSessionId2")
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).send(expectedUnmuteVideo, "theSessionId2")
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         localStateBroadcasterMcu!!.destroy()

--- a/app/src/test/java/com/nextcloud/talk/call/LocalStateBroadcasterMcuTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/call/LocalStateBroadcasterMcuTest.kt
@@ -218,34 +218,34 @@ class LocalStateBroadcasterMcuTest {
 
         testScheduler.advanceTimeBy(0, TimeUnit.SECONDS)
 
-        var messageCount = 1
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        var dataChannelMessageCount = 1
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(1, TimeUnit.SECONDS)
 
-        messageCount = 2
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        dataChannelMessageCount = 2
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
 
-        messageCount = 3
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        dataChannelMessageCount = 3
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(4, TimeUnit.SECONDS)
 
-        messageCount = 4
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        dataChannelMessageCount = 4
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         val callParticipantModel2 = MutableCallParticipantModel("theSessionId2")
@@ -254,50 +254,50 @@ class LocalStateBroadcasterMcuTest {
 
         testScheduler.advanceTimeBy(0, TimeUnit.SECONDS)
 
-        messageCount = 5
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        dataChannelMessageCount = 5
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(1, TimeUnit.SECONDS)
 
-        messageCount = 6
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        dataChannelMessageCount = 6
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
 
-        messageCount = 7
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        dataChannelMessageCount = 7
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(4, TimeUnit.SECONDS)
 
-        messageCount = 8
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        dataChannelMessageCount = 8
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(8, TimeUnit.SECONDS)
 
-        messageCount = 9
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        dataChannelMessageCount = 9
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(16, TimeUnit.SECONDS)
 
-        messageCount = 10
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        dataChannelMessageCount = 10
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(100, TimeUnit.SECONDS)
@@ -331,52 +331,52 @@ class LocalStateBroadcasterMcuTest {
 
         testScheduler.advanceTimeBy(0, TimeUnit.SECONDS)
 
-        var messageCount = 1
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        var dataChannelMessageCount = 1
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(1, TimeUnit.SECONDS)
 
-        messageCount = 2
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        dataChannelMessageCount = 2
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
 
-        messageCount = 3
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        dataChannelMessageCount = 3
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(4, TimeUnit.SECONDS)
 
-        messageCount = 4
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        dataChannelMessageCount = 4
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         localStateBroadcasterMcu!!.handleCallParticipantRemoved(callParticipantModel)
 
         testScheduler.advanceTimeBy(8, TimeUnit.SECONDS)
 
-        messageCount = 5
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        dataChannelMessageCount = 5
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(16, TimeUnit.SECONDS)
 
-        messageCount = 6
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
-        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        dataChannelMessageCount = 6
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(dataChannelMessageCount)).sendToAll(expectedVideoOn)
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
 
         testScheduler.advanceTimeBy(100, TimeUnit.SECONDS)

--- a/app/src/test/java/com/nextcloud/talk/call/LocalStateBroadcasterMcuTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/call/LocalStateBroadcasterMcuTest.kt
@@ -1,0 +1,439 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.call
+
+import com.nextcloud.talk.models.json.signaling.DataChannelMessage
+import io.reactivex.plugins.RxJavaPlugins
+import io.reactivex.schedulers.TestScheduler
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.times
+import java.util.concurrent.TimeUnit
+
+@Suppress("LongMethod")
+class LocalStateBroadcasterMcuTest {
+
+    private var localCallParticipantModel: MutableLocalCallParticipantModel? = null
+    private var mockedMessageSender: MessageSender? = null
+
+    private var localStateBroadcasterMcu: LocalStateBroadcasterMcu? = null
+
+    @Before
+    fun setUp() {
+        localCallParticipantModel = MutableLocalCallParticipantModel()
+        localCallParticipantModel!!.isAudioEnabled = true
+        localCallParticipantModel!!.isSpeaking = true
+        localCallParticipantModel!!.isVideoEnabled = true
+        mockedMessageSender = Mockito.mock(MessageSender::class.java)
+    }
+
+    @Test
+    fun testStateSentWithExponentialBackoffWhenParticipantAdded() {
+        val testScheduler = TestScheduler()
+        RxJavaPlugins.setIoSchedulerHandler { testScheduler }
+
+        localStateBroadcasterMcu = LocalStateBroadcasterMcu(
+            localCallParticipantModel,
+            mockedMessageSender
+        )
+
+        val callParticipantModel = MutableCallParticipantModel("theSessionId")
+
+        localStateBroadcasterMcu!!.handleCallParticipantAdded(callParticipantModel)
+
+        // Sending will be done in another thread, so just adding the participant does not send anything until that
+        // other thread could run.
+        Mockito.verifyNoInteractions(mockedMessageSender)
+
+        val expectedAudioOn = DataChannelMessage("audioOn")
+        val expectedSpeaking = DataChannelMessage("speaking")
+        val expectedVideoOn = DataChannelMessage("videoOn")
+
+        testScheduler.advanceTimeBy(0, TimeUnit.SECONDS)
+
+        var messageCount = 1
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        testScheduler.advanceTimeBy(1, TimeUnit.SECONDS)
+
+        messageCount = 2
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
+
+        messageCount = 3
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        testScheduler.advanceTimeBy(4, TimeUnit.SECONDS)
+
+        messageCount = 4
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        testScheduler.advanceTimeBy(8, TimeUnit.SECONDS)
+
+        messageCount = 5
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        testScheduler.advanceTimeBy(16, TimeUnit.SECONDS)
+
+        messageCount = 6
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        testScheduler.advanceTimeBy(100, TimeUnit.SECONDS)
+
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+    }
+
+    @Test
+    fun testStateSentWithExponentialBackoffIsTheCurrentState() {
+        // This test could have been included in "testStateSentWithExponentialBackoffWhenParticipantAdded", but was
+        // kept separate for clarity.
+
+        val testScheduler = TestScheduler()
+        RxJavaPlugins.setIoSchedulerHandler { testScheduler }
+
+        localStateBroadcasterMcu = LocalStateBroadcasterMcu(
+            localCallParticipantModel,
+            mockedMessageSender
+        )
+
+        val callParticipantModel = MutableCallParticipantModel("theSessionId")
+
+        localStateBroadcasterMcu!!.handleCallParticipantAdded(callParticipantModel)
+
+        // Sending will be done in another thread, so just adding the participant does not send anything until that
+        // other thread could run.
+        Mockito.verifyNoInteractions(mockedMessageSender)
+
+        val expectedAudioOn = DataChannelMessage("audioOn")
+        val expectedSpeaking = DataChannelMessage("speaking")
+        val expectedVideoOn = DataChannelMessage("videoOn")
+
+        testScheduler.advanceTimeBy(0, TimeUnit.SECONDS)
+
+        Mockito.verify(mockedMessageSender!!, times(1)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(1)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(1)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        localCallParticipantModel!!.isSpeaking = false
+
+        val expectedStoppedSpeaking = DataChannelMessage("stoppedSpeaking")
+
+        // Changing the state causes the normal state update to be sent, independently of the initial state
+        Mockito.verify(mockedMessageSender!!, times(1)).sendToAll(expectedStoppedSpeaking)
+
+        testScheduler.advanceTimeBy(1, TimeUnit.SECONDS)
+
+        Mockito.verify(mockedMessageSender!!, times(2)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(2)).sendToAll(expectedStoppedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(2)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        localCallParticipantModel!!.isAudioEnabled = false
+
+        val expectedAudioOff = DataChannelMessage("audioOff")
+
+        // Changing the state causes the normal state update to be sent, independently of the initial state
+        Mockito.verify(mockedMessageSender!!, times(1)).sendToAll(expectedAudioOff)
+
+        testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
+
+        Mockito.verify(mockedMessageSender!!, times(2)).sendToAll(expectedAudioOff)
+        Mockito.verify(mockedMessageSender!!, times(3)).sendToAll(expectedStoppedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(3)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        localCallParticipantModel!!.isVideoEnabled = false
+
+        val expectedVideoOff = DataChannelMessage("videoOff")
+
+        // Changing the state causes the normal state update to be sent, independently of the initial state
+        Mockito.verify(mockedMessageSender!!, times(1)).sendToAll(expectedVideoOff)
+
+        testScheduler.advanceTimeBy(4, TimeUnit.SECONDS)
+
+        Mockito.verify(mockedMessageSender!!, times(3)).sendToAll(expectedAudioOff)
+        Mockito.verify(mockedMessageSender!!, times(4)).sendToAll(expectedStoppedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(2)).sendToAll(expectedVideoOff)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        localCallParticipantModel!!.isVideoEnabled = true
+
+        // Changing the state causes the normal state update to be sent, independently of the initial state
+        Mockito.verify(mockedMessageSender!!, times(4)).sendToAll(expectedVideoOn)
+
+        testScheduler.advanceTimeBy(8, TimeUnit.SECONDS)
+
+        Mockito.verify(mockedMessageSender!!, times(4)).sendToAll(expectedAudioOff)
+        Mockito.verify(mockedMessageSender!!, times(5)).sendToAll(expectedStoppedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(5)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+    }
+
+    @Test
+    fun testStateSentWithExponentialBackoffRestartedWhenAnotherParticipantAdded() {
+        val testScheduler = TestScheduler()
+        RxJavaPlugins.setIoSchedulerHandler { testScheduler }
+
+        localStateBroadcasterMcu = LocalStateBroadcasterMcu(
+            localCallParticipantModel,
+            mockedMessageSender
+        )
+
+        val callParticipantModel = MutableCallParticipantModel("theSessionId")
+
+        localStateBroadcasterMcu!!.handleCallParticipantAdded(callParticipantModel)
+
+        // Sending will be done in another thread, so just adding the participant does not send anything until that
+        // other thread could run.
+        Mockito.verifyNoInteractions(mockedMessageSender)
+
+        val expectedAudioOn = DataChannelMessage("audioOn")
+        val expectedSpeaking = DataChannelMessage("speaking")
+        val expectedVideoOn = DataChannelMessage("videoOn")
+
+        testScheduler.advanceTimeBy(0, TimeUnit.SECONDS)
+
+        var messageCount = 1
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        testScheduler.advanceTimeBy(1, TimeUnit.SECONDS)
+
+        messageCount = 2
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
+
+        messageCount = 3
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        testScheduler.advanceTimeBy(4, TimeUnit.SECONDS)
+
+        messageCount = 4
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        val callParticipantModel2 = MutableCallParticipantModel("theSessionId2")
+
+        localStateBroadcasterMcu!!.handleCallParticipantAdded(callParticipantModel2)
+
+        testScheduler.advanceTimeBy(0, TimeUnit.SECONDS)
+
+        messageCount = 5
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        testScheduler.advanceTimeBy(1, TimeUnit.SECONDS)
+
+        messageCount = 6
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
+
+        messageCount = 7
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        testScheduler.advanceTimeBy(4, TimeUnit.SECONDS)
+
+        messageCount = 8
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        testScheduler.advanceTimeBy(8, TimeUnit.SECONDS)
+
+        messageCount = 9
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        testScheduler.advanceTimeBy(16, TimeUnit.SECONDS)
+
+        messageCount = 10
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        testScheduler.advanceTimeBy(100, TimeUnit.SECONDS)
+
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+    }
+
+    @Test
+    fun testStateStillSentWithExponentialBackoffWhenParticipantRemoved() {
+        // For simplicity the exponential backoff is not aborted when the participant that triggered it is removed.
+
+        val testScheduler = TestScheduler()
+        RxJavaPlugins.setIoSchedulerHandler { testScheduler }
+
+        localStateBroadcasterMcu = LocalStateBroadcasterMcu(
+            localCallParticipantModel,
+            mockedMessageSender
+        )
+
+        val callParticipantModel = MutableCallParticipantModel("theSessionId")
+
+        localStateBroadcasterMcu!!.handleCallParticipantAdded(callParticipantModel)
+
+        // Sending will be done in another thread, so just adding the participant does not send anything until that
+        // other thread could run.
+        Mockito.verifyNoInteractions(mockedMessageSender)
+
+        val expectedAudioOn = DataChannelMessage("audioOn")
+        val expectedSpeaking = DataChannelMessage("speaking")
+        val expectedVideoOn = DataChannelMessage("videoOn")
+
+        testScheduler.advanceTimeBy(0, TimeUnit.SECONDS)
+
+        var messageCount = 1
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        testScheduler.advanceTimeBy(1, TimeUnit.SECONDS)
+
+        messageCount = 2
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
+
+        messageCount = 3
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        testScheduler.advanceTimeBy(4, TimeUnit.SECONDS)
+
+        messageCount = 4
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        localStateBroadcasterMcu!!.handleCallParticipantRemoved(callParticipantModel)
+
+        testScheduler.advanceTimeBy(8, TimeUnit.SECONDS)
+
+        messageCount = 5
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        testScheduler.advanceTimeBy(16, TimeUnit.SECONDS)
+
+        messageCount = 6
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        testScheduler.advanceTimeBy(100, TimeUnit.SECONDS)
+
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+    }
+
+    @Test
+    fun testStateNoLongerSentOnceDestroyed() {
+        val testScheduler = TestScheduler()
+        RxJavaPlugins.setIoSchedulerHandler { testScheduler }
+
+        localStateBroadcasterMcu = LocalStateBroadcasterMcu(
+            localCallParticipantModel,
+            mockedMessageSender
+        )
+
+        val callParticipantModel = MutableCallParticipantModel("theSessionId")
+
+        localStateBroadcasterMcu!!.handleCallParticipantAdded(callParticipantModel)
+
+        // Sending will be done in another thread, so just adding the participant does not send anything until that
+        // other thread could run.
+        Mockito.verifyNoInteractions(mockedMessageSender)
+
+        val expectedAudioOn = DataChannelMessage("audioOn")
+        val expectedSpeaking = DataChannelMessage("speaking")
+        val expectedVideoOn = DataChannelMessage("videoOn")
+
+        testScheduler.advanceTimeBy(0, TimeUnit.SECONDS)
+
+        var messageCount = 1
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        testScheduler.advanceTimeBy(1, TimeUnit.SECONDS)
+
+        messageCount = 2
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        testScheduler.advanceTimeBy(2, TimeUnit.SECONDS)
+
+        messageCount = 3
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!, times(messageCount)).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+
+        localStateBroadcasterMcu!!.destroy()
+
+        testScheduler.advanceTimeBy(100, TimeUnit.SECONDS)
+
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+    }
+}

--- a/app/src/test/java/com/nextcloud/talk/call/LocalStateBroadcasterNoMcuTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/call/LocalStateBroadcasterNoMcuTest.kt
@@ -7,6 +7,8 @@
 package com.nextcloud.talk.call
 
 import com.nextcloud.talk.models.json.signaling.DataChannelMessage
+import com.nextcloud.talk.models.json.signaling.NCMessagePayload
+import com.nextcloud.talk.models.json.signaling.NCSignalingMessage
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
@@ -26,6 +28,30 @@ class LocalStateBroadcasterNoMcuTest {
         localCallParticipantModel!!.isSpeaking = true
         localCallParticipantModel!!.isVideoEnabled = true
         mockedMessageSenderNoMcu = Mockito.mock(MessageSenderNoMcu::class.java)
+    }
+
+    private fun getExpectedUnmuteAudio(): NCSignalingMessage {
+        val expectedUnmuteAudio = NCSignalingMessage()
+        expectedUnmuteAudio.roomType = "video"
+        expectedUnmuteAudio.type = "unmute"
+
+        val payload = NCMessagePayload()
+        payload.name = "audio"
+        expectedUnmuteAudio.payload = payload
+
+        return expectedUnmuteAudio
+    }
+
+    private fun getExpectedUnmuteVideo(): NCSignalingMessage {
+        val expectedUnmuteVideo = NCSignalingMessage()
+        expectedUnmuteVideo.roomType = "video"
+        expectedUnmuteVideo.type = "unmute"
+
+        val payload = NCMessagePayload()
+        payload.name = "video"
+        expectedUnmuteVideo.payload = payload
+
+        return expectedUnmuteVideo
     }
 
     @Test
@@ -49,9 +75,14 @@ class LocalStateBroadcasterNoMcuTest {
         val expectedSpeaking = DataChannelMessage("speaking")
         val expectedVideoOn = DataChannelMessage("videoOn")
 
+        val expectedUnmuteAudio = getExpectedUnmuteAudio()
+        val expectedUnmuteVideo = getExpectedUnmuteVideo()
+
         Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedAudioOn, "theSessionId")
         Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedSpeaking, "theSessionId")
         Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedVideoOn, "theSessionId")
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedUnmuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSenderNoMcu)
     }
 
@@ -76,9 +107,14 @@ class LocalStateBroadcasterNoMcuTest {
         val expectedSpeaking = DataChannelMessage("speaking")
         val expectedVideoOn = DataChannelMessage("videoOn")
 
+        val expectedUnmuteAudio = getExpectedUnmuteAudio()
+        val expectedUnmuteVideo = getExpectedUnmuteVideo()
+
         Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedAudioOn, "theSessionId")
         Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedSpeaking, "theSessionId")
         Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedVideoOn, "theSessionId")
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedUnmuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSenderNoMcu)
     }
 
@@ -103,9 +139,14 @@ class LocalStateBroadcasterNoMcuTest {
         val expectedSpeaking = DataChannelMessage("speaking")
         val expectedVideoOn = DataChannelMessage("videoOn")
 
+        val expectedUnmuteAudio = getExpectedUnmuteAudio()
+        val expectedUnmuteVideo = getExpectedUnmuteVideo()
+
         Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedAudioOn, "theSessionId")
         Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedSpeaking, "theSessionId")
         Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedVideoOn, "theSessionId")
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedUnmuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSenderNoMcu)
 
         callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.COMPLETED)
@@ -134,9 +175,14 @@ class LocalStateBroadcasterNoMcuTest {
         val expectedSpeaking = DataChannelMessage("speaking")
         val expectedVideoOn = DataChannelMessage("videoOn")
 
+        val expectedUnmuteAudio = getExpectedUnmuteAudio()
+        val expectedUnmuteVideo = getExpectedUnmuteVideo()
+
         Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedAudioOn, "theSessionId")
         Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedSpeaking, "theSessionId")
         Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedVideoOn, "theSessionId")
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedUnmuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSenderNoMcu)
 
         callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.COMPLETED)
@@ -191,9 +237,14 @@ class LocalStateBroadcasterNoMcuTest {
         val expectedSpeaking = DataChannelMessage("speaking")
         val expectedVideoOn = DataChannelMessage("videoOn")
 
+        val expectedUnmuteAudio = getExpectedUnmuteAudio()
+        val expectedUnmuteVideo = getExpectedUnmuteVideo()
+
         Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedAudioOn, "theSessionId")
         Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedSpeaking, "theSessionId")
         Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedVideoOn, "theSessionId")
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedUnmuteAudio, "theSessionId")
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedUnmuteVideo, "theSessionId")
         Mockito.verifyNoMoreInteractions(mockedMessageSenderNoMcu)
 
         callParticipantModel2.setIceConnectionState(PeerConnection.IceConnectionState.CONNECTED)
@@ -201,6 +252,8 @@ class LocalStateBroadcasterNoMcuTest {
         Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedAudioOn, "theSessionId2")
         Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedSpeaking, "theSessionId2")
         Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedVideoOn, "theSessionId2")
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedUnmuteAudio, "theSessionId2")
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedUnmuteVideo, "theSessionId2")
         Mockito.verifyNoMoreInteractions(mockedMessageSenderNoMcu)
     }
 

--- a/app/src/test/java/com/nextcloud/talk/call/LocalStateBroadcasterNoMcuTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/call/LocalStateBroadcasterNoMcuTest.kt
@@ -1,0 +1,304 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.call
+
+import com.nextcloud.talk.models.json.signaling.DataChannelMessage
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+import org.webrtc.PeerConnection
+
+class LocalStateBroadcasterNoMcuTest {
+
+    private var localCallParticipantModel: MutableLocalCallParticipantModel? = null
+    private var mockedMessageSenderNoMcu: MessageSenderNoMcu? = null
+
+    private var localStateBroadcasterNoMcu: LocalStateBroadcasterNoMcu? = null
+
+    @Before
+    fun setUp() {
+        localCallParticipantModel = MutableLocalCallParticipantModel()
+        localCallParticipantModel!!.isAudioEnabled = true
+        localCallParticipantModel!!.isSpeaking = true
+        localCallParticipantModel!!.isVideoEnabled = true
+        mockedMessageSenderNoMcu = Mockito.mock(MessageSenderNoMcu::class.java)
+    }
+
+    @Test
+    fun testStateSentWhenIceConnected() {
+        localStateBroadcasterNoMcu = LocalStateBroadcasterNoMcu(
+            localCallParticipantModel,
+            mockedMessageSenderNoMcu
+        )
+
+        val callParticipantModel = MutableCallParticipantModel("theSessionId")
+
+        localStateBroadcasterNoMcu!!.handleCallParticipantAdded(callParticipantModel)
+
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.CHECKING)
+
+        Mockito.verifyNoInteractions(mockedMessageSenderNoMcu)
+
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.CONNECTED)
+
+        val expectedAudioOn = DataChannelMessage("audioOn")
+        val expectedSpeaking = DataChannelMessage("speaking")
+        val expectedVideoOn = DataChannelMessage("videoOn")
+
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedAudioOn, "theSessionId")
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedSpeaking, "theSessionId")
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedVideoOn, "theSessionId")
+        Mockito.verifyNoMoreInteractions(mockedMessageSenderNoMcu)
+    }
+
+    @Test
+    fun testStateSentWhenIceCompleted() {
+        localStateBroadcasterNoMcu = LocalStateBroadcasterNoMcu(
+            localCallParticipantModel,
+            mockedMessageSenderNoMcu
+        )
+
+        val callParticipantModel = MutableCallParticipantModel("theSessionId")
+
+        localStateBroadcasterNoMcu!!.handleCallParticipantAdded(callParticipantModel)
+
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.CHECKING)
+
+        Mockito.verifyNoInteractions(mockedMessageSenderNoMcu)
+
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.COMPLETED)
+
+        val expectedAudioOn = DataChannelMessage("audioOn")
+        val expectedSpeaking = DataChannelMessage("speaking")
+        val expectedVideoOn = DataChannelMessage("videoOn")
+
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedAudioOn, "theSessionId")
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedSpeaking, "theSessionId")
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedVideoOn, "theSessionId")
+        Mockito.verifyNoMoreInteractions(mockedMessageSenderNoMcu)
+    }
+
+    @Test
+    fun testStateNotSentWhenIceCompletedAfterConnected() {
+        localStateBroadcasterNoMcu = LocalStateBroadcasterNoMcu(
+            localCallParticipantModel,
+            mockedMessageSenderNoMcu
+        )
+
+        val callParticipantModel = MutableCallParticipantModel("theSessionId")
+
+        localStateBroadcasterNoMcu!!.handleCallParticipantAdded(callParticipantModel)
+
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.CHECKING)
+
+        Mockito.verifyNoInteractions(mockedMessageSenderNoMcu)
+
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.CONNECTED)
+
+        val expectedAudioOn = DataChannelMessage("audioOn")
+        val expectedSpeaking = DataChannelMessage("speaking")
+        val expectedVideoOn = DataChannelMessage("videoOn")
+
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedAudioOn, "theSessionId")
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedSpeaking, "theSessionId")
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedVideoOn, "theSessionId")
+        Mockito.verifyNoMoreInteractions(mockedMessageSenderNoMcu)
+
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.COMPLETED)
+
+        Mockito.verifyNoMoreInteractions(mockedMessageSenderNoMcu)
+    }
+
+    @Test
+    fun testStateNotSentWhenIceConnectedAgain() {
+        localStateBroadcasterNoMcu = LocalStateBroadcasterNoMcu(
+            localCallParticipantModel,
+            mockedMessageSenderNoMcu
+        )
+
+        val callParticipantModel = MutableCallParticipantModel("theSessionId")
+
+        localStateBroadcasterNoMcu!!.handleCallParticipantAdded(callParticipantModel)
+
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.CHECKING)
+
+        Mockito.verifyNoInteractions(mockedMessageSenderNoMcu)
+
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.CONNECTED)
+
+        val expectedAudioOn = DataChannelMessage("audioOn")
+        val expectedSpeaking = DataChannelMessage("speaking")
+        val expectedVideoOn = DataChannelMessage("videoOn")
+
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedAudioOn, "theSessionId")
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedSpeaking, "theSessionId")
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedVideoOn, "theSessionId")
+        Mockito.verifyNoMoreInteractions(mockedMessageSenderNoMcu)
+
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.COMPLETED)
+
+        Mockito.verifyNoMoreInteractions(mockedMessageSenderNoMcu)
+
+        // Completed -> Connected could happen with an ICE restart
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.CONNECTED)
+
+        Mockito.verifyNoMoreInteractions(mockedMessageSenderNoMcu)
+
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.DISCONNECTED)
+
+        Mockito.verifyNoMoreInteractions(mockedMessageSenderNoMcu)
+
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.CONNECTED)
+
+        Mockito.verifyNoMoreInteractions(mockedMessageSenderNoMcu)
+
+        // Failed -> Checking could happen with an ICE restart
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.FAILED)
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.CHECKING)
+
+        Mockito.verifyNoMoreInteractions(mockedMessageSenderNoMcu)
+
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.CONNECTED)
+
+        Mockito.verifyNoMoreInteractions(mockedMessageSenderNoMcu)
+    }
+
+    @Test
+    fun testStateNotSentToOtherParticipantsWhenIceConnected() {
+        localStateBroadcasterNoMcu = LocalStateBroadcasterNoMcu(
+            localCallParticipantModel,
+            mockedMessageSenderNoMcu
+        )
+
+        val callParticipantModel = MutableCallParticipantModel("theSessionId")
+        val callParticipantModel2 = MutableCallParticipantModel("theSessionId2")
+
+        localStateBroadcasterNoMcu!!.handleCallParticipantAdded(callParticipantModel)
+        localStateBroadcasterNoMcu!!.handleCallParticipantAdded(callParticipantModel2)
+
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.CHECKING)
+        callParticipantModel2.setIceConnectionState(PeerConnection.IceConnectionState.CHECKING)
+
+        Mockito.verifyNoInteractions(mockedMessageSenderNoMcu)
+
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.CONNECTED)
+
+        val expectedAudioOn = DataChannelMessage("audioOn")
+        val expectedSpeaking = DataChannelMessage("speaking")
+        val expectedVideoOn = DataChannelMessage("videoOn")
+
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedAudioOn, "theSessionId")
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedSpeaking, "theSessionId")
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedVideoOn, "theSessionId")
+        Mockito.verifyNoMoreInteractions(mockedMessageSenderNoMcu)
+
+        callParticipantModel2.setIceConnectionState(PeerConnection.IceConnectionState.CONNECTED)
+
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedAudioOn, "theSessionId2")
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedSpeaking, "theSessionId2")
+        Mockito.verify(mockedMessageSenderNoMcu!!).send(expectedVideoOn, "theSessionId2")
+        Mockito.verifyNoMoreInteractions(mockedMessageSenderNoMcu)
+    }
+
+    @Test
+    fun testStateNotSentWhenIceConnectedAfterParticipantIsRemoved() {
+        // This should not happen, as peer connections are expected to be ended when a call participant is removed, but
+        // just in case.
+
+        localStateBroadcasterNoMcu = LocalStateBroadcasterNoMcu(
+            localCallParticipantModel,
+            mockedMessageSenderNoMcu
+        )
+
+        val callParticipantModel = MutableCallParticipantModel("theSessionId")
+
+        localStateBroadcasterNoMcu!!.handleCallParticipantAdded(callParticipantModel)
+
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.CHECKING)
+
+        Mockito.verifyNoInteractions(mockedMessageSenderNoMcu)
+
+        localStateBroadcasterNoMcu!!.handleCallParticipantRemoved(callParticipantModel)
+
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.CONNECTED)
+
+        Mockito.verifyNoInteractions(mockedMessageSenderNoMcu)
+    }
+
+    @Test
+    fun testStateNotSentWhenIceCompletedAfterParticipantIsRemoved() {
+        // This should not happen, as peer connections are expected to be ended when a call participant is removed, but
+        // just in case.
+
+        localStateBroadcasterNoMcu = LocalStateBroadcasterNoMcu(
+            localCallParticipantModel,
+            mockedMessageSenderNoMcu
+        )
+
+        val callParticipantModel = MutableCallParticipantModel("theSessionId")
+
+        localStateBroadcasterNoMcu!!.handleCallParticipantAdded(callParticipantModel)
+
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.CHECKING)
+
+        Mockito.verifyNoInteractions(mockedMessageSenderNoMcu)
+
+        localStateBroadcasterNoMcu!!.handleCallParticipantRemoved(callParticipantModel)
+
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.COMPLETED)
+
+        Mockito.verifyNoInteractions(mockedMessageSenderNoMcu)
+    }
+
+    @Test
+    fun testStateNotSentWhenIceConnectedAfterDestroyed() {
+        localStateBroadcasterNoMcu = LocalStateBroadcasterNoMcu(
+            localCallParticipantModel,
+            mockedMessageSenderNoMcu
+        )
+
+        val callParticipantModel = MutableCallParticipantModel("theSessionId")
+        val callParticipantModel2 = MutableCallParticipantModel("theSessionId2")
+
+        localStateBroadcasterNoMcu!!.handleCallParticipantAdded(callParticipantModel)
+        localStateBroadcasterNoMcu!!.handleCallParticipantAdded(callParticipantModel2)
+
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.CHECKING)
+        callParticipantModel2.setIceConnectionState(PeerConnection.IceConnectionState.CHECKING)
+
+        Mockito.verifyNoInteractions(mockedMessageSenderNoMcu)
+
+        localStateBroadcasterNoMcu!!.destroy()
+
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.CONNECTED)
+        callParticipantModel2.setIceConnectionState(PeerConnection.IceConnectionState.CONNECTED)
+
+        Mockito.verifyNoInteractions(mockedMessageSenderNoMcu)
+    }
+
+    @Test
+    fun testStateNotSentWhenIceCompletedAfterDestroyed() {
+        localStateBroadcasterNoMcu = LocalStateBroadcasterNoMcu(
+            localCallParticipantModel,
+            mockedMessageSenderNoMcu
+        )
+
+        val callParticipantModel = MutableCallParticipantModel("theSessionId")
+
+        localStateBroadcasterNoMcu!!.handleCallParticipantAdded(callParticipantModel)
+
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.CHECKING)
+
+        Mockito.verifyNoInteractions(mockedMessageSenderNoMcu)
+
+        localStateBroadcasterNoMcu!!.destroy()
+
+        callParticipantModel.setIceConnectionState(PeerConnection.IceConnectionState.COMPLETED)
+
+        Mockito.verifyNoInteractions(mockedMessageSenderNoMcu)
+    }
+}

--- a/app/src/test/java/com/nextcloud/talk/call/LocalStateBroadcasterTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/call/LocalStateBroadcasterTest.kt
@@ -7,6 +7,8 @@
 package com.nextcloud.talk.call
 
 import com.nextcloud.talk.models.json.signaling.DataChannelMessage
+import com.nextcloud.talk.models.json.signaling.NCMessagePayload
+import com.nextcloud.talk.models.json.signaling.NCSignalingMessage
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
@@ -49,7 +51,15 @@ class LocalStateBroadcasterTest {
 
         val expectedAudioOn = DataChannelMessage("audioOn")
 
+        val expectedUnmuteAudio = NCSignalingMessage()
+        expectedUnmuteAudio.roomType = "video"
+        expectedUnmuteAudio.type = "unmute"
+        val payload = NCMessagePayload()
+        payload.name = "audio"
+        expectedUnmuteAudio.payload = payload
+
         Mockito.verify(mockedMessageSender!!).sendToAll(expectedAudioOn)
+        Mockito.verify(mockedMessageSender!!).sendToAll(expectedUnmuteAudio)
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
     }
 
@@ -74,7 +84,15 @@ class LocalStateBroadcasterTest {
 
         val expectedAudioOff = DataChannelMessage("audioOff")
 
+        val expectedMuteAudio = NCSignalingMessage()
+        expectedMuteAudio.roomType = "video"
+        expectedMuteAudio.type = "mute"
+        val payload = NCMessagePayload()
+        payload.name = "audio"
+        expectedMuteAudio.payload = payload
+
         Mockito.verify(mockedMessageSender!!).sendToAll(expectedAudioOff)
+        Mockito.verify(mockedMessageSender!!).sendToAll(expectedMuteAudio)
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
     }
 
@@ -141,10 +159,18 @@ class LocalStateBroadcasterTest {
         val expectedAudioOn = DataChannelMessage("audioOn")
         val expectedSpeaking = DataChannelMessage("speaking")
 
+        val expectedUnmuteAudio = NCSignalingMessage()
+        expectedUnmuteAudio.roomType = "video"
+        expectedUnmuteAudio.type = "unmute"
+        val payload = NCMessagePayload()
+        payload.name = "audio"
+        expectedUnmuteAudio.payload = payload
+
         val inOrder = Mockito.inOrder(mockedMessageSender)
 
         inOrder.verify(mockedMessageSender!!).sendToAll(expectedAudioOn)
         inOrder.verify(mockedMessageSender!!).sendToAll(expectedSpeaking)
+        Mockito.verify(mockedMessageSender!!).sendToAll(expectedUnmuteAudio)
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
     }
 
@@ -187,10 +213,18 @@ class LocalStateBroadcasterTest {
         val expectedStoppedSpeaking = DataChannelMessage("stoppedSpeaking")
         val expectedAudioOff = DataChannelMessage("audioOff")
 
+        val expectedMuteAudio = NCSignalingMessage()
+        expectedMuteAudio.roomType = "video"
+        expectedMuteAudio.type = "mute"
+        val payload = NCMessagePayload()
+        payload.name = "audio"
+        expectedMuteAudio.payload = payload
+
         val inOrder = Mockito.inOrder(mockedMessageSender)
 
         inOrder.verify(mockedMessageSender!!).sendToAll(expectedStoppedSpeaking)
         inOrder.verify(mockedMessageSender!!).sendToAll(expectedAudioOff)
+        Mockito.verify(mockedMessageSender!!).sendToAll(expectedMuteAudio)
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
     }
 
@@ -216,7 +250,15 @@ class LocalStateBroadcasterTest {
 
         val expectedVideoOn = DataChannelMessage("videoOn")
 
+        val expectedUnmuteVideo = NCSignalingMessage()
+        expectedUnmuteVideo.roomType = "video"
+        expectedUnmuteVideo.type = "unmute"
+        val payload = NCMessagePayload()
+        payload.name = "video"
+        expectedUnmuteVideo.payload = payload
+
         Mockito.verify(mockedMessageSender!!).sendToAll(expectedVideoOn)
+        Mockito.verify(mockedMessageSender!!).sendToAll(expectedUnmuteVideo)
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
     }
 
@@ -241,7 +283,15 @@ class LocalStateBroadcasterTest {
 
         val expectedVideoOff = DataChannelMessage("videoOff")
 
+        val expectedMuteVideo = NCSignalingMessage()
+        expectedMuteVideo.roomType = "video"
+        expectedMuteVideo.type = "mute"
+        val payload = NCMessagePayload()
+        payload.name = "video"
+        expectedMuteVideo.payload = payload
+
         Mockito.verify(mockedMessageSender!!).sendToAll(expectedVideoOff)
+        Mockito.verify(mockedMessageSender!!).sendToAll(expectedMuteVideo)
         Mockito.verifyNoMoreInteractions(mockedMessageSender)
     }
 

--- a/app/src/test/java/com/nextcloud/talk/call/LocalStateBroadcasterTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/call/LocalStateBroadcasterTest.kt
@@ -14,6 +14,20 @@ import org.mockito.Mockito
 @Suppress("TooManyFunctions")
 class LocalStateBroadcasterTest {
 
+    private class LocalStateBroadcaster(
+        localCallParticipantModel: LocalCallParticipantModel?,
+        messageSender: MessageSender?
+    ) : com.nextcloud.talk.call.LocalStateBroadcaster(localCallParticipantModel, messageSender) {
+
+        override fun handleCallParticipantAdded(callParticipantModel: CallParticipantModel) {
+            // Not used in base class tests
+        }
+
+        override fun handleCallParticipantRemoved(callParticipantModel: CallParticipantModel) {
+            // Not used in base class tests
+        }
+    }
+
     private var localCallParticipantModel: MutableLocalCallParticipantModel? = null
     private var mockedMessageSender: MessageSender? = null
 

--- a/app/src/test/java/com/nextcloud/talk/call/LocalStateBroadcasterTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/call/LocalStateBroadcasterTest.kt
@@ -1,0 +1,260 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.call
+
+import com.nextcloud.talk.models.json.signaling.DataChannelMessage
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+
+@Suppress("TooManyFunctions")
+class LocalStateBroadcasterTest {
+
+    private var localCallParticipantModel: MutableLocalCallParticipantModel? = null
+    private var mockedMessageSender: MessageSender? = null
+
+    private var localStateBroadcaster: LocalStateBroadcaster? = null
+
+    @Before
+    fun setUp() {
+        localCallParticipantModel = MutableLocalCallParticipantModel()
+        mockedMessageSender = Mockito.mock(MessageSender::class.java)
+    }
+
+    @Test
+    fun testEnableAudio() {
+        localCallParticipantModel!!.isAudioEnabled = false
+
+        localStateBroadcaster = LocalStateBroadcaster(localCallParticipantModel, mockedMessageSender)
+
+        localCallParticipantModel!!.isAudioEnabled = true
+
+        val expectedAudioOn = DataChannelMessage("audioOn")
+
+        Mockito.verify(mockedMessageSender!!).sendToAll(expectedAudioOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+    }
+
+    @Test
+    fun testEnableAudioTwice() {
+        localCallParticipantModel!!.isAudioEnabled = true
+
+        localStateBroadcaster = LocalStateBroadcaster(localCallParticipantModel, mockedMessageSender)
+
+        localCallParticipantModel!!.isAudioEnabled = true
+
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+    }
+
+    @Test
+    fun testDisableAudio() {
+        localCallParticipantModel!!.isAudioEnabled = true
+
+        localStateBroadcaster = LocalStateBroadcaster(localCallParticipantModel, mockedMessageSender)
+
+        localCallParticipantModel!!.isAudioEnabled = false
+
+        val expectedAudioOff = DataChannelMessage("audioOff")
+
+        Mockito.verify(mockedMessageSender!!).sendToAll(expectedAudioOff)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+    }
+
+    @Test
+    fun testDisableAudioTwice() {
+        localCallParticipantModel!!.isAudioEnabled = false
+
+        localStateBroadcaster = LocalStateBroadcaster(localCallParticipantModel, mockedMessageSender)
+
+        localCallParticipantModel!!.isAudioEnabled = false
+
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+    }
+
+    @Test
+    fun testEnableSpeaking() {
+        localCallParticipantModel!!.isAudioEnabled = true
+        localCallParticipantModel!!.isSpeaking = false
+
+        localStateBroadcaster = LocalStateBroadcaster(localCallParticipantModel, mockedMessageSender)
+
+        localCallParticipantModel!!.isSpeaking = true
+
+        val expectedSpeaking = DataChannelMessage("speaking")
+
+        Mockito.verify(mockedMessageSender!!).sendToAll(expectedSpeaking)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+    }
+
+    @Test
+    fun testEnableSpeakingTwice() {
+        localCallParticipantModel!!.isAudioEnabled = true
+        localCallParticipantModel!!.isSpeaking = true
+
+        localStateBroadcaster = LocalStateBroadcaster(localCallParticipantModel, mockedMessageSender)
+
+        localCallParticipantModel!!.isSpeaking = true
+
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+    }
+
+    @Test
+    fun testEnableSpeakingWithAudioDisabled() {
+        localCallParticipantModel!!.isAudioEnabled = false
+        localCallParticipantModel!!.isSpeaking = false
+
+        localStateBroadcaster = LocalStateBroadcaster(localCallParticipantModel, mockedMessageSender)
+
+        localCallParticipantModel!!.isSpeaking = true
+
+        Mockito.verifyNoInteractions(mockedMessageSender)
+    }
+
+    @Test
+    fun testEnableAudioWhileSpeaking() {
+        localCallParticipantModel!!.isAudioEnabled = false
+        localCallParticipantModel!!.isSpeaking = false
+
+        localStateBroadcaster = LocalStateBroadcaster(localCallParticipantModel, mockedMessageSender)
+
+        localCallParticipantModel!!.isSpeaking = true
+        localCallParticipantModel!!.isAudioEnabled = true
+
+        val expectedAudioOn = DataChannelMessage("audioOn")
+        val expectedSpeaking = DataChannelMessage("speaking")
+
+        val inOrder = Mockito.inOrder(mockedMessageSender)
+
+        inOrder.verify(mockedMessageSender!!).sendToAll(expectedAudioOn)
+        inOrder.verify(mockedMessageSender!!).sendToAll(expectedSpeaking)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+    }
+
+    @Test
+    fun testDisableSpeaking() {
+        localCallParticipantModel!!.isAudioEnabled = true
+        localCallParticipantModel!!.isSpeaking = true
+
+        localStateBroadcaster = LocalStateBroadcaster(localCallParticipantModel, mockedMessageSender)
+
+        localCallParticipantModel!!.isSpeaking = false
+
+        val expectedStoppedSpeaking = DataChannelMessage("stoppedSpeaking")
+
+        Mockito.verify(mockedMessageSender!!).sendToAll(expectedStoppedSpeaking)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+    }
+
+    @Test
+    fun testDisableSpeakingTwice() {
+        localCallParticipantModel!!.isAudioEnabled = true
+        localCallParticipantModel!!.isSpeaking = false
+
+        localStateBroadcaster = LocalStateBroadcaster(localCallParticipantModel, mockedMessageSender)
+
+        localCallParticipantModel!!.isSpeaking = false
+
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+    }
+
+    @Test
+    fun testDisableAudioWhileSpeaking() {
+        localCallParticipantModel!!.isAudioEnabled = true
+        localCallParticipantModel!!.isSpeaking = true
+
+        localStateBroadcaster = LocalStateBroadcaster(localCallParticipantModel, mockedMessageSender)
+
+        localCallParticipantModel!!.isAudioEnabled = false
+
+        val expectedStoppedSpeaking = DataChannelMessage("stoppedSpeaking")
+        val expectedAudioOff = DataChannelMessage("audioOff")
+
+        val inOrder = Mockito.inOrder(mockedMessageSender)
+
+        inOrder.verify(mockedMessageSender!!).sendToAll(expectedStoppedSpeaking)
+        inOrder.verify(mockedMessageSender!!).sendToAll(expectedAudioOff)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+    }
+
+    @Test
+    fun testDisableSpeakingWithAudioDisabled() {
+        localCallParticipantModel!!.isAudioEnabled = false
+        localCallParticipantModel!!.isSpeaking = true
+
+        localStateBroadcaster = LocalStateBroadcaster(localCallParticipantModel, mockedMessageSender)
+
+        localCallParticipantModel!!.isSpeaking = false
+
+        Mockito.verifyNoInteractions(mockedMessageSender)
+    }
+
+    @Test
+    fun testEnableVideo() {
+        localCallParticipantModel!!.isVideoEnabled = false
+
+        localStateBroadcaster = LocalStateBroadcaster(localCallParticipantModel, mockedMessageSender)
+
+        localCallParticipantModel!!.isVideoEnabled = true
+
+        val expectedVideoOn = DataChannelMessage("videoOn")
+
+        Mockito.verify(mockedMessageSender!!).sendToAll(expectedVideoOn)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+    }
+
+    @Test
+    fun testEnableVideoTwice() {
+        localCallParticipantModel!!.isVideoEnabled = true
+
+        localStateBroadcaster = LocalStateBroadcaster(localCallParticipantModel, mockedMessageSender)
+
+        localCallParticipantModel!!.isVideoEnabled = true
+
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+    }
+
+    @Test
+    fun testDisableVideo() {
+        localCallParticipantModel!!.isVideoEnabled = true
+
+        localStateBroadcaster = LocalStateBroadcaster(localCallParticipantModel, mockedMessageSender)
+
+        localCallParticipantModel!!.isVideoEnabled = false
+
+        val expectedVideoOff = DataChannelMessage("videoOff")
+
+        Mockito.verify(mockedMessageSender!!).sendToAll(expectedVideoOff)
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+    }
+
+    @Test
+    fun testDisableVideoTwice() {
+        localCallParticipantModel!!.isVideoEnabled = false
+
+        localStateBroadcaster = LocalStateBroadcaster(localCallParticipantModel, mockedMessageSender)
+
+        localCallParticipantModel!!.isVideoEnabled = false
+
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+    }
+
+    @Test
+    fun testChangeStateAfterDestroying() {
+        localCallParticipantModel!!.isAudioEnabled = false
+        localCallParticipantModel!!.isSpeaking = false
+        localCallParticipantModel!!.isVideoEnabled = false
+
+        localStateBroadcaster = LocalStateBroadcaster(localCallParticipantModel, mockedMessageSender)
+
+        localStateBroadcaster!!.destroy()
+        localCallParticipantModel!!.isAudioEnabled = true
+        localCallParticipantModel!!.isSpeaking = true
+        localCallParticipantModel!!.isVideoEnabled = true
+
+        Mockito.verifyNoMoreInteractions(mockedMessageSender)
+    }
+}

--- a/app/src/test/java/com/nextcloud/talk/call/MessageSenderMcuTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/call/MessageSenderMcuTest.kt
@@ -7,6 +7,7 @@
 package com.nextcloud.talk.call
 
 import com.nextcloud.talk.models.json.signaling.DataChannelMessage
+import com.nextcloud.talk.signaling.SignalingMessageSender
 import com.nextcloud.talk.webrtc.PeerConnectionWrapper
 import org.junit.Before
 import org.junit.Test
@@ -27,6 +28,10 @@ class MessageSenderMcuTest {
 
     @Before
     fun setUp() {
+        val signalingMessageSender = Mockito.mock(SignalingMessageSender::class.java)
+
+        val callParticipants = HashMap<String, CallParticipant>()
+
         peerConnectionWrappers = ArrayList()
 
         peerConnectionWrapper1 = Mockito.mock(PeerConnectionWrapper::class.java)
@@ -59,7 +64,12 @@ class MessageSenderMcuTest {
         Mockito.`when`(ownPeerConnectionWrapperScreen!!.videoStreamType).thenReturn("screen")
         peerConnectionWrappers!!.add(ownPeerConnectionWrapperScreen)
 
-        messageSender = MessageSenderMcu(peerConnectionWrappers, "ownSessionId")
+        messageSender = MessageSenderMcu(
+            signalingMessageSender,
+            callParticipants.keys,
+            peerConnectionWrappers,
+            "ownSessionId"
+        )
     }
 
     @Test

--- a/app/src/test/java/com/nextcloud/talk/call/MessageSenderMcuTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/call/MessageSenderMcuTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.call
+
+import com.nextcloud.talk.models.json.signaling.DataChannelMessage
+import com.nextcloud.talk.webrtc.PeerConnectionWrapper
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.never
+
+class MessageSenderMcuTest {
+
+    private var peerConnectionWrappers: MutableList<PeerConnectionWrapper?>? = null
+    private var peerConnectionWrapper1: PeerConnectionWrapper? = null
+    private var peerConnectionWrapper2: PeerConnectionWrapper? = null
+    private var ownPeerConnectionWrapper: PeerConnectionWrapper? = null
+
+    private var messageSender: MessageSenderMcu? = null
+
+    @Before
+    fun setUp() {
+        peerConnectionWrappers = ArrayList()
+
+        peerConnectionWrapper1 = Mockito.mock(PeerConnectionWrapper::class.java)
+        Mockito.`when`(peerConnectionWrapper1!!.sessionId).thenReturn("theSessionId1")
+        Mockito.`when`(peerConnectionWrapper1!!.videoStreamType).thenReturn("video")
+        peerConnectionWrappers!!.add(peerConnectionWrapper1)
+
+        peerConnectionWrapper2 = Mockito.mock(PeerConnectionWrapper::class.java)
+        Mockito.`when`(peerConnectionWrapper2!!.sessionId).thenReturn("theSessionId2")
+        Mockito.`when`(peerConnectionWrapper2!!.videoStreamType).thenReturn("video")
+        peerConnectionWrappers!!.add(peerConnectionWrapper2)
+
+        ownPeerConnectionWrapper = Mockito.mock(PeerConnectionWrapper::class.java)
+        Mockito.`when`(ownPeerConnectionWrapper!!.sessionId).thenReturn("ownSessionId")
+        Mockito.`when`(ownPeerConnectionWrapper!!.videoStreamType).thenReturn("video")
+        peerConnectionWrappers!!.add(ownPeerConnectionWrapper)
+
+        messageSender = MessageSenderMcu(peerConnectionWrappers, "ownSessionId")
+    }
+
+    @Test
+    fun testSendDataChannelMessageToAll() {
+        val message = DataChannelMessage()
+        messageSender!!.sendToAll(message)
+
+        Mockito.verify(ownPeerConnectionWrapper!!).send(message)
+        Mockito.verify(peerConnectionWrapper1!!, never()).send(message)
+        Mockito.verify(peerConnectionWrapper2!!, never()).send(message)
+    }
+
+    @Test
+    fun testSendDataChannelMessageToAllWithoutOwnPeerConnection() {
+        peerConnectionWrappers!!.remove(ownPeerConnectionWrapper)
+
+        val message = DataChannelMessage()
+        messageSender!!.sendToAll(message)
+
+        Mockito.verify(ownPeerConnectionWrapper!!, never()).send(message)
+        Mockito.verify(peerConnectionWrapper1!!, never()).send(message)
+        Mockito.verify(peerConnectionWrapper2!!, never()).send(message)
+    }
+}

--- a/app/src/test/java/com/nextcloud/talk/call/MessageSenderMcuTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/call/MessageSenderMcuTest.kt
@@ -18,7 +18,10 @@ class MessageSenderMcuTest {
     private var peerConnectionWrappers: MutableList<PeerConnectionWrapper?>? = null
     private var peerConnectionWrapper1: PeerConnectionWrapper? = null
     private var peerConnectionWrapper2: PeerConnectionWrapper? = null
+    private var peerConnectionWrapper2Screen: PeerConnectionWrapper? = null
+    private var peerConnectionWrapper4Screen: PeerConnectionWrapper? = null
     private var ownPeerConnectionWrapper: PeerConnectionWrapper? = null
+    private var ownPeerConnectionWrapperScreen: PeerConnectionWrapper? = null
 
     private var messageSender: MessageSenderMcu? = null
 
@@ -36,10 +39,25 @@ class MessageSenderMcuTest {
         Mockito.`when`(peerConnectionWrapper2!!.videoStreamType).thenReturn("video")
         peerConnectionWrappers!!.add(peerConnectionWrapper2)
 
+        peerConnectionWrapper2Screen = Mockito.mock(PeerConnectionWrapper::class.java)
+        Mockito.`when`(peerConnectionWrapper2Screen!!.sessionId).thenReturn("theSessionId2")
+        Mockito.`when`(peerConnectionWrapper2Screen!!.videoStreamType).thenReturn("screen")
+        peerConnectionWrappers!!.add(peerConnectionWrapper2Screen)
+
+        peerConnectionWrapper4Screen = Mockito.mock(PeerConnectionWrapper::class.java)
+        Mockito.`when`(peerConnectionWrapper4Screen!!.sessionId).thenReturn("theSessionId4")
+        Mockito.`when`(peerConnectionWrapper4Screen!!.videoStreamType).thenReturn("screen")
+        peerConnectionWrappers!!.add(peerConnectionWrapper4Screen)
+
         ownPeerConnectionWrapper = Mockito.mock(PeerConnectionWrapper::class.java)
         Mockito.`when`(ownPeerConnectionWrapper!!.sessionId).thenReturn("ownSessionId")
         Mockito.`when`(ownPeerConnectionWrapper!!.videoStreamType).thenReturn("video")
         peerConnectionWrappers!!.add(ownPeerConnectionWrapper)
+
+        ownPeerConnectionWrapperScreen = Mockito.mock(PeerConnectionWrapper::class.java)
+        Mockito.`when`(ownPeerConnectionWrapperScreen!!.sessionId).thenReturn("ownSessionId")
+        Mockito.`when`(ownPeerConnectionWrapperScreen!!.videoStreamType).thenReturn("screen")
+        peerConnectionWrappers!!.add(ownPeerConnectionWrapperScreen)
 
         messageSender = MessageSenderMcu(peerConnectionWrappers, "ownSessionId")
     }
@@ -50,19 +68,41 @@ class MessageSenderMcuTest {
         messageSender!!.sendToAll(message)
 
         Mockito.verify(ownPeerConnectionWrapper!!).send(message)
+        Mockito.verify(ownPeerConnectionWrapperScreen!!, never()).send(message)
         Mockito.verify(peerConnectionWrapper1!!, never()).send(message)
         Mockito.verify(peerConnectionWrapper2!!, never()).send(message)
+        Mockito.verify(peerConnectionWrapper2Screen!!, never()).send(message)
+        Mockito.verify(peerConnectionWrapper4Screen!!, never()).send(message)
     }
 
     @Test
-    fun testSendDataChannelMessageToAllWithoutOwnPeerConnection() {
+    fun testSendDataChannelMessageToAllIfOwnScreenPeerConnection() {
         peerConnectionWrappers!!.remove(ownPeerConnectionWrapper)
 
         val message = DataChannelMessage()
         messageSender!!.sendToAll(message)
 
         Mockito.verify(ownPeerConnectionWrapper!!, never()).send(message)
+        Mockito.verify(ownPeerConnectionWrapperScreen!!, never()).send(message)
         Mockito.verify(peerConnectionWrapper1!!, never()).send(message)
         Mockito.verify(peerConnectionWrapper2!!, never()).send(message)
+        Mockito.verify(peerConnectionWrapper2Screen!!, never()).send(message)
+        Mockito.verify(peerConnectionWrapper4Screen!!, never()).send(message)
+    }
+
+    @Test
+    fun testSendDataChannelMessageToAllWithoutOwnPeerConnection() {
+        peerConnectionWrappers!!.remove(ownPeerConnectionWrapper)
+        peerConnectionWrappers!!.remove(ownPeerConnectionWrapperScreen)
+
+        val message = DataChannelMessage()
+        messageSender!!.sendToAll(message)
+
+        Mockito.verify(ownPeerConnectionWrapper!!, never()).send(message)
+        Mockito.verify(ownPeerConnectionWrapperScreen!!, never()).send(message)
+        Mockito.verify(peerConnectionWrapper1!!, never()).send(message)
+        Mockito.verify(peerConnectionWrapper2!!, never()).send(message)
+        Mockito.verify(peerConnectionWrapper2Screen!!, never()).send(message)
+        Mockito.verify(peerConnectionWrapper4Screen!!, never()).send(message)
     }
 }

--- a/app/src/test/java/com/nextcloud/talk/call/MessageSenderNoMcuTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/call/MessageSenderNoMcuTest.kt
@@ -51,6 +51,39 @@ class MessageSenderNoMcuTest {
     }
 
     @Test
+    fun testSendDataChannelMessage() {
+        val message = DataChannelMessage()
+        messageSender!!.send(message, "theSessionId2")
+
+        Mockito.verify(peerConnectionWrapper2!!).send(message)
+        Mockito.verify(peerConnectionWrapper1!!, never()).send(message)
+        Mockito.verify(peerConnectionWrapper2Screen!!, never()).send(message)
+        Mockito.verify(peerConnectionWrapper4Screen!!, never()).send(message)
+    }
+
+    @Test
+    fun testSendDataChannelMessageIfScreenPeerConnection() {
+        val message = DataChannelMessage()
+        messageSender!!.send(message, "theSessionId4")
+
+        Mockito.verify(peerConnectionWrapper1!!, never()).send(message)
+        Mockito.verify(peerConnectionWrapper2!!, never()).send(message)
+        Mockito.verify(peerConnectionWrapper2Screen!!, never()).send(message)
+        Mockito.verify(peerConnectionWrapper4Screen!!, never()).send(message)
+    }
+
+    @Test
+    fun testSendDataChannelMessageIfNoPeerConnection() {
+        val message = DataChannelMessage()
+        messageSender!!.send(message, "theSessionId3")
+
+        Mockito.verify(peerConnectionWrapper1!!, never()).send(message)
+        Mockito.verify(peerConnectionWrapper2!!, never()).send(message)
+        Mockito.verify(peerConnectionWrapper2Screen!!, never()).send(message)
+        Mockito.verify(peerConnectionWrapper4Screen!!, never()).send(message)
+    }
+
+    @Test
     fun testSendDataChannelMessageToAll() {
         val message = DataChannelMessage()
         messageSender!!.sendToAll(message)

--- a/app/src/test/java/com/nextcloud/talk/call/MessageSenderNoMcuTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/call/MessageSenderNoMcuTest.kt
@@ -11,12 +11,15 @@ import com.nextcloud.talk.webrtc.PeerConnectionWrapper
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
+import org.mockito.Mockito.never
 
 class MessageSenderNoMcuTest {
 
     private var peerConnectionWrappers: MutableList<PeerConnectionWrapper?>? = null
     private var peerConnectionWrapper1: PeerConnectionWrapper? = null
     private var peerConnectionWrapper2: PeerConnectionWrapper? = null
+    private var peerConnectionWrapper2Screen: PeerConnectionWrapper? = null
+    private var peerConnectionWrapper4Screen: PeerConnectionWrapper? = null
 
     private var messageSender: MessageSenderNoMcu? = null
 
@@ -34,6 +37,16 @@ class MessageSenderNoMcuTest {
         Mockito.`when`(peerConnectionWrapper2!!.videoStreamType).thenReturn("video")
         peerConnectionWrappers!!.add(peerConnectionWrapper2)
 
+        peerConnectionWrapper2Screen = Mockito.mock(PeerConnectionWrapper::class.java)
+        Mockito.`when`(peerConnectionWrapper2Screen!!.sessionId).thenReturn("theSessionId2")
+        Mockito.`when`(peerConnectionWrapper2Screen!!.videoStreamType).thenReturn("screen")
+        peerConnectionWrappers!!.add(peerConnectionWrapper2Screen)
+
+        peerConnectionWrapper4Screen = Mockito.mock(PeerConnectionWrapper::class.java)
+        Mockito.`when`(peerConnectionWrapper4Screen!!.sessionId).thenReturn("theSessionId4")
+        Mockito.`when`(peerConnectionWrapper4Screen!!.videoStreamType).thenReturn("screen")
+        peerConnectionWrappers!!.add(peerConnectionWrapper4Screen)
+
         messageSender = MessageSenderNoMcu(peerConnectionWrappers)
     }
 
@@ -44,5 +57,7 @@ class MessageSenderNoMcuTest {
 
         Mockito.verify(peerConnectionWrapper1!!).send(message)
         Mockito.verify(peerConnectionWrapper2!!).send(message)
+        Mockito.verify(peerConnectionWrapper2Screen!!, never()).send(message)
+        Mockito.verify(peerConnectionWrapper4Screen!!, never()).send(message)
     }
 }

--- a/app/src/test/java/com/nextcloud/talk/call/MessageSenderNoMcuTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/call/MessageSenderNoMcuTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.call
+
+import com.nextcloud.talk.models.json.signaling.DataChannelMessage
+import com.nextcloud.talk.webrtc.PeerConnectionWrapper
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+
+class MessageSenderNoMcuTest {
+
+    private var peerConnectionWrappers: MutableList<PeerConnectionWrapper?>? = null
+    private var peerConnectionWrapper1: PeerConnectionWrapper? = null
+    private var peerConnectionWrapper2: PeerConnectionWrapper? = null
+
+    private var messageSender: MessageSenderNoMcu? = null
+
+    @Before
+    fun setUp() {
+        peerConnectionWrappers = ArrayList()
+
+        peerConnectionWrapper1 = Mockito.mock(PeerConnectionWrapper::class.java)
+        Mockito.`when`(peerConnectionWrapper1!!.sessionId).thenReturn("theSessionId1")
+        Mockito.`when`(peerConnectionWrapper1!!.videoStreamType).thenReturn("video")
+        peerConnectionWrappers!!.add(peerConnectionWrapper1)
+
+        peerConnectionWrapper2 = Mockito.mock(PeerConnectionWrapper::class.java)
+        Mockito.`when`(peerConnectionWrapper2!!.sessionId).thenReturn("theSessionId2")
+        Mockito.`when`(peerConnectionWrapper2!!.videoStreamType).thenReturn("video")
+        peerConnectionWrappers!!.add(peerConnectionWrapper2)
+
+        messageSender = MessageSenderNoMcu(peerConnectionWrappers)
+    }
+
+    @Test
+    fun testSendDataChannelMessageToAll() {
+        val message = DataChannelMessage()
+        messageSender!!.sendToAll(message)
+
+        Mockito.verify(peerConnectionWrapper1!!).send(message)
+        Mockito.verify(peerConnectionWrapper2!!).send(message)
+    }
+}

--- a/app/src/test/java/com/nextcloud/talk/call/MessageSenderNoMcuTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/call/MessageSenderNoMcuTest.kt
@@ -7,6 +7,7 @@
 package com.nextcloud.talk.call
 
 import com.nextcloud.talk.models.json.signaling.DataChannelMessage
+import com.nextcloud.talk.signaling.SignalingMessageSender
 import com.nextcloud.talk.webrtc.PeerConnectionWrapper
 import org.junit.Before
 import org.junit.Test
@@ -25,6 +26,10 @@ class MessageSenderNoMcuTest {
 
     @Before
     fun setUp() {
+        val signalingMessageSender = Mockito.mock(SignalingMessageSender::class.java)
+
+        val callParticipants = HashMap<String, CallParticipant>()
+
         peerConnectionWrappers = ArrayList()
 
         peerConnectionWrapper1 = Mockito.mock(PeerConnectionWrapper::class.java)
@@ -47,7 +52,7 @@ class MessageSenderNoMcuTest {
         Mockito.`when`(peerConnectionWrapper4Screen!!.videoStreamType).thenReturn("screen")
         peerConnectionWrappers!!.add(peerConnectionWrapper4Screen)
 
-        messageSender = MessageSenderNoMcu(peerConnectionWrappers)
+        messageSender = MessageSenderNoMcu(signalingMessageSender, callParticipants.keys, peerConnectionWrappers)
     }
 
     @Test

--- a/app/src/test/java/com/nextcloud/talk/call/MessageSenderTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/call/MessageSenderTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.call
+
+import com.nextcloud.talk.models.json.signaling.DataChannelMessage
+import com.nextcloud.talk.models.json.signaling.NCSignalingMessage
+import com.nextcloud.talk.signaling.SignalingMessageSender
+import com.nextcloud.talk.webrtc.PeerConnectionWrapper
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.any
+import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.times
+import org.mockito.invocation.InvocationOnMock
+
+class MessageSenderTest {
+
+    private class MessageSender(
+        signalingMessageSender: SignalingMessageSender?,
+        callParticipantSessionIds: Set<String>?,
+        peerConnectionWrappers: List<PeerConnectionWrapper>?
+    ) : com.nextcloud.talk.call.MessageSender(
+        signalingMessageSender,
+        callParticipantSessionIds,
+        peerConnectionWrappers
+    ) {
+
+        override fun sendToAll(dataChannelMessage: DataChannelMessage?) {
+            // Not used in base class tests
+        }
+    }
+
+    private var signalingMessageSender: SignalingMessageSender? = null
+
+    private var callParticipants: MutableMap<String, CallParticipant>? = null
+
+    private var messageSender: MessageSender? = null
+
+    @Before
+    fun setUp() {
+        signalingMessageSender = Mockito.mock(SignalingMessageSender::class.java)
+
+        callParticipants = HashMap()
+
+        val callParticipant1: CallParticipant = Mockito.mock(CallParticipant::class.java)
+        callParticipants!!["theSessionId1"] = callParticipant1
+
+        val callParticipant2: CallParticipant = Mockito.mock(CallParticipant::class.java)
+        callParticipants!!["theSessionId2"] = callParticipant2
+
+        val callParticipant3: CallParticipant = Mockito.mock(CallParticipant::class.java)
+        callParticipants!!["theSessionId3"] = callParticipant3
+
+        val callParticipant4: CallParticipant = Mockito.mock(CallParticipant::class.java)
+        callParticipants!!["theSessionId4"] = callParticipant4
+
+        val peerConnectionWrappers = ArrayList<PeerConnectionWrapper>()
+
+        messageSender = MessageSender(signalingMessageSender, callParticipants!!.keys, peerConnectionWrappers)
+    }
+
+    @Test
+    fun testSendSignalingMessage() {
+        val message: NCSignalingMessage = Mockito.mock(NCSignalingMessage::class.java)
+        messageSender!!.send(message, "theSessionId2")
+
+        Mockito.verify(message).to = "theSessionId2"
+        Mockito.verify(signalingMessageSender!!).send(message)
+    }
+
+    @Test
+    fun testSendSignalingMessageIfUnknownSessionId() {
+        val message: NCSignalingMessage = Mockito.mock(NCSignalingMessage::class.java)
+        messageSender!!.send(message, "unknownSessionId")
+
+        Mockito.verify(message).to = "unknownSessionId"
+        Mockito.verify(signalingMessageSender!!).send(message)
+    }
+
+    @Test
+    fun testSendSignalingMessageToAll() {
+        val sentTo: MutableList<String?> = ArrayList()
+        doAnswer { invocation: InvocationOnMock ->
+            val arguments = invocation.arguments
+            val message = (arguments[0] as NCSignalingMessage)
+
+            sentTo.add(message.to)
+            null
+        }.`when`(signalingMessageSender!!).send(any())
+
+        val message = NCSignalingMessage()
+        messageSender!!.sendToAll(message)
+
+        assertTrue(sentTo.contains("theSessionId1"))
+        assertTrue(sentTo.contains("theSessionId2"))
+        assertTrue(sentTo.contains("theSessionId3"))
+        assertTrue(sentTo.contains("theSessionId4"))
+        Mockito.verify(signalingMessageSender!!, times(4)).send(message)
+        Mockito.verifyNoMoreInteractions(signalingMessageSender)
+    }
+
+    @Test
+    fun testSendSignalingMessageToAllWhenParticipantsWereUpdated() {
+        val callParticipant5: CallParticipant = Mockito.mock(CallParticipant::class.java)
+        callParticipants!!["theSessionId5"] = callParticipant5
+
+        callParticipants!!.remove("theSessionId2")
+        callParticipants!!.remove("theSessionId3")
+
+        val sentTo: MutableList<String?> = ArrayList()
+        doAnswer { invocation: InvocationOnMock ->
+            val arguments = invocation.arguments
+            val message = (arguments[0] as NCSignalingMessage)
+
+            sentTo.add(message.to)
+            null
+        }.`when`(signalingMessageSender!!).send(any())
+
+        val message = NCSignalingMessage()
+        messageSender!!.sendToAll(message)
+
+        assertTrue(sentTo.contains("theSessionId1"))
+        assertTrue(sentTo.contains("theSessionId4"))
+        assertTrue(sentTo.contains("theSessionId5"))
+        Mockito.verify(signalingMessageSender!!, times(3)).send(message)
+        Mockito.verifyNoMoreInteractions(signalingMessageSender)
+    }
+}


### PR DESCRIPTION
Fixes #3358

Requires #4536

First of all, sorry for the long, long delay and thanks a lot to everyone who provided information on the issue.

Note that the description below treats #4536 as part of this pull request (so the behaviours of the code are described in a pre-4536 state).

The problem started to happen in https://github.com/nextcloud/talk-android/commit/a0fa84124b9959a6b47a8021c3c57467461cc8dc because, as described in the first part of https://github.com/nextcloud/talk-android/issues/3358#issuecomment-2254251856, the video is set as not available (or, rather, not known if available) when the connection state changes to `NEW` or `CHECKING`. This was done following the implementation of the WebUI; the idea is that until the connection is completly established it is not really known if the video is enabled or not, even if the stream has a video track (it could be a disabled video anyway, so [the legacy behaviour to set it available if there is a track should be removed](https://github.com/nextcloud/talk-android/blob/3b7c5e1d27ec2a63b1e3549f9a7917ad0ae7a11c/app/src/main/java/com/nextcloud/talk/call/CallParticipant.java#L194-L197), but that is a different story), so the other client should explicitly provide that information once the connection is established (turns out that, although all that is correct with data channels, with signaling messages it would be possible to provide the state even before the peer connection is established, so this might need to be adjusted in the future). Although the change itself caused the video to no longer be shown (in some cases) the problem is in the sending side of the Android app.

As also described in the second part of https://github.com/nextcloud/talk-android/issues/3358#issuecomment-2254251856 `sendInitialMediaStatus` would not do anything when called on a subscriber peer connection, both because it does not have a local stream and because, even if it had, it is not the right connection to send data channel messages when using the HPB, as they must be sent in the publisher connection. But independently of that `sendInitialMediaStatus` will not be called anyway in most cases; it will not be called [when the data channel is open](https://github.com/nextcloud/talk-android/blob/b870b0f2089b8156374b816e4c213c1518e1c2f9/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java#L383-L386), because [for subscribers the observer is registered after the data channel was open already](https://github.com/nextcloud/talk-android/blob/b870b0f2089b8156374b816e4c213c1518e1c2f9/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java#L519-L526), and it will be randomly called [when the connection state changes to `CONNECTED`](https://github.com/nextcloud/talk-android/blob/b870b0f2089b8156374b816e4c213c1518e1c2f9/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java#L463-L467), because it depends on `hasInitiated`, which is meant to be used to initiate the peer connection without HPB [if the local participant session ID is "higher" than the remote participant session ID](https://github.com/nextcloud/talk-android/blob/b870b0f2089b8156374b816e4c213c1518e1c2f9/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java#L130), but is not needed and, moreover, is wrong when using the external signaling server as in that case the comparison is made between the Nextcloud session ID and the signaling session ID.

In the case of publisher connections the data channel message will be also randomly sent when the connection state changes to `CONNECTED` due to the comparison between Nextcloud session ID and signaling session ID, although it will be always sent when the data channel is open. This means that if participant A is in a call and participant B joins then the state of participant A will not be sent to participant B (because it will be sent on the subscriber connection), but the state of participant B will be sent to participant A (because it will be sent on the publisher connection when the data channel is open). But then... why is the video of participant B visible for participant A only sometimes?

The reason is that when the HPB is used the connection is not established directly between both clients, but between the clients and the HPB. Therefore, when the data channel is open for participant B it is open between participant B and the HPB, but the data channel may not be open yet between participant A and the HPB. If the message is sent at this point it will reach the HPB, but it will not be relayed to participant A. Due to that reason the WebUI does not send just a single state message after the connection is established, but several ones with an exponential backoff to "ensure" that the state is received by the other participants even if their subscriber connection takes a while to be established.

But now the question is, why is video coming from the Android app always shown in the iOS app and the WebUI, despite all of the above?

[The iOS app shows the video by default](https://github.com/nextcloud/talk-ios/blob/821aa669e8ca260c18c140695ca0f4a6a6664240/NextcloudTalk/CallViewController.m#L1934-L1935), so if a video track is sent by the Android app it is shown even if the Android app does not send a data channel message to enable it.

In the case of the WebUI received videos are disabled by default, but [they are automatically enabled if it is detected that a video is being sent](https://github.com/nextcloud/spreed/blob/32ba79dec837d3c2f33015ccb2522bc4b4534b46/src/utils/webrtc/webrtc.js#L1238-L1241) (which is a legacy behaviour and should not work like that, video should be shown only if explicitly enabled, but that is a different story). Therefore, again the video track sent by the Android app is shown even if the Android app does not send a data channel message to enable it.

In order to solve the issue, this pull request introduces the `LocalStateBroadcasterXXX` helper classes that take care of sending the local state to the other participants as needed. That is:
- Send the current state to another participant in the call when that participant joins (if the local participant is the one that joined all the other participants joined from its point of view, so the state is sent to all of them); if the HPB is used the state is sent several times with an exponential backoff to solve the problem explained above about the connection not being established yet in the other end
- Send the state changes to all the participants in the call; in this case a single message is sent
  - If the state is changed but a connection was not established yet the changed state should be eventually received through the initial exponential backoff (as it sends the current state, not the original state)

Before this pull request the state was sent only through data channels; now the state is sent through signaling messages too, as it is expected by other clients (in the past data channels were found to be problematic, but the signaling messages were more reliable and convenient, so that is why the state was moved to be sent also through signaling messages; the only exception is the speaking state, which, due to its potential frequency and being not so relevant, was left only as data channel messages to avoid hammering the database when the HPB is not used). Note that this should be backwards compatible with older Nextcloud versions, as if any signaling message was not handled it was just ignored, so there is no problem sending them.

The `LocalStateBroadcaster` (or, rather, its subclasses) also takes into account the differences between the internal or the external signaling server in order to send the messages using the appropriate connection.

All this is almost the same done in the WebUI, with some little improvements:
- In the WebUI, when another participant joins the call, the message is sent to all participants rather than only to the participant that joined.
  - This is still the case in the Android app with Janus and data channels, but there is no way around that.
- In the WebUI the state is sent again whenever the connection changes to the _connected_ state. Therefore the state is sent again without need when a connection is temporarily interrupted (changes to _disconnected_ and then back to _connected_). However, in the case of an ICE restart that would also send the state again, which would happen without HPB after the connection failed.
- In the WebUI the state is not sent if the connection changes to the _completed_ state; although typically the connection will go through the _connected_ state before reaching the _completed_ state it is possible to go directly from _checking_ to _completed_, and in that case the state would not be sent.
- In the WebUI, when the HPB is used, the state starts to be sent when a receiver connection is established with the other peer. Here the state is sent as soon as the remote participant is found, as the remote participant might already have a receiver connection to the local participant before the local participant has a receiver connection to the remote participant (although in most cases it should not make any difference, as establishing connections when the HPB is used is usually pretty fast).

Despite the improvements this approach is far from perfect and there is still an excessive amount of initial messages sent with the HPB due to the repeated sending. But this is tracked in https://github.com/nextcloud/spreed/issues/8549 and it will need to be solved across all the clients at the same time.

## Follow ups
- Send nick and raised hand state in `LocalStateBroadcaster`
- Send status also when no peer connection will be established (right now it is not a problem because only media state is sent, but it will be with non-media state, like the nick and raised hand)

## How to test
- Setup the HPB
- Start a call with the Android app
- Join the call with the Android app in another device

### Result with this pull request

The video of the other participant is visible

### Result without this pull request

The video of the other participant may or may not be visible (most likely it will not be)