### PR TITLE
Edit checkbox messages directly

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingTextMessageViewHolder.kt
@@ -102,7 +102,6 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) :
                 true,
                 viewThemeUtils
             )
-
             processedMessageText = messageUtils.processMessageParameters(
                 binding.messageText.context,
                 viewThemeUtils,
@@ -110,7 +109,6 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) :
                 message,
                 itemView
             )
-
             val messageParameters = message.messageParameters
             if (
                 (messageParameters == null || messageParameters.size <= 0) &&
@@ -120,7 +118,6 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) :
                 itemView.isSelected = true
                 binding.messageAuthor.visibility = View.GONE
             }
-
             binding.messageText.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSize)
             binding.messageText.text = processedMessageText
         } else {
@@ -192,8 +189,10 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) :
             val checkBox = CheckBox(checkBoxContainer.context).apply {
                 text = taskText
                 this.isChecked = isChecked
-                this.isEnabled = (chatMessage.actorType == "bots" ||
-                    chatActivity.userAllowedByPrivilages(chatMessage))  && messageIsEditable
+                this.isEnabled = (
+                    chatMessage.actorType == "bots" ||
+                        chatActivity.userAllowedByPrivilages(chatMessage)
+                    ) && messageIsEditable
                 setOnCheckedChangeListener { _, _ ->
                     updateCheckboxStates(chatMessage, user, checkboxList)
                 }
@@ -367,5 +366,3 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) :
         private const val AGE_THRESHOLD_FOR_EDIT_MESSAGE: Long = 86400000
     }
 }
-
-

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingTextMessageViewHolder.kt
@@ -188,7 +188,7 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) :
     }
 
     private fun updateCheckboxStates(chatMessage: ChatMessage, user: User, checkboxes: List<CheckBox>) {
-       job =  CoroutineScope(Dispatchers.Main).launch {
+        job = CoroutineScope(Dispatchers.Main).launch {
             withContext(Dispatchers.IO) {
                 val apiVersion: Int = ApiUtils.getChatApiVersion(
                     user.capabilities?.spreedCapability!!,
@@ -205,10 +205,12 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) :
                     withContext(Dispatchers.Main) {
                         if (result.isSuccess) {
                             val editedMessage = result.getOrNull()?.ocs?.data!!.parentMessage!!
-                            Log.d(TAG," EditedMessage: $editedMessage")
+                            Log.d(TAG, "EditedMessage: $editedMessage")
                             binding.messageEditIndicator.apply {
                                 visibility = View.VISIBLE
                             }
+                            binding.messageTime.text =
+                                dateUtils.getLocalTimeStringFromTimestamp(editedMessage.lastEditTimestamp!!)
                         } else {
                             Snackbar.make(binding.root, R.string.nc_common_error_sorry, Snackbar.LENGTH_LONG).show()
                         }

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingTextMessageViewHolder.kt
@@ -92,6 +92,8 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) :
     private fun processMessage(message: ChatMessage, hasCheckboxes: Boolean) {
         var textSize = context.resources!!.getDimension(R.dimen.chat_text_size)
         if (!hasCheckboxes) {
+            binding.messageText.visibility = View.VISIBLE
+            binding.checkboxContainer.visibility = View.GONE
             var processedMessageText = messageUtils.enrichChatMessageText(
                 binding.messageText.context,
                 message,
@@ -121,7 +123,8 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) :
             binding.messageText.text = processedMessageText
 
         }else{
-            binding.messageText.text = ""
+            binding.messageText.visibility = View.GONE
+            binding.checkboxContainer.visibility = View.VISIBLE
         }
 
         if (message.lastEditTimestamp != 0L && !message.isDeleted) {
@@ -233,7 +236,7 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) :
         var updatedMessage = originalMessage
         val regex = """(- \[(X|x| )])\s*(.+)""".toRegex(RegexOption.MULTILINE)
 
-        checkboxes.forEach { checkBox ->
+        checkboxes.forEach { _ ->
             updatedMessage = regex.replace(updatedMessage) { matchResult ->
                 val taskText = matchResult.groupValues[TASK_TEXT_GROUP_INDEX].trim()
                 val checkboxState = if (checkboxes.find { it.text == taskText }?.isChecked == true) "X" else " "
@@ -347,6 +350,11 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) :
         this.commonMessageInterface = commonMessageInterface
     }
 
+    override fun viewDetached() {
+        super.viewDetached()
+        job?.cancel()
+    }
+
     companion object {
         const val TEXT_SIZE_MULTIPLIER = 2.5
         private val TAG = IncomingTextMessageViewHolder::class.java.simpleName
@@ -355,3 +363,5 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) :
         private const val AGE_THRESHOLD_FOR_EDIT_MESSAGE: Long = 86400000
     }
 }
+
+

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingTextMessageViewHolder.kt
@@ -14,6 +14,7 @@ import android.util.Log
 import android.util.TypedValue
 import android.view.View
 import android.widget.CheckBox
+import androidx.core.content.ContextCompat
 import androidx.core.text.toSpanned
 import autodagger.AutoInjector
 import coil.load
@@ -132,6 +133,7 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) :
             binding.messageEditIndicator.visibility = View.GONE
             binding.messageTime.text = dateUtils.getLocalTimeStringFromTimestamp(message.timestamp)
         }
+        binding.messageTime.setTextColor(ContextCompat.getColor(context, R.color.no_emphasis_text))
         // parent message handling
         if (!message.isDeleted && message.parentMessageId != null) {
             processParentMessage(message)
@@ -193,6 +195,9 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) :
                     chatMessage.actorType == "bots" ||
                         chatActivity.userAllowedByPrivilages(chatMessage)
                     ) && messageIsEditable
+
+                setTextColor(ContextCompat.getColor(context, R.color.no_emphasis_text))
+
                 setOnCheckedChangeListener { _, _ ->
                     updateCheckboxStates(chatMessage, user, checkboxList)
                 }

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingTextMessageViewHolder.kt
@@ -168,8 +168,9 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) :
         val checkboxList = mutableListOf<CheckBox>()
 
         matches.forEach { matchResult ->
-            val isChecked = matchResult.groupValues[2] == "X" || matchResult.groupValues[2] == "x"
-            val taskText = matchResult.groupValues[3].trim()
+            val isChecked = matchResult.groupValues[CHECKED_GROUP_INDEX] == "X" ||
+                matchResult.groupValues[CHECKED_GROUP_INDEX] == "x"
+            val taskText = matchResult.groupValues[TASK_TEXT_GROUP_INDEX].trim()
 
             val checkBox = CheckBox(checkBoxContainer.context).apply {
                 text = taskText
@@ -341,5 +342,7 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) :
     companion object {
         const val TEXT_SIZE_MULTIPLIER = 2.5
         private val TAG = IncomingTextMessageViewHolder::class.java.simpleName
+        private const val CHECKED_GROUP_INDEX = 2
+        private const val TASK_TEXT_GROUP_INDEX = 3
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingTextMessageViewHolder.kt
@@ -84,12 +84,15 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) :
         itemView.isSelected = false
         val user = currentUserProvider.currentUser.blockingGet()
 
-        var textSize = context.resources!!.getDimension(R.dimen.chat_text_size)
-
         val hasCheckboxes = processCheckboxes(
             message,
             user
         )
+        processMessage(message, hasCheckboxes)
+    }
+
+    private fun processMessage(message: ChatMessage, hasCheckboxes: Boolean) {
+        var textSize = context.resources!!.getDimension(R.dimen.chat_text_size)
         if (!hasCheckboxes) {
             var processedMessageText = messageUtils.enrichChatMessageText(
                 binding.messageText.context,
@@ -227,7 +230,7 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) :
 
         checkboxes.forEach { checkBox ->
             updatedMessage = regex.replace(updatedMessage) { matchResult ->
-                val taskText = matchResult.groupValues[3].trim()
+                val taskText = matchResult.groupValues[TASK_TEXT_GROUP_INDEX].trim()
                 val checkboxState = if (checkboxes.find { it.text == taskText }?.isChecked == true) "X" else " "
                 "- [$checkboxState] $taskText"
             }

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
@@ -32,9 +32,12 @@ import com.nextcloud.talk.data.network.NetworkMonitor
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.databinding.ItemCustomOutcomingTextMessageBinding
 import com.nextcloud.talk.models.json.chat.ReadStatus
+import com.nextcloud.talk.models.json.conversations.ConversationEnums
 import com.nextcloud.talk.ui.theme.ViewThemeUtils
 import com.nextcloud.talk.utils.ApiUtils
+import com.nextcloud.talk.utils.CapabilitiesUtil.hasSpreedFeatureCapability
 import com.nextcloud.talk.utils.DateUtils
+import com.nextcloud.talk.utils.SpreedFeatures
 import com.nextcloud.talk.utils.TextMatchers
 import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import com.nextcloud.talk.utils.message.MessageUtils
@@ -132,8 +135,7 @@ class OutcomingTextMessageViewHolder(itemView: View) :
             binding.messageTime.layoutParams = layoutParams
             viewThemeUtils.platform.colorTextView(binding.messageText, ColorRole.ON_SURFACE_VARIANT)
             binding.messageText.text = processedMessageText
-
-        }else{
+        } else {
             binding.messageText.visibility = View.GONE
             binding.checkboxContainer.visibility = View.VISIBLE
         }
@@ -193,12 +195,23 @@ class OutcomingTextMessageViewHolder(itemView: View) :
     }
 
     private fun processCheckboxes(chatMessage: ChatMessage, user: User): Boolean {
+        val chatActivity = commonMessageInterface as ChatActivity
         val message = chatMessage.message!!.toSpanned()
         val messageTextView = binding.messageText
         val checkBoxContainer = binding.checkboxContainer
         val isOlderThanTwentyFourHours = chatMessage
             .createdAt
             .before(Date(System.currentTimeMillis() - AGE_THRESHOLD_FOR_EDIT_MESSAGE))
+        val messageIsEditable = hasSpreedFeatureCapability(
+            user.capabilities?.spreedCapability!!,
+            SpreedFeatures.EDIT_MESSAGES
+        ) && !isOlderThanTwentyFourHours
+
+        val isNoTimeLimitOnNoteToSelf = hasSpreedFeatureCapability(
+            user.capabilities?.spreedCapability!!,
+            SpreedFeatures
+                .EDIT_MESSAGES_NOTE_TO_SELF
+        ) && chatActivity.currentConversation?.type == ConversationEnums.ConversationType.NOTE_TO_SELF
 
         checkBoxContainer.removeAllViews()
         val regex = """(- \[(X|x| )])\s*(.+)""".toRegex(RegexOption.MULTILINE)
@@ -221,7 +234,7 @@ class OutcomingTextMessageViewHolder(itemView: View) :
             val checkBox = CheckBox(checkBoxContainer.context).apply {
                 text = taskText
                 this.isChecked = isChecked
-                this.isEnabled = !isOlderThanTwentyFourHours
+                this.isEnabled = messageIsEditable || isNoTimeLimitOnNoteToSelf
                 setOnCheckedChangeListener { _, _ ->
                     updateCheckboxStates(chatMessage, user, checkboxList)
                 }
@@ -230,8 +243,6 @@ class OutcomingTextMessageViewHolder(itemView: View) :
             checkboxList.add(checkBox)
             viewThemeUtils.platform.themeCheckbox(checkBox)
         }
-
-        checkBoxContainer.visibility = View.VISIBLE
         return true
     }
 

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
@@ -13,31 +13,39 @@ import android.content.Context
 import android.util.Log
 import android.util.TypedValue
 import android.view.View
+import android.widget.CheckBox
 import androidx.core.content.res.ResourcesCompat
+import androidx.core.text.toSpanned
 import androidx.lifecycle.lifecycleScope
 import autodagger.AutoInjector
 import coil.load
 import com.google.android.flexbox.FlexboxLayout
+import com.google.android.material.snackbar.Snackbar
 import com.nextcloud.android.common.ui.theme.utils.ColorRole
 import com.nextcloud.talk.R
 import com.nextcloud.talk.application.NextcloudTalkApplication
 import com.nextcloud.talk.application.NextcloudTalkApplication.Companion.sharedApplication
 import com.nextcloud.talk.chat.ChatActivity
+import com.nextcloud.talk.chat.data.ChatMessageRepository
 import com.nextcloud.talk.chat.data.model.ChatMessage
 import com.nextcloud.talk.data.network.NetworkMonitor
+import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.databinding.ItemCustomOutcomingTextMessageBinding
 import com.nextcloud.talk.models.json.chat.ReadStatus
 import com.nextcloud.talk.ui.theme.ViewThemeUtils
 import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.DateUtils
 import com.nextcloud.talk.utils.TextMatchers
+import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import com.nextcloud.talk.utils.message.MessageUtils
 import com.stfalcon.chatkit.messages.MessageHolders.OutcomingTextMessageViewHolder
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.Date
 import javax.inject.Inject
 
 @AutoInjector(NextcloudTalkApplication::class)
@@ -65,30 +73,32 @@ class OutcomingTextMessageViewHolder(itemView: View) :
 
     lateinit var commonMessageInterface: CommonMessageInterface
 
+    @Inject
+    lateinit var chatRepository: ChatMessageRepository
+
+    @Inject
+    lateinit var currentUserProvider: CurrentUserProviderNew
+
+    private var job: Job? = null
+
     @Suppress("Detekt.LongMethod")
     override fun onBind(message: ChatMessage) {
         super.onBind(message)
         sharedApplication!!.componentApplication.inject(this)
+        val user = currentUserProvider.currentUser.blockingGet()
+        val hasCheckboxes = processCheckboxes(
+            message,
+            user
+        )
+        processMessage(message, hasCheckboxes)
+    }
+
+    private fun processMessage(message: ChatMessage, hasCheckboxes: Boolean) {
         realView.isSelected = false
         val layoutParams = binding.messageTime.layoutParams as FlexboxLayout.LayoutParams
         layoutParams.isWrapBefore = false
-        var textSize = context.resources.getDimension(R.dimen.chat_text_size)
         viewThemeUtils.platform.colorTextView(binding.messageTime, ColorRole.ON_SURFACE_VARIANT)
-
-        var processedMessageText = messageUtils.enrichChatMessageText(
-            binding.messageText.context,
-            message,
-            false,
-            viewThemeUtils
-        )
-        processedMessageText = messageUtils.processMessageParameters(
-            binding.messageText.context,
-            viewThemeUtils,
-            processedMessageText!!,
-            message,
-            itemView
-        )
-
+        var textSize = context.resources.getDimension(R.dimen.chat_text_size)
         var isBubbled = true
         if (
             (message.messageParameters == null || message.messageParameters!!.size <= 0) &&
@@ -105,7 +115,25 @@ class OutcomingTextMessageViewHolder(itemView: View) :
         binding.messageText.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSize)
         binding.messageTime.layoutParams = layoutParams
         viewThemeUtils.platform.colorTextView(binding.messageText, ColorRole.ON_SURFACE_VARIANT)
-        binding.messageText.text = processedMessageText
+
+        if (!hasCheckboxes) {
+            var processedMessageText = messageUtils.enrichChatMessageText(
+                binding.messageText.context,
+                message,
+                false,
+                viewThemeUtils
+            )
+            processedMessageText = messageUtils.processMessageParameters(
+                binding.messageText.context,
+                viewThemeUtils,
+                processedMessageText!!,
+                message,
+                itemView
+            )
+            binding.messageText.text = processedMessageText
+        }else{
+            binding.messageText.text = ""
+        }
 
         if (message.lastEditTimestamp != 0L && !message.isDeleted) {
             binding.messageEditIndicator.visibility = View.VISIBLE
@@ -159,6 +187,94 @@ class OutcomingTextMessageViewHolder(itemView: View) :
             viewThemeUtils,
             isBubbled
         )
+    }
+
+    private fun processCheckboxes(chatMessage: ChatMessage, user: User): Boolean {
+        val message = chatMessage.message!!.toSpanned()
+        val messageTextView = binding.messageText
+        val checkBoxContainer = binding.checkboxContainer
+        val isOlderThanTwentyFourHours = chatMessage
+            .createdAt
+            .before(Date(System.currentTimeMillis() - AGE_THRESHOLD_FOR_EDIT_MESSAGE))
+
+        checkBoxContainer.removeAllViews()
+        val regex = """(- \[(X|x| )])\s*(.+)""".toRegex(RegexOption.MULTILINE)
+        val matches = regex.findAll(message)
+
+        if (matches.none()) return false
+
+        val firstPart = message.toString().substringBefore("\n- [")
+        messageTextView.text = messageUtils.enrichChatMessageText(
+            binding.messageText.context, firstPart, true, viewThemeUtils
+        )
+
+        val checkboxList = mutableListOf<CheckBox>()
+
+        matches.forEach { matchResult ->
+            val isChecked = matchResult.groupValues[CHECKED_GROUP_INDEX] == "X" ||
+                matchResult.groupValues[CHECKED_GROUP_INDEX] == "x"
+            val taskText = matchResult.groupValues[TASK_TEXT_GROUP_INDEX].trim()
+
+            val checkBox = CheckBox(checkBoxContainer.context).apply {
+                text = taskText
+                this.isChecked = isChecked
+                this.isEnabled = !isOlderThanTwentyFourHours
+                setOnCheckedChangeListener { _, _ ->
+                    updateCheckboxStates(chatMessage, user, checkboxList)
+                }
+            }
+            checkBoxContainer.addView(checkBox)
+            checkboxList.add(checkBox)
+            viewThemeUtils.platform.themeCheckbox(checkBox)
+        }
+
+        checkBoxContainer.visibility = View.VISIBLE
+        return true
+    }
+
+    private fun updateCheckboxStates(chatMessage: ChatMessage, user: User, checkboxes: List<CheckBox>) {
+        job = CoroutineScope(Dispatchers.Main).launch {
+            withContext(Dispatchers.IO) {
+                val apiVersion: Int = ApiUtils.getChatApiVersion(
+                    user.capabilities?.spreedCapability!!,
+                    intArrayOf(1)
+                )
+                val updatedMessage = updateMessageWithCheckboxStates(chatMessage.message!!, checkboxes)
+                chatRepository.editChatMessage(
+                    user.getCredentials(),
+                    ApiUtils.getUrlForChatMessage(apiVersion, user.baseUrl!!, chatMessage.token!!, chatMessage.id),
+                    updatedMessage
+                ).collect { result ->
+                    withContext(Dispatchers.Main) {
+                        if (result.isSuccess) {
+                            val editedMessage = result.getOrNull()?.ocs?.data!!.parentMessage!!
+                            Log.d(TAG, "EditedMessage: $editedMessage")
+                            binding.messageEditIndicator.apply {
+                                visibility = View.VISIBLE
+                            }
+                            binding.messageTime.text =
+                                dateUtils.getLocalTimeStringFromTimestamp(editedMessage.lastEditTimestamp!!)
+                        } else {
+                            Snackbar.make(binding.root, R.string.nc_common_error_sorry, Snackbar.LENGTH_LONG).show()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun updateMessageWithCheckboxStates(originalMessage: String, checkboxes: List<CheckBox>): String {
+        var updatedMessage = originalMessage
+        val regex = """(- \[(X|x| )])\s*(.+)""".toRegex(RegexOption.MULTILINE)
+
+        checkboxes.forEach { checkBox ->
+            updatedMessage = regex.replace(updatedMessage) { matchResult ->
+                val taskText = matchResult.groupValues[TASK_TEXT_GROUP_INDEX].trim()
+                val checkboxState = if (checkboxes.find { it.text == taskText }?.isChecked == true) "X" else " "
+                "- [$checkboxState] $taskText"
+            }
+        }
+        return updatedMessage
     }
 
     private fun updateStatus(readStatusDrawableInt: Int, description: String?) {
@@ -248,5 +364,8 @@ class OutcomingTextMessageViewHolder(itemView: View) :
     companion object {
         const val TEXT_SIZE_MULTIPLIER = 2.5
         private val TAG = OutcomingTextMessageViewHolder::class.java.simpleName
+        private const val CHECKED_GROUP_INDEX = 2
+        private const val TASK_TEXT_GROUP_INDEX = 3
+        private const val AGE_THRESHOLD_FOR_EDIT_MESSAGE: Long = 86400000
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
@@ -14,6 +14,7 @@ import android.util.Log
 import android.util.TypedValue
 import android.view.View
 import android.widget.CheckBox
+import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.text.toSpanned
 import androidx.lifecycle.lifecycleScope
@@ -148,6 +149,7 @@ class OutcomingTextMessageViewHolder(itemView: View) :
             binding.messageEditIndicator.visibility = View.GONE
             binding.messageTime.text = dateUtils.getLocalTimeStringFromTimestamp(message.timestamp)
         }
+        binding.messageTime.setTextColor(ContextCompat.getColor(context, R.color.no_emphasis_text))
         setBubbleOnChatMessage(message)
         // parent message handling
         if (!message.isDeleted && message.parentMessageId != null) {
@@ -236,6 +238,9 @@ class OutcomingTextMessageViewHolder(itemView: View) :
                 text = taskText
                 this.isChecked = isChecked
                 this.isEnabled = messageIsEditable || isNoTimeLimitOnNoteToSelf
+
+                setTextColor(ContextCompat.getColor(context, R.color.no_emphasis_text))
+
                 setOnCheckedChangeListener { _, _ ->
                     updateCheckboxStates(chatMessage, user, checkboxList)
                 }

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
@@ -94,29 +94,14 @@ class OutcomingTextMessageViewHolder(itemView: View) :
     }
 
     private fun processMessage(message: ChatMessage, hasCheckboxes: Boolean) {
-        realView.isSelected = false
-        val layoutParams = binding.messageTime.layoutParams as FlexboxLayout.LayoutParams
-        layoutParams.isWrapBefore = false
-        viewThemeUtils.platform.colorTextView(binding.messageTime, ColorRole.ON_SURFACE_VARIANT)
-        var textSize = context.resources.getDimension(R.dimen.chat_text_size)
         var isBubbled = true
-        if (
-            (message.messageParameters == null || message.messageParameters!!.size <= 0) &&
-            TextMatchers.isMessageWithSingleEmoticonOnly(message.text)
-        ) {
-            textSize = (textSize * TEXT_SIZE_MULTIPLIER).toFloat()
-            layoutParams.isWrapBefore = true
-            realView.isSelected = true
-            isBubbled = false
-        }
-
-        setBubbleOnChatMessage(message)
-
-        binding.messageText.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSize)
-        binding.messageTime.layoutParams = layoutParams
-        viewThemeUtils.platform.colorTextView(binding.messageText, ColorRole.ON_SURFACE_VARIANT)
-
         if (!hasCheckboxes) {
+            realView.isSelected = false
+            val layoutParams = binding.messageTime.layoutParams as FlexboxLayout.LayoutParams
+            layoutParams.isWrapBefore = false
+            var textSize = context.resources.getDimension(R.dimen.chat_text_size)
+            viewThemeUtils.platform.colorTextView(binding.messageTime, ColorRole.ON_SURFACE_VARIANT)
+
             var processedMessageText = messageUtils.enrichChatMessageText(
                 binding.messageText.context,
                 message,
@@ -130,7 +115,22 @@ class OutcomingTextMessageViewHolder(itemView: View) :
                 message,
                 itemView
             )
+
+            if (
+                (message.messageParameters == null || message.messageParameters!!.size <= 0) &&
+                TextMatchers.isMessageWithSingleEmoticonOnly(message.text)
+            ) {
+                textSize = (textSize * TEXT_SIZE_MULTIPLIER).toFloat()
+                layoutParams.isWrapBefore = true
+                realView.isSelected = true
+                isBubbled = false
+            }
+
+            binding.messageText.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSize)
+            binding.messageTime.layoutParams = layoutParams
+            viewThemeUtils.platform.colorTextView(binding.messageText, ColorRole.ON_SURFACE_VARIANT)
             binding.messageText.text = processedMessageText
+
         }else{
             binding.messageText.text = ""
         }
@@ -142,7 +142,7 @@ class OutcomingTextMessageViewHolder(itemView: View) :
             binding.messageEditIndicator.visibility = View.GONE
             binding.messageTime.text = dateUtils.getLocalTimeStringFromTimestamp(message.timestamp)
         }
-
+        setBubbleOnChatMessage(message)
         // parent message handling
         if (!message.isDeleted && message.parentMessageId != null) {
             processParentMessage(message)

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
@@ -96,6 +96,7 @@ class OutcomingTextMessageViewHolder(itemView: View) :
         processMessage(message, hasCheckboxes)
     }
 
+    @Suppress("Detekt.LongMethod")
     private fun processMessage(message: ChatMessage, hasCheckboxes: Boolean) {
         var isBubbled = true
         val layoutParams = binding.messageTime.layoutParams as FlexboxLayout.LayoutParams

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
@@ -95,12 +95,15 @@ class OutcomingTextMessageViewHolder(itemView: View) :
 
     private fun processMessage(message: ChatMessage, hasCheckboxes: Boolean) {
         var isBubbled = true
+        val layoutParams = binding.messageTime.layoutParams as FlexboxLayout.LayoutParams
+        var textSize = context.resources.getDimension(R.dimen.chat_text_size)
         if (!hasCheckboxes) {
             realView.isSelected = false
-            val layoutParams = binding.messageTime.layoutParams as FlexboxLayout.LayoutParams
             layoutParams.isWrapBefore = false
-            var textSize = context.resources.getDimension(R.dimen.chat_text_size)
             viewThemeUtils.platform.colorTextView(binding.messageTime, ColorRole.ON_SURFACE_VARIANT)
+
+            binding.messageText.visibility = View.VISIBLE
+            binding.checkboxContainer.visibility = View.GONE
 
             var processedMessageText = messageUtils.enrichChatMessageText(
                 binding.messageText.context,
@@ -126,15 +129,15 @@ class OutcomingTextMessageViewHolder(itemView: View) :
                 isBubbled = false
             }
 
-            binding.messageText.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSize)
             binding.messageTime.layoutParams = layoutParams
             viewThemeUtils.platform.colorTextView(binding.messageText, ColorRole.ON_SURFACE_VARIANT)
             binding.messageText.text = processedMessageText
 
         }else{
-            binding.messageText.text = ""
+            binding.messageText.visibility = View.GONE
+            binding.checkboxContainer.visibility = View.VISIBLE
         }
-
+        binding.messageText.setTextSize(TypedValue.COMPLEX_UNIT_PX, textSize)
         if (message.lastEditTimestamp != 0L && !message.isDeleted) {
             binding.messageEditIndicator.visibility = View.VISIBLE
             binding.messageTime.text = dateUtils.getLocalTimeStringFromTimestamp(message.lastEditTimestamp!!)
@@ -267,7 +270,7 @@ class OutcomingTextMessageViewHolder(itemView: View) :
         var updatedMessage = originalMessage
         val regex = """(- \[(X|x| )])\s*(.+)""".toRegex(RegexOption.MULTILINE)
 
-        checkboxes.forEach { checkBox ->
+        checkboxes.forEach { _ ->
             updatedMessage = regex.replace(updatedMessage) { matchResult ->
                 val taskText = matchResult.groupValues[TASK_TEXT_GROUP_INDEX].trim()
                 val checkboxState = if (checkboxes.find { it.text == taskText }?.isChecked == true) "X" else " "
@@ -359,6 +362,11 @@ class OutcomingTextMessageViewHolder(itemView: View) :
 
     fun assignCommonMessageInterface(commonMessageInterface: CommonMessageInterface) {
         this.commonMessageInterface = commonMessageInterface
+    }
+
+    override fun viewDetached() {
+        super.viewDetached()
+        job?.cancel()
     }
 
     companion object {

--- a/app/src/main/java/com/nextcloud/talk/utils/message/MessageUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/message/MessageUtils.kt
@@ -65,7 +65,7 @@ class MessageUtils(val context: Context) {
         }
     }
 
-    private fun enrichChatMessageText(
+    fun enrichChatMessageText(
         context: Context,
         message: String,
         incoming: Boolean,

--- a/app/src/main/res/layout/item_custom_incoming_text_message.xml
+++ b/app/src/main/res/layout/item_custom_incoming_text_message.xml
@@ -64,11 +64,20 @@
             app:layout_wrapBefore="true"
             tools:text="Talk to you later!" />
 
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:layout_marginStart="8dp"
+            android:gravity="end"
+            android:orientation="horizontal"
+            android:layout_below="@id/messageText"
+            app:layout_alignSelf="flex_end">
+
         <TextView
             android:id="@id/messageTime"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@id/messageText"
             android:layout_marginStart="8dp"
             android:alpha="0.6"
             android:textColor="@color/no_emphasis_text"
@@ -84,7 +93,6 @@
             android:id="@+id/messageEditIndicator"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@id/messageText"
             android:layout_marginStart="8dp"
             android:gravity="end"
             android:alpha="0.6"
@@ -95,6 +103,7 @@
             android:textSize="12sp">
 
         </TextView>
+        </LinearLayout>
 
         <include
             android:id="@+id/reactions"

--- a/app/src/main/res/layout/item_custom_incoming_text_message.xml
+++ b/app/src/main/res/layout/item_custom_incoming_text_message.xml
@@ -93,8 +93,8 @@
             android:textColor="@color/no_emphasis_text"
             android:textIsSelectable="false"
             android:gravity = "end"
-            app:layout_alignSelf="flex_end"
             app:layout_flexGrow="1"
+            app:layout_alignSelf="flex_end"
             app:layout_wrapBefore="false"
             tools:text="12:38" />
 
@@ -110,7 +110,6 @@
             app:layout_alignSelf="flex_end"
             android:text = "@string/hint_edited_message"
             android:textSize="12sp">
-
         </TextView>
         </LinearLayout>
 

--- a/app/src/main/res/layout/item_custom_incoming_text_message.xml
+++ b/app/src/main/res/layout/item_custom_incoming_text_message.xml
@@ -64,6 +64,16 @@
             app:layout_wrapBefore="true"
             tools:text="Talk to you later!" />
 
+
+        <LinearLayout
+            android:id="@+id/checkboxContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_below="@id/messageText">
+
+        </LinearLayout>
+
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -94,7 +104,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
-            android:gravity="end"
             android:alpha="0.6"
             android:textColor="@color/no_emphasis_text"
             android:textIsSelectable="false"

--- a/app/src/main/res/layout/item_custom_incoming_text_message.xml
+++ b/app/src/main/res/layout/item_custom_incoming_text_message.xml
@@ -74,25 +74,17 @@
 
         </LinearLayout>
 
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:layout_marginStart="8dp"
-            android:gravity="end"
-            android:orientation="horizontal"
-            android:layout_below="@id/messageText"
-            app:layout_alignSelf="flex_end">
-
         <TextView
             android:id="@id/messageTime"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_below="@id/messageText"
             android:layout_marginStart="8dp"
             android:alpha="0.6"
             android:textColor="@color/no_emphasis_text"
             android:textIsSelectable="false"
-            android:gravity = "end"
+            android:gravity="end"
+            app:layout_alignSelf="center"
             app:layout_flexGrow="1"
             app:layout_alignSelf="flex_end"
             app:layout_wrapBefore="false"
@@ -103,6 +95,7 @@
             android:id="@+id/messageEditIndicator"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_below="@id/messageText"
             android:layout_marginStart="8dp"
             android:alpha="0.6"
             android:textColor="@color/no_emphasis_text"
@@ -111,7 +104,6 @@
             android:text = "@string/hint_edited_message"
             android:textSize="12sp">
         </TextView>
-        </LinearLayout>
 
         <include
             android:id="@+id/reactions"

--- a/app/src/main/res/layout/item_custom_incoming_text_message.xml
+++ b/app/src/main/res/layout/item_custom_incoming_text_message.xml
@@ -67,11 +67,12 @@
 
         <LinearLayout
             android:id="@+id/checkboxContainer"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            android:layout_below="@id/messageText">
-
+            android:layout_below="@id/messageText"
+            android:layout_marginBottom="8dp"
+            android:visibility="gone">
         </LinearLayout>
 
         <TextView
@@ -84,9 +85,8 @@
             android:textColor="@color/no_emphasis_text"
             android:textIsSelectable="false"
             android:gravity="end"
-            app:layout_alignSelf="center"
-            app:layout_flexGrow="1"
             app:layout_alignSelf="flex_end"
+            app:layout_flexGrow="1"
             app:layout_wrapBefore="false"
             tools:text="12:38" />
 

--- a/app/src/main/res/layout/item_custom_outcoming_text_message.xml
+++ b/app/src/main/res/layout/item_custom_outcoming_text_message.xml
@@ -43,6 +43,17 @@
             android:textIsSelectable="false"
             tools:text="Talk to you later!" />
 
+        <LinearLayout
+            android:id="@+id/checkboxContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_below="@id/messageText"
+            android:layout_marginTop="8dp"
+            android:visibility="gone">
+
+        </LinearLayout>
+
         <TextView
             android:id="@id/messageTime"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_custom_outcoming_text_message.xml
+++ b/app/src/main/res/layout/item_custom_outcoming_text_message.xml
@@ -41,15 +41,17 @@
             android:textAlignment="viewStart"
             android:textColorHighlight="@color/nc_grey"
             android:textIsSelectable="false"
+            app:layout_alignSelf="flex_start"
+            app:layout_flexGrow="1"
             tools:text="Talk to you later!" />
 
         <LinearLayout
             android:id="@+id/checkboxContainer"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
+            android:layout_marginBottom="8dp"
             android:layout_below="@id/messageText"
-            android:layout_marginTop="8dp"
             android:visibility="gone">
 
         </LinearLayout>
@@ -65,7 +67,6 @@
             android:textColor="@color/no_emphasis_text"
             android:textIsSelectable="false"
             app:layout_alignSelf="flex_end"
-            android:layout_gravity="end"
             app:layout_flexGrow="1"
             app:layout_wrapBefore="false"
             tools:text="10:35" />
@@ -79,7 +80,6 @@
             android:alpha="0.6"
             android:textColor="@color/no_emphasis_text"
             android:textIsSelectable="false"
-            android:gravity="end"
             app:layout_alignSelf="flex_end"
             android:text = "@string/hint_edited_message"
             android:textSize="12sp">
@@ -94,7 +94,6 @@
             android:layout_marginStart="8dp"
             android:contentDescription="@null"
             app:layout_alignSelf="flex_end"
-            android:gravity="end"
             app:tint="@color/high_emphasis_text"
             tools:src="@drawable/ic_check_all" />
 
@@ -105,7 +104,7 @@
             android:layout_below="@id/messageTime"
             android:layout_marginStart="8dp"
             android:contentDescription="@null"
-            app:layout_alignSelf="center"
+            app:layout_alignSelf="flex_end"
             app:tint="@color/high_emphasis_text"
             tools:src="@drawable/ic_warning_white"/>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -588,7 +588,7 @@ How to translate with transifex:
     <string name="nc_phone_book_integration_chat_via">Chat via %s</string>
     <string name="nc_phone_book_integration_account_not_found">Account not found</string>
     <string name= "nc_edit">Edit</string>
-
+    <string name="edited_by">(edited by %1$s)</string>
     <!--  save feature -->
     <string name="nc_save_message">Save</string>
     <string name="nc_dialog_save_to_storage_title">Save to storage?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -588,7 +588,7 @@ How to translate with transifex:
     <string name="nc_phone_book_integration_chat_via">Chat via %s</string>
     <string name="nc_phone_book_integration_account_not_found">Account not found</string>
     <string name= "nc_edit">Edit</string>
-    <string name="edited_by">(edited by %1$s)</string>
+
     <!--  save feature -->
     <string name="nc_save_message">Save</string>
     <string name="nc_dialog_save_to_storage_title">Save to storage?</string>


### PR DESCRIPTION
Resolve #4806

- [X] Allow directly editing (tick/untick) checkboxes in the chat message and time limit is 24 hours.
- [X] Allow directly editing checkboxes in the chat message of note to self conversations and time limit is unlimited.
- [X] In group conversations, moderators and the author of a message can edit a checkbox.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot_20250317-162400](https://github.com/user-attachments/assets/de5a39eb-b500-4e05-a651-48b0c6828fc0) | ![Screenshot_20250317-162045](https://github.com/user-attachments/assets/2231f4d9-40c3-4dcb-ba72-bc8f95ee9857)


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)