### PR TITLE
catch http 405 if endpoint is not available.

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/viewmodel/ConversationInfoViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/viewmodel/ConversationInfoViewModel.kt
@@ -319,14 +319,19 @@ class ConversationInfoViewModel @Inject constructor(
         }
     }
 
+    @Suppress("Detekt.TooGenericExceptionCaught")
     fun getProfileData(user: User, userId: String) {
         val url = ApiUtils.getUrlForProfile(user.baseUrl!!, userId)
         viewModelScope.launch {
-            val profile = conversationsRepository.getProfile(user.getCredentials(), url)
-            if (profile != null) {
-                _getProfileViewState.value = GetProfileSuccessState(profile)
-            } else {
-                _getProfileViewState.value = GetProfileErrorState
+            try {
+                val profile = conversationsRepository.getProfile(user.getCredentials(), url)
+                if (profile != null) {
+                    _getProfileViewState.value = GetProfileSuccessState(profile)
+                } else {
+                    _getProfileViewState.value = GetProfileErrorState
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to get profile data (if not supported there wil be http405)", e)
             }
         }
     }


### PR DESCRIPTION
fix #4983

Catch http 405 if endpoint is not available, e.g. for older server versions

Without this fix there would be the crash:

```
 E  FATAL EXCEPTION: main
 Process: com.nextcloud.talk2, PID: 7161
  retrofit2.HttpException: HTTP 405
  at retrofit2.KotlinExtensions$await$2$2.onResponse(KotlinExtensions.kt:53)
  at retrofit2.OkHttpCall$1.onResponse(OkHttpCall.java:164)
  at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:519)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
  at java.lang.Thread.run(Thread.java:1012)
Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@4a67b41, Dispatchers.Main.immediate]
```

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)