### PR TITLE
fix Conscrypt initialization order

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/application/NextcloudTalkApplication.kt
+++ b/app/src/main/java/com/nextcloud/talk/application/NextcloudTalkApplication.kt
@@ -142,13 +142,13 @@ class NextcloudTalkApplication : MultiDexApplication(), LifecycleObserver {
         buildComponent()
         DavUtils.registerCustomFactories()
 
+        Security.insertProviderAt(Conscrypt.newProvider(), 1)
+
         componentApplication.inject(this)
 
         Coil.setImageLoader(buildDefaultImageLoader())
         setAppTheme(appPreferences.theme)
         super.onCreate()
-
-        Security.insertProviderAt(Conscrypt.newProvider(), 1)
 
         ClosedInterfaceImpl().providerInstallerInstallIfNeededAsync()
         DeviceUtils.ignoreSpecialBatteryFeatures()


### PR DESCRIPTION
`SSLSocketFactoryCompat` relies on `SSLContext.getInstance("TLS")`, which is called from `componentApplication.inject(this)` in `NextcloudTalkApplication.onCreate()` - before Conscrypt is set as the provider.

This caused issues on Android 7.0 devices when connecting to Nextcloud's push notification server. The result was a handshake error, because Android 7.0's native implementation only supports TLSv1.2 and the secp256r1 group, while the server supports only secp384r1.

Setting Conscrypt as a provider earlier ensures that the native implementation is not used, and the connection completes successfully.

Call stack:
```
<init>:44, SSLSocketFactoryCompat (com.nextcloud.talk.utils.ssl)
provideSslSocketFactoryCompat:156, RestModule (com.nextcloud.talk.dagger.modules)
provideSslSocketFactoryCompat:56, RestModule_ProvideSslSocketFactoryCompatFactory (com.nextcloud.talk.dagger.modules)
get:46, RestModule_ProvideSslSocketFactoryCompatFactory (com.nextcloud.talk.dagger.modules)
get:14, RestModule_ProvideSslSocketFactoryCompatFactory (com.nextcloud.talk.dagger.modules)
getSynchronized:54, DoubleCheck (dagger.internal)
get:45, DoubleCheck (dagger.internal)
get:69, RestModule_ProvideHttpClientFactory (com.nextcloud.talk.dagger.modules)
get:19, RestModule_ProvideHttpClientFactory (com.nextcloud.talk.dagger.modules)
getSynchronized:54, DoubleCheck (dagger.internal)
get:45, DoubleCheck (dagger.internal)
injectNextcloudTalkApplication:1393, DaggerNextcloudTalkApplicationComponent$NextcloudTalkApplicationComponentImpl (com.nextcloud.talk.application)
inject:867, DaggerNextcloudTalkApplicationComponent$NextcloudTalkApplicationComponentImpl (com.nextcloud.talk.application)
onCreate:145, NextcloudTalkApplication (com.nextcloud.talk.application)
```

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)