### PR TITLE
enable to select authentication cert in server selection screen

### DIFF
--- a/app/src/main/res/values/setup.xml
+++ b/app/src/main/res/values/setup.xml
@@ -20,7 +20,7 @@
 
     <!-- Branding -->
     <bool name="hide_provider">false</bool>
-    <bool name="hide_auth_cert">true</bool>
+    <bool name="hide_auth_cert">false</bool>
     <bool name="multiaccount_support">true</bool>
     <string name="weblogin_url" translatable="false"></string>
 


### PR DESCRIPTION
resolve #3907
resolve #4421

This will enable the "Select authentication certificate" option on server selection screen.

I plan to have this enabled for v21.0.0 RC1 and collect some feedback before deciding to include it in v21.0.0 final.


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)