### PR TITLE
Avoid Npe in sendChatMessage

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.isActive
@@ -847,13 +848,17 @@ class OfflineFirstChatRepository @Inject constructor(
             .catch { e ->
                 Log.e(TAG, "Error when sending message", e)
 
-                val failedMessage = chatDao.getTempMessageForConversation(internalConversationId, referenceId).first()
-                failedMessage.sendingFailed = true
-                chatDao.updateChatMessage(failedMessage)
+                val failedMessage = chatDao.getTempMessageForConversation(
+                    internalConversationId,
+                    referenceId
+                ).firstOrNull()
+                failedMessage?.let {
+                    it.sendingFailed = true
+                    chatDao.updateChatMessage(it)
 
-                val failedMessageModel = failedMessage.asModel()
-                _updateMessageFlow.emit(failedMessageModel)
-
+                    val failedMessageModel = it.asModel()
+                    _updateMessageFlow.emit(failedMessageModel)
+                }
                 emit(Result.failure(e))
             }
     }


### PR DESCRIPTION
as chatDao.getTempMessageForConversation could have returned null


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)