### PR TITLE
Add new photo picker

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
@@ -402,6 +402,11 @@ class MessageInputFragment : Fragment() {
             AttachmentDialog(requireActivity(), requireActivity() as ChatActivity).show()
         }
 
+        binding.fragmentMessageInputView.attachmentButton.setOnLongClickListener {
+            chatActivity.showGalleryPicker()
+            true
+        }
+
         binding.fragmentMessageInputView.button?.setOnClickListener {
             submitMessage(false)
         }

--- a/app/src/main/java/com/nextcloud/talk/jobs/UploadAndShareFilesWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/UploadAndShareFilesWorker.kt
@@ -89,16 +89,6 @@ class UploadAndShareFilesWorker(val context: Context, workerParameters: WorkerPa
     override fun doWork(): Result {
         NextcloudTalkApplication.sharedApplication!!.componentApplication.inject(this)
 
-        if (!platformPermissionUtil.isFilesPermissionGranted()) {
-            Log.w(
-                TAG,
-                "Storage permission is not granted. As a developer please make sure you check for" +
-                    "permissions via UploadAndShareFilesWorker.isStoragePermissionGranted() and " +
-                    "UploadAndShareFilesWorker.requestStoragePermission() beforehand. If you already " +
-                    "did but end up with this warning, the user most likely revoked the permission"
-            )
-        }
-
         return try {
             currentUser = currentUserProvider.currentUser.blockingGet()
             val sourceFile = inputData.getString(DEVICE_SOURCE_FILE)

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/AttachmentDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/AttachmentDialog.kt
@@ -20,8 +20,8 @@ import com.nextcloud.talk.application.NextcloudTalkApplication
 import com.nextcloud.talk.chat.ChatActivity
 import com.nextcloud.talk.databinding.DialogAttachmentBinding
 import com.nextcloud.talk.ui.theme.ViewThemeUtils
-import com.nextcloud.talk.utils.SpreedFeatures
 import com.nextcloud.talk.utils.CapabilitiesUtil
+import com.nextcloud.talk.utils.SpreedFeatures
 import javax.inject.Inject
 
 @AutoInjector(NextcloudTalkApplication::class)
@@ -89,6 +89,11 @@ class AttachmentDialog(val activity: Activity, var chatActivity: ChatActivity) :
     private fun initItemsClickListeners() {
         dialogAttachmentBinding.menuShareLocation.setOnClickListener {
             chatActivity.showShareLocationScreen()
+            dismiss()
+        }
+
+        dialogAttachmentBinding.menuAttachFileFromGallery.setOnClickListener {
+            chatActivity.showGalleryPicker()
             dismiss()
         }
 

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/FileAttachmentPreviewFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/FileAttachmentPreviewFragment.kt
@@ -17,7 +17,6 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.nextcloud.talk.R
 import com.nextcloud.talk.application.NextcloudTalkApplication
 import com.nextcloud.talk.databinding.DialogFileAttachmentPreviewBinding
-import com.nextcloud.talk.jobs.UploadAndShareFilesWorker
 import com.nextcloud.talk.ui.theme.ViewThemeUtils
 import com.nextcloud.talk.utils.permissions.PlatformPermissionUtil
 import javax.inject.Inject
@@ -70,12 +69,8 @@ class FileAttachmentPreviewFragment : DialogFragment() {
         }
 
         binding.buttonSend.setOnClickListener {
-            if (permissionUtil.isFilesPermissionGranted()) {
-                val caption: String = binding.dialogFileAttachmentPreviewCaption.text.toString()
-                uploadFiles(filesList, caption)
-            } else {
-                UploadAndShareFilesWorker.requestStoragePermission(requireActivity())
-            }
+            val caption: String = binding.dialogFileAttachmentPreviewCaption.text.toString()
+            uploadFiles(filesList, caption)
             dismiss()
         }
     }

--- a/app/src/main/res/drawable/baseline_photo_library_24.xml
+++ b/app/src/main/res/drawable/baseline_photo_library_24.xml
@@ -1,0 +1,15 @@
+<!--
+  ~ Nextcloud Talk - Android Client
+  ~
+  ~ SPDX-FileCopyrightText: 2025 Your Name <your@email.com>
+  ~ SPDX-License-Identifier: GPL-3.0-or-later
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="@android:color/white"
+        android:pathData="M22,16L22,4c0,-1.1 -0.9,-2 -2,-2L8,2c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2zM11,12l2.03,2.71L16,11l4,5L8,16l3,-4zM2,6v14c0,1.1 0.9,2 2,2h14v-2L4,20L4,6L2,6z"/>
+</vector>

--- a/app/src/main/res/layout/dialog_attachment.xml
+++ b/app/src/main/res/layout/dialog_attachment.xml
@@ -197,6 +197,39 @@
     </LinearLayout>
 
     <LinearLayout
+        android:id="@+id/menu_attach_file_from_gallery"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/bottom_sheet_item_height"
+        android:background="?android:attr/selectableItemBackground"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingStart="@dimen/standard_padding"
+        android:paddingEnd="@dimen/standard_padding"
+        tools:ignore="UseCompoundDrawables">
+
+        <ImageView
+            android:id="@+id/menu_icon_attach_file_from_gallery"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@null"
+            android:src="@drawable/baseline_photo_library_24"
+            app:tint="@color/high_emphasis_menu_icon" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/txt_attach_file_from_gallery"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="start|center_vertical"
+            android:paddingStart="@dimen/standard_double_padding"
+            android:paddingEnd="@dimen/zero"
+            android:text="Gallery"
+            android:textAlignment="viewStart"
+            android:textColor="@color/high_emphasis_text"
+            android:textSize="@dimen/bottom_sheet_text_size" />
+
+    </LinearLayout>
+
+    <LinearLayout
         android:id="@+id/menu_attach_file_from_local"
         android:layout_width="match_parent"
         android:layout_height="@dimen/bottom_sheet_item_height"

--- a/app/src/main/res/layout/dialog_attachment.xml
+++ b/app/src/main/res/layout/dialog_attachment.xml
@@ -123,7 +123,7 @@
             android:layout_gravity="start|center_vertical"
             android:paddingStart="@dimen/standard_double_padding"
             android:paddingEnd="@dimen/zero"
-            android:text="Gallery"
+            android:text="@string/nc_gallery"
             android:textAlignment="viewStart"
             android:textColor="@color/high_emphasis_text"
             android:textSize="@dimen/bottom_sheet_text_size" />

--- a/app/src/main/res/layout/dialog_attachment.xml
+++ b/app/src/main/res/layout/dialog_attachment.xml
@@ -32,105 +32,6 @@
         android:textSize="@dimen/bottom_sheet_text_size" />
 
     <LinearLayout
-        android:id="@+id/menu_attach_poll"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/bottom_sheet_item_height"
-        android:background="?android:attr/selectableItemBackground"
-        android:gravity="center_vertical"
-        android:orientation="horizontal"
-        android:paddingStart="@dimen/standard_padding"
-        android:paddingEnd="@dimen/standard_padding"
-        tools:ignore="UseCompoundDrawables">
-
-        <ImageView
-            android:id="@+id/menu_icon_attach_poll"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:contentDescription="@null"
-            android:src="@drawable/ic_baseline_bar_chart_24"
-            app:tint="@color/high_emphasis_menu_icon" />
-
-        <androidx.appcompat.widget.AppCompatTextView
-            android:id="@+id/txt_attach_poll"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="start|center_vertical"
-            android:paddingStart="@dimen/standard_double_padding"
-            android:paddingEnd="@dimen/zero"
-            android:text="@string/nc_create_poll"
-            android:textAlignment="viewStart"
-            android:textColor="@color/high_emphasis_text"
-            android:textSize="@dimen/bottom_sheet_text_size" />
-
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/menu_attach_contact"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/bottom_sheet_item_height"
-        android:background="?android:attr/selectableItemBackground"
-        android:gravity="center_vertical"
-        android:orientation="horizontal"
-        android:paddingStart="@dimen/standard_padding"
-        android:paddingEnd="@dimen/standard_padding"
-        tools:ignore="UseCompoundDrawables">
-
-        <ImageView
-            android:id="@+id/menu_icon_share_contact"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:contentDescription="@null"
-            android:src="@drawable/ic_baseline_person_24"
-            app:tint="@color/high_emphasis_menu_icon" />
-
-        <androidx.appcompat.widget.AppCompatTextView
-            android:id="@+id/shareContactText"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="start|center_vertical"
-            android:paddingStart="@dimen/standard_double_padding"
-            android:paddingEnd="@dimen/zero"
-            android:text="@string/nc_share_contact"
-            android:textAlignment="viewStart"
-            android:textColor="@color/high_emphasis_text"
-            android:textSize="@dimen/bottom_sheet_text_size" />
-
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/menu_share_location"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/bottom_sheet_item_height"
-        android:background="?android:attr/selectableItemBackground"
-        android:gravity="center_vertical"
-        android:orientation="horizontal"
-        android:paddingStart="@dimen/standard_padding"
-        android:paddingEnd="@dimen/standard_padding"
-        tools:ignore="UseCompoundDrawables">
-
-        <ImageView
-            android:id="@+id/menu_icon_share_location"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:contentDescription="@null"
-            android:src="@drawable/ic_baseline_location_on_24"
-            app:tint="@color/high_emphasis_menu_icon" />
-
-        <androidx.appcompat.widget.AppCompatTextView
-            android:id="@+id/txt_share_location"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="start|center_vertical"
-            android:paddingStart="@dimen/standard_double_padding"
-            android:paddingEnd="@dimen/zero"
-            android:text="@string/nc_share_location"
-            android:textAlignment="viewStart"
-            android:textColor="@color/high_emphasis_text"
-            android:textSize="@dimen/bottom_sheet_text_size" />
-
-    </LinearLayout>
-
-    <LinearLayout
         android:id="@+id/menu_attach_picture_from_cam"
         android:layout_width="match_parent"
         android:layout_height="@dimen/bottom_sheet_item_height"
@@ -292,6 +193,112 @@
             android:textColor="@color/high_emphasis_text"
             android:textSize="@dimen/bottom_sheet_text_size"
             tools:text="Share from Nextcloud" />
+
+    </LinearLayout>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:background="@color/low_emphasis_text"/>
+
+    <LinearLayout
+        android:id="@+id/menu_attach_poll"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/bottom_sheet_item_height"
+        android:background="?android:attr/selectableItemBackground"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingStart="@dimen/standard_padding"
+        android:paddingEnd="@dimen/standard_padding"
+        tools:ignore="UseCompoundDrawables">
+
+        <ImageView
+            android:id="@+id/menu_icon_attach_poll"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_baseline_bar_chart_24"
+            app:tint="@color/high_emphasis_menu_icon" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/txt_attach_poll"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="start|center_vertical"
+            android:paddingStart="@dimen/standard_double_padding"
+            android:paddingEnd="@dimen/zero"
+            android:text="@string/nc_create_poll"
+            android:textAlignment="viewStart"
+            android:textColor="@color/high_emphasis_text"
+            android:textSize="@dimen/bottom_sheet_text_size" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/menu_share_location"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/bottom_sheet_item_height"
+        android:background="?android:attr/selectableItemBackground"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingStart="@dimen/standard_padding"
+        android:paddingEnd="@dimen/standard_padding"
+        tools:ignore="UseCompoundDrawables">
+
+        <ImageView
+            android:id="@+id/menu_icon_share_location"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_baseline_location_on_24"
+            app:tint="@color/high_emphasis_menu_icon" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/txt_share_location"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="start|center_vertical"
+            android:paddingStart="@dimen/standard_double_padding"
+            android:paddingEnd="@dimen/zero"
+            android:text="@string/nc_share_location"
+            android:textAlignment="viewStart"
+            android:textColor="@color/high_emphasis_text"
+            android:textSize="@dimen/bottom_sheet_text_size" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/menu_attach_contact"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/bottom_sheet_item_height"
+        android:background="?android:attr/selectableItemBackground"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingStart="@dimen/standard_padding"
+        android:paddingEnd="@dimen/standard_padding"
+        tools:ignore="UseCompoundDrawables">
+
+        <ImageView
+            android:id="@+id/menu_icon_share_contact"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_baseline_person_24"
+            app:tint="@color/high_emphasis_menu_icon" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/shareContactText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="start|center_vertical"
+            android:paddingStart="@dimen/standard_double_padding"
+            android:paddingEnd="@dimen/zero"
+            android:text="@string/nc_share_contact"
+            android:textAlignment="viewStart"
+            android:textColor="@color/high_emphasis_text"
+            android:textSize="@dimen/bottom_sheet_text_size" />
 
     </LinearLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -541,6 +541,7 @@ How to translate with transifex:
     <string name="nc_upload_confirm_send_single">Send this file to %1$s?</string>
     <string name="nc_upload_in_progess">Uploading</string>
     <string name="nc_upload_from_device">Upload from device</string>
+    <string name="nc_gallery">Gallery</string>
 
     <string name="nc_upload_notification_text">%1$s to %2$s - %3$s\%%</string>
     <string name="nc_upload_failed_notification_title">Failure</string>


### PR DESCRIPTION
resolve #4313

- Add [Photo picker](https://developer.android.com/training/data-storage/shared/photopicker#kotlin)  to have access to photos and videos with a single click without having to grant file permissions.

- Open the photo picker also with a longclick on the attachment icon.

This PR also replaces https://github.com/nextcloud/talk-android/issues/4715 (photo picker is now used instead because it's more privacy friendly)

### How to test

Please test all kind of different scenarios to add photos/files to the chat and be aware if permissions behave like expected. (File permissions are only necessary when selecting "Upload from device")

Sidenote: There is currently a bug that files are shown duplicated after uploading (https://github.com/nextcloud/talk-android/issues/4764 should be related). This has to be solved in another PR.


### 🖼️ Screenshots


🏚️ Before | 🏡 After (Gallery added and modified order) | 🏡 After (Photo picker opens after click on "Gallery")
------- | -------- | -------- 
![grafik](https://github.com/user-attachments/assets/140ae282-b6f3-4e75-8e0b-41b20ea7493a) | ![grafik](https://github.com/user-attachments/assets/c6cd5592-d826-4e77-87e2-977fcec5873b)  | ![grafik](https://github.com/user-attachments/assets/37ab7469-6c93-4f9f-b776-dbf76bd3f710)


### 🚧 TODO

- [x] string hardcodings
- [x] double check permissions

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)