### PR TITLE
fix wrong plurals implementation

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -1245,8 +1245,9 @@ class ChatActivity :
         val deleteNoticeText = binding.conversationDeleteNotice.findViewById<TextView>(R.id.deletion_message)
         viewThemeUtils.material.themeCardView(binding.conversationDeleteNotice)
 
-        deleteNoticeText.text = String.format(
-            resources.getString(R.string.nc_conversation_auto_delete_notice),
+        deleteNoticeText.text = resources.getQuantityString(
+            R.plurals.nc_conversation_auto_delete_info,
+            retentionPeriod,
             retentionPeriod
         )
         viewThemeUtils.material.colorMaterialButtonPrimaryTonal(

--- a/app/src/main/res/layout/remainder_to_delete_conversation.xml
+++ b/app/src/main/res/layout/remainder_to_delete_conversation.xml
@@ -19,7 +19,6 @@
         android:id="@+id/deletion_message"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/nc_conversation_auto_delete_notice"
         android:textSize="14sp"
         android:lineSpacingExtra="4dp"
         android:gravity="center"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -520,12 +520,11 @@ How to translate with transifex:
     <string name="nc_forward_message">Forward</string>
     <string name="nc_reply">Reply</string>
     <string name="nc_reply_privately">Reply privately</string>
-    <string name="nc_delete_message">Delete</string>
-    <plurals name="nc_conversation_auto_delete_notice">
+    <plurals name="nc_conversation_auto_delete_info">
         <item quantity="one">This conversation will be automatically deleted for everyone in %1$d day of no activity</item>
         <item quantity="other">This conversation will be automatically deleted for everyone in %1$d days of no activity</item>
     </plurals>
-    <string name="nc_conversation_auto_delete_notice">This conversation will be automatically deleted for everyone in %1$d days of no activity</string>
+    <string name="nc_delete_message">Delete</string>
     <string name="nc_delete_now">Delete now</string>
     <string name="nc_keep">Keep</string>
     <string name="nc_delete_message_leaked_to_matterbridge">Message deleted successfully, but it might have been leaked to other services</string>


### PR DESCRIPTION
fixes bugs from https://github.com/nextcloud/talk-android/pull/5032/files#diff-5e01f7d37a66e4ca03deefc205d8e7008661cdd0284a05aaba1858e6b7bf9103R524-R528

- key was duplicated
- kotlin handling of plurals was missing

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)