### PR TITLE
Bugfix/4779/color status bar

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/components/SetStatusBarColor.kt
+++ b/app/src/main/java/com/nextcloud/talk/components/SetStatusBarColor.kt
@@ -10,20 +10,18 @@ package com.nextcloud.talk.components
 
 import android.app.Activity
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.graphics.toArgb
-
 import androidx.compose.ui.platform.LocalView
-import androidx.compose.ui.res.colorResource
 import androidx.core.view.WindowCompat
-import com.nextcloud.talk.R
 
 @Composable
 fun SetStatusBarColor() {
     val view = LocalView.current
     val isDarkMod = isSystemInDarkTheme()
-    val statusBarColor = colorResource(R.color.bg_default).toArgb()
+    val statusBarColor = MaterialTheme.colorScheme.surface.toArgb()
 
     DisposableEffect(isDarkMod) {
         val activity = view.context as Activity

--- a/app/src/main/java/com/nextcloud/talk/components/SetStatusBarColor.kt
+++ b/app/src/main/java/com/nextcloud/talk/components/SetStatusBarColor.kt
@@ -20,15 +20,16 @@ import androidx.core.view.WindowCompat
 @Composable
 fun SetStatusBarColor() {
     val view = LocalView.current
-    val isDarkMod = isSystemInDarkTheme()
+    val isDarkMode = isSystemInDarkTheme()
     val statusBarColor = MaterialTheme.colorScheme.surface.toArgb()
 
-    DisposableEffect(isDarkMod) {
+    DisposableEffect(isDarkMode) {
         val activity = view.context as Activity
         activity.window.statusBarColor = statusBarColor
 
         WindowCompat.getInsetsController(activity.window, activity.window.decorView).apply {
-            isAppearanceLightStatusBars = !isDarkMod
+            isAppearanceLightStatusBars = !isDarkMode
+            isAppearanceLightNavigationBars = !isDarkMode
         }
         onDispose { }
     }

--- a/app/src/main/java/com/nextcloud/talk/components/SetupSystemBars.kt
+++ b/app/src/main/java/com/nextcloud/talk/components/SetupSystemBars.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
 @Composable
-fun SetStatusBarColor() {
+fun SetupSystemBars() {
     val view = LocalView.current
     val isDarkMode = isSystemInDarkTheme()
     val statusBarColor = MaterialTheme.colorScheme.surface.toArgb()

--- a/app/src/main/java/com/nextcloud/talk/contacts/ContactsActivityCompose.kt
+++ b/app/src/main/java/com/nextcloud/talk/contacts/ContactsActivityCompose.kt
@@ -68,9 +68,8 @@ class ContactsActivityCompose : BaseActivity() {
                     contactsViewModel = contactsViewModel,
                     uiState = uiState.value
                 )
+                SetStatusBarColor()
             }
-
-            SetStatusBarColor()
         }
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/contacts/ContactsActivityCompose.kt
+++ b/app/src/main/java/com/nextcloud/talk/contacts/ContactsActivityCompose.kt
@@ -19,7 +19,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import autodagger.AutoInjector
 import com.nextcloud.talk.activities.BaseActivity
 import com.nextcloud.talk.application.NextcloudTalkApplication
-import com.nextcloud.talk.components.SetStatusBarColor
+import com.nextcloud.talk.components.SetupSystemBars
 import com.nextcloud.talk.models.json.autocomplete.AutocompleteUser
 import javax.inject.Inject
 
@@ -68,7 +68,7 @@ class ContactsActivityCompose : BaseActivity() {
                     contactsViewModel = contactsViewModel,
                     uiState = uiState.value
                 )
-                SetStatusBarColor()
+                SetupSystemBars()
             }
         }
     }

--- a/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationActivity.kt
@@ -2,6 +2,7 @@
  * Nextcloud Talk - Android Client
  *
  * SPDX-FileCopyrightText: 2024 Sowjanya Kota <sowjanya.kch@gmail.com>
+ * SPDX-FileCopyrightText: 2025 Marcel Hibbe <dev@mhibbe.de>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
@@ -22,7 +23,6 @@ import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -58,7 +58,6 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -70,7 +69,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -79,7 +77,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
-import androidx.core.view.WindowCompat
 import androidx.lifecycle.ViewModelProvider
 import autodagger.AutoInjector
 import coil.compose.AsyncImage
@@ -87,6 +84,7 @@ import com.nextcloud.talk.R
 import com.nextcloud.talk.activities.BaseActivity
 import com.nextcloud.talk.application.NextcloudTalkApplication
 import com.nextcloud.talk.chat.ChatActivity
+import com.nextcloud.talk.components.SetStatusBarColor
 import com.nextcloud.talk.contacts.ContactsActivityCompose
 import com.nextcloud.talk.contacts.loadImage
 import com.nextcloud.talk.models.json.autocomplete.AutocompleteUser
@@ -118,26 +116,9 @@ class ConversationCreationActivity : BaseActivity() {
                 colorScheme = colorScheme
             ) {
                 ConversationCreationScreen(conversationCreationViewModel, context, pickImage)
+                SetStatusBarColor()
             }
-            SetStatusBarColor()
         }
-    }
-}
-
-@Composable
-private fun SetStatusBarColor() {
-    val view = LocalView.current
-    val isDarkMod = isSystemInDarkTheme()
-
-    DisposableEffect(isDarkMod) {
-        val activity = view.context as Activity
-        activity.window.statusBarColor = activity.getColor(R.color.bg_default)
-
-        WindowCompat.getInsetsController(activity.window, activity.window.decorView).apply {
-            isAppearanceLightStatusBars = !isDarkMod
-        }
-
-        onDispose { }
     }
 }
 

--- a/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationActivity.kt
@@ -84,7 +84,7 @@ import com.nextcloud.talk.R
 import com.nextcloud.talk.activities.BaseActivity
 import com.nextcloud.talk.application.NextcloudTalkApplication
 import com.nextcloud.talk.chat.ChatActivity
-import com.nextcloud.talk.components.SetStatusBarColor
+import com.nextcloud.talk.components.SetupSystemBars
 import com.nextcloud.talk.contacts.ContactsActivityCompose
 import com.nextcloud.talk.contacts.loadImage
 import com.nextcloud.talk.models.json.autocomplete.AutocompleteUser
@@ -116,7 +116,7 @@ class ConversationCreationActivity : BaseActivity() {
                 colorScheme = colorScheme
             ) {
                 ConversationCreationScreen(conversationCreationViewModel, context, pickImage)
-                SetStatusBarColor()
+                SetupSystemBars()
             }
         }
     }

--- a/app/src/main/java/com/nextcloud/talk/diagnose/DiagnoseActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/diagnose/DiagnoseActivity.kt
@@ -36,7 +36,7 @@ import com.nextcloud.talk.api.NcApi
 import com.nextcloud.talk.application.NextcloudTalkApplication
 import com.nextcloud.talk.arbitrarystorage.ArbitraryStorageManager
 import com.nextcloud.talk.components.StandardAppBar
-import com.nextcloud.talk.components.SetStatusBarColor
+import com.nextcloud.talk.components.SetupSystemBars
 import com.nextcloud.talk.users.UserManager
 import com.nextcloud.talk.utils.BrandingUtils
 import com.nextcloud.talk.utils.ClosedInterfaceImpl
@@ -117,7 +117,7 @@ class DiagnoseActivity : BaseActivity() {
                         }
                     }
                 )
-                SetStatusBarColor()
+                SetupSystemBars()
             }
         }
     }

--- a/app/src/main/java/com/nextcloud/talk/diagnose/DiagnoseActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/diagnose/DiagnoseActivity.kt
@@ -117,9 +117,8 @@ class DiagnoseActivity : BaseActivity() {
                         }
                     }
                 )
+                SetStatusBarColor()
             }
-
-            SetStatusBarColor()
         }
     }
 


### PR DESCRIPTION
fix #4779

Fix color of status bar and navigation bar buttons color for Compose Screens.

### 🖼️ Screenshots

example for Conversation Creation Screen:

| before | after |
|---|---|
|![grafik](https://github.com/user-attachments/assets/615eb80b-162f-4282-b497-923205509330)|![grafik](https://github.com/user-attachments/assets/f610e51f-0a4a-4155-af4a-c2d6d653a991)|

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)