### PR TITLE
hopefully fix NPE for currentUser in addToConversationItems

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -235,6 +235,8 @@ class ConversationsListActivity :
         super.onCreate(savedInstanceState)
         NextcloudTalkApplication.sharedApplication!!.componentApplication.inject(this)
 
+        currentUser = currentUserProvider.currentUser.blockingGet()
+
         conversationsListViewModel = ViewModelProvider(this, viewModelFactory)[ConversationsListViewModel::class.java]
 
         binding = ActivityConversationsBinding.inflate(layoutInflater)
@@ -284,7 +286,7 @@ class ConversationsListActivity :
         if (!eventBus.isRegistered(this)) {
             eventBus.register(this)
         }
-        currentUser = userManager.currentUser.blockingGet()
+
         if (currentUser != null) {
             if (isServerEOL(currentUser!!.serverVersion?.major)) {
                 showServerEOLDialog()
@@ -309,7 +311,7 @@ class ConversationsListActivity :
             fetchRooms()
             fetchPendingInvitations()
         } else {
-            Log.e(TAG, "userManager.currentUser.blockingGet() returned null")
+            Log.e(TAG, "currentUser was null")
             Snackbar.make(binding.root, R.string.nc_common_error_sorry, Snackbar.LENGTH_LONG).show()
         }
 
@@ -421,7 +423,7 @@ class ConversationsListActivity :
     }
 
     fun filterConversation() {
-        val accountId = UserIdUtils.getIdForUser(userManager.currentUser.blockingGet())
+        val accountId = UserIdUtils.getIdForUser(currentUser)
         filterState[FilterConversationFragment.UNREAD] = (
             arbitraryStorageManager.getStorageSetting(
                 accountId,
@@ -1365,7 +1367,7 @@ class ConversationsListActivity :
                     val conversation = clickedItem.model
                     conversationsListBottomDialog = ConversationsListBottomDialog(
                         this@ConversationsListActivity,
-                        userManager.currentUser.blockingGet(),
+                        currentUser!!,
                         conversation
                     )
                     conversationsListBottomDialog!!.show()
@@ -1557,7 +1559,7 @@ class ConversationsListActivity :
         val callsChannelNotEnabled = !NotificationUtils.isCallsNotificationChannelEnabled(this)
 
         val serverNotificationAppInstalled =
-            userManager.currentUser.blockingGet().capabilities?.notificationsCapability?.features?.isNotEmpty() ?: false
+            currentUser?.capabilities?.notificationsCapability?.features?.isNotEmpty() ?: false
 
         val settingsOfUserAreWrong = notificationPermissionNotGranted ||
             batteryOptimizationNotIgnored ||


### PR DESCRIPTION
fix #4610

It seems there could have been a race condition because currentUser was initialized too late.
 I was not able to reproduce but hopefully this fixes it:
 - initialize currentUser earlier (moved from onResume to onCreate)
 - use currentUserProvider instead userManager

NPEs were reported via gplay:

1)
```
Exception java.lang.NullPointerException:
  at com.nextcloud.talk.conversationlist.ConversationsListActivity.addToConversationItems (ConversationsListActivity.kt:851)
  at com.nextcloud.talk.conversationlist.ConversationsListActivity.access$addToConversationItems (ConversationsListActivity.kt:151)
  at com.nextcloud.talk.conversationlist.ConversationsListActivity$initObservers$5$1.invokeSuspend (ConversationsListActivity.kt:394)
  at com.nextcloud.talk.conversationlist.ConversationsListActivity$initObservers$5$1.invoke (Unknown Source:8)
  at com.nextcloud.talk.conversationlist.ConversationsListActivity$initObservers$5$1.invoke (Unknown Source:4)
```

2)
```
Exception java.lang.RuntimeException:
  at android.app.ActivityThread.performResumeActivity (ActivityThread.java:5427)
  at android.app.ActivityThread.handleResumeActivity (ActivityThread.java:5508)
  ...
Caused by java.lang.NullPointerException:
  at com.nextcloud.talk.conversationlist.ConversationsListActivity.shouldShowNotificationWarning (ConversationsListActivity.kt:1557)
```

---

Long term solution: https://github.com/nextcloud/talk-android/issues/4609 + better usage of MVVM

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)