### PR TITLE
fix crash in call view

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/call/components/ParticipantGrid.kt
+++ b/app/src/main/java/com/nextcloud/talk/call/components/ParticipantGrid.kt
@@ -9,6 +9,7 @@
 
 package com.nextcloud.talk.call.components
 
+import android.annotation.SuppressLint
 import android.content.res.Configuration
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -29,6 +30,7 @@ import com.nextcloud.talk.adapters.ParticipantUiState
 import org.webrtc.EglBase
 import kotlin.math.ceil
 
+@SuppressLint("UnusedBoxWithConstraintsScope")
 @Suppress("LongParameterList")
 @Composable
 fun ParticipantGrid(
@@ -78,7 +80,9 @@ fun ParticipantGrid(
 
         LazyVerticalGrid(
             columns = GridCells.Fixed(columns),
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(availableHeight),
             verticalArrangement = Arrangement.spacedBy(itemSpacing),
             horizontalArrangement = Arrangement.spacedBy(itemSpacing),
             contentPadding = PaddingValues(vertical = edgePadding, horizontal = edgePadding)

--- a/app/src/main/java/com/nextcloud/talk/call/components/ParticipantTile.kt
+++ b/app/src/main/java/com/nextcloud/talk/call/components/ParticipantTile.kt
@@ -7,6 +7,7 @@
 
 package com.nextcloud.talk.call.components
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -40,6 +41,7 @@ const val NICK_OFFSET = 4f
 const val NICK_BLUR_RADIUS = 4f
 const val AVATAR_SIZE_FACTOR = 0.6f
 
+@SuppressLint("UnusedBoxWithConstraintsScope")
 @Suppress("Detekt.LongMethod")
 @Composable
 fun ParticipantTile(


### PR DESCRIPTION
fix #5073

LazyVerticalGrid was measured with infinite height, which Compose does not allow. By applying the availableHeight explicitly, this should fix the Exception:

```
Exception java.lang.IllegalStateException: Vertically scrollable component was measured with an infinity maximum height constraints, which is disallowed. One of the common reasons is nesting layouts like LazyColumn and Column(Modifier.verticalScroll()). If you want to add a header before the list of items please add a header as a separate item() before the main items() inside the LazyColumn scope. There are could be other reasons for this to happen: your ComposeView was added into a LinearLayout with some weight, you applied Modifier.wrapContentSize(unbounded = true) or wrote a custom layout. Please try to remove the source of infinite constraints in the hierarchy above the scrolling container.
  at androidx.compose.foundation.CheckScrollableContainerConstraintsKt.checkScrollableContainerConstraints-K40F9xA (CheckScrollableContainerConstraints.kt:35)
  at androidx.compose.foundation.lazy.grid.LazyGridKt$rememberLazyGridMeasurePolicy$1$1.invoke-0kLqBqw (LazyGrid.kt:174)
  at androidx.compose.foundation.lazy.grid.LazyGridKt$rememberLazyGridMeasurePolicy$1$1.invoke (LazyGrid.kt:172)
...
```


- Also:
Suppress UnusedBoxWithConstraintsScope as it seems that the maxHeight and maxWidth variables are not recognized as being used when they are "only" used in calculations.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)