### PR TITLE
avoid duplicate messages

### DIFF
--- a/app/schemas/com.nextcloud.talk.data.source.local.TalkDatabase/17.json
+++ b/app/schemas/com.nextcloud.talk.data.source.local.TalkDatabase/17.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 17,
-    "identityHash": "c6e75dfc4f897469a82de6aeff6208c1",
+    "identityHash": "5bc4247e179307faa995552da5d34324",
     "entities": [
       {
         "tableName": "User",
@@ -445,7 +445,7 @@
       },
       {
         "tableName": "ChatMessages",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`internalId` TEXT NOT NULL, `accountId` INTEGER NOT NULL, `token` TEXT NOT NULL, `id` INTEGER NOT NULL, `internalConversationId` TEXT NOT NULL, `actorDisplayName` TEXT NOT NULL, `message` TEXT NOT NULL, `actorId` TEXT NOT NULL, `actorType` TEXT NOT NULL, `deleted` INTEGER NOT NULL, `expirationTimestamp` INTEGER NOT NULL, `isReplyable` INTEGER NOT NULL, `isTemporary` INTEGER NOT NULL, `lastEditActorDisplayName` TEXT, `lastEditActorId` TEXT, `lastEditActorType` TEXT, `lastEditTimestamp` INTEGER, `markdown` INTEGER, `messageParameters` TEXT, `messageType` TEXT NOT NULL, `parent` INTEGER, `reactions` TEXT, `reactionsSelf` TEXT, `referenceId` TEXT, `sendingFailed` INTEGER NOT NULL, `sendStatus` TEXT, `silent` INTEGER NOT NULL, `systemMessage` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`internalId`), FOREIGN KEY(`internalConversationId`) REFERENCES `Conversations`(`internalId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`internalId` TEXT NOT NULL, `accountId` INTEGER NOT NULL, `token` TEXT NOT NULL, `id` INTEGER NOT NULL, `internalConversationId` TEXT NOT NULL, `actorDisplayName` TEXT NOT NULL, `message` TEXT NOT NULL, `actorId` TEXT NOT NULL, `actorType` TEXT NOT NULL, `deleted` INTEGER NOT NULL, `expirationTimestamp` INTEGER NOT NULL, `isReplyable` INTEGER NOT NULL, `isTemporary` INTEGER NOT NULL, `lastEditActorDisplayName` TEXT, `lastEditActorId` TEXT, `lastEditActorType` TEXT, `lastEditTimestamp` INTEGER, `markdown` INTEGER, `messageParameters` TEXT, `messageType` TEXT NOT NULL, `parent` INTEGER, `reactions` TEXT, `reactionsSelf` TEXT, `referenceId` TEXT, `sendStatus` TEXT, `silent` INTEGER NOT NULL, `systemMessage` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`internalId`), FOREIGN KEY(`internalConversationId`) REFERENCES `Conversations`(`internalId`) ON UPDATE CASCADE ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "internalId",
@@ -580,12 +580,6 @@
             "fieldPath": "referenceId",
             "columnName": "referenceId",
             "affinity": "TEXT"
-          },
-          {
-            "fieldPath": "sendingFailed",
-            "columnName": "sendingFailed",
-            "affinity": "INTEGER",
-            "notNull": true
           },
           {
             "fieldPath": "sendStatus",
@@ -730,7 +724,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c6e75dfc4f897469a82de6aeff6208c1')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '5bc4247e179307faa995552da5d34324')"
     ]
   }
 }

--- a/app/schemas/com.nextcloud.talk.data.source.local.TalkDatabase/17.json
+++ b/app/schemas/com.nextcloud.talk.data.source.local.TalkDatabase/17.json
@@ -1,0 +1,736 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 17,
+    "identityHash": "c6e75dfc4f897469a82de6aeff6208c1",
+    "entities": [
+      {
+        "tableName": "User",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `userId` TEXT, `username` TEXT, `baseUrl` TEXT, `token` TEXT, `displayName` TEXT, `pushConfigurationState` TEXT, `capabilities` TEXT, `serverVersion` TEXT DEFAULT '', `clientCertificate` TEXT, `externalSignalingServer` TEXT, `current` INTEGER NOT NULL, `scheduledForDeletion` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "baseUrl",
+            "columnName": "baseUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "token",
+            "columnName": "token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "pushConfigurationState",
+            "columnName": "pushConfigurationState",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "capabilities",
+            "columnName": "capabilities",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "serverVersion",
+            "columnName": "serverVersion",
+            "affinity": "TEXT",
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "clientCertificate",
+            "columnName": "clientCertificate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "externalSignalingServer",
+            "columnName": "externalSignalingServer",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "current",
+            "columnName": "current",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scheduledForDeletion",
+            "columnName": "scheduledForDeletion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "ArbitraryStorage",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountIdentifier` INTEGER NOT NULL, `key` TEXT NOT NULL, `object` TEXT, `value` TEXT, PRIMARY KEY(`accountIdentifier`, `key`))",
+        "fields": [
+          {
+            "fieldPath": "accountIdentifier",
+            "columnName": "accountIdentifier",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storageObject",
+            "columnName": "object",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "accountIdentifier",
+            "key"
+          ]
+        }
+      },
+      {
+        "tableName": "Conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`internalId` TEXT NOT NULL, `accountId` INTEGER NOT NULL, `token` TEXT NOT NULL, `displayName` TEXT NOT NULL, `actorId` TEXT NOT NULL, `actorType` TEXT NOT NULL, `avatarVersion` TEXT NOT NULL, `callFlag` INTEGER NOT NULL, `callRecording` INTEGER NOT NULL, `callStartTime` INTEGER NOT NULL, `canDeleteConversation` INTEGER NOT NULL, `canLeaveConversation` INTEGER NOT NULL, `canStartCall` INTEGER NOT NULL, `description` TEXT NOT NULL, `hasCall` INTEGER NOT NULL, `hasPassword` INTEGER NOT NULL, `isCustomAvatar` INTEGER NOT NULL, `isFavorite` INTEGER NOT NULL, `lastActivity` INTEGER NOT NULL, `lastCommonReadMessage` INTEGER NOT NULL, `lastMessage` TEXT, `lastPing` INTEGER NOT NULL, `lastReadMessage` INTEGER NOT NULL, `lobbyState` TEXT NOT NULL, `lobbyTimer` INTEGER NOT NULL, `messageExpiration` INTEGER NOT NULL, `name` TEXT NOT NULL, `notificationCalls` INTEGER NOT NULL, `notificationLevel` TEXT NOT NULL, `objectType` TEXT NOT NULL, `objectId` TEXT NOT NULL, `participantType` TEXT NOT NULL, `permissions` INTEGER NOT NULL, `readOnly` TEXT NOT NULL, `recordingConsent` INTEGER NOT NULL, `remoteServer` TEXT, `remoteToken` TEXT, `sessionId` TEXT NOT NULL, `status` TEXT, `statusClearAt` INTEGER, `statusIcon` TEXT, `statusMessage` TEXT, `type` TEXT NOT NULL, `unreadMention` INTEGER NOT NULL, `unreadMentionDirect` INTEGER NOT NULL, `unreadMessages` INTEGER NOT NULL, `hasArchived` INTEGER NOT NULL, `hasSensitive` INTEGER NOT NULL, `hasImportant` INTEGER NOT NULL, PRIMARY KEY(`internalId`), FOREIGN KEY(`accountId`) REFERENCES `User`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "internalId",
+            "columnName": "internalId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "token",
+            "columnName": "token",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actorId",
+            "columnName": "actorId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actorType",
+            "columnName": "actorType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "avatarVersion",
+            "columnName": "avatarVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "callFlag",
+            "columnName": "callFlag",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "callRecording",
+            "columnName": "callRecording",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "callStartTime",
+            "columnName": "callStartTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canDeleteConversation",
+            "columnName": "canDeleteConversation",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canLeaveConversation",
+            "columnName": "canLeaveConversation",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canStartCall",
+            "columnName": "canStartCall",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasCall",
+            "columnName": "hasCall",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasPassword",
+            "columnName": "hasPassword",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasCustomAvatar",
+            "columnName": "isCustomAvatar",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favorite",
+            "columnName": "isFavorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastActivity",
+            "columnName": "lastActivity",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastCommonReadMessage",
+            "columnName": "lastCommonReadMessage",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastMessage",
+            "columnName": "lastMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastPing",
+            "columnName": "lastPing",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastReadMessage",
+            "columnName": "lastReadMessage",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lobbyState",
+            "columnName": "lobbyState",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lobbyTimer",
+            "columnName": "lobbyTimer",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageExpiration",
+            "columnName": "messageExpiration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationCalls",
+            "columnName": "notificationCalls",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationLevel",
+            "columnName": "notificationLevel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "objectType",
+            "columnName": "objectType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "objectId",
+            "columnName": "objectId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "participantType",
+            "columnName": "participantType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "permissions",
+            "columnName": "permissions",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationReadOnlyState",
+            "columnName": "readOnly",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordingConsentRequired",
+            "columnName": "recordingConsent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remoteServer",
+            "columnName": "remoteServer",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remoteToken",
+            "columnName": "remoteToken",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "statusClearAt",
+            "columnName": "statusClearAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "statusIcon",
+            "columnName": "statusIcon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "statusMessage",
+            "columnName": "statusMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unreadMention",
+            "columnName": "unreadMention",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unreadMentionDirect",
+            "columnName": "unreadMentionDirect",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unreadMessages",
+            "columnName": "unreadMessages",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasArchived",
+            "columnName": "hasArchived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasSensitive",
+            "columnName": "hasSensitive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasImportant",
+            "columnName": "hasImportant",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "internalId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_Conversations_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Conversations_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "User",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "accountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "ChatMessages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`internalId` TEXT NOT NULL, `accountId` INTEGER NOT NULL, `token` TEXT NOT NULL, `id` INTEGER NOT NULL, `internalConversationId` TEXT NOT NULL, `actorDisplayName` TEXT NOT NULL, `message` TEXT NOT NULL, `actorId` TEXT NOT NULL, `actorType` TEXT NOT NULL, `deleted` INTEGER NOT NULL, `expirationTimestamp` INTEGER NOT NULL, `isReplyable` INTEGER NOT NULL, `isTemporary` INTEGER NOT NULL, `lastEditActorDisplayName` TEXT, `lastEditActorId` TEXT, `lastEditActorType` TEXT, `lastEditTimestamp` INTEGER, `markdown` INTEGER, `messageParameters` TEXT, `messageType` TEXT NOT NULL, `parent` INTEGER, `reactions` TEXT, `reactionsSelf` TEXT, `referenceId` TEXT, `sendingFailed` INTEGER NOT NULL, `sendStatus` TEXT, `silent` INTEGER NOT NULL, `systemMessage` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, PRIMARY KEY(`internalId`), FOREIGN KEY(`internalConversationId`) REFERENCES `Conversations`(`internalId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "internalId",
+            "columnName": "internalId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "token",
+            "columnName": "token",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "internalConversationId",
+            "columnName": "internalConversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actorDisplayName",
+            "columnName": "actorDisplayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actorId",
+            "columnName": "actorId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actorType",
+            "columnName": "actorType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expirationTimestamp",
+            "columnName": "expirationTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "replyable",
+            "columnName": "isReplyable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isTemporary",
+            "columnName": "isTemporary",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastEditActorDisplayName",
+            "columnName": "lastEditActorDisplayName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastEditActorId",
+            "columnName": "lastEditActorId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastEditActorType",
+            "columnName": "lastEditActorType",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastEditTimestamp",
+            "columnName": "lastEditTimestamp",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "renderMarkdown",
+            "columnName": "markdown",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "messageParameters",
+            "columnName": "messageParameters",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "messageType",
+            "columnName": "messageType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentMessageId",
+            "columnName": "parent",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "reactions",
+            "columnName": "reactions",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "reactionsSelf",
+            "columnName": "reactionsSelf",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "referenceId",
+            "columnName": "referenceId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sendingFailed",
+            "columnName": "sendingFailed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sendStatus",
+            "columnName": "sendStatus",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "silent",
+            "columnName": "silent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "systemMessageType",
+            "columnName": "systemMessage",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "internalId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ChatMessages_internalId",
+            "unique": true,
+            "columnNames": [
+              "internalId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_ChatMessages_internalId` ON `${TABLE_NAME}` (`internalId`)"
+          },
+          {
+            "name": "index_ChatMessages_internalConversationId",
+            "unique": false,
+            "columnNames": [
+              "internalConversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ChatMessages_internalConversationId` ON `${TABLE_NAME}` (`internalConversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "internalConversationId"
+            ],
+            "referencedColumns": [
+              "internalId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "ChatBlocks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `internalConversationId` TEXT NOT NULL, `accountId` INTEGER, `token` TEXT, `oldestMessageId` INTEGER NOT NULL, `newestMessageId` INTEGER NOT NULL, `hasHistory` INTEGER NOT NULL, FOREIGN KEY(`internalConversationId`) REFERENCES `Conversations`(`internalId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "internalConversationId",
+            "columnName": "internalConversationId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "token",
+            "columnName": "token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "oldestMessageId",
+            "columnName": "oldestMessageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newestMessageId",
+            "columnName": "newestMessageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasHistory",
+            "columnName": "hasHistory",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_ChatBlocks_internalConversationId",
+            "unique": false,
+            "columnNames": [
+              "internalConversationId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ChatBlocks_internalConversationId` ON `${TABLE_NAME}` (`internalConversationId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Conversations",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "internalConversationId"
+            ],
+            "referencedColumns": [
+              "internalId"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c6e75dfc4f897469a82de6aeff6208c1')"
+    ]
+  }
+}

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
@@ -29,6 +29,7 @@ import com.nextcloud.talk.application.NextcloudTalkApplication.Companion.sharedA
 import com.nextcloud.talk.chat.ChatActivity
 import com.nextcloud.talk.chat.data.ChatMessageRepository
 import com.nextcloud.talk.chat.data.model.ChatMessage
+import com.nextcloud.talk.data.database.model.SendStatus
 import com.nextcloud.talk.data.network.NetworkMonitor
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.databinding.ItemCustomOutcomingTextMessageBinding
@@ -184,7 +185,7 @@ class OutcomingTextMessageViewHolder(itemView: View) :
         binding.checkMark.visibility = View.INVISIBLE
         binding.sendingProgress.visibility = View.GONE
 
-        if (message.sendingFailed) {
+        if (message.sendStatus == SendStatus.FAILED) {
             updateStatus(R.drawable.baseline_error_outline_24, context.resources?.getString(R.string.nc_message_failed))
         } else if (message.isTemporary) {
             updateStatus(R.drawable.baseline_schedule_24, context.resources?.getString(R.string.nc_message_sending))

--- a/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
@@ -200,7 +200,7 @@ class MessageInputFragment : Fragment() {
                     val connectionGained = (!wasOnline && isOnline)
                     Log.d(TAG, "isOnline: $isOnline\nwasOnline: $wasOnline\nconnectionGained: $connectionGained")
                     if (connectionGained) {
-                        chatActivity.messageInputViewModel.sendTempMessages(
+                        chatActivity.messageInputViewModel.sendUnsentMessages(
                             chatActivity.conversationUser!!.getCredentials(),
                             ApiUtils.getUrlForChat(
                                 chatActivity.chatApiVersion,

--- a/app/src/main/java/com/nextcloud/talk/chat/data/ChatMessageRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/ChatMessageRepository.kt
@@ -110,7 +110,7 @@ interface ChatMessageRepository : LifecycleAwareManager {
 
     suspend fun editTempChatMessage(message: ChatMessage, editedMessageText: String): Flow<Boolean>
 
-    suspend fun sendTempChatMessages(credentials: String, url: String)
+    suspend fun sendUnsentChatMessages(credentials: String, url: String)
 
     suspend fun deleteTempMessage(chatMessage: ChatMessage)
 }

--- a/app/src/main/java/com/nextcloud/talk/chat/data/model/ChatMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/model/ChatMessage.kt
@@ -14,6 +14,7 @@ import android.util.Log
 import com.bluelinelabs.logansquare.annotation.JsonIgnore
 import com.nextcloud.talk.R
 import com.nextcloud.talk.application.NextcloudTalkApplication.Companion.sharedApplication
+import com.nextcloud.talk.data.database.model.SendStatus
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.models.json.chat.ChatUtils.Companion.getParsedMessage
 import com.nextcloud.talk.models.json.chat.ReadStatus
@@ -119,7 +120,7 @@ data class ChatMessage(
 
     var referenceId: String? = null,
 
-    var sendingFailed: Boolean = true,
+    var sendStatus: SendStatus? = null,
 
     var silent: Boolean = false
 

--- a/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
@@ -19,6 +19,7 @@ import com.nextcloud.talk.data.database.mappers.asEntity
 import com.nextcloud.talk.data.database.mappers.asModel
 import com.nextcloud.talk.data.database.model.ChatBlockEntity
 import com.nextcloud.talk.data.database.model.ChatMessageEntity
+import com.nextcloud.talk.data.database.model.SendStatus
 import com.nextcloud.talk.data.network.NetworkMonitor
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.extensions.toIntOrZero
@@ -365,11 +366,18 @@ class OfflineFirstChatRepository @Inject constructor(
         lookIntoFuture: Boolean,
         showUnreadMessagesMarker: Boolean
     ) {
+        receivedChatMessages.forEach {
+            Log.d(TAG, "receivedChatMessage: " + it.message)
+        }
+
         // remove all temp messages from UI
         val oldTempMessages = chatDao.getTempMessagesForConversation(internalConversationId)
             .first()
             .map(ChatMessageEntity::asModel)
-        oldTempMessages.forEach { _removeMessageFlow.emit(it) }
+        oldTempMessages.forEach {
+            Log.d(TAG, "oldTempMessage to be removed from UI: " + it.message)
+            _removeMessageFlow.emit(it)
+        }
 
         // add new messages to UI
         val tripleChatMessages = Triple(lookIntoFuture, showUnreadMessagesMarker, receivedChatMessages)
@@ -378,6 +386,9 @@ class OfflineFirstChatRepository @Inject constructor(
         // remove temp messages from DB that are now found in the new messages
         val chatMessagesReferenceIds = receivedChatMessages.mapTo(HashSet(receivedChatMessages.size)) { it.referenceId }
         val tempChatMessagesThatCanBeReplaced = oldTempMessages.filter { it.referenceId in chatMessagesReferenceIds }
+        tempChatMessagesThatCanBeReplaced.forEach {
+            Log.d(TAG, "oldTempMessage that was identified in newMessages: " + it.message)
+        }
         chatDao.deleteTempChatMessages(
             internalConversationId,
             tempChatMessagesThatCanBeReplaced.map { it.referenceId!! }
@@ -388,6 +399,10 @@ class OfflineFirstChatRepository @Inject constructor(
             .first()
             .sortedBy { it.internalId }
             .map(ChatMessageEntity::asModel)
+
+        remainingTempMessages.forEach {
+            Log.d(TAG, "remainingTempMessage: " + it.message)
+        }
 
         val triple = Triple(true, false, remainingTempMessages)
         _messageFlow.emit(triple)
@@ -830,6 +845,8 @@ class OfflineFirstChatRepository @Inject constructor(
             }
         }
 
+        Log.d(TAG, "sending chat message: " + message)
+
         return flow {
             val response = network.sendChatMessage(
                 credentials,
@@ -843,6 +860,17 @@ class OfflineFirstChatRepository @Inject constructor(
 
             val chatMessageModel = response.ocs?.data?.asModel()
 
+            val sentMessage = chatDao.getTempMessageForConversation(
+                internalConversationId,
+                referenceId
+            ).firstOrNull()
+
+            sentMessage?.let {
+                it.sendStatus = SendStatus.SENT_PENDING_ACK
+                chatDao.updateChatMessage(it)
+            }
+
+            Log.d(TAG, "sending chat message succeeded: " + message)
             emit(Result.success(chatMessageModel))
         }
             .catch { e ->
@@ -853,7 +881,8 @@ class OfflineFirstChatRepository @Inject constructor(
                     referenceId
                 ).firstOrNull()
                 failedMessage?.let {
-                    it.sendingFailed = true
+                    // it.sendingFailed = true
+                    it.sendStatus = SendStatus.FAILED
                     chatDao.updateChatMessage(it)
 
                     val failedMessageModel = it.asModel()
@@ -874,7 +903,8 @@ class OfflineFirstChatRepository @Inject constructor(
         referenceId: String
     ): Flow<Result<ChatMessage?>> {
         val messageToResend = chatDao.getTempMessageForConversation(internalConversationId, referenceId).first()
-        messageToResend.sendingFailed = false
+        // messageToResend.sendingFailed = false
+        messageToResend.sendStatus = SendStatus.PENDING
         chatDao.updateChatMessage(messageToResend)
 
         val messageToResendModel = messageToResend.asModel()
@@ -931,7 +961,7 @@ class OfflineFirstChatRepository @Inject constructor(
         }
 
     override suspend fun sendTempChatMessages(credentials: String, url: String) {
-        val tempMessages = chatDao.getTempMessagesForConversation(internalConversationId).first()
+        val tempMessages = chatDao.getPendingOrFailedMessagesForConversation(internalConversationId).first()
         tempMessages.sortedBy { it.internalId }.onEach {
             sendChatMessage(
                 credentials,

--- a/app/src/main/java/com/nextcloud/talk/chat/viewmodels/MessageInputViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/viewmodels/MessageInputViewModel.kt
@@ -169,9 +169,9 @@ class MessageInputViewModel @Inject constructor(
         }
     }
 
-    fun sendTempMessages(credentials: String, url: String) {
+    fun sendUnsentMessages(credentials: String, url: String) {
         viewModelScope.launch {
-            chatRepository.sendTempChatMessages(
+            chatRepository.sendUnsentChatMessages(
                 credentials,
                 url
             )

--- a/app/src/main/java/com/nextcloud/talk/data/database/dao/ChatMessagesDao.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/database/dao/ChatMessagesDao.kt
@@ -55,6 +55,29 @@ interface ChatMessagesDao {
         SELECT *
         FROM ChatMessages
         WHERE internalConversationId = :internalConversationId
+        AND isTemporary = 1 
+        AND (sendStatus = 'PENDING' OR sendStatus = 'FAILED')
+        ORDER BY timestamp DESC, id DESC
+        """
+    )
+    fun getPendingOrFailedMessagesForConversation(internalConversationId: String): Flow<List<ChatMessageEntity>>
+
+    @Query(
+        """
+        SELECT *
+        FROM ChatMessages
+        WHERE internalConversationId = :internalConversationId
+        AND (isTemporary = 1 OR sendStatus = 'SENT_PENDING_ACK')
+        ORDER BY timestamp DESC, id DESC
+        """
+    )
+    fun getTempOrSendingAckMessagesForConversation(internalConversationId: String): Flow<List<ChatMessageEntity>>
+
+    @Query(
+        """
+        SELECT *
+        FROM ChatMessages
+        WHERE internalConversationId = :internalConversationId
         AND referenceId = :referenceId
         AND isTemporary = 1
         ORDER BY timestamp DESC, id DESC

--- a/app/src/main/java/com/nextcloud/talk/data/database/dao/ChatMessagesDao.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/database/dao/ChatMessagesDao.kt
@@ -56,22 +56,11 @@ interface ChatMessagesDao {
         FROM ChatMessages
         WHERE internalConversationId = :internalConversationId
         AND isTemporary = 1 
-        AND (sendStatus = 'PENDING' OR sendStatus = 'FAILED')
+        AND sendStatus != 'SENT_PENDING_ACK'
         ORDER BY timestamp DESC, id DESC
         """
     )
-    fun getPendingOrFailedMessagesForConversation(internalConversationId: String): Flow<List<ChatMessageEntity>>
-
-    @Query(
-        """
-        SELECT *
-        FROM ChatMessages
-        WHERE internalConversationId = :internalConversationId
-        AND (isTemporary = 1 OR sendStatus = 'SENT_PENDING_ACK')
-        ORDER BY timestamp DESC, id DESC
-        """
-    )
-    fun getTempOrSendingAckMessagesForConversation(internalConversationId: String): Flow<List<ChatMessageEntity>>
+    fun getTempUnsentMessagesForConversation(internalConversationId: String): Flow<List<ChatMessageEntity>>
 
     @Query(
         """

--- a/app/src/main/java/com/nextcloud/talk/data/database/mappers/ChatMessageMapUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/database/mappers/ChatMessageMapUtils.kt
@@ -68,7 +68,7 @@ fun ChatMessageEntity.asModel() =
         isDeleted = deleted,
         referenceId = referenceId,
         isTemporary = isTemporary,
-        sendingFailed = sendingFailed,
+        sendStatus = sendStatus,
         readStatus = ReadStatus.NONE,
         silent = silent
     )

--- a/app/src/main/java/com/nextcloud/talk/data/database/model/ChatMessageEntity.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/database/model/ChatMessageEntity.kt
@@ -64,7 +64,6 @@ data class ChatMessageEntity(
     @ColumnInfo(name = "reactions") var reactions: LinkedHashMap<String, Int>? = null,
     @ColumnInfo(name = "reactionsSelf") var reactionsSelf: ArrayList<String>? = null,
     @ColumnInfo(name = "referenceId") var referenceId: String? = null,
-    @ColumnInfo(name = "sendingFailed") var sendingFailed: Boolean = false,
     @ColumnInfo(name = "sendStatus") var sendStatus: SendStatus? = null,
     @ColumnInfo(name = "silent") var silent: Boolean = false,
     @ColumnInfo(name = "systemMessage") var systemMessageType: ChatMessage.SystemMessageType,

--- a/app/src/main/java/com/nextcloud/talk/data/database/model/ChatMessageEntity.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/database/model/ChatMessageEntity.kt
@@ -65,6 +65,7 @@ data class ChatMessageEntity(
     @ColumnInfo(name = "reactionsSelf") var reactionsSelf: ArrayList<String>? = null,
     @ColumnInfo(name = "referenceId") var referenceId: String? = null,
     @ColumnInfo(name = "sendingFailed") var sendingFailed: Boolean = false,
+    @ColumnInfo(name = "sendStatus") var sendStatus: SendStatus? = null,
     @ColumnInfo(name = "silent") var silent: Boolean = false,
     @ColumnInfo(name = "systemMessage") var systemMessageType: ChatMessage.SystemMessageType,
     @ColumnInfo(name = "timestamp") var timestamp: Long = 0

--- a/app/src/main/java/com/nextcloud/talk/data/database/model/SendStatus.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/database/model/SendStatus.kt
@@ -1,7 +1,7 @@
 /*
  * Nextcloud Talk - Android Client
  *
- * SPDX-FileCopyrightText: 2025 Your Name <your@email.com>
+ * SPDX-FileCopyrightText: 2025 Marcel Hibbe <dev@mhibbe.de>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/app/src/main/java/com/nextcloud/talk/data/database/model/SendStatus.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/database/model/SendStatus.kt
@@ -1,0 +1,14 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2025 Your Name <your@email.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.nextcloud.talk.data.database.model
+
+enum class SendStatus {
+    PENDING,
+    SENT_PENDING_ACK,
+    FAILED
+}

--- a/app/src/main/java/com/nextcloud/talk/data/source/local/Migrations.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/source/local/Migrations.kt
@@ -1,18 +1,31 @@
 /*
  * Nextcloud Talk - Android Client
  *
+ * SPDX-FileCopyrightText: 2024-2025 Marcel Hibbe <dev@mhibbe.de>
  * SPDX-FileCopyrightText: 2022 Andy Scherzinger <info@andy-scherzinger.de>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 package com.nextcloud.talk.data.source.local
 
 import android.util.Log
+import androidx.room.DeleteColumn
+import androidx.room.migration.AutoMigrationSpec
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import java.sql.SQLException
 
 @Suppress("MagicNumber")
 object Migrations {
+
+    //region Auto migrations
+
+    @DeleteColumn(tableName = "ChatMessages", columnName = "sendingFailed")
+    class AutoMigration16To17 : AutoMigrationSpec
+
+    //endregion
+
+    //region Manual migrations
+
     val MIGRATION_6_8 = object : Migration(6, 8) {
         override fun migrate(db: SupportSQLiteDatabase) {
             Log.i("Migrations", "Migrating 6 to 8")
@@ -76,12 +89,7 @@ object Migrations {
         }
     }
 
-    val MIGRATION_16_17 = object : Migration(16, 17) {
-        override fun migrate(db: SupportSQLiteDatabase) {
-            Log.i("Migrations", "Migrating 16 to 17")
-            addSendStatus(db)
-        }
-    }
+    //endregion
 
     fun migrateToRoom(db: SupportSQLiteDatabase) {
         db.execSQL(
@@ -323,17 +331,6 @@ object Migrations {
             )
         } catch (e: SQLException) {
             Log.i("Migrations", "Something went wrong when adding column hasImportant to table Conversations")
-        }
-    }
-
-    private fun addSendStatus(db: SupportSQLiteDatabase) {
-        try {
-            db.execSQL(
-                "ALTER TABLE ChatMessages " +
-                    "ADD COLUMN sendStatus TEXT NOT NULL DEFAULT 'PENDING'"
-            )
-        } catch (e: SQLException) {
-            Log.i("Migrations", "Something went wrong when adding column sendStatus to table ChatMessages")
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/data/source/local/Migrations.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/source/local/Migrations.kt
@@ -76,6 +76,13 @@ object Migrations {
         }
     }
 
+    val MIGRATION_16_17 = object : Migration(16, 17) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            Log.i("Migrations", "Migrating 16 to 17")
+            addSendStatus(db)
+        }
+    }
+
     fun migrateToRoom(db: SupportSQLiteDatabase) {
         db.execSQL(
             "CREATE TABLE User_new (" +
@@ -316,6 +323,17 @@ object Migrations {
             )
         } catch (e: SQLException) {
             Log.i("Migrations", "Something went wrong when adding column hasImportant to table Conversations")
+        }
+    }
+
+    private fun addSendStatus(db: SupportSQLiteDatabase) {
+        try {
+            db.execSQL(
+                "ALTER TABLE ChatMessages " +
+                    "ADD COLUMN sendStatus TEXT NOT NULL DEFAULT 'PENDING'"
+            )
+        } catch (e: SQLException) {
+            Log.i("Migrations", "Something went wrong when adding column sendStatus to table ChatMessages")
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/data/source/local/TalkDatabase.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/source/local/TalkDatabase.kt
@@ -29,6 +29,7 @@ import com.nextcloud.talk.data.source.local.converters.ExternalSignalingServerCo
 import com.nextcloud.talk.data.source.local.converters.HashMapHashMapConverter
 import com.nextcloud.talk.data.source.local.converters.LinkedHashMapConverter
 import com.nextcloud.talk.data.source.local.converters.PushConfigurationConverter
+import com.nextcloud.talk.data.source.local.converters.SendStatusConverter
 import com.nextcloud.talk.data.source.local.converters.ServerVersionConverter
 import com.nextcloud.talk.data.source.local.converters.SignalingSettingsConverter
 import com.nextcloud.talk.data.storage.ArbitraryStoragesDao
@@ -49,7 +50,7 @@ import java.util.Locale
         ChatMessageEntity::class,
         ChatBlockEntity::class
     ],
-    version = 16,
+    version = 17,
     autoMigrations = [
         AutoMigration(from = 9, to = 10)
     ],
@@ -63,7 +64,8 @@ import java.util.Locale
     SignalingSettingsConverter::class,
     HashMapHashMapConverter::class,
     LinkedHashMapConverter::class,
-    ArrayListConverter::class
+    ArrayListConverter::class,
+    SendStatusConverter::class
 )
 abstract class TalkDatabase : RoomDatabase() {
 
@@ -108,7 +110,7 @@ abstract class TalkDatabase : RoomDatabase() {
             return Room
                 .databaseBuilder(context.applicationContext, TalkDatabase::class.java, dbName)
                 // comment out openHelperFactory to view the database entries in Android Studio for debugging
-                .openHelperFactory(factory)
+                // .openHelperFactory(factory)
                 .addMigrations(
                     Migrations.MIGRATION_6_8,
                     Migrations.MIGRATION_7_8,
@@ -118,7 +120,8 @@ abstract class TalkDatabase : RoomDatabase() {
                     Migrations.MIGRATION_12_13,
                     Migrations.MIGRATION_13_14,
                     Migrations.MIGRATION_14_15,
-                    Migrations.MIGRATION_15_16
+                    Migrations.MIGRATION_15_16,
+                    Migrations.MIGRATION_16_17
                 )
                 .allowMainThreadQueries()
                 .addCallback(

--- a/app/src/main/java/com/nextcloud/talk/data/source/local/TalkDatabase.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/source/local/TalkDatabase.kt
@@ -1,7 +1,7 @@
 /*
  * Nextcloud Talk - Android Client
  *
- * SPDX-FileCopyrightText: 2023-2024 Marcel Hibbe <dev@mhibbe.de>
+ * SPDX-FileCopyrightText: 2023-2025 Marcel Hibbe <dev@mhibbe.de>
  * SPDX-FileCopyrightText: 2022 Andy Scherzinger <info@andy-scherzinger.de>
  * SPDX-FileCopyrightText: 2017-2020 Mario Danic <mario@lovelyhq.com>
  * SPDX-License-Identifier: GPL-3.0-or-later
@@ -23,6 +23,7 @@ import com.nextcloud.talk.data.database.dao.ConversationsDao
 import com.nextcloud.talk.data.database.model.ChatBlockEntity
 import com.nextcloud.talk.data.database.model.ChatMessageEntity
 import com.nextcloud.talk.data.database.model.ConversationEntity
+import com.nextcloud.talk.data.source.local.Migrations.AutoMigration16To17
 import com.nextcloud.talk.data.source.local.converters.ArrayListConverter
 import com.nextcloud.talk.data.source.local.converters.CapabilitiesConverter
 import com.nextcloud.talk.data.source.local.converters.ExternalSignalingServerConverter
@@ -52,7 +53,8 @@ import java.util.Locale
     ],
     version = 17,
     autoMigrations = [
-        AutoMigration(from = 9, to = 10)
+        AutoMigration(from = 9, to = 10),
+        AutoMigration(from = 16, to = 17, spec = AutoMigration16To17::class)
     ],
     exportSchema = true
 )
@@ -110,7 +112,7 @@ abstract class TalkDatabase : RoomDatabase() {
             return Room
                 .databaseBuilder(context.applicationContext, TalkDatabase::class.java, dbName)
                 // comment out openHelperFactory to view the database entries in Android Studio for debugging
-                // .openHelperFactory(factory)
+                .openHelperFactory(factory)
                 .addMigrations(
                     Migrations.MIGRATION_6_8,
                     Migrations.MIGRATION_7_8,
@@ -120,8 +122,7 @@ abstract class TalkDatabase : RoomDatabase() {
                     Migrations.MIGRATION_12_13,
                     Migrations.MIGRATION_13_14,
                     Migrations.MIGRATION_14_15,
-                    Migrations.MIGRATION_15_16,
-                    Migrations.MIGRATION_16_17
+                    Migrations.MIGRATION_15_16
                 )
                 .allowMainThreadQueries()
                 .addCallback(

--- a/app/src/main/java/com/nextcloud/talk/data/source/local/converters/SendStatusConverter.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/source/local/converters/SendStatusConverter.kt
@@ -1,7 +1,7 @@
 /*
  * Nextcloud Talk - Android Client
  *
- * SPDX-FileCopyrightText: 2025 Your Name <your@email.com>
+ * SPDX-FileCopyrightText: 2025 Marcel Hibbe <dev@mhibbe.de>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/app/src/main/java/com/nextcloud/talk/data/source/local/converters/SendStatusConverter.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/source/local/converters/SendStatusConverter.kt
@@ -1,0 +1,23 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2025 Your Name <your@email.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.nextcloud.talk.data.source.local.converters
+
+import androidx.room.TypeConverter
+import com.nextcloud.talk.data.database.model.SendStatus
+
+class SendStatusConverter {
+    @TypeConverter
+    fun fromStatus(value: SendStatus): String {
+        return value.name
+    }
+
+    @TypeConverter
+    fun toStatus(value: String): SendStatus {
+        return SendStatus.valueOf(value)
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/TempMessageActionsDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/TempMessageActionsDialog.kt
@@ -18,6 +18,7 @@ import com.nextcloud.talk.R
 import com.nextcloud.talk.application.NextcloudTalkApplication
 import com.nextcloud.talk.chat.ChatActivity
 import com.nextcloud.talk.chat.data.model.ChatMessage
+import com.nextcloud.talk.data.database.model.SendStatus
 import com.nextcloud.talk.data.network.NetworkMonitor
 import com.nextcloud.talk.databinding.DialogTempMessageActionsBinding
 import com.nextcloud.talk.ui.theme.ViewThemeUtils
@@ -58,9 +59,10 @@ class TempMessageActionsDialog(
 
     private fun initMenuItems() {
         this.lifecycleScope.launch {
-            initResendMessage(message.sendingFailed && networkMonitor.isOnline.value)
-            initMenuEditMessage(message.sendingFailed || !networkMonitor.isOnline.value)
-            initMenuDeleteMessage(message.sendingFailed || !networkMonitor.isOnline.value)
+            val sendingFailed = message.sendStatus == SendStatus.FAILED
+            initResendMessage(sendingFailed && networkMonitor.isOnline.value)
+            initMenuEditMessage(sendingFailed || !networkMonitor.isOnline.value)
+            initMenuDeleteMessage(sendingFailed || !networkMonitor.isOnline.value)
             initMenuItemCopy()
         }
     }

--- a/app/src/main/java/com/nextcloud/talk/utils/preview/ComposePreviewUtilsDaos.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/preview/ComposePreviewUtilsDaos.kt
@@ -30,16 +30,9 @@ class DummyChatMessagesDaoImpl : ChatMessagesDao {
     override fun getTempMessagesForConversation(internalConversationId: String): Flow<List<ChatMessageEntity>> =
         flowOf()
 
-    override fun getPendingOrFailedMessagesForConversation(
-        internalConversationId: String
-    ): Flow<List<ChatMessageEntity>> {
-        TODO("Not yet implemented")
-    }
-
-    override fun getTempOrSendingAckMessagesForConversation(
-        internalConversationId: String
-    ): Flow<List<ChatMessageEntity>> {
-        TODO("Not yet implemented")
+    override fun getTempUnsentMessagesForConversation(internalConversationId: String): Flow<List<ChatMessageEntity>> {
+        // nothing to return here as long this class is only used for the Search window
+        return flowOf()
     }
 
     override fun getTempMessageForConversation(

--- a/app/src/main/java/com/nextcloud/talk/utils/preview/ComposePreviewUtilsDaos.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/preview/ComposePreviewUtilsDaos.kt
@@ -30,6 +30,18 @@ class DummyChatMessagesDaoImpl : ChatMessagesDao {
     override fun getTempMessagesForConversation(internalConversationId: String): Flow<List<ChatMessageEntity>> =
         flowOf()
 
+    override fun getPendingOrFailedMessagesForConversation(
+        internalConversationId: String
+    ): Flow<List<ChatMessageEntity>> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getTempOrSendingAckMessagesForConversation(
+        internalConversationId: String
+    ): Flow<List<ChatMessageEntity>> {
+        TODO("Not yet implemented")
+    }
+
     override fun getTempMessageForConversation(
         internalConversationId: String,
         referenceId: String


### PR DESCRIPTION
this should fix #4921 (although i was never able to reproduce it)

This adds a sending status to make sure messages that are being sent are not sent again while they are not yet contained in the chat messages list from server.

Will be further improved when solving https://github.com/nextcloud/talk-android/issues/4596 

# Todo

- [ ] try out migration in real world scenario


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)