### PR TITLE
Avoid duplicated messages when activity comes back from background

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -562,6 +562,7 @@ class ChatActivity :
     override fun onStop() {
         super.onStop()
         active = false
+        adapter = null
         this.lifecycle.removeObserver(AudioUtils)
         this.lifecycle.removeObserver(chatViewModel)
     }
@@ -2677,7 +2678,6 @@ class ChatActivity :
 
         currentlyPlayedVoiceMessage?.let { stopMediaPlayer(it) } // FIXME, mediaplayer can sometimes be null here
 
-        adapter = null
         disposables.dispose()
     }
 


### PR DESCRIPTION
onDestroy is not called when navigating to the next activity or bringing the app to background. That's why the adapter was not set to null and all messages were added another time the next time the activity comes to foreground. With this fix, the adapter is set to null in onStop.

This also perfectly explains issue #4673 so i will close it with this PR... 
fix #4673

### STR:
1. open chat (best is one with only a few messages to see immediately when something is duplicated)
2. navigate to ConversationInfo screen or press home button
3. come back to chat with return or bring app back to foreground

### Without this fix:
- messages are duplicated

### With this fix:
messages are not dupliacted 

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)