### PR TITLE
Fixing NPE in ConversationInfoActivity

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
@@ -195,6 +195,18 @@ class ConversationInfoActivity :
         binding.addParticipantsAction.setOnClickListener { addParticipants() }
         binding.listBansButton.setOnClickListener { listBans() }
 
+        updateRoomAndCapabilities()
+
+        themeTextViews()
+        themeSwitchPreferences()
+
+        binding.addParticipantsAction.visibility = GONE
+
+        binding.progressBar.let { viewThemeUtils.platform.colorCircularProgressBar(it, ColorRole.PRIMARY) }
+        initObservers()
+    }
+
+    private fun updateRoomAndCapabilities() {
         CoroutineScope(Dispatchers.IO).launch {
             val model = viewModel.getRoomBlocking(conversationUser, conversationToken)
             spreedCapabilities = viewModel.getCapabilitiesBlocking(conversationUser, conversationToken, model)
@@ -218,15 +230,11 @@ class ConversationInfoActivity :
 
                 handleConversation()
             }
+        }.invokeOnCompletion { cause ->
+            if (cause != null) {
+                Log.d(TAG, "Error retrieving room and capabilities $cause")
+            }
         }
-
-        themeTextViews()
-        themeSwitchPreferences()
-
-        binding.addParticipantsAction.visibility = GONE
-
-        binding.progressBar.let { viewThemeUtils.platform.colorCircularProgressBar(it, ColorRole.PRIMARY) }
-        initObservers()
     }
 
     private fun initObservers() {
@@ -800,8 +808,9 @@ class ConversationInfoActivity :
                     binding.archiveConversationText.text = resources.getString(R.string.unarchive_conversation)
                     binding.archiveConversationTextHint.text = resources.getString(R.string.unarchive_hint)
                 }
+            }.invokeOnCompletion {
+                updateRoomAndCapabilities()
             }
-            viewModel.getRoom(conversationUser, conversationToken)
         }
 
         if (conversation!!.hasArchived) {

--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/viewmodel/ConversationInfoViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/viewmodel/ConversationInfoViewModel.kt
@@ -120,6 +120,9 @@ class ConversationInfoViewModel @Inject constructor(
             ?.subscribe(GetRoomObserver())
     }
 
+    fun getRoomBlocking(user: User, token: String): ConversationModel =
+        chatNetworkDataSource.getRoom(user, token).blockingFirst()
+
     fun getCapabilities(user: User, token: String, conversationModel: ConversationModel) {
         _getCapabilitiesViewState.value = GetCapabilitiesStartState
 
@@ -147,6 +150,14 @@ class ConversationInfoViewModel @Inject constructor(
                         // unused atm
                     }
                 })
+        }
+    }
+
+    fun getCapabilitiesBlocking(user: User, token: String, conversationModel: ConversationModel): SpreedCapability {
+        return if (conversationModel.remoteServer.isNullOrEmpty()) {
+            user.capabilities!!.spreedCapability!!
+        } else {
+            chatNetworkDataSource.getCapabilities(user, token).blockingFirst()
         }
     }
 


### PR DESCRIPTION
- tries to fix #4750 

Made the room and capabilities logic synchronous. I don't think there was a race condition, although I didn't verify, but rather I'm leaning towards `conversation` being overwritten twice, perhaps a double call of the `ChatNetworkDataSource.getRoom`? 

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)