### PR TITLE
simplify how search results are shown

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -307,12 +307,7 @@ class ChatActivity :
                 runBlocking {
                     val id = intent?.getStringExtra(MessageSearchActivity.RESULT_KEY_MESSAGE_ID)
                     id?.let {
-                        val isSaved = chatViewModel.isMessageSaved(id.toLong())
-                        if (isSaved) {
-                            onMessageSearchResult(intent)
-                        } else {
-                            startContextChatWindowForMessage(id)
-                        }
+                        startContextChatWindowForMessage(id)
                     }
                 }
             }
@@ -2297,13 +2292,6 @@ class ChatActivity :
         }
     }
 
-    private fun onMessageSearchResult(intent: Intent?) {
-        val messageId = intent?.getStringExtra(MessageSearchActivity.RESULT_KEY_MESSAGE_ID)
-        messageId?.let { id ->
-            scrollToAndCenterMessageWithId(id)
-        }
-    }
-
     private fun executeIfResultOk(result: ActivityResult, onResult: (intent: Intent?) -> Unit) {
         if (result.resultCode == Activity.RESULT_OK) {
             onResult(result.data)
@@ -2319,7 +2307,7 @@ class ChatActivity :
         if (position != null && position >= 0) {
             binding.messagesListView.scrollToPosition(position)
         } else {
-            startContextChatWindowForMessage(messageId)
+            Log.d(TAG, "message $messageId that should be scrolled to was not found (scrollToMessageWithId)")
         }
     }
 
@@ -2332,10 +2320,12 @@ class ChatActivity :
                     binding.messagesListView.height / 2
                 )
             } else {
-                startContextChatWindowForMessage(messageId)
+                Log.d(
+                    TAG,
+                    "message $messageId that should be scrolled " +
+                        "to was not found (scrollToAndCenterMessageWithId)"
+                )
             }
-        } ?: run {
-            startContextChatWindowForMessage(messageId)
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/chat/data/ChatMessageRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/ChatMessageRepository.kt
@@ -76,8 +76,6 @@ interface ChatMessageRepository : LifecycleAwareManager {
      */
     suspend fun getMessage(messageId: Long, bundle: Bundle): Flow<ChatMessage>
 
-    suspend fun checkIfMessageIsSaved(messageId: Long): Boolean
-
     @Suppress("LongParameterList")
     suspend fun sendChatMessage(
         credentials: String,

--- a/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
@@ -475,15 +475,6 @@ class OfflineFirstChatRepository @Inject constructor(
             .map(ChatMessageEntity::asModel)
     }
 
-    override suspend fun checkIfMessageIsSaved(messageId: Long): Boolean {
-        try {
-            chatDao.getChatMessageForConversation(internalConversationId, messageId)
-            return true
-        } catch (_: Exception) {
-            return false
-        }
-    }
-
     @Suppress("UNCHECKED_CAST", "MagicNumber", "Detekt.TooGenericExceptionCaught")
     private fun getMessagesFromServer(bundle: Bundle): Pair<Int, List<ChatMessageJson>>? {
         val fieldMap = bundle.getSerializable(BundleKeys.KEY_FIELD_MAP) as HashMap<String, Int>

--- a/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
@@ -285,10 +285,6 @@ class ChatViewModel @Inject constructor(
         conversationRepository.getRoom(token)
     }
 
-    suspend fun isMessageSaved(messageId: Long): Boolean {
-        return chatRepository.checkIfMessageIsSaved(messageId)
-    }
-
     fun getCapabilities(user: User, token: String, conversationModel: ConversationModel) {
         Log.d(TAG, "Remote server ${conversationModel.remoteServer}")
         if (conversationModel.remoteServer.isNullOrEmpty()) {


### PR DESCRIPTION
1. reverting changes from commit 971cc79b76ea2b784cd7ae971a54130e832f2d75. The scroll to methods are used in other places and a user reported that the search window suddenly opened without to search.
2. remove checkIfMessageIsSaved method. If the message is saved or not does not matter. The only fact for "scroll to" would be that it's loaded in the adapter.
3. As the adapter is always null with the current implementation (when coming back from the first search window), the "scroll to" is replaced with the startContextChatWindowForMessage. This could be changed again when adapter is not null anymore after coming back from the other screen...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)