### PR TITLE
show maintenance warning in conv list on top

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -1045,6 +1045,10 @@ class ConversationsListActivity :
         binding.chatListConnectionLost.visibility = if (show) View.VISIBLE else View.GONE
     }
 
+    private fun showMaintenanceModeWarning(show: Boolean) {
+        binding.chatListMaintenanceWarning.visibility = if (show) View.VISIBLE else View.GONE
+    }
+
     private fun handleUI(show: Boolean) {
         binding.floatingActionButton.isEnabled = show
         binding.searchText.isEnabled = show
@@ -1133,6 +1137,8 @@ class ConversationsListActivity :
     private fun prepareViews() {
         hideLogoForBrandedClients()
 
+        showMaintenanceModeWarning(false)
+
         layoutManager = SmoothScrollLinearLayoutManager(this)
         binding.recyclerView.layoutManager = layoutManager
         binding.recyclerView.setHasFixedSize(true)
@@ -1156,6 +1162,7 @@ class ConversationsListActivity :
             false
         }
         binding.swipeRefreshLayoutView.setOnRefreshListener {
+            showMaintenanceModeWarning(false)
             fetchRooms()
             fetchPendingInvitations()
         }
@@ -1931,44 +1938,7 @@ class ConversationsListActivity :
 
     private fun showServiceUnavailableDialog(httpException: HttpException) {
         if (httpException.response()?.headers()?.get(MAINTENANCE_MODE_HEADER_KEY) == "1") {
-            binding.floatingActionButton.let {
-                val dialogBuilder = MaterialAlertDialogBuilder(it.context)
-                    .setIcon(
-                        viewThemeUtils.dialog.colorMaterialAlertDialogIcon(
-                            context,
-                            R.drawable.ic_info_white_24dp
-                        )
-                    )
-                    .setTitle(R.string.nc_dialog_maintenance_mode)
-                    .setMessage(R.string.nc_dialog_maintenance_mode_description)
-                    .setCancelable(false)
-                    .setNegativeButton(R.string.nc_settings_remove_account) { _, _ ->
-                        deleteUserAndRestartApp()
-                    }
-
-                if (resources!!.getBoolean(R.bool.multiaccount_support) && userManager.users.blockingGet().size > 1) {
-                    dialogBuilder.setPositiveButton(R.string.nc_switch_account) { _, _ ->
-                        val newFragment: DialogFragment = ChooseAccountDialogFragment.newInstance()
-                        newFragment.show(supportFragmentManager, ChooseAccountDialogFragment.TAG)
-                    }
-                }
-
-                if (resources!!.getBoolean(R.bool.multiaccount_support)) {
-                    dialogBuilder.setNeutralButton(R.string.nc_account_chooser_add_account) { _, _ ->
-                        val intent = Intent(this, ServerSelectionActivity::class.java)
-                        intent.putExtra(ADD_ADDITIONAL_ACCOUNT, true)
-                        startActivity(intent)
-                    }
-                }
-
-                viewThemeUtils.dialog.colorMaterialAlertDialogBackground(it.context, dialogBuilder)
-                val dialog = dialogBuilder.show()
-                viewThemeUtils.platform.colorTextButtons(
-                    dialog.getButton(AlertDialog.BUTTON_POSITIVE),
-                    dialog.getButton(AlertDialog.BUTTON_NEGATIVE),
-                    dialog.getButton(AlertDialog.BUTTON_NEUTRAL)
-                )
-            }
+            showMaintenanceModeWarning(true)
         } else {
             showErrorDialog()
         }

--- a/app/src/main/res/layout/activity_conversations.xml
+++ b/app/src/main/res/layout/activity_conversations.xml
@@ -37,6 +37,17 @@
             android:visibility="gone"
             tools:visibility="visible" />
 
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/chat_list_maintenance_warning"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/hwSecurityRed"
+            android:gravity="center"
+            android:text="@string/nc_dialog_maintenance_mode_description"
+            android:textColor="@color/white"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/search_toolbar"
             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -652,7 +652,6 @@ How to translate with transifex:
     <string name="nc_dialog_outdated_client_description">The app is too old and no longer supported by this server. Please update.</string>
     <string name="nc_dialog_outdated_client_option_update">Update</string>
     <string name="nc_switch_account">Switch account</string>
-    <string name="nc_dialog_maintenance_mode">Maintenance mode</string>
     <string name="nc_dialog_maintenance_mode_description">Server is currently in maintenance mode.</string>
 
     <!-- Take photo -->


### PR DESCRIPTION
Resolve https://github.com/nextcloud/talk-android/issues/2737 (and replace https://github.com/nextcloud/talk-android/pull/4760)

Since offline support it makes more sense to view this as a permanent warning on top, which still allows to see all offline saved conversations. The actions are still available via account switcher.

before | after
------- | -------- 
![grafik](https://github.com/user-attachments/assets/2e6163a0-51c5-44cc-8f25-6bbc8f2761a3) | ![grafik](https://github.com/user-attachments/assets/6c7414fc-06ee-4ff6-adba-ce61ca65d6c3) 

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)