### PR TITLE
replace userManager.currentUser usage by currentUserProvider usage

### DIFF
--- a/app/src/androidTest/java/com/nextcloud/talk/ui/LoginIT.java
+++ b/app/src/androidTest/java/com/nextcloud/talk/ui/LoginIT.java
@@ -126,7 +126,7 @@ public class LoginIT {
 
         activityScenario.onActivity(activity -> {
             assertEquals(loginName,
-                         Objects.requireNonNull(activity.userManager.getCurrentUser().blockingGet()).getUserId());
+                         Objects.requireNonNull(activity.currentUserProvider.currentUser.blockingGet()).getUserId());
         });
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/account/AccountVerificationActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/account/AccountVerificationActivity.kt
@@ -416,7 +416,7 @@ class AccountVerificationActivity : BaseActivity() {
         cookieManager.cookieStore.removeAll()
 
         if (userManager.users.blockingGet().size == 1 ||
-            userManager.currentUser.blockingGet().id != internalAccountId
+            currentUserProvider.currentUser.blockingGet().id != internalAccountId
         ) {
             val userToSetAsActive = userManager.getUserWithId(internalAccountId).blockingGet()
             Log.d(TAG, "userToSetAsActive: " + userToSetAsActive.username)

--- a/app/src/main/java/com/nextcloud/talk/account/WebViewLoginActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/account/WebViewLoginActivity.kt
@@ -224,7 +224,7 @@ class WebViewLoginActivity : BaseActivity() {
                 if (!reauthorizeAccount) {
                     alias = appPreferences.temporaryClientCertAlias
                 }
-                val user = userManager.currentUser.blockingGet()
+                val user = currentUserProvider.currentUser.blockingGet()
                 if (TextUtils.isEmpty(alias) && user != null) {
                     alias = user.clientCertificate
                 }
@@ -373,7 +373,7 @@ class WebViewLoginActivity : BaseActivity() {
     }
 
     private fun updateUserAndRestartApp(loginData: LoginData) {
-        val currentUser = userManager.currentUser.blockingGet()
+        val currentUser = currentUserProvider.currentUser.blockingGet()
         if (currentUser != null) {
             currentUser.clientCertificate = appPreferences.temporaryClientCertAlias
             currentUser.token = loginData.token

--- a/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
@@ -164,7 +164,7 @@ class MainActivity : BaseActivity(), ActionBarProvider {
                     val user = userId.substringBeforeLast("@")
                     val baseUrl = userId.substringAfterLast("@")
 
-                    if (userManager.currentUser.blockingGet()?.baseUrl!!.endsWith(baseUrl) == true) {
+                    if (currentUserProvider.currentUser.blockingGet()?.baseUrl!!.endsWith(baseUrl) == true) {
                         startConversation(user)
                     } else {
                         Snackbar.make(
@@ -181,7 +181,7 @@ class MainActivity : BaseActivity(), ActionBarProvider {
     private fun startConversation(userId: String) {
         val roomType = "1"
 
-        val currentUser = userManager.currentUser.blockingGet()
+        val currentUser = currentUserProvider.currentUser.blockingGet()
 
         val apiVersion = ApiUtils.getConversationApiVersion(currentUser, intArrayOf(ApiUtils.API_V4, 1))
         val credentials = ApiUtils.getCredentials(currentUser?.username, currentUser?.token)

--- a/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
@@ -75,6 +75,7 @@ import com.nextcloud.talk.utils.CapabilitiesUtil
 import com.nextcloud.talk.utils.CharPolicy
 import com.nextcloud.talk.utils.ImageEmojiEditText
 import com.nextcloud.talk.utils.SpreedFeatures
+import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import com.nextcloud.talk.utils.text.Spans
 import com.otaliastudios.autocomplete.Autocomplete
 import com.stfalcon.chatkit.commons.models.IMessage
@@ -115,6 +116,9 @@ class MessageInputFragment : Fragment() {
 
     @Inject
     lateinit var userManager: UserManager
+
+    @Inject
+    lateinit var currentUserProvider: CurrentUserProviderNew
 
     @Inject
     lateinit var networkMonitor: NetworkMonitor
@@ -217,7 +221,7 @@ class MessageInputFragment : Fragment() {
             if (show) {
                 binding.fragmentCallStarted.callAuthorChip.text = message.actorDisplayName
                 binding.fragmentCallStarted.callAuthorChipSecondary.text = message.actorDisplayName
-                val user = userManager.currentUser.blockingGet()
+                val user = currentUserProvider.currentUser.blockingGet()
                 val url: String = if (message.actorType == "guests" || message.actorType == "guest") {
                     ApiUtils.getUrlForGuestAvatar(user!!.baseUrl!!, message.actorDisplayName, true)
                 } else {

--- a/app/src/main/java/com/nextcloud/talk/contacts/ContactsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/contacts/ContactsActivity.kt
@@ -158,7 +158,7 @@ class ContactsActivity :
             }
         }
 
-        currentUser = userManager.currentUser.blockingGet()
+        currentUser = currentUserProvider.currentUser.blockingGet()
         if (currentUser != null) {
             credentials = ApiUtils.getCredentials(currentUser!!.username, currentUser!!.token)
         }

--- a/app/src/main/java/com/nextcloud/talk/contacts/ContactsRepositoryImpl.kt
+++ b/app/src/main/java/com/nextcloud/talk/contacts/ContactsRepositoryImpl.kt
@@ -12,15 +12,17 @@ import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.models.RetrofitBucket
 import com.nextcloud.talk.models.json.autocomplete.AutocompleteOverall
 import com.nextcloud.talk.models.json.conversations.RoomOverall
-import com.nextcloud.talk.users.UserManager
 import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.ContactUtils
+import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
+import javax.inject.Inject
 
-class ContactsRepositoryImpl(
+class ContactsRepositoryImpl @Inject constructor(
     private val ncApiCoroutines: NcApiCoroutines,
-    private val userManager: UserManager
+    currentUserProvider: CurrentUserProviderNew
 ) : ContactsRepository {
-    private val _currentUser = userManager.currentUser.blockingGet()
+
+    private val _currentUser = currentUserProvider.currentUser.blockingGet()
     val currentUser: User = _currentUser
     val credentials = ApiUtils.getCredentials(_currentUser.username, _currentUser.token)
     val apiVersion = ApiUtils.getConversationApiVersion(_currentUser, intArrayOf(ApiUtils.API_V4, 1))

--- a/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationRepositoryImpl.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationRepositoryImpl.kt
@@ -14,21 +14,22 @@ import com.nextcloud.talk.models.domain.ConversationModel
 import com.nextcloud.talk.models.json.conversations.RoomOverall
 import com.nextcloud.talk.models.json.generic.GenericOverall
 import com.nextcloud.talk.models.json.participants.AddParticipantOverall
-import com.nextcloud.talk.users.UserManager
 import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.ApiUtils.getRetrofitBucketForAddParticipant
 import com.nextcloud.talk.utils.ApiUtils.getRetrofitBucketForAddParticipantWithSource
 import com.nextcloud.talk.utils.Mimetype
+import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import java.io.File
+import javax.inject.Inject
 
-class ConversationCreationRepositoryImpl(
+class ConversationCreationRepositoryImpl @Inject constructor(
     private val ncApiCoroutines: NcApiCoroutines,
-    private val userManager: UserManager
+    currentUserProvider: CurrentUserProviderNew
 ) : ConversationCreationRepository {
-    private val _currentUser = userManager.currentUser.blockingGet()
+    private val _currentUser = currentUserProvider.currentUser.blockingGet()
     val currentUser: User = _currentUser
     val credentials = ApiUtils.getCredentials(_currentUser.username, _currentUser.token)
     val apiVersion = ApiUtils.getConversationApiVersion(_currentUser, intArrayOf(ApiUtils.API_V4, ApiUtils.API_V1))

--- a/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationViewModel.kt
@@ -18,7 +18,7 @@ import com.nextcloud.talk.models.json.autocomplete.AutocompleteUser
 import com.nextcloud.talk.models.json.conversations.Conversation
 import com.nextcloud.talk.models.json.generic.GenericMeta
 import com.nextcloud.talk.repositories.conversations.ConversationsRepositoryImpl.Companion.STATUS_CODE_OK
-import com.nextcloud.talk.users.UserManager
+import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -26,7 +26,7 @@ import javax.inject.Inject
 
 class ConversationCreationViewModel @Inject constructor(
     private val repository: ConversationCreationRepository,
-    private val userManager: UserManager
+    private val currentUserProvider: CurrentUserProviderNew
 ) : ViewModel() {
     private val _selectedParticipants = MutableStateFlow<List<AutocompleteUser>>(emptyList())
     val selectedParticipants: StateFlow<List<AutocompleteUser>> = _selectedParticipants
@@ -35,7 +35,7 @@ class ConversationCreationViewModel @Inject constructor(
     private val _selectedImageUri = MutableStateFlow<Uri?>(null)
     val selectedImageUri: StateFlow<Uri?> = _selectedImageUri
 
-    private val _currentUser = userManager.currentUser.blockingGet()
+    private val _currentUser = currentUserProvider.currentUser.blockingGet()
     val currentUser: User = _currentUser
 
     private val _isPasswordEnabled = mutableStateOf(false)

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/viewmodels/ConversationsListViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/viewmodels/ConversationsListViewModel.kt
@@ -14,6 +14,7 @@ import com.nextcloud.talk.conversationlist.data.OfflineConversationsRepository
 import com.nextcloud.talk.invitation.data.InvitationsModel
 import com.nextcloud.talk.invitation.data.InvitationsRepository
 import com.nextcloud.talk.users.UserManager
+import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import io.reactivex.Observer
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
@@ -30,6 +31,9 @@ class ConversationsListViewModel @Inject constructor(
 
     @Inject
     lateinit var invitationsRepository: InvitationsRepository
+
+    @Inject
+    lateinit var currentUserProvider: CurrentUserProviderNew
 
     sealed interface ViewState
 
@@ -90,7 +94,7 @@ class ConversationsListViewModel @Inject constructor(
         }
 
         override fun onNext(invitationsModel: InvitationsModel) {
-            val currentUser = userManager.currentUser.blockingGet()
+            val currentUser = currentUserProvider.currentUser.blockingGet()
 
             if (invitationsModel.user.userId?.equals(currentUser.userId) == true &&
                 invitationsModel.user.baseUrl?.equals(currentUser.baseUrl) == true

--- a/app/src/main/java/com/nextcloud/talk/dagger/modules/RepositoryModule.kt
+++ b/app/src/main/java/com/nextcloud/talk/dagger/modules/RepositoryModule.kt
@@ -58,7 +58,6 @@ import com.nextcloud.talk.shareditems.repositories.SharedItemsRepository
 import com.nextcloud.talk.shareditems.repositories.SharedItemsRepositoryImpl
 import com.nextcloud.talk.translate.repositories.TranslateRepository
 import com.nextcloud.talk.translate.repositories.TranslateRepositoryImpl
-import com.nextcloud.talk.users.UserManager
 import com.nextcloud.talk.utils.DateUtils
 import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import dagger.Module
@@ -183,12 +182,14 @@ class RepositoryModule {
         )
 
     @Provides
-    fun provideContactsRepository(ncApiCoroutines: NcApiCoroutines, userManager: UserManager): ContactsRepository =
-        ContactsRepositoryImpl(ncApiCoroutines, userManager)
+    fun provideContactsRepository(
+        ncApiCoroutines: NcApiCoroutines,
+        currentUserProviderNew: CurrentUserProviderNew
+    ): ContactsRepository = ContactsRepositoryImpl(ncApiCoroutines, currentUserProviderNew)
 
     @Provides
     fun provideConversationCreationRepository(
         ncApiCoroutines: NcApiCoroutines,
-        userManager: UserManager
-    ): ConversationCreationRepository = ConversationCreationRepositoryImpl(ncApiCoroutines, userManager)
+        currentUserProviderNew: CurrentUserProviderNew
+    ): ConversationCreationRepository = ConversationCreationRepositoryImpl(ncApiCoroutines, currentUserProviderNew)
 }

--- a/app/src/main/java/com/nextcloud/talk/diagnose/DiagnoseActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/diagnose/DiagnoseActivity.kt
@@ -306,26 +306,26 @@ class DiagnoseActivity : BaseActivity() {
     }
 
     private fun setupAccountValues() {
+        val currentUser = currentUserProvider.currentUser.blockingGet()
+
         addHeadline(context.resources.getString(R.string.nc_diagnose_account_category_title))
 
         addKey(context.resources.getString(R.string.nc_diagnose_account_server))
-        addValue(userManager.currentUser.blockingGet().baseUrl!!)
+        addValue(currentUser.baseUrl!!)
 
         addKey(context.resources.getString(R.string.nc_diagnose_account_user_name))
-        addValue(userManager.currentUser.blockingGet().displayName!!)
+        addValue(currentUser.displayName!!)
 
         addKey(context.resources.getString(R.string.nc_diagnose_account_user_status_enabled))
         addValue(
             translateBoolean(
-                (userManager.currentUser.blockingGet().capabilities?.userStatusCapability?.enabled)
+                (currentUser.capabilities?.userStatusCapability?.enabled)
             )
         )
 
         addKey(context.resources.getString(R.string.nc_diagnose_account_server_notification_app))
         addValue(
-            translateBoolean(
-                userManager.currentUser.blockingGet().capabilities?.notificationsCapability?.features?.isNotEmpty()
-            )
+            translateBoolean(currentUser.capabilities?.notificationsCapability?.features?.isNotEmpty())
         )
 
         if (isGooglePlayServicesAvailable) {
@@ -333,16 +333,14 @@ class DiagnoseActivity : BaseActivity() {
         }
 
         addKey(context.resources.getString(R.string.nc_diagnose_server_version))
-        addValue(userManager.currentUser.blockingGet().serverVersion?.versionString!!)
+        addValue(currentUser.serverVersion?.versionString!!)
 
         addKey(context.resources.getString(R.string.nc_diagnose_server_talk_version))
-        addValue(userManager.currentUser.blockingGet().capabilities?.spreedCapability?.version!!)
+        addValue(currentUser.capabilities?.spreedCapability?.version!!)
 
         addKey(context.resources.getString(R.string.nc_diagnose_signaling_mode_title))
 
-        if (userManager.currentUser.blockingGet().externalSignalingServer?.externalSignalingServer?.isNotEmpty()
-            == true
-        ) {
+        if (currentUser.externalSignalingServer?.externalSignalingServer?.isNotEmpty() == true) {
             addValue(context.resources.getString(R.string.nc_diagnose_signaling_mode_extern))
         } else {
             addValue(context.resources.getString(R.string.nc_diagnose_signaling_mode_intern))
@@ -350,7 +348,7 @@ class DiagnoseActivity : BaseActivity() {
     }
 
     private fun setupPushRegistrationDiagnose() {
-        val accountId = UserIdUtils.getIdForUser(userManager.currentUser.blockingGet())
+        val accountId = UserIdUtils.getIdForUser(currentUserProvider.currentUser.blockingGet())
 
         val latestPushRegistrationAtServer = arbitraryStorageManager.getStorageSetting(
             accountId,

--- a/app/src/main/java/com/nextcloud/talk/jobs/ContactAddressBookWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/ContactAddressBookWorker.kt
@@ -38,6 +38,7 @@ import com.nextcloud.talk.users.UserManager
 import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.ContactUtils
 import com.nextcloud.talk.utils.DateConstants
+import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import com.nextcloud.talk.utils.preferences.AppPreferences
 import io.reactivex.Observer
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -58,6 +59,9 @@ class ContactAddressBookWorker(val context: Context, workerParameters: WorkerPar
     lateinit var userManager: UserManager
 
     @Inject
+    lateinit var currentUserProvider: CurrentUserProviderNew
+
+    @Inject
     lateinit var appPreferences: AppPreferences
 
     private lateinit var accountName: String
@@ -66,7 +70,7 @@ class ContactAddressBookWorker(val context: Context, workerParameters: WorkerPar
     override fun doWork(): Result {
         sharedApplication!!.componentApplication.inject(this)
 
-        val currentUser = userManager.currentUser.blockingGet()
+        val currentUser = currentUserProvider.currentUser.blockingGet()
 
         accountName = context.getString(R.string.nc_app_product_name)
         accountType = BuildConfig.APPLICATION_ID

--- a/app/src/main/java/com/nextcloud/talk/jobs/DownloadFileToCacheWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/DownloadFileToCacheWorker.kt
@@ -18,6 +18,7 @@ import com.nextcloud.talk.application.NextcloudTalkApplication
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.users.UserManager
 import com.nextcloud.talk.utils.ApiUtils
+import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import com.nextcloud.talk.utils.preferences.AppPreferences
 import okhttp3.ResponseBody
 import java.io.BufferedInputStream
@@ -40,6 +41,9 @@ class DownloadFileToCacheWorker(val context: Context, workerParameters: WorkerPa
     lateinit var userManager: UserManager
 
     @Inject
+    lateinit var currentUserProvider: CurrentUserProviderNew
+
+    @Inject
     lateinit var appPreferences: AppPreferences
 
     override fun doWork(): Result {
@@ -50,7 +54,7 @@ class DownloadFileToCacheWorker(val context: Context, workerParameters: WorkerPa
         }
 
         try {
-            val currentUser = userManager.currentUser.blockingGet()
+            val currentUser = currentUserProvider.currentUser.blockingGet()
             val baseUrl = inputData.getString(KEY_BASE_URL)
             val userId = inputData.getString(KEY_USER_ID)
             val attachmentFolder = inputData.getString(KEY_ATTACHMENT_FOLDER)

--- a/app/src/main/java/com/nextcloud/talk/jobs/LeaveConversationWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/LeaveConversationWorker.kt
@@ -25,6 +25,7 @@ import com.nextcloud.talk.utils.ApiUtils.getConversationApiVersion
 import com.nextcloud.talk.utils.ApiUtils.getCredentials
 import com.nextcloud.talk.utils.ApiUtils.getUrlForParticipantsSelf
 import com.nextcloud.talk.utils.bundle.BundleKeys
+import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import io.reactivex.Observer
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
@@ -43,12 +44,15 @@ class LeaveConversationWorker(context: Context, workerParams: WorkerParameters) 
     @Inject
     lateinit var userManager: UserManager
 
+    @Inject
+    lateinit var currentUserProvider: CurrentUserProviderNew
+
     private val result = SettableFuture.create<Result>()
 
     override fun startWork(): ListenableFuture<Result> {
         NextcloudTalkApplication.sharedApplication!!.componentApplication.inject(this)
         val conversationToken = inputData.getString(BundleKeys.KEY_ROOM_TOKEN)
-        val currentUser = userManager.currentUser.blockingGet()
+        val currentUser = currentUserProvider.currentUser.blockingGet()
 
         if (currentUser != null && conversationToken != null) {
             val credentials = getCredentials(currentUser.username, currentUser.token)

--- a/app/src/main/java/com/nextcloud/talk/jobs/UploadAndShareFilesWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/UploadAndShareFilesWorker.kt
@@ -41,6 +41,7 @@ import com.nextcloud.talk.utils.NotificationUtils
 import com.nextcloud.talk.utils.RemoteFileUtils
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_INTERNAL_USER_ID
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_ROOM_TOKEN
+import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import com.nextcloud.talk.utils.permissions.PlatformPermissionUtil
 import com.nextcloud.talk.utils.preferences.AppPreferences
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
@@ -57,6 +58,9 @@ class UploadAndShareFilesWorker(val context: Context, workerParameters: WorkerPa
 
     @Inject
     lateinit var userManager: UserManager
+
+    @Inject
+    lateinit var currentUserProvider: CurrentUserProviderNew
 
     @Inject
     lateinit var appPreferences: AppPreferences
@@ -95,7 +99,7 @@ class UploadAndShareFilesWorker(val context: Context, workerParameters: WorkerPa
         }
 
         return try {
-            currentUser = userManager.currentUser.blockingGet()
+            currentUser = currentUserProvider.currentUser.blockingGet()
             val sourceFile = inputData.getString(DEVICE_SOURCE_FILE)
             roomToken = inputData.getString(ROOM_TOKEN)!!
             conversationName = inputData.getString(CONVERSATION_NAME)!!

--- a/app/src/main/java/com/nextcloud/talk/location/LocationPickerActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/location/LocationPickerActivity.kt
@@ -452,7 +452,7 @@ class LocationPickerActivity :
             "{\"type\":\"geo-location\",\"id\":\"geo:$selectedLat,$selectedLon\",\"latitude\":\"$selectedLat\"," +
                 "\"longitude\":\"$selectedLon\",\"name\":\"$locationNameToShare\"}"
 
-        val currentUser = userManager.currentUser.blockingGet()
+        val currentUser = currentUserProvider.currentUser.blockingGet()
 
         ncApi.sendLocation(
             ApiUtils.getCredentials(currentUser.username, currentUser.token),

--- a/app/src/main/java/com/nextcloud/talk/polls/viewmodels/PollMainViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/polls/viewmodels/PollMainViewModel.kt
@@ -14,6 +14,7 @@ import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.polls.model.Poll
 import com.nextcloud.talk.polls.repositories.PollRepository
 import com.nextcloud.talk.users.UserManager
+import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import io.reactivex.Observer
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
@@ -24,6 +25,9 @@ class PollMainViewModel @Inject constructor(private val repository: PollReposito
 
     @Inject
     lateinit var userManager: UserManager
+
+    @Inject
+    lateinit var currentUserProvider: CurrentUserProviderNew
 
     lateinit var user: User
     lateinit var roomToken: String
@@ -161,11 +165,7 @@ class PollMainViewModel @Inject constructor(private val repository: PollReposito
     }
 
     private fun isPollCreatedByCurrentUser(poll: Poll): Boolean {
-        if (userManager.currentUser.isEmpty.blockingGet()) {
-            return false
-        } else {
-            return userManager.currentUser.blockingGet().userId == poll.actorId
-        }
+        return currentUserProvider.currentUser.blockingGet().userId == poll.actorId
     }
 
     fun dismissDialog() {

--- a/app/src/main/java/com/nextcloud/talk/presenters/MentionAutocompletePresenter.java
+++ b/app/src/main/java/com/nextcloud/talk/presenters/MentionAutocompletePresenter.java
@@ -23,6 +23,7 @@ import com.nextcloud.talk.models.json.mention.MentionOverall;
 import com.nextcloud.talk.ui.theme.ViewThemeUtils;
 import com.nextcloud.talk.users.UserManager;
 import com.nextcloud.talk.utils.ApiUtils;
+import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew;
 import com.otaliastudios.autocomplete.RecyclerViewPresenter;
 
 import java.util.ArrayList;
@@ -54,6 +55,9 @@ public class MentionAutocompletePresenter extends RecyclerViewPresenter<Mention>
     UserManager userManager;
 
     @Inject
+    CurrentUserProviderNew currentUserProvider;
+
+    @Inject
     ViewThemeUtils viewThemeUtils;
 
     private User currentUser;
@@ -69,7 +73,7 @@ public class MentionAutocompletePresenter extends RecyclerViewPresenter<Mention>
         super(context);
         this.context = context;
         NextcloudTalkApplication.Companion.getSharedApplication().getComponentApplication().inject(this);
-        currentUser = userManager.getCurrentUser().blockingGet();
+        currentUser = currentUserProvider.getCurrentUser().blockingGet();
     }
 
     public MentionAutocompletePresenter(Context context, String roomToken, int chatApiVersion) {
@@ -78,7 +82,7 @@ public class MentionAutocompletePresenter extends RecyclerViewPresenter<Mention>
         this.context = context;
         this.chatApiVersion = chatApiVersion;
         NextcloudTalkApplication.Companion.getSharedApplication().getComponentApplication().inject(this);
-        currentUser = userManager.getCurrentUser().blockingGet();
+        currentUser = currentUserProvider.getCurrentUser().blockingGet();
     }
 
     @Override

--- a/app/src/main/java/com/nextcloud/talk/profile/ProfileActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/profile/ProfileActivity.kt
@@ -128,7 +128,7 @@ class ProfileActivity : BaseActivity() {
         adapter = UserInfoAdapter(null, viewThemeUtils, this)
         binding.userinfoList.adapter = adapter
         binding.userinfoList.setItemViewCacheSize(DEFAULT_CACHE_SIZE)
-        currentUser = userManager.currentUser.blockingGet()
+        currentUser = currentUserProvider.currentUser.blockingGet()
         val credentials = ApiUtils.getCredentials(currentUser!!.username, currentUser!!.token)
 
         pickImage = PickImage(this, currentUser)

--- a/app/src/main/java/com/nextcloud/talk/receivers/DirectReplyReceiver.kt
+++ b/app/src/main/java/com/nextcloud/talk/receivers/DirectReplyReceiver.kt
@@ -30,6 +30,7 @@ import com.nextcloud.talk.utils.NotificationUtils
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_INTERNAL_USER_ID
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_ROOM_TOKEN
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_SYSTEM_NOTIFICATION_ID
+import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import com.nextcloud.talk.utils.message.SendMessageUtils
 import io.reactivex.Observer
 import io.reactivex.Single
@@ -43,6 +44,9 @@ class DirectReplyReceiver : BroadcastReceiver() {
 
     @Inject
     lateinit var userManager: UserManager
+
+    @Inject
+    lateinit var currentUserProvider: CurrentUserProviderNew
 
     @Inject
     lateinit var ncApi: NcApi
@@ -65,7 +69,7 @@ class DirectReplyReceiver : BroadcastReceiver() {
         systemNotificationId = intent!!.getIntExtra(KEY_SYSTEM_NOTIFICATION_ID, 0)
         roomToken = intent.getStringExtra(KEY_ROOM_TOKEN)
 
-        val id = intent.getLongExtra(KEY_INTERNAL_USER_ID, userManager.currentUser.blockingGet().id!!)
+        val id = intent.getLongExtra(KEY_INTERNAL_USER_ID, currentUserProvider.currentUser.blockingGet().id!!)
         currentUser = userManager.getUserWithId(id).blockingGet()
 
         replyMessage = getMessageText(intent)

--- a/app/src/main/java/com/nextcloud/talk/receivers/DismissRecordingAvailableReceiver.kt
+++ b/app/src/main/java/com/nextcloud/talk/receivers/DismissRecordingAvailableReceiver.kt
@@ -21,6 +21,7 @@ import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.bundle.BundleKeys
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_INTERNAL_USER_ID
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_SYSTEM_NOTIFICATION_ID
+import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import io.reactivex.Observer
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
@@ -32,6 +33,9 @@ class DismissRecordingAvailableReceiver : BroadcastReceiver() {
 
     @Inject
     lateinit var userManager: UserManager
+
+    @Inject
+    lateinit var currentUserProvider: CurrentUserProviderNew
 
     @Inject
     lateinit var ncApi: NcApi
@@ -53,7 +57,7 @@ class DismissRecordingAvailableReceiver : BroadcastReceiver() {
         systemNotificationId = intent!!.getIntExtra(KEY_SYSTEM_NOTIFICATION_ID, 0)
         link = intent.getStringExtra(BundleKeys.KEY_DISMISS_RECORDING_URL)
 
-        val id = intent.getLongExtra(KEY_INTERNAL_USER_ID, userManager.currentUser.blockingGet().id!!)
+        val id = intent.getLongExtra(KEY_INTERNAL_USER_ID, currentUserProvider.currentUser.blockingGet().id!!)
         currentUser = userManager.getUserWithId(id).blockingGet()
 
         dismissNcRecordingAvailableNotification()

--- a/app/src/main/java/com/nextcloud/talk/receivers/MarkAsReadReceiver.kt
+++ b/app/src/main/java/com/nextcloud/talk/receivers/MarkAsReadReceiver.kt
@@ -23,6 +23,7 @@ import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_INTERNAL_USER_ID
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_MESSAGE_ID
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_ROOM_TOKEN
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_SYSTEM_NOTIFICATION_ID
+import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import io.reactivex.Observer
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
@@ -34,6 +35,9 @@ class MarkAsReadReceiver : BroadcastReceiver() {
 
     @Inject
     lateinit var userManager: UserManager
+
+    @Inject
+    lateinit var currentUserProvider: CurrentUserProviderNew
 
     @Inject
     lateinit var ncApi: NcApi
@@ -57,7 +61,7 @@ class MarkAsReadReceiver : BroadcastReceiver() {
         roomToken = intent.getStringExtra(KEY_ROOM_TOKEN)
         messageId = intent.getIntExtra(KEY_MESSAGE_ID, 0)
 
-        val id = intent.getLongExtra(KEY_INTERNAL_USER_ID, userManager.currentUser.blockingGet().id!!)
+        val id = intent.getLongExtra(KEY_INTERNAL_USER_ID, currentUserProvider.currentUser.blockingGet().id!!)
         currentUser = userManager.getUserWithId(id).blockingGet()
 
         markAsRead()

--- a/app/src/main/java/com/nextcloud/talk/receivers/ShareRecordingToChatReceiver.kt
+++ b/app/src/main/java/com/nextcloud/talk/receivers/ShareRecordingToChatReceiver.kt
@@ -24,6 +24,7 @@ import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.bundle.BundleKeys
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_INTERNAL_USER_ID
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_SYSTEM_NOTIFICATION_ID
+import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import io.reactivex.Observer
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
@@ -35,6 +36,9 @@ class ShareRecordingToChatReceiver : BroadcastReceiver() {
 
     @Inject
     lateinit var userManager: UserManager
+
+    @Inject
+    lateinit var currentUserProvider: CurrentUserProviderNew
 
     @Inject
     lateinit var ncApi: NcApi
@@ -53,7 +57,7 @@ class ShareRecordingToChatReceiver : BroadcastReceiver() {
         systemNotificationId = intent!!.getIntExtra(KEY_SYSTEM_NOTIFICATION_ID, 0)
         link = intent.getStringExtra(BundleKeys.KEY_SHARE_RECORDING_TO_CHAT_URL)
 
-        val id = intent.getLongExtra(KEY_INTERNAL_USER_ID, userManager.currentUser.blockingGet().id!!)
+        val id = intent.getLongExtra(KEY_INTERNAL_USER_ID, currentUserProvider.currentUser.blockingGet().id!!)
         currentUser = userManager.getUserWithId(id).blockingGet()
 
         shareRecordingToChat()

--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -480,12 +480,13 @@ class SettingsActivity :
 
     private fun setupServerNotificationAppCheck() {
         val serverNotificationAppInstalled =
-            userManager.currentUser.blockingGet().capabilities?.notificationsCapability?.features?.isNotEmpty() ?: false
+            currentUserProvider.currentUser.blockingGet().capabilities?.notificationsCapability?.features?.isNotEmpty()
+                ?: false
         if (!serverNotificationAppInstalled) {
             binding.settingsServerNotificationAppWrapper.visibility = View.VISIBLE
 
             val description = context.getString(R.string.nc_settings_contact_admin_of) + LINEBREAK +
-                userManager.currentUser.blockingGet().baseUrl!!
+                currentUserProvider.currentUser.blockingGet().baseUrl!!
 
             binding.settingsServerNotificationAppDescription.text = description
             if (openedByNotificationWarning) {

--- a/app/src/main/java/com/nextcloud/talk/translate/viewmodels/TranslateViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/translate/viewmodels/TranslateViewModel.kt
@@ -15,8 +15,8 @@ import androidx.lifecycle.ViewModel
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.translate.repositories.TranslateRepository
 import com.nextcloud.talk.translate.repositories.model.Language
-import com.nextcloud.talk.users.UserManager
 import com.nextcloud.talk.utils.ApiUtils
+import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import io.reactivex.Observer
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
@@ -25,7 +25,7 @@ import javax.inject.Inject
 
 class TranslateViewModel @Inject constructor(
     private val repository: TranslateRepository,
-    private val userManager: UserManager
+    private val currentUserProvider: CurrentUserProviderNew
 ) : ViewModel() {
 
     sealed interface ViewState
@@ -44,7 +44,7 @@ class TranslateViewModel @Inject constructor(
         get() = _viewState
 
     fun translateMessage(toLanguage: String, fromLanguage: String?, text: String) {
-        val currentUser: User = userManager.currentUser.blockingGet()
+        val currentUser: User = currentUserProvider.currentUser.blockingGet()
         val authorization: String = ApiUtils.getCredentials(currentUser.username, currentUser.token)!!
         val url: String = ApiUtils.getUrlForTranslation(currentUser.baseUrl!!)
         val calculatedFromLanguage =
@@ -67,7 +67,7 @@ class TranslateViewModel @Inject constructor(
     }
 
     fun getLanguages() {
-        val currentUser: User = userManager.currentUser.blockingGet()
+        val currentUser: User = currentUserProvider.currentUser.blockingGet()
         val authorization: String = ApiUtils.getCredentials(currentUser.username, currentUser.token)!!
         val url: String = ApiUtils.getUrlForLanguages(currentUser.baseUrl!!)
         Log.d(TAG, "URL is: $url")

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/ChooseAccountDialogFragment.java
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/ChooseAccountDialogFragment.java
@@ -40,6 +40,7 @@ import com.nextcloud.talk.users.UserManager;
 import com.nextcloud.talk.utils.ApiUtils;
 import com.nextcloud.talk.utils.CapabilitiesUtil;
 import com.nextcloud.talk.utils.DisplayUtils;
+import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew;
 
 import java.net.CookieManager;
 import java.util.ArrayList;
@@ -71,6 +72,9 @@ public class ChooseAccountDialogFragment extends DialogFragment {
 
     @Inject
     UserManager userManager;
+
+    @Inject
+    CurrentUserProviderNew currentUserProvider;
 
     @Inject
     CookieManager cookieManager;
@@ -109,7 +113,7 @@ public class ChooseAccountDialogFragment extends DialogFragment {
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         Objects.requireNonNull(NextcloudTalkApplication.Companion.getSharedApplication()).getComponentApplication().inject(this);
-        User user = userManager.getCurrentUser().blockingGet();
+        User user = currentUserProvider.getCurrentUser().blockingGet();
 
         themeViews();
         setupCurrentUser(user);
@@ -268,7 +272,7 @@ public class ChooseAccountDialogFragment extends DialogFragment {
     private void loadCurrentStatus(User user) {
         String credentials = ApiUtils.getCredentials(user.getUsername(), user.getToken());
 
-        if (CapabilitiesUtil.isUserStatusAvailable(userManager.getCurrentUser().blockingGet())) {
+        if (CapabilitiesUtil.isUserStatusAvailable(currentUserProvider.getCurrentUser().blockingGet())) {
             binding.statusView.setVisibility(View.VISIBLE);
 
             ncApi.status(credentials, ApiUtils.getUrlForStatus(user.getBaseUrl())).

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/ChooseAccountShareToDialogFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/ChooseAccountShareToDialogFragment.kt
@@ -29,6 +29,7 @@ import com.nextcloud.talk.extensions.loadUserAvatar
 import com.nextcloud.talk.models.json.participants.Participant
 import com.nextcloud.talk.ui.theme.ViewThemeUtils
 import com.nextcloud.talk.users.UserManager
+import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.common.SmoothScrollLinearLayoutManager
 import java.net.CookieManager
@@ -39,6 +40,9 @@ class ChooseAccountShareToDialogFragment : DialogFragment() {
     @JvmField
     @Inject
     var userManager: UserManager? = null
+
+    @Inject
+    lateinit var currentUserProvider: CurrentUserProviderNew
 
     @JvmField
     @Inject
@@ -61,7 +65,7 @@ class ChooseAccountShareToDialogFragment : DialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         sharedApplication!!.componentApplication.inject(this)
-        val user = userManager!!.currentUser.blockingGet()
+        val user = currentUserProvider.currentUser.blockingGet()
         themeViews()
         setupCurrentUser(user)
         setupListeners(user)

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/ConversationsListBottomDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/ConversationsListBottomDialog.kt
@@ -42,6 +42,7 @@ import com.nextcloud.talk.utils.ShareUtils
 import com.nextcloud.talk.utils.SpreedFeatures
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_INTERNAL_USER_ID
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_ROOM_TOKEN
+import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import io.reactivex.Observer
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
@@ -74,6 +75,9 @@ class ConversationsListBottomDialog(
 
     @Inject
     lateinit var userManager: UserManager
+
+    @Inject
+    lateinit var currentUserProvider: CurrentUserProviderNew
 
     lateinit var credentials: String
 
@@ -217,7 +221,7 @@ class ConversationsListBottomDialog(
     }
 
     private fun handleArchiving() {
-        val currentUser = userManager.currentUser.blockingGet()
+        val currentUser = currentUserProvider.currentUser.blockingGet()
         val token = conversation.token
         lifecycleScope.launch {
             if (conversation.hasArchived) {

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/DateTimeCompose.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/DateTimeCompose.kt
@@ -54,8 +54,8 @@ import com.nextcloud.talk.R
 import com.nextcloud.talk.application.NextcloudTalkApplication
 import com.nextcloud.talk.chat.viewmodels.ChatViewModel
 import com.nextcloud.talk.ui.theme.ViewThemeUtils
-import com.nextcloud.talk.users.UserManager
 import com.nextcloud.talk.utils.bundle.BundleKeys
+import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import java.time.DayOfWeek
 import java.time.Instant
 import java.time.LocalDate
@@ -72,7 +72,7 @@ class DateTimeCompose(val bundle: Bundle) {
 
     init {
         NextcloudTalkApplication.sharedApplication!!.componentApplication.inject(this)
-        val user = userManager.currentUser.blockingGet()
+        val user = currentUserProvider.currentUser.blockingGet()
         val roomToken = bundle.getString(BundleKeys.KEY_ROOM_TOKEN)!!
         val messageId = bundle.getString(BundleKeys.KEY_MESSAGE_ID)!!
         val apiVersion = bundle.getInt(BundleKeys.KEY_CHAT_API_VERSION)
@@ -83,7 +83,7 @@ class DateTimeCompose(val bundle: Bundle) {
     lateinit var chatViewModel: ChatViewModel
 
     @Inject
-    lateinit var userManager: UserManager
+    lateinit var currentUserProvider: CurrentUserProviderNew
 
     @Inject
     lateinit var viewThemeUtils: ViewThemeUtils
@@ -133,7 +133,7 @@ class DateTimeCompose(val bundle: Bundle) {
         ) {
             TextButton(
                 onClick = {
-                    val user = userManager.currentUser.blockingGet()
+                    val user = currentUserProvider.currentUser.blockingGet()
                     val roomToken = bundle.getString(BundleKeys.KEY_ROOM_TOKEN)!!
                     val messageId = bundle.getString(BundleKeys.KEY_MESSAGE_ID)!!
                     val apiVersion = bundle.getInt(BundleKeys.KEY_CHAT_API_VERSION)
@@ -161,7 +161,7 @@ class DateTimeCompose(val bundle: Bundle) {
 
             TextButton(
                 onClick = {
-                    val user = userManager.currentUser.blockingGet()
+                    val user = currentUserProvider.currentUser.blockingGet()
                     val roomToken = bundle.getString(BundleKeys.KEY_ROOM_TOKEN)!!
                     val messageId = bundle.getString(BundleKeys.KEY_MESSAGE_ID)!!
                     val apiVersion = bundle.getInt(BundleKeys.KEY_CHAT_API_VERSION)

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/FilterConversationFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/FilterConversationFragment.kt
@@ -21,10 +21,10 @@ import com.nextcloud.talk.arbitrarystorage.ArbitraryStorageManager
 import com.nextcloud.talk.conversationlist.ConversationsListActivity
 import com.nextcloud.talk.databinding.DialogFilterConversationBinding
 import com.nextcloud.talk.ui.theme.ViewThemeUtils
-import com.nextcloud.talk.users.UserManager
 import com.nextcloud.talk.utils.CapabilitiesUtil.hasSpreedFeatureCapability
 import com.nextcloud.talk.utils.SpreedFeatures
 import com.nextcloud.talk.utils.UserIdUtils
+import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import javax.inject.Inject
 
 @AutoInjector(NextcloudTalkApplication::class)
@@ -34,7 +34,7 @@ class FilterConversationFragment : DialogFragment() {
     private lateinit var filterState: HashMap<String, Boolean>
 
     @Inject
-    lateinit var userManager: UserManager
+    lateinit var currentUserProvider: CurrentUserProviderNew
 
     @Inject
     lateinit var viewThemeUtils: ViewThemeUtils
@@ -108,7 +108,7 @@ class FilterConversationFragment : DialogFragment() {
         binding.mentionedFilterChip.isChecked = filterState[MENTION]!!
 
         binding.archivedFilterChip.visibility = View.GONE
-        userManager.currentUser.blockingGet().capabilities?.spreedCapability?.let {
+        currentUserProvider.currentUser.blockingGet().capabilities?.spreedCapability?.let {
             if (hasSpreedFeatureCapability(it, SpreedFeatures.ARCHIVE_CONVERSATIONS)) {
                 binding.archivedFilterChip.visibility = View.VISIBLE
                 binding.archivedFilterChip.isChecked = filterState[ARCHIVE]!!
@@ -118,7 +118,7 @@ class FilterConversationFragment : DialogFragment() {
 
     private fun processSubmit() {
         // store
-        val accountId = UserIdUtils.getIdForUser(userManager.currentUser.blockingGet())
+        val accountId = UserIdUtils.getIdForUser(currentUserProvider.currentUser.blockingGet())
         val mentionValue = filterState[MENTION] == true
         val unreadValue = filterState[UNREAD] == true
         val archivedValue = filterState[ARCHIVE] == true

--- a/app/src/main/java/com/nextcloud/talk/utils/database/user/CurrentUserProviderImpl.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/database/user/CurrentUserProviderImpl.kt
@@ -12,10 +12,12 @@ import com.nextcloud.talk.users.UserManager
 import io.reactivex.Maybe
 import io.reactivex.disposables.Disposable
 import javax.inject.Inject
+import javax.inject.Singleton
 
 /**
  * Listens to changes in the database and provides the current user without needing to query the database everytime.
  */
+@Singleton
 class CurrentUserProviderImpl @Inject constructor(private val userManager: UserManager) : CurrentUserProviderNew {
 
     private var _currentUser: User? = null

--- a/app/src/main/java/com/nextcloud/talk/utils/ssl/KeyManager.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/ssl/KeyManager.java
@@ -15,6 +15,7 @@ import android.util.Log;
 import com.nextcloud.talk.application.NextcloudTalkApplication;
 import com.nextcloud.talk.data.user.model.User;
 import com.nextcloud.talk.users.UserManager;
+import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew;
 import com.nextcloud.talk.utils.preferences.AppPreferences;
 
 import java.net.Socket;
@@ -27,6 +28,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import javax.inject.Inject;
 import javax.net.ssl.X509KeyManager;
 
 import androidx.annotation.Nullable;
@@ -34,6 +36,9 @@ import androidx.annotation.Nullable;
 public class KeyManager implements X509KeyManager {
     private static final String TAG = "KeyManager";
     private final X509KeyManager keyManager;
+
+    @Inject
+    CurrentUserProviderNew currentUserProvider;
 
     private UserManager userManager;
     private AppPreferences appPreferences;
@@ -50,7 +55,7 @@ public class KeyManager implements X509KeyManager {
     @Override
     public String chooseClientAlias(String[] strings, Principal[] principals, Socket socket) {
         String alias;
-        User currentUser = userManager.getCurrentUser().blockingGet();
+        User currentUser = currentUserProvider.getCurrentUser().blockingGet();
         if ((currentUser != null &&
             !TextUtils.isEmpty(alias = currentUser.getClientCertificate())) ||
             !TextUtils.isEmpty(alias = appPreferences.getTemporaryClientCertAlias())


### PR DESCRIPTION
userManager.currentUser was called too often. I was not able to prove that a bug is related to it but i think it may fix some hidden bugs.

CurrentUserProviderImpl is now used throughout the code to access the current user. userManager.currentUser is only used from CurrentUserProviderImpl whenever the _currentUser was null (should only happen on app startup)

To avoid multiple initialization of CurrentUserProviderImpl it was changed to be a @Singleton

The handling should soon be replaced with coroutine flows. However for the v21.0.0 release it's still done with RxJava to avoid bugs.


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)