### PR TITLE
Switched the "Close" and "Set" Buttons in the remind-me-later dialog

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/DateTimeCompose.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/DateTimeCompose.kt
@@ -151,6 +151,16 @@ class DateTimeCompose(val bundle: Bundle) {
 
             TextButton(
                 onClick = {
+                    shouldDismiss.value = true
+                },
+                modifier = Modifier
+                    .weight(CUBED_PADDING)
+            ) {
+                Text(stringResource(R.string.close))
+            }
+
+            TextButton(
+                onClick = {
                     val user = userManager.currentUser.blockingGet()
                     val roomToken = bundle.getString(BundleKeys.KEY_ROOM_TOKEN)!!
                     val messageId = bundle.getString(BundleKeys.KEY_MESSAGE_ID)!!
@@ -164,16 +174,6 @@ class DateTimeCompose(val bundle: Bundle) {
                     .weight(CUBED_PADDING)
             ) {
                 Text(stringResource(R.string.set))
-            }
-
-            TextButton(
-                onClick = {
-                    shouldDismiss.value = true
-                },
-                modifier = Modifier
-                    .weight(CUBED_PADDING)
-            ) {
-                Text(stringResource(R.string.close))
             }
         }
     }


### PR DESCRIPTION
From Talk-Helpdesk, aligns with material standards

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot_20250127-110902](https://github.com/user-attachments/assets/ce619b21-c88b-44a3-aeb1-fcb8d318c6fb) | ![Screenshot_20250127-110755](https://github.com/user-attachments/assets/81315a9d-2df5-46f1-9fbb-08c70e9f72b7)

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)