### PR TITLE
use ubuntu-latest for analysis and codeql

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
     analysis:
-        runs-on: [ubuntu-latest, self-hosted]
+        runs-on: ubuntu-latest
         steps:
             -   name: Setup variables
                 id: get-vars

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
     analysis:
-        runs-on: ubuntu-24.04
+        runs-on: ubuntu-latest
         steps:
             -   name: Setup variables
                 id: get-vars

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
     analysis:
-        runs-on: ubuntu-latest
+        runs-on: [ubuntu-latest, self-hosted]
         steps:
             -   name: Setup variables
                 id: get-vars

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, self-hosted]
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: [ubuntu-latest, self-hosted]
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set Swap Space
+        if: runner.environment == 'github-hosted'
         uses: pierotofy/set-swap-space@49819abfb41bd9b44fb781159c033dba90353a7c # v1.0
         with:
           swap-size-gb: 10


### PR DESCRIPTION
Not sure if there are still valid reasons to use 24.04 Basically testing if github actions run in the PR and then may merge

Using ubuntu-latest would allow that the self-hosted runners can be used instead to only use the ones from github. This should speed up the checks...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)