### PR TITLE
switch video capture between 4:3 and 16:9 ratio for portrait/landscape

### DIFF
--- a/app/src/main/res/layout/call_activity.xml
+++ b/app/src/main/res/layout/call_activity.xml
@@ -52,8 +52,8 @@
 
                 <org.webrtc.SurfaceViewRenderer
                     android:id="@+id/selfVideoRenderer"
-                    android:layout_width="@dimen/call_self_video_short_side_length"
-                    android:layout_height="@dimen/call_self_video_long_side_length"
+                    android:layout_width="80dp"
+                    android:layout_height="104dp"
                     android:layout_gravity="center"
                     android:layout_margin="16dp"
                     android:clickable="false"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -54,8 +54,6 @@
     <dimen name="dialog_padding">24dp</dimen>
     <dimen name="dialog_padding_top_bottom">18dp</dimen>
 
-    <dimen name="call_self_video_long_side_length">150dp</dimen>
-    <dimen name="call_self_video_short_side_length">80dp</dimen>
     <dimen name="call_grid_item_min_height">180dp</dimen>
     <dimen name="call_controls_height">110dp</dimen>
     <dimen name="call_participant_progress_bar_size">48dp</dimen>


### PR DESCRIPTION
This PR will switch video capture for calls between 4:3 and 16:9 ratio depending on portrait/ landscape mode. This results in a higher Field of View.
Before this change, 16:9 was always applied to the video capture. Now 4:3 is applied for portrait and 19:9 for landscape.

Also: simplify placement of self video view (it was buggy) as well as applying the ratio there as well.

### 🖼️ Screenshots

🏚️ Before: Smartphone held in portrait mode (16:9) | 🏡 After: Smartphone held in portrait mode (4:3) 
---|---
![Bildschirmfoto vom 2025-04-03 19-11-39_moto_16to3_portrait (Kopie)](https://github.com/user-attachments/assets/476162ea-81c8-4b91-b553-d660375e859d) | ![Bildschirmfoto vom 2025-04-03 19-22-19_moto_4to3_portrait (Kopie)](https://github.com/user-attachments/assets/6262abec-f794-43f2-a1a2-95dcfeb75df9)


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)