### PR TITLE
add hotfix to avoid NoSupportedApiException in ContactsRepositoryImpl

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/contacts/ContactsRepositoryImpl.kt
+++ b/app/src/main/java/com/nextcloud/talk/contacts/ContactsRepositoryImpl.kt
@@ -7,6 +7,7 @@
 
 package com.nextcloud.talk.contacts
 
+import android.util.Log
 import com.nextcloud.talk.api.NcApiCoroutines
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.models.RetrofitBucket
@@ -14,6 +15,7 @@ import com.nextcloud.talk.models.json.autocomplete.AutocompleteOverall
 import com.nextcloud.talk.models.json.conversations.RoomOverall
 import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.ContactUtils
+import com.nextcloud.talk.utils.NoSupportedApiException
 import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
 import javax.inject.Inject
 
@@ -25,7 +27,6 @@ class ContactsRepositoryImpl @Inject constructor(
     private val _currentUser = currentUserProvider.currentUser.blockingGet()
     val currentUser: User = _currentUser
     val credentials = ApiUtils.getCredentials(_currentUser.username, _currentUser.token)
-    val apiVersion = ApiUtils.getConversationApiVersion(_currentUser, intArrayOf(ApiUtils.API_V4, 1))
 
     override suspend fun getContacts(searchQuery: String?, shareTypes: List<String>): AutocompleteOverall {
         val retrofitBucket: RetrofitBucket = ApiUtils.getRetrofitBucketForContactsSearchFor14(
@@ -51,6 +52,24 @@ class ContactsRepositoryImpl @Inject constructor(
         userId: String,
         conversationName: String?
     ): RoomOverall {
+        val apiVersion =
+            try {
+                ApiUtils.getConversationApiVersion(_currentUser, intArrayOf(ApiUtils.API_V4, 1))
+            } catch (e: NoSupportedApiException) {
+                // There were crash reports for:
+                // Exception java.lang.RuntimeException:
+                // ...
+                // Caused by com.nextcloud.talk.utils.NoSupportedApiException:
+                // at com.nextcloud.talk.utils.ApiUtils.getConversationApiVersion (ApiUtils.kt:134)
+                // at com.nextcloud.talk.contacts.ContactsRepositoryImpl.<init> (ContactsRepositoryImpl.kt:28)
+                //
+                // This could happen because of missing capabilities for user and should be fixed.
+                // As a fallback, API v4 is guessed
+
+                Log.e(TAG, "Failed to get an Api version for conversation.", e)
+                ApiUtils.API_V4
+            }
+
         val retrofitBucket: RetrofitBucket = ApiUtils.getRetrofitBucketForCreateRoom(
             apiVersion,
             _currentUser.baseUrl,
@@ -73,5 +92,9 @@ class ContactsRepositoryImpl @Inject constructor(
             avatarId,
             requestBigSize
         )
+    }
+
+    companion object {
+        private val TAG = ContactsRepositoryImpl::class.simpleName
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/data/user/model/User.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/user/model/User.kt
@@ -9,6 +9,7 @@
 package com.nextcloud.talk.data.user.model
 
 import android.os.Parcelable
+import android.util.Log
 import com.nextcloud.talk.models.ExternalSignalingServer
 import com.nextcloud.talk.models.json.capabilities.Capabilities
 import com.nextcloud.talk.models.json.capabilities.ServerVersion
@@ -37,6 +38,13 @@ data class User(
     fun getCredentials(): String = ApiUtils.getCredentials(username, token)!!
 
     fun hasSpreedFeatureCapability(capabilityName: String): Boolean {
+        if (capabilities == null) {
+            Log.e(TAG, "Capabilities are null in hasSpreedFeatureCapability. false is returned for capability check")
+        }
         return capabilities?.spreedCapability?.features?.contains(capabilityName) ?: false
+    }
+
+    companion object {
+        private val TAG = User::class.simpleName
     }
 }


### PR DESCRIPTION
There were crash reports for:

```
Exception java.lang.RuntimeException:
...
Caused by com.nextcloud.talk.utils.NoSupportedApiException: at com.nextcloud.talk.utils.ApiUtils.getConversationApiVersion (ApiUtils.kt:134) at com.nextcloud.talk.contacts.ContactsRepositoryImpl.<init> (ContactsRepositoryImpl.kt:28)
```

This could happen because of missing capabilities for user and should be fixed. As a fallback, API v4 is guessed


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)