### PR TITLE
Fix audio and video not received

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -204,7 +204,7 @@ class CallActivity : CallBaseActivity() {
     private var audioConstraints: MediaConstraints? = null
     private var videoConstraints: MediaConstraints? = null
     private var sdpConstraints: MediaConstraints? = null
-    private var sdpConstraintsForMCU: MediaConstraints? = null
+    private var sdpConstraintsForMCUPublisher: MediaConstraints? = null
     private var videoSource: VideoSource? = null
     private var localVideoTrack: VideoTrack? = null
     private var audioSource: AudioSource? = null
@@ -809,7 +809,7 @@ class CallActivity : CallBaseActivity() {
 
         // create sdpConstraints
         sdpConstraints = MediaConstraints()
-        sdpConstraintsForMCU = MediaConstraints()
+        sdpConstraintsForMCUPublisher = MediaConstraints()
         sdpConstraints!!.mandatory.add(MediaConstraints.KeyValuePair("OfferToReceiveAudio", "true"))
         var offerToReceiveVideoString = "true"
         if (isVoiceOnlyCall) {
@@ -818,10 +818,10 @@ class CallActivity : CallBaseActivity() {
         sdpConstraints!!.mandatory.add(
             MediaConstraints.KeyValuePair("OfferToReceiveVideo", offerToReceiveVideoString)
         )
-        sdpConstraintsForMCU!!.mandatory.add(MediaConstraints.KeyValuePair("OfferToReceiveAudio", "false"))
-        sdpConstraintsForMCU!!.mandatory.add(MediaConstraints.KeyValuePair("OfferToReceiveVideo", "false"))
-        sdpConstraintsForMCU!!.optional.add(MediaConstraints.KeyValuePair("internalSctpDataChannels", "true"))
-        sdpConstraintsForMCU!!.optional.add(MediaConstraints.KeyValuePair("DtlsSrtpKeyAgreement", "true"))
+        sdpConstraintsForMCUPublisher!!.mandatory.add(MediaConstraints.KeyValuePair("OfferToReceiveAudio", "false"))
+        sdpConstraintsForMCUPublisher!!.mandatory.add(MediaConstraints.KeyValuePair("OfferToReceiveVideo", "false"))
+        sdpConstraintsForMCUPublisher!!.optional.add(MediaConstraints.KeyValuePair("internalSctpDataChannels", "true"))
+        sdpConstraintsForMCUPublisher!!.optional.add(MediaConstraints.KeyValuePair("DtlsSrtpKeyAgreement", "true"))
         sdpConstraints!!.optional.add(MediaConstraints.KeyValuePair("internalSctpDataChannels", "true"))
         sdpConstraints!!.optional.add(MediaConstraints.KeyValuePair("DtlsSrtpKeyAgreement", "true"))
         if (!isVoiceOnlyCall) {
@@ -2374,7 +2374,7 @@ class CallActivity : CallBaseActivity() {
         return PeerConnectionWrapper(
             peerConnectionFactory,
             iceServers,
-            sdpConstraintsForMCU,
+            sdpConstraintsForMCUPublisher,
             sessionId,
             callSession,
             tempLocalStream,

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -2350,18 +2350,22 @@ class CallActivity : CallBaseActivity() {
         sessionId: String?,
         type: String
     ): PeerConnectionWrapper {
+        val tempSdpConstraints: MediaConstraints?
         val tempIsMCUPublisher: Boolean
         val tempHasMCU: Boolean
         val tempLocalStream: MediaStream?
         if (hasMCU && publisher) {
+            tempSdpConstraints = sdpConstraintsForMCUPublisher
             tempIsMCUPublisher = true
             tempHasMCU = true
             tempLocalStream = localStream
         } else if (hasMCU) {
+            tempSdpConstraints = sdpConstraints
             tempIsMCUPublisher = false
             tempHasMCU = true
             tempLocalStream = null
         } else {
+            tempSdpConstraints = sdpConstraints
             tempIsMCUPublisher = false
             tempHasMCU = false
             tempLocalStream = if ("screen" != type) {
@@ -2374,7 +2378,7 @@ class CallActivity : CallBaseActivity() {
         return PeerConnectionWrapper(
             peerConnectionFactory,
             iceServers,
-            sdpConstraintsForMCUPublisher,
+            tempSdpConstraints,
             sessionId,
             callSession,
             tempLocalStream,


### PR DESCRIPTION
Fixes a regression introduced in #4527 (specifically, [in the refactoring of the creation of `PeerConnectionWrapper` objects in _CallActivity.kt_](https://github.com/nextcloud/talk-android/commit/12620a5c3eaed9c1dfb0ff9d5b3fbef95df3746d#diff-4c6a4b66806639eeb2704fc66676d5369afb70e0ef78b5fc84be268638f7e900L2335-R2388)

The SDP constraints for publisher connections when the MCU is used were set for all connections. Those constraints set `OfferToReceiveAudio` and `OfferToReceiveVideo` to false, which disables receiving audio and video when the local participant is the one sending the offer. Therefore, audio and video was not received when the MCU was not used and the local participant was the one initiating the connection (which is based on the session IDs of both the local and remote participants).
    
The `OfferToReceiveXXX` configurations have no effect when set on an answer (and thus are not even set, [an empty `MediaConstraints` is used in that case](https://github.com/nextcloud/talk-android/blob/b870b0f2089b8156374b816e4c213c1518e1c2f9/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java#L597)). However, [when `OfferToReceiveVideo = false` is set the video transceiver is explicitly stopped](https://github.com/nextcloud/talk-android/blob/b870b0f2089b8156374b816e4c213c1518e1c2f9/app/src/main/java/com/nextcloud/talk/webrtc/PeerConnectionWrapper.java#L584-L591) (which is used to avoid receiving video [when joining a call with audio only](https://github.com/nextcloud/talk-android/blob/12620a5c3eaed9c1dfb0ff9d5b3fbef95df3746d/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt#L815-L817)). Therefore, as `OfferToReceiveVideo = false` was always set, video was never received in subscriber connections when the MCU is used, or connections initiated by the other peer when the MCU is not used.

## How to test (scenario 1)

- Setup the HPB
- Open a conversation in the Android app
- Open the same conversation in the browser
- Start a call in the browser with both audio and video enabled
- Join the call in the Android app (via videocall)

### Result with this pull request

The audio and video of the browser are received in the Android app

### Result without this pull request

The audio of the browser is received in the Android app, but the video is not



## How to test (scenario 2)

- Do not setup the HPB
- Open a conversation in the Android app
- Open the same conversation in the browser
- Check if the session ID of the Android participant is higher than the session ID of the browser participant; if not, reload the page until it is (or open the conversation again in the Android app, as preferred)
  - You can check the sessions in the browser console with `store.getters.participantsList('THE_CONVERSATION_TOKEN').forEach(participant => console.log(participant.actorId + " " + participant.sessionIds))`
  - For the comparison purposes note that "0" < "9" < "A" < "Z" < "a" < "z"
- Start a call in the browser with both audio and video enabled
- Join the call in the Android app (via videocall)

### Result with this pull request

The audio and video of the browser are received in the Android app

### Result without this pull request

Neither the audio nor the video of the browser are received in the Android app



## How to test (scenario 3)

- Do not setup the HPB
- Open a conversation in the Android app
- Open the same conversation in the browser
- Check if the session ID of the Android participant is lower than the session ID of the browser participant; if not, reload the page until it is (or open the conversation again in the Android app, as preferred)
  - You can check the sessions in the browser console with `store.getters.participantsList('THE_CONVERSATION_TOKEN').forEach(participant => console.log(participant.actorId + " " + participant.sessionIds))`
  - For the comparison purposes note that "0" < "9" < "A" < "Z" < "a" < "z"
- Start a call in the browser with both audio and video enabled
- Join the call in the Android app (via videocall)

### Result with this pull request

The audio and video of the browser are received in the Android app

### Result without this pull request

The audio of the browser is received in the Android app, but the video is not. Note that enabling or disabling the video in the browser will cause a reconnection due to [a new video track being added by the browser to the connection](https://github.com/nextcloud/spreed/blob/64622149776d62b088a4b64145d5a4b4901921fa/src/utils/webrtc/simplewebrtc/peer.js#L868) (and then that track being rejected again by the app by stopping the transceiver once the connection is established again); this does not happen in scenario 2, because in scenario 2 the transceiver is active, even if only receiving in the browser, while in scenario 3 the transceiver was stopped by the Android app.
