### PR TITLE
initialize rootEglBase earlier (hopefully fixes crash)

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -376,6 +376,8 @@ class CallActivity : CallBaseActivity() {
         Log.d(TAG, "onCreate")
         super.onCreate(savedInstanceState)
         sharedApplication!!.componentApplication.inject(this)
+
+        rootEglBase = EglBase.create()
         binding = CallActivityBinding.inflate(layoutInflater)
         setContentView(binding!!.root)
         hideNavigationIfNoPipAvailable()
@@ -765,7 +767,6 @@ class CallActivity : CallBaseActivity() {
     }
 
     private fun basicInitialization() {
-        rootEglBase = EglBase.create()
         createCameraEnumerator()
 
         // Create a new PeerConnectionFactory instance.


### PR DESCRIPTION
There was a report that the app crashed after coming back from PIP mode.
And i once saw in logs
`call to OpenGL ES API with no current context (logged once per thread)`
By initializing rootEglBase very early there is a chance this fixes these issues.

**Might** fix https://github.com/nextcloud/talk-android/issues/4982





### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)