### PR TITLE
no "unread messages" popup for invisible messages

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -861,14 +861,15 @@ class ChatActivity :
                     var chatMessageList = triple.third
 
                     chatMessageList = handleSystemMessages(chatMessageList)
+                    if (chatMessageList.isEmpty()) {
+                        return@onEach
+                    }
 
                     determinePreviousMessageIds(chatMessageList)
 
                     handleExpandableSystemMessages(chatMessageList)
 
-                    if (chatMessageList.isNotEmpty() &&
-                        ChatMessage.SystemMessageType.CLEARED_CHAT == chatMessageList[0].systemMessageType
-                    ) {
+                    if (ChatMessage.SystemMessageType.CLEARED_CHAT == chatMessageList[0].systemMessageType) {
                         adapter?.clear()
                         adapter?.notifyDataSetChanged()
                     }


### PR DESCRIPTION
fix #4628

If chatMessageList is empty after handleSystemMessages it makes no sense to call the following methods. Also processMessagesFromTheFuture was executed which caused that the popup was shown.

A better solution for the future should be to handle(remove) the "to-hide" system messages already in the repo or viewmodel

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)