### PR TITLE
show a snackbar with meaningful message when server is in maintenance mode.

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -1878,7 +1878,7 @@ class ConversationsListActivity :
             binding.floatingActionButton.let {
                 Snackbar.make(
                     binding.root,
-                    R.string.nc_dialog_maintenance_mode_description,
+                    R.string.maintenance_mode_description,
                     Snackbar.LENGTH_LONG
                 ).show()
             }

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -1876,42 +1876,11 @@ class ConversationsListActivity :
     private fun showServiceUnavailableDialog(httpException: HttpException) {
         if (httpException.response()?.headers()?.get(MAINTENANCE_MODE_HEADER_KEY) == "1") {
             binding.floatingActionButton.let {
-                val dialogBuilder = MaterialAlertDialogBuilder(it.context)
-                    .setIcon(
-                        viewThemeUtils.dialog.colorMaterialAlertDialogIcon(
-                            context,
-                            R.drawable.ic_info_white_24dp
-                        )
-                    )
-                    .setTitle(R.string.nc_dialog_maintenance_mode)
-                    .setMessage(R.string.nc_dialog_maintenance_mode_description)
-                    .setCancelable(false)
-                    .setNegativeButton(R.string.nc_settings_remove_account) { _, _ ->
-                        deleteUserAndRestartApp()
-                    }
-
-                if (resources!!.getBoolean(R.bool.multiaccount_support) && userManager.users.blockingGet().size > 1) {
-                    dialogBuilder.setPositiveButton(R.string.nc_switch_account) { _, _ ->
-                        val newFragment: DialogFragment = ChooseAccountDialogFragment.newInstance()
-                        newFragment.show(supportFragmentManager, ChooseAccountDialogFragment.TAG)
-                    }
-                }
-
-                if (resources!!.getBoolean(R.bool.multiaccount_support)) {
-                    dialogBuilder.setNeutralButton(R.string.nc_account_chooser_add_account) { _, _ ->
-                        val intent = Intent(this, ServerSelectionActivity::class.java)
-                        intent.putExtra(ADD_ADDITIONAL_ACCOUNT, true)
-                        startActivity(intent)
-                    }
-                }
-
-                viewThemeUtils.dialog.colorMaterialAlertDialogBackground(it.context, dialogBuilder)
-                val dialog = dialogBuilder.show()
-                viewThemeUtils.platform.colorTextButtons(
-                    dialog.getButton(AlertDialog.BUTTON_POSITIVE),
-                    dialog.getButton(AlertDialog.BUTTON_NEGATIVE),
-                    dialog.getButton(AlertDialog.BUTTON_NEUTRAL)
-                )
+                Snackbar.make(
+                    binding.root,
+                    R.string.nc_dialog_maintenance_mode_description,
+                    Snackbar.LENGTH_LONG
+                ).show()
             }
         } else {
             showErrorDialog()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -656,8 +656,7 @@ How to translate with transifex:
     <string name="nc_dialog_outdated_client_description">The app is too old and no longer supported by this server. Please update.</string>
     <string name="nc_dialog_outdated_client_option_update">Update</string>
     <string name="nc_switch_account">Switch account</string>
-    <string name="nc_dialog_maintenance_mode_description">Server is currently in maintenance mode. Please try again
-        later.</string>
+    <string name="maintenance_mode_description">Server is currently in maintenance mode. Please try again later</string>
 
     <!-- Take photo -->
     <string name="take_photo">Take a photo</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -656,8 +656,8 @@ How to translate with transifex:
     <string name="nc_dialog_outdated_client_description">The app is too old and no longer supported by this server. Please update.</string>
     <string name="nc_dialog_outdated_client_option_update">Update</string>
     <string name="nc_switch_account">Switch account</string>
-    <string name="nc_dialog_maintenance_mode">Maintenance mode</string>
-    <string name="nc_dialog_maintenance_mode_description">Server is currently in maintenance mode.</string>
+    <string name="nc_dialog_maintenance_mode_description">Server is currently in maintenance mode. Please try again
+        later.</string>
 
     <!-- Take photo -->
     <string name="take_photo">Take a photo</string>


### PR DESCRIPTION
Resolve #2737

Show a snackbar with meaningful message when the server is in maintenance mode instead of dialog to perform add or remove account operations. While these options are available already in UI even when the server is in maintenance mode, a simple snackbar can be used.

![server_maintenance_mode](https://github.com/user-attachments/assets/378957c9-cae4-4bbf-b06f-96ddaaa8f438)



### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)