### PR TITLE
Use recent emojis in message actions dialog + use same recent emojis like for status picker

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
@@ -261,6 +261,7 @@ class MessageActionsDialog(
                 val searchResults = searchEmojiManager.search(keyword)
                 if (searchResults.isNotEmpty()) {
                     initialEmojisFromSearch.add(searchResults[0].component1())
+                    recentEmojiManager.addEmoji(searchResults[0].component1())
                 }
                 if (initialEmojisFromSearch.size >= 8) {
                     return@forEach
@@ -301,9 +302,12 @@ class MessageActionsDialog(
                         val result = SearchEmojiManager().search(keyword)
                         if (result.isNotEmpty()) {
                             recentEmojiManager.addEmoji(result[0].component1())
+                            recentEmojiManager.persist()
                         }
                     }
+
                     textView.visibility = View.VISIBLE
+
                 } else {
                     textView.visibility = View.GONE
                 }
@@ -508,6 +512,7 @@ class MessageActionsDialog(
                 .subscribeOn(Schedulers.io())
                 ?.observeOn(AndroidSchedulers.mainThread())
                 ?.subscribe(ReactionDeletedObserver())
+
         } else {
             reactionsRepository.addReaction(currentConversation!!.token!!, message, emoji)
                 .subscribeOn(Schedulers.io())

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
@@ -249,7 +249,7 @@ class MessageActionsDialog(
             isPermitted(hasChatPermission) &&
             isReactableMessageType(message)
         ) {
-            val recentEmojiManager = RecentEmojiManager(context,6)
+            val recentEmojiManager = RecentEmojiManager(context, 6)
             val recentEmojis = recentEmojiManager.getRecentEmojis()
             val searchEmojiManager = SearchEmojiManager()
 

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
@@ -41,6 +41,8 @@ import com.nextcloud.talk.utils.ConversationUtils
 import com.nextcloud.talk.utils.DateConstants
 import com.nextcloud.talk.utils.DateUtils
 import com.nextcloud.talk.utils.SpreedFeatures
+import com.vanniktech.emoji.Emoji
+import com.vanniktech.emoji.EmojiManager
 import com.vanniktech.emoji.EmojiPopup
 import com.vanniktech.emoji.EmojiTextView
 import com.vanniktech.emoji.installDisableKeyboardInput
@@ -248,7 +250,12 @@ class MessageActionsDialog(
             isReactableMessageType(message)
         ) {
             val recentEmojiManager = RecentEmojiManager(context, 6)
-            val topEmojis = recentEmojiManager.getRecentEmojis()
+            val recentEmojis = recentEmojiManager.getRecentEmojis().map { it.unicode }
+            val fallbackEmojis = listOf("👍", "👎", "❤️", "😂", "😕", "😢")
+
+            val combinedEmojis = (recentEmojis + fallbackEmojis)
+                .distinct()
+                .take(6)
 
             val emojiTextViews = listOf(
                 dialogMessageActionsBinding.emojiThumbsUp,
@@ -259,21 +266,17 @@ class MessageActionsDialog(
                 dialogMessageActionsBinding.emojiSad
             )
 
-            val fallbackEmojis = listOf("👍", "👎", "❤️", "😂", "😕", "😢")
-            val emojisToDisplay = if (topEmojis.isNotEmpty()) {
-                topEmojis.map { it.unicode }
-            } else {
-                fallbackEmojis
-            }
-
             emojiTextViews.forEachIndexed { index, textView ->
-                val emoji = emojisToDisplay.getOrNull(index)
+                val emoji = combinedEmojis.getOrNull(index)
                 if (emoji != null) {
                     textView.text = emoji
                     checkAndSetEmojiSelfReaction(textView)
                     textView.setOnClickListener {
                         clickOnEmoji(message, emoji)
                     }
+                    textView.visibility = View.VISIBLE
+                } else {
+                    textView.visibility = View.INVISIBLE
                 }
             }
 

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
@@ -277,47 +277,7 @@ class MessageActionsDialog(
             }
             val combinedEmojis = (recentEmojis + initialEmojisFromSearch).toList().distinct().take(MAX_RECENTS)
 
-            val emojiSearchKeywords = mapOf(
-                "👍" to "thumbsup",
-                "👎" to "thumbsdown",
-                "❤️" to "heart",
-                "😂" to "joy",
-                "😕" to "confused",
-                "😢" to "cry",
-                "🙏" to "pray",
-                "🔥" to "fire"
-            )
-
-            val emojiTextViews = listOf(
-                dialogMessageActionsBinding.emojiThumbsUp,
-                dialogMessageActionsBinding.emojiThumbsDown,
-                dialogMessageActionsBinding.emojiHeart,
-                dialogMessageActionsBinding.emojiLaugh,
-                dialogMessageActionsBinding.emojiConfused,
-                dialogMessageActionsBinding.emojiCry,
-                dialogMessageActionsBinding.emojiPray,
-                dialogMessageActionsBinding.emojiFire
-            )
-
-            emojiTextViews.forEachIndexed { index, textView ->
-                val emoji = combinedEmojis.getOrNull(index)?.unicode
-                if (emoji != null) {
-                    textView.text = emoji
-                    checkAndSetEmojiSelfReaction(textView)
-                    textView.setOnClickListener {
-                        clickOnEmoji(message, emoji)
-                        val keyword = emojiSearchKeywords[emoji] ?: ""
-                        val result = SearchEmojiManager().search(keyword)
-                        if (result.isNotEmpty()) {
-                            recentEmojiManager.addEmoji(result[ZERO_INDEX].component1())
-                            recentEmojiManager.persist()
-                        }
-                    }
-                    textView.visibility = View.VISIBLE
-                } else {
-                    textView.visibility = View.GONE
-                }
-            }
+            setupEmojiView(combinedEmojis, recentEmojiManager)
 
             dialogMessageActionsBinding.emojiMore.setOnClickListener {
                 dismiss()
@@ -326,6 +286,50 @@ class MessageActionsDialog(
             dialogMessageActionsBinding.emojiBar.visibility = View.VISIBLE
         } else {
             dialogMessageActionsBinding.emojiBar.visibility = View.GONE
+        }
+    }
+
+    private fun setupEmojiView(combinedEmojis: List<Emoji>, recentEmojiManager: RecentEmojiManager) {
+        val emojiSearchKeywords = mapOf(
+            "👍" to "thumbsup",
+            "👎" to "thumbsdown",
+            "❤️" to "heart",
+            "😂" to "joy",
+            "😕" to "confused",
+            "😢" to "cry",
+            "🙏" to "pray",
+            "🔥" to "fire"
+        )
+
+        val emojiTextViews = listOf(
+            dialogMessageActionsBinding.emojiThumbsUp,
+            dialogMessageActionsBinding.emojiThumbsDown,
+            dialogMessageActionsBinding.emojiHeart,
+            dialogMessageActionsBinding.emojiLaugh,
+            dialogMessageActionsBinding.emojiConfused,
+            dialogMessageActionsBinding.emojiCry,
+            dialogMessageActionsBinding.emojiPray,
+            dialogMessageActionsBinding.emojiFire
+        )
+
+        emojiTextViews.forEachIndexed { index, textView ->
+            val emoji = combinedEmojis.getOrNull(index)?.unicode
+            if (emoji != null) {
+                textView.text = emoji
+                checkAndSetEmojiSelfReaction(textView)
+                textView.setOnClickListener {
+                    clickOnEmoji(message, emoji)
+                    val keyword = emojiSearchKeywords[emoji] ?: ""
+                    val result = SearchEmojiManager().search(keyword)
+                    if (result.isNotEmpty()) {
+                        recentEmojiManager.addEmoji(result[ZERO_INDEX].component1())
+                        recentEmojiManager.persist()
+                    }
+                }
+                textView.visibility = View.VISIBLE
+            } else {
+                textView.visibility = View.GONE
+            }
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
@@ -249,11 +249,12 @@ class MessageActionsDialog(
             isPermitted(hasChatPermission) &&
             isReactableMessageType(message)
         ) {
-            val recentEmojiManager = RecentEmojiManager(context, 6)
+            val recentEmojiManager = RecentEmojiManager(context, 8)
             val recentEmojis = recentEmojiManager.getRecentEmojis()
             val searchEmojiManager = SearchEmojiManager()
 
-            val initialSearchKeywords = listOf("thumbsup", "thumbsdown", "heart", "joy", "confused", "cry")
+            val initialSearchKeywords = listOf("thumbsup", "thumbsdown", "heart", "joy", "confused", "cry","pray",
+                "fire")
             val initialEmojisFromSearch = mutableSetOf<Emoji>()
 
             initialSearchKeywords.forEach { keyword ->
@@ -261,11 +262,11 @@ class MessageActionsDialog(
                 if (searchResults.isNotEmpty()) {
                     initialEmojisFromSearch.add(searchResults[0].component1())
                 }
-                if (initialEmojisFromSearch.size >= 6) {
+                if (initialEmojisFromSearch.size >= 8) {
                     return@forEach
                 }
             }
-            val combinedEmojis = (recentEmojis + initialEmojisFromSearch).toList().distinct().take(6)
+            val combinedEmojis = (recentEmojis + initialEmojisFromSearch).toList().distinct().take(8)
 
             val emojiSearchKeywords = mapOf(
                 "👍" to "thumbsup",
@@ -273,7 +274,9 @@ class MessageActionsDialog(
                 "❤️" to "heart",
                 "😂" to "joy",
                 "😕" to "confused",
-                "😢" to "cry"
+                "😢" to "cry",
+                "🙏" to "pray",
+                "🔥" to "fire"
             )
 
             val emojiTextViews = listOf(
@@ -282,7 +285,9 @@ class MessageActionsDialog(
                 dialogMessageActionsBinding.emojiHeart,
                 dialogMessageActionsBinding.emojiLaugh,
                 dialogMessageActionsBinding.emojiConfused,
-                dialogMessageActionsBinding.emojiCry
+                dialogMessageActionsBinding.emojiCry,
+                dialogMessageActionsBinding.emojiPray,
+                dialogMessageActionsBinding.emojiFire
             )
 
             emojiTextViews.forEachIndexed { index, textView ->

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
@@ -41,8 +41,6 @@ import com.nextcloud.talk.utils.ConversationUtils
 import com.nextcloud.talk.utils.DateConstants
 import com.nextcloud.talk.utils.DateUtils
 import com.nextcloud.talk.utils.SpreedFeatures
-import com.vanniktech.emoji.Emoji
-import com.vanniktech.emoji.EmojiManager
 import com.vanniktech.emoji.EmojiPopup
 import com.vanniktech.emoji.EmojiTextView
 import com.vanniktech.emoji.installDisableKeyboardInput
@@ -276,7 +274,7 @@ class MessageActionsDialog(
                     }
                     textView.visibility = View.VISIBLE
                 } else {
-                    textView.visibility = View.INVISIBLE
+                    textView.visibility = View.GONE
                 }
             }
 

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
@@ -45,6 +45,7 @@ import com.vanniktech.emoji.EmojiPopup
 import com.vanniktech.emoji.EmojiTextView
 import com.vanniktech.emoji.installDisableKeyboardInput
 import com.vanniktech.emoji.installForceSingleEmoji
+import com.vanniktech.emoji.recent.RecentEmojiManager
 import io.reactivex.Observer
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
@@ -246,29 +247,34 @@ class MessageActionsDialog(
             isPermitted(hasChatPermission) &&
             isReactableMessageType(message)
         ) {
-            checkAndSetEmojiSelfReaction(dialogMessageActionsBinding.emojiThumbsUp)
-            dialogMessageActionsBinding.emojiThumbsUp.setOnClickListener {
-                clickOnEmoji(message, dialogMessageActionsBinding.emojiThumbsUp.text.toString())
+            val recentEmojiManager = RecentEmojiManager(context, 6)
+            val topEmojis = recentEmojiManager.getRecentEmojis()
+
+            val emojiTextViews = listOf(
+                dialogMessageActionsBinding.emojiThumbsUp,
+                dialogMessageActionsBinding.emojiThumbsDown,
+                dialogMessageActionsBinding.emojiHeart,
+                dialogMessageActionsBinding.emojiLaugh,
+                dialogMessageActionsBinding.emojiConfused,
+                dialogMessageActionsBinding.emojiSad
+            )
+
+            val fallbackEmojis = listOf("👍", "👎", "❤️", "😂", "😕", "😢")
+            val emojisToDisplay = if (topEmojis.isNotEmpty()) {
+                topEmojis.map { it.unicode }
+            } else {
+                fallbackEmojis
             }
-            checkAndSetEmojiSelfReaction(dialogMessageActionsBinding.emojiThumbsDown)
-            dialogMessageActionsBinding.emojiThumbsDown.setOnClickListener {
-                clickOnEmoji(message, dialogMessageActionsBinding.emojiThumbsDown.text.toString())
-            }
-            checkAndSetEmojiSelfReaction(dialogMessageActionsBinding.emojiLaugh)
-            dialogMessageActionsBinding.emojiLaugh.setOnClickListener {
-                clickOnEmoji(message, dialogMessageActionsBinding.emojiLaugh.text.toString())
-            }
-            checkAndSetEmojiSelfReaction(dialogMessageActionsBinding.emojiHeart)
-            dialogMessageActionsBinding.emojiHeart.setOnClickListener {
-                clickOnEmoji(message, dialogMessageActionsBinding.emojiHeart.text.toString())
-            }
-            checkAndSetEmojiSelfReaction(dialogMessageActionsBinding.emojiConfused)
-            dialogMessageActionsBinding.emojiConfused.setOnClickListener {
-                clickOnEmoji(message, dialogMessageActionsBinding.emojiConfused.text.toString())
-            }
-            checkAndSetEmojiSelfReaction(dialogMessageActionsBinding.emojiSad)
-            dialogMessageActionsBinding.emojiSad.setOnClickListener {
-                clickOnEmoji(message, dialogMessageActionsBinding.emojiSad.text.toString())
+
+            emojiTextViews.forEachIndexed { index, textView ->
+                val emoji = emojisToDisplay.getOrNull(index)
+                if (emoji != null) {
+                    textView.text = emoji
+                    checkAndSetEmojiSelfReaction(textView)
+                    textView.setOnClickListener {
+                        clickOnEmoji(message, emoji)
+                    }
+                }
             }
 
             dialogMessageActionsBinding.emojiMore.setOnClickListener {

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
@@ -249,25 +249,33 @@ class MessageActionsDialog(
             isPermitted(hasChatPermission) &&
             isReactableMessageType(message)
         ) {
-            val recentEmojiManager = RecentEmojiManager(context, 8)
+            val recentEmojiManager = RecentEmojiManager(context, MAX_RECENTS)
             val recentEmojis = recentEmojiManager.getRecentEmojis()
             val searchEmojiManager = SearchEmojiManager()
 
-            val initialSearchKeywords = listOf("thumbsup", "thumbsdown", "heart", "joy", "confused", "cry","pray",
-                "fire")
+            val initialSearchKeywords = listOf(
+                "thumbsup",
+                "thumbsdown",
+                "heart",
+                "joy",
+                "confused",
+                "cry",
+                "pray",
+                "fire"
+            )
             val initialEmojisFromSearch = mutableSetOf<Emoji>()
 
             initialSearchKeywords.forEach { keyword ->
                 val searchResults = searchEmojiManager.search(keyword)
                 if (searchResults.isNotEmpty()) {
-                    initialEmojisFromSearch.add(searchResults[0].component1())
-                    recentEmojiManager.addEmoji(searchResults[0].component1())
+                    initialEmojisFromSearch.add(searchResults[ZERO_INDEX].component1())
+                    recentEmojiManager.addEmoji(searchResults[ZERO_INDEX].component1())
                 }
-                if (initialEmojisFromSearch.size >= 8) {
+                if (initialEmojisFromSearch.size >= MAX_RECENTS) {
                     return@forEach
                 }
             }
-            val combinedEmojis = (recentEmojis + initialEmojisFromSearch).toList().distinct().take(8)
+            val combinedEmojis = (recentEmojis + initialEmojisFromSearch).toList().distinct().take(MAX_RECENTS)
 
             val emojiSearchKeywords = mapOf(
                 "👍" to "thumbsup",
@@ -301,13 +309,11 @@ class MessageActionsDialog(
                         val keyword = emojiSearchKeywords[emoji] ?: ""
                         val result = SearchEmojiManager().search(keyword)
                         if (result.isNotEmpty()) {
-                            recentEmojiManager.addEmoji(result[0].component1())
+                            recentEmojiManager.addEmoji(result[ZERO_INDEX].component1())
                             recentEmojiManager.persist()
                         }
                     }
-
                     textView.visibility = View.VISIBLE
-
                 } else {
                     textView.visibility = View.GONE
                 }
@@ -512,7 +518,6 @@ class MessageActionsDialog(
                 .subscribeOn(Schedulers.io())
                 ?.observeOn(AndroidSchedulers.mainThread())
                 ?.subscribe(ReactionDeletedObserver())
-
         } else {
             reactionsRepository.addReaction(currentConversation!!.token!!, message, emoji)
                 .subscribeOn(Schedulers.io())
@@ -574,5 +579,7 @@ class MessageActionsDialog(
         private const val DELAY: Long = 200
         private const val AGE_THRESHOLD_FOR_EDIT_MESSAGE: Long = 86400000
         private const val ACTOR_BOTS = "bots"
+        private const val ZERO_INDEX = 0
+        private const val MAX_RECENTS = 8
     }
 }

--- a/app/src/main/res/layout/dialog_message_actions.xml
+++ b/app/src/main/res/layout/dialog_message_actions.xml
@@ -17,9 +17,15 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
+    <HorizontalScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fillViewport="true"
+        android:scrollbars="none">
+
     <LinearLayout
         android:id="@+id/emojiBar"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/standard_quarter_margin"
         android:layout_marginTop="@dimen/standard_half_margin"
@@ -94,6 +100,28 @@
             android:text="@string/emoji_sad"
             android:textSize="20sp" />
 
+        <com.vanniktech.emoji.EmojiTextView
+            android:id="@+id/emojiPray"
+            android:layout_width="@dimen/reaction_bottom_sheet_layout_size"
+            android:layout_height="@dimen/reaction_bottom_sheet_layout_size"
+            android:layout_marginLeft="@dimen/standard_quarter_margin"
+            android:layout_marginRight="@dimen/standard_quarter_margin"
+            android:cursorVisible="false"
+            android:gravity="center"
+            android:text="@string/emoji_pray"
+            android:textSize="20sp" />
+
+        <com.vanniktech.emoji.EmojiTextView
+            android:id="@+id/emojiFire"
+            android:layout_width="@dimen/reaction_bottom_sheet_layout_size"
+            android:layout_height="@dimen/reaction_bottom_sheet_layout_size"
+            android:layout_marginLeft="@dimen/standard_quarter_margin"
+            android:layout_marginRight="@dimen/standard_half_margin"
+            android:cursorVisible="false"
+            android:gravity="center"
+            android:text="@string/emoji_fire"
+            android:textSize="20sp" />
+
         <com.vanniktech.emoji.EmojiEditText
             android:id="@+id/emojiMore"
             android:layout_width="0dp"
@@ -106,6 +134,7 @@
             android:paddingStart="@dimen/zero"
             android:paddingEnd="@dimen/standard_padding" />
     </LinearLayout>
+    </HorizontalScrollView>
 
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/dialog_message_actions.xml
+++ b/app/src/main/res/layout/dialog_message_actions.xml
@@ -84,7 +84,7 @@
             android:textSize="20sp" />
 
         <com.vanniktech.emoji.EmojiTextView
-            android:id="@+id/emojiSad"
+            android:id="@+id/emojiCry"
             android:layout_width="@dimen/reaction_bottom_sheet_layout_size"
             android:layout_height="@dimen/reaction_bottom_sheet_layout_size"
             android:layout_marginLeft="@dimen/standard_quarter_margin"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -378,6 +378,8 @@ How to translate with transifex:
     <string name="emoji_heart" translatable="false">❤️</string>
     <string name="emoji_confused" translatable="false">😯</string>
     <string name="emoji_sad" translatable="false">😢</string>
+    <string name="emoji_pray" translatable="false">🙏</string>
+    <string name="emoji_fire" translatable="false">🔥</string>
     <string name="emoji_more" translatable="false">More emojis</string>
     <string name="dontClear">Don\'t clear</string>
     <string name="today">Today</string>


### PR DESCRIPTION
Resolve #4906 #4908

- recently used emojis will be displayed on long press of a message.
- Reaction list should be shared between reacting on messages and user status.

### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)