### PR TITLE
Follow up fixes for 'Archive Conversations

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
@@ -820,6 +820,7 @@ class ConversationInfoActivity :
                     binding.archiveConversationTextHint.text = resources.getString(R.string.unarchive_hint)
                 }
             }
+            viewModel.getRoom(conversationUser, conversationToken)
         }
 
         if (conversation!!.hasArchived) {

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -455,8 +455,20 @@ class ConversationsListActivity :
                 newItems.add(i)
             }
         }
+
+        val archiveFilterOn = filterState[FilterConversationFragment.ARCHIVE] ?: false
+        if (archiveFilterOn && newItems.isEmpty()) {
+            binding.noArchivedConversationLayout.visibility = View.VISIBLE
+        } else {
+            binding.noArchivedConversationLayout.visibility = View.GONE
+        }
+
         adapter!!.updateDataSet(newItems, true)
         setFilterableItems(newItems)
+        if (archiveFilterOn) {
+            // Never a notification from archived conversations
+            binding.newMentionPopupBubble.visibility = View.GONE
+        }
 
         updateFilterConversationButtonColor()
     }

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/ConversationsListBottomDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/ConversationsListBottomDialog.kt
@@ -26,6 +26,7 @@ import com.nextcloud.talk.api.NcApi
 import com.nextcloud.talk.api.NcApiCoroutines
 import com.nextcloud.talk.application.NextcloudTalkApplication
 import com.nextcloud.talk.conversation.RenameConversationDialogFragment
+import com.nextcloud.talk.conversationinfo.viewmodel.ConversationInfoViewModel
 import com.nextcloud.talk.conversationlist.ConversationsListActivity
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.databinding.DialogConversationOperationsBinding
@@ -67,6 +68,9 @@ class ConversationsListBottomDialog(
 
     @Inject
     lateinit var viewThemeUtils: ViewThemeUtils
+
+    @Inject
+    lateinit var conversationInfoViewModel: ConversationInfoViewModel
 
     @Inject
     lateinit var userManager: UserManager
@@ -186,6 +190,26 @@ class ConversationsListBottomDialog(
                 conversation.name,
                 canGeneratePrettyURL
             )
+            dismiss()
+        }
+
+        binding.conversationArchiveText.text = if (conversation.hasArchived) {
+            this.activity.resources.getString(R.string.unarchive_conversation)
+        } else {
+            this.activity.resources.getString(R.string.archive_conversation)
+        }
+
+        binding.conversationArchive.setOnClickListener {
+            val currentUser = userManager.currentUser.blockingGet()
+            val token = conversation.token
+            lifecycleScope.launch {
+                if (conversation.hasArchived) {
+                    conversationInfoViewModel.unarchiveConversation(currentUser, token)
+                } else {
+                    conversationInfoViewModel.archiveConversation(currentUser, token)
+                }
+            }
+            activity.fetchRooms()
             dismiss()
         }
 

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/ConversationsListBottomDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/ConversationsListBottomDialog.kt
@@ -200,17 +200,7 @@ class ConversationsListBottomDialog(
         }
 
         binding.conversationArchive.setOnClickListener {
-            val currentUser = userManager.currentUser.blockingGet()
-            val token = conversation.token
-            lifecycleScope.launch {
-                if (conversation.hasArchived) {
-                    conversationInfoViewModel.unarchiveConversation(currentUser, token)
-                } else {
-                    conversationInfoViewModel.archiveConversation(currentUser, token)
-                }
-            }
-            activity.fetchRooms()
-            dismiss()
+            handleArchiving()
         }
 
         binding.conversationOperationRename.setOnClickListener {
@@ -224,6 +214,33 @@ class ConversationsListBottomDialog(
         binding.conversationOperationDelete.setOnClickListener {
             deleteConversation()
         }
+    }
+
+    private fun handleArchiving() {
+        val currentUser = userManager.currentUser.blockingGet()
+        val token = conversation.token
+        lifecycleScope.launch {
+            if (conversation.hasArchived) {
+                conversationInfoViewModel.unarchiveConversation(currentUser, token)
+                activity.showSnackbar(
+                    String.format(
+                        context.resources.getString(R.string.unarchived_conversation),
+                        conversation.displayName
+                    )
+                )
+                dismiss()
+            } else {
+                conversationInfoViewModel.archiveConversation(currentUser, token)
+                activity.showSnackbar(
+                    String.format(
+                        context.resources.getString(R.string.archived_conversation),
+                        conversation.displayName
+                    )
+                )
+                dismiss()
+            }
+        }
+        activity.fetchRooms()
     }
 
     @Suppress("Detekt.TooGenericExceptionCaught")

--- a/app/src/main/res/layout/activity_conversation_info.xml
+++ b/app/src/main/res/layout/activity_conversation_info.xml
@@ -410,7 +410,6 @@
                 android:orientation="horizontal"
                 android:background="?android:attr/selectableItemBackground">
 
-
                 <ImageView
                     android:layout_width="24dp"
                     android:layout_height="40dp"
@@ -425,48 +424,7 @@
                     android:gravity="center_vertical"
                     android:text="@string/show_banned_participants"
                     android:textSize="@dimen/headline_text_size" />
-
             </LinearLayout>
-
-            <LinearLayout
-                android:id="@+id/archive_conversation_btn"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingStart="@dimen/standard_margin"
-                android:paddingTop="@dimen/standard_half_margin"
-                android:paddingEnd="@dimen/standard_margin"
-                android:paddingBottom="@dimen/standard_half_margin"
-                android:orientation="horizontal"
-                android:background="?android:attr/selectableItemBackground">
-
-
-                <ImageView
-                    android:id="@+id/archive_conversation_icon"
-                    android:layout_width="24dp"
-                    android:layout_height="40dp"
-                    android:layout_marginEnd="@dimen/standard_margin"
-                    android:contentDescription="@null"
-                    tools:src="@drawable/outline_archive_24"
-                    app:tint="@color/nc_darkYellow" />
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/archive_conversation_text"
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:gravity="center_vertical"
-                    tools:text="@string/unarchive_conversation"
-                    android:textColor="@color/nc_darkYellow"
-                    android:textSize="@dimen/headline_text_size" />
-
-            </LinearLayout>
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/archive_conversation_text_hint"
-                android:layout_marginHorizontal="@dimen/standard_margin"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/archive_hint"
-                android:textColor="@color/nc_darkYellow"/>
 
             <LinearLayout
                 android:id="@+id/danger_zone_options"
@@ -483,6 +441,41 @@
                     android:textColor="@color/design_default_color_error"
                     android:textSize="@dimen/headline_text_size"
                     android:textStyle="bold" />
+
+                <LinearLayout
+                    android:id="@+id/archive_conversation_btn"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?android:attr/selectableItemBackground"
+                    android:orientation="horizontal"
+                    android:paddingStart="@dimen/standard_margin"
+                    android:paddingEnd="@dimen/standard_margin">
+
+                    <ImageView
+                        android:id="@+id/archive_conversation_icon"
+                        android:layout_width="24dp"
+                        android:layout_height="40dp"
+                        android:layout_marginEnd="@dimen/standard_margin"
+                        android:contentDescription="@null"
+                        app:tint="@color/grey_600"
+                        tools:src="@drawable/outline_archive_24" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/archive_conversation_text"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:gravity="center_vertical"
+                        android:textSize="@dimen/headline_text_size"
+                        tools:text="@string/unarchive_conversation" />
+                </LinearLayout>
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/archive_conversation_text_hint"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/standard_margin"
+                    android:text="@string/archive_hint"
+                    android:textColor="@color/disabled_text" />
 
                 <LinearLayout
                     android:id="@+id/leaveConversationAction"

--- a/app/src/main/res/layout/activity_conversation_info.xml
+++ b/app/src/main/res/layout/activity_conversation_info.xml
@@ -447,7 +447,7 @@
                     android:layout_marginEnd="@dimen/standard_margin"
                     android:contentDescription="@null"
                     tools:src="@drawable/outline_archive_24"
-                    app:tint="@color/grey_600" />
+                    app:tint="@color/nc_darkYellow" />
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/archive_conversation_text"
@@ -455,6 +455,7 @@
                     android:layout_height="match_parent"
                     android:gravity="center_vertical"
                     tools:text="@string/unarchive_conversation"
+                    android:textColor="@color/nc_darkYellow"
                     android:textSize="@dimen/headline_text_size" />
 
             </LinearLayout>
@@ -464,7 +465,8 @@
                 android:layout_marginHorizontal="@dimen/standard_margin"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/archive_hint" />
+                android:text="@string/archive_hint"
+                android:textColor="@color/nc_darkYellow"/>
 
             <LinearLayout
                 android:id="@+id/danger_zone_options"

--- a/app/src/main/res/layout/activity_conversations.xml
+++ b/app/src/main/res/layout/activity_conversations.xml
@@ -223,8 +223,8 @@
             android:layout_width="match_parent"
             android:layout_height="72dp"
             android:contentDescription="@string/nc_app_product_name"
-            android:src="@drawable/ic_list_empty_error"
-            app:tint="@color/hwSecurityRed" />
+            android:src="@drawable/outline_archive_24"
+            app:tint="@color/grey_600" />
 
         <TextView
             android:layout_width="match_parent"
@@ -238,7 +238,7 @@
             android:paddingBottom="@dimen/standard_half_padding"
             android:text="@string/no_conversations_archived"
             android:textAlignment="center"
-            android:textColor="@color/conversation_item_header"
+            android:textColor="@color/high_emphasis_text"
             android:textSize="22sp" />
     </RelativeLayout>
 

--- a/app/src/main/res/layout/activity_conversations.xml
+++ b/app/src/main/res/layout/activity_conversations.xml
@@ -168,7 +168,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:visibility="gone"
-        tools:visibility="visible">
+        tools:visibility="gone">
 
         <ImageView
             android:id="@+id/empty_list_icon"
@@ -208,6 +208,38 @@
             android:textAlignment="center"
             android:textColor="@color/textColorMaxContrast"
             android:textSize="16sp" />
+    </RelativeLayout>
+
+    <RelativeLayout
+        android:id="@+id/no_archived_conversation_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:visibility="gone"
+        tools:visibility="visible">
+
+        <ImageView
+            android:id="@+id/no_archived_conversation_icon"
+            android:layout_width="match_parent"
+            android:layout_height="72dp"
+            android:contentDescription="@string/nc_app_product_name"
+            android:src="@drawable/ic_list_empty_error"
+            app:tint="@color/hwSecurityRed" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/no_archived_conversation_icon"
+            android:layout_gravity="center_horizontal"
+            android:ellipsize="end"
+            android:gravity="center"
+            android:maxLines="2"
+            android:paddingTop="@dimen/standard_padding"
+            android:paddingBottom="@dimen/standard_half_padding"
+            android:text="@string/no_conversations_archived"
+            android:textAlignment="center"
+            android:textColor="@color/conversation_item_header"
+            android:textSize="22sp" />
     </RelativeLayout>
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout

--- a/app/src/main/res/layout/dialog_conversation_operations.xml
+++ b/app/src/main/res/layout/dialog_conversation_operations.xml
@@ -196,6 +196,37 @@
             </LinearLayout>
 
             <LinearLayout
+                android:id="@+id/conversation_archive"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/bottom_sheet_item_height"
+                android:background="?android:attr/selectableItemBackground"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:paddingStart="@dimen/standard_padding"
+                android:paddingEnd="@dimen/standard_padding"
+                tools:ignore="UseCompoundDrawables">
+
+                <ImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:contentDescription="@null"
+                    android:src="@drawable/outline_archive_24"
+                    app:tint="@color/high_emphasis_menu_icon" />
+
+                <androidx.appcompat.widget.AppCompatTextView
+                    android:id="@+id/conversation_archive_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="start|center_vertical"
+                    android:paddingStart="40dp"
+                    android:paddingEnd="@dimen/zero"
+                    android:text="@string/archive_conversation"
+                    android:textAlignment="viewStart"
+                    android:textColor="@color/high_emphasis_text"
+                    android:textSize="@dimen/bottom_sheet_text_size" />
+            </LinearLayout>
+
+            <LinearLayout
                 android:id="@+id/conversation_operation_rename"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/bottom_sheet_item_height"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -848,4 +848,6 @@ How to translate with transifex:
     <string name="user_absence_replacement">Replacement: </string>
     <string name="resend_message">Resend</string>
     <string name="no_conversations_archived">No conversations archived</string>
+    <string name="archived_conversation">Archived %1$s</string>
+    <string name="unarchived_conversation">Unarchived %1$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -847,4 +847,5 @@ How to translate with transifex:
     <string name="user_absence_for_one_day">%1$s is out of office today</string>
     <string name="user_absence_replacement">Replacement: </string>
     <string name="resend_message">Resend</string>
+    <string name="no_conversations_archived">No conversations archived</string>
 </resources>


### PR DESCRIPTION
- fixes #4607
- fixes #4608  

### 🚧 TODO

- [x] It should be possible to archive from the context menu on the conversation list
- [x] The option somehow does not look like a option, maybe because other things around it are red and participant list?
- [x] The option can not be toggled multiple times: After turning it on, you need to leave the details in order to be able to turn if off again. Pressing it a second time without leaving and coming back does not do anything.
- [x] After filtering for archived conversations and forgetting about it, i was shocked for some seconds why the conversations don't load. Turned out i had the filter enabled but no conv is archived. In this case we should give a hint about it as a text in middle of the screen.
- [x] the "Unread mentions" bubble is not updated when filtering.

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)