### PR TITLE
avoid NPE in onLoadMore

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -2818,21 +2818,23 @@ class ChatActivity :
         DateFormatter.isSameDay(message1.createdAt, message2.createdAt)
 
     override fun onLoadMore(page: Int, totalItemsCount: Int) {
-        val id = (
-            adapter?.items?.last {
-                it.item is ChatMessage
-            }?.item as ChatMessage
-            ).jsonMessageId
+        val messageId = (
+            adapter?.items
+                ?.lastOrNull { it.item is ChatMessage }
+                ?.item as? ChatMessage
+            )?.jsonMessageId
 
-        val urlForChatting = ApiUtils.getUrlForChat(chatApiVersion, conversationUser?.baseUrl, roomToken)
+        messageId?.let {
+            val urlForChatting = ApiUtils.getUrlForChat(chatApiVersion, conversationUser?.baseUrl, roomToken)
 
-        chatViewModel.loadMoreMessages(
-            beforeMessageId = id.toLong(),
-            withUrl = urlForChatting,
-            withCredentials = credentials!!,
-            withMessageLimit = MESSAGE_PULL_LIMIT,
-            roomToken = currentConversation!!.token
-        )
+            chatViewModel.loadMoreMessages(
+                beforeMessageId = it.toLong(),
+                withUrl = urlForChatting,
+                withCredentials = credentials!!,
+                withMessageLimit = MESSAGE_PULL_LIMIT,
+                roomToken = currentConversation!!.token
+            )
+        }
     }
 
     override fun format(date: Date): String =


### PR DESCRIPTION
For v21.0.0, the following crash was reported:

Exception java.lang.NullPointerException: null cannot be cast to non-null type com.nextcloud.talk.chat.data.model.ChatMessage
  at com.nextcloud.talk.chat.ChatActivity.onLoadMore (ChatActivity.kt:3107)
  at com.stfalcon.chatkit.messages.MessagesListAdapter.onLoadMore (MessagesListAdapter.java:148)
  at com.stfalcon.chatkit.messages.RecyclerScrollMoreListener.onScrolled (RecyclerScrollMoreListener.java:82)
  at androidx.recyclerview.widget.RecyclerView.dispatchOnScrolled (RecyclerView.java:5688)
  at androidx.recyclerview.widget.RecyclerView.dispatchLayoutStep3 (RecyclerView.java:4741)
  at androidx.recyclerview.widget.RecyclerView.dispatchLayout (RecyclerView.java:4367)
  at androidx.recyclerview.widget.RecyclerView.onLayout (RecyclerView.java:4919)

This is now improved:
- lastOrNull prevents exceptions if no matching item is found
- as? is a safe cast that returns null if the cast fails

Whole expression becomes null-safe, and id will be null if anything along the way doesn't match. Only when not null, onLoadMore continues.


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)