### PR TITLE
$s -> $d

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -729,7 +729,7 @@ How to translate with transifex:
     <string name="polls_question">Question</string>
     <string name="polls_question_hint">Your question</string>
     <string name="polls_options">Options</string>
-    <string name="polls_option_hint">Option %1$s</string>
+    <string name="polls_option_hint">Option %1$d</string>
     <string name="polls_option_delete">Delete option %1$s</string>
     <string name="polls_settings">Settings</string>
     <string name="polls_private_poll">Private poll</string>


### PR DESCRIPTION
Lint complained with:
Suspicious argument type for formatting argument #1 in polls_option_hint: conversion is s, received int (argument #2 in method call) (Did you mean formatting character d, 'o' or x?)