### PR TITLE
Fixing duplicate messages

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -211,7 +211,6 @@ import java.util.Date
 import java.util.Locale
 import java.util.concurrent.ExecutionException
 import javax.inject.Inject
-import kotlin.collections.set
 import kotlin.math.roundToInt
 
 @AutoInjector(NextcloudTalkApplication::class)
@@ -785,7 +784,7 @@ class ChatActivity :
                 .onEach { triple ->
                     val lookIntoFuture = triple.first
                     val setUnreadMessagesMarker = triple.second
-                    var chatMessageList = triple.third
+                    var chatMessageList = triple.third.filterDuplicates()
 
                     chatMessageList = handleSystemMessages(chatMessageList)
                     if (chatMessageList.isEmpty()) {
@@ -2730,6 +2729,17 @@ class ChatActivity :
             (message2.actorId == message1.actorId) &&
             (!isLessThan5Min) &&
             (message2.lastEditTimestamp == 0L || message1.lastEditTimestamp == 0L)
+    }
+
+    private fun List<ChatMessage>.filterDuplicates(): List<ChatMessage> {
+        val newlist = mutableListOf<ChatMessage>()
+        val currentList = adapter!!.items.filter { it.item is ChatMessage }.map { it.item as ChatMessage }.reversed()
+        for (message in this) {
+            if (!currentList.any { it.id == message.id }) {
+                newlist.add(message)
+            }
+        }
+        return newlist
     }
 
     private fun determinePreviousMessageIds(chatMessageList: List<ChatMessage>) {


### PR DESCRIPTION
- fixes #4764 

> workaround with duplicate filtering, underlying issue still exists

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)