### PR TITLE
Show delete all messages in 1:1 only when canDeleteConversation is true

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
@@ -1065,21 +1065,13 @@ class ConversationInfoActivity :
         ) {
             binding.addParticipantsAction.visibility = GONE
             binding.startGroupChat.visibility = VISIBLE
+            showDeleteAllMessagesOption(conversationCopy)
         } else if (ConversationUtils.canModerate(conversationCopy, spreedCapabilities)) {
             binding.addParticipantsAction.visibility = VISIBLE
-            if (hasSpreedFeatureCapability(
-                    spreedCapabilities,
-                    SpreedFeatures.CLEAR_HISTORY
-                ) && conversationCopy.canDeleteConversation
-            ) {
-                binding.clearConversationHistory.visibility = VISIBLE
-            } else {
-                binding.clearConversationHistory.visibility = GONE
-            }
+            showDeleteAllMessagesOption(conversationCopy)
             showOptionsMenu()
         } else {
             binding.addParticipantsAction.visibility = GONE
-
             if (ConversationUtils.isNoteToSelfConversation(conversation)) {
                 binding.notificationSettingsView.notificationSettings.visibility = VISIBLE
             } else {
@@ -1279,6 +1271,7 @@ class ConversationInfoActivity :
             binding.recordingConsentView.recordingConsentAll.visibility = VISIBLE
         }
 
+
         fun showSwitch() {
             binding.recordingConsentView.recordingConsentForConversation.visibility = VISIBLE
             binding.recordingConsentView.recordingConsentAll.visibility = GONE
@@ -1308,6 +1301,18 @@ class ConversationInfoActivity :
             }
         } else {
             hide()
+        }
+    }
+
+    fun showDeleteAllMessagesOption(conversationCopy: ConversationModel){
+        if (hasSpreedFeatureCapability(
+                spreedCapabilities,
+                SpreedFeatures.CLEAR_HISTORY
+            ) && conversationCopy.canDeleteConversation
+        ) {
+            binding.clearConversationHistory.visibility = VISIBLE
+        } else {
+            binding.clearConversationHistory.visibility = GONE
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
@@ -1271,7 +1271,6 @@ class ConversationInfoActivity :
             binding.recordingConsentView.recordingConsentAll.visibility = VISIBLE
         }
 
-
         fun showSwitch() {
             binding.recordingConsentView.recordingConsentForConversation.visibility = VISIBLE
             binding.recordingConsentView.recordingConsentAll.visibility = GONE
@@ -1304,7 +1303,7 @@ class ConversationInfoActivity :
         }
     }
 
-    fun showDeleteAllMessagesOption(conversationCopy: ConversationModel){
+    fun showDeleteAllMessagesOption(conversationCopy: ConversationModel) {
         if (hasSpreedFeatureCapability(
                 spreedCapabilities,
                 SpreedFeatures.CLEAR_HISTORY


### PR DESCRIPTION
- show delete all messages in one to one conversation only when canDeleteConversation is true


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)