### PR TITLE
Fixes message timestamp color

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingTextMessageViewHolder.kt
@@ -20,6 +20,7 @@ import autodagger.AutoInjector
 import coil.load
 import com.google.android.flexbox.FlexboxLayout
 import com.google.android.material.snackbar.Snackbar
+import com.nextcloud.android.common.ui.theme.utils.ColorRole
 import com.nextcloud.talk.R
 import com.nextcloud.talk.application.NextcloudTalkApplication
 import com.nextcloud.talk.application.NextcloudTalkApplication.Companion.sharedApplication
@@ -157,7 +158,7 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) :
             binding.messageEditIndicator.visibility = View.GONE
             binding.messageTime.text = dateUtils.getLocalTimeStringFromTimestamp(message.timestamp)
         }
-        binding.messageTime.setTextColor(ContextCompat.getColor(context, R.color.no_emphasis_text))
+        viewThemeUtils.platform.colorTextView(binding.messageTime, ColorRole.ON_SURFACE_VARIANT)
         // parent message handling
         if (!message.isDeleted && message.parentMessageId != null) {
             processParentMessage(message)

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
@@ -105,7 +105,6 @@ class OutcomingTextMessageViewHolder(itemView: View) :
         if (!hasCheckboxes) {
             realView.isSelected = false
             layoutParams.isWrapBefore = false
-            viewThemeUtils.platform.colorTextView(binding.messageTime, ColorRole.ON_SURFACE_VARIANT)
 
             binding.messageText.visibility = View.VISIBLE
             binding.checkboxContainer.visibility = View.GONE
@@ -172,7 +171,7 @@ class OutcomingTextMessageViewHolder(itemView: View) :
             binding.messageEditIndicator.visibility = View.GONE
             binding.messageTime.text = dateUtils.getLocalTimeStringFromTimestamp(message.timestamp)
         }
-        binding.messageTime.setTextColor(ContextCompat.getColor(context, R.color.no_emphasis_text))
+        viewThemeUtils.platform.colorTextView(binding.messageTime, ColorRole.ON_SURFACE_VARIANT)
         setBubbleOnChatMessage(message)
         // parent message handling
         if (!message.isDeleted && message.parentMessageId != null) {


### PR DESCRIPTION
- fixes #5018 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
![Screenshot 2025-06-03 at 12 16 47 PM](https://github.com/user-attachments/assets/a532ce3f-7527-44c0-b95f-a0d2bfafa919) | ![Screenshot 2025-06-03 at 12 12 23 PM](https://github.com/user-attachments/assets/c8678da1-03c6-4783-b470-81d0df59bda1)
![Screenshot 2025-06-03 at 12 15 58 PM](https://github.com/user-attachments/assets/28e890a8-c08e-43a0-b21b-5afa48ab1f12) | ![Screenshot 2025-06-03 at 12 13 07 PM](https://github.com/user-attachments/assets/bbb98520-6e53-403f-8119-1dace1965fef)

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)