### PR TITLE
Try to run analysis also for merge commits

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -29,7 +29,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Disabled on forks
-              if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+              if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
               run: |
                   echo 'Can not analyze PRs from forks'
                   exit 1


### PR DESCRIPTION
Trying to fix
https://github.com/nextcloud/android-config/pull/248/files

which caused that analysis is not only blocked for forks, bit also for merge commits.

Solution: If it's not a PR the step should be omitted..

This commit will be checked when workflow runs on github. It will be merged just to test it's working..

- [ ] If it works, do the change in android-config repo


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)