### PR TITLE
Fix handling of signaling message responses

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/models/json/websocket/BaseWebSocketMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/websocket/BaseWebSocketMessage.kt
@@ -15,9 +15,11 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 @JsonObject
 data class BaseWebSocketMessage(
+    @JsonField(name = ["id"])
+    override var id: String? = null,
     @JsonField(name = ["type"])
     override var type: String? = null
 ) : BaseWebSocketMessageInterface, Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
-    constructor() : this(null)
+    constructor() : this(null, null)
 }

--- a/app/src/main/java/com/nextcloud/talk/models/json/websocket/BaseWebSocketMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/websocket/BaseWebSocketMessage.kt
@@ -16,8 +16,8 @@ import kotlinx.parcelize.Parcelize
 @JsonObject
 data class BaseWebSocketMessage(
     @JsonField(name = ["type"])
-    var type: String? = null
-) : Parcelable {
+    override var type: String? = null
+) : BaseWebSocketMessageInterface, Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
     constructor() : this(null)
 }

--- a/app/src/main/java/com/nextcloud/talk/models/json/websocket/BaseWebSocketMessageInterface.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/websocket/BaseWebSocketMessageInterface.kt
@@ -10,5 +10,6 @@ package com.nextcloud.talk.models.json.websocket
  * Interface with the properties common to all websocket signaling messages.
  */
 interface BaseWebSocketMessageInterface {
+    var id: String?
     var type: String?
 }

--- a/app/src/main/java/com/nextcloud/talk/models/json/websocket/BaseWebSocketMessageInterface.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/websocket/BaseWebSocketMessageInterface.kt
@@ -1,0 +1,14 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2025 Daniel Calviño Sánchez <danxuliu@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.models.json.websocket
+
+/**
+ * Interface with the properties common to all websocket signaling messages.
+ */
+interface BaseWebSocketMessageInterface {
+    var type: String?
+}

--- a/app/src/main/java/com/nextcloud/talk/models/json/websocket/CallOverallWebSocketMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/websocket/CallOverallWebSocketMessage.kt
@@ -16,10 +16,10 @@ import kotlinx.parcelize.Parcelize
 @JsonObject
 data class CallOverallWebSocketMessage(
     @JsonField(name = ["type"])
-    var type: String? = null,
+    override var type: String? = null,
     @JsonField(name = ["message"])
     var callWebSocketMessage: CallWebSocketMessage? = null
-) : Parcelable {
+) : BaseWebSocketMessageInterface, Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
     constructor() : this(null, null)
 }

--- a/app/src/main/java/com/nextcloud/talk/models/json/websocket/CallOverallWebSocketMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/websocket/CallOverallWebSocketMessage.kt
@@ -15,11 +15,13 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 @JsonObject
 data class CallOverallWebSocketMessage(
+    @JsonField(name = ["id"])
+    override var id: String? = null,
     @JsonField(name = ["type"])
     override var type: String? = null,
     @JsonField(name = ["message"])
     var callWebSocketMessage: CallWebSocketMessage? = null
 ) : BaseWebSocketMessageInterface, Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
-    constructor() : this(null, null)
+    constructor() : this(null, null, null)
 }

--- a/app/src/main/java/com/nextcloud/talk/models/json/websocket/ErrorOverallWebSocketMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/websocket/ErrorOverallWebSocketMessage.kt
@@ -16,10 +16,10 @@ import kotlinx.parcelize.Parcelize
 @JsonObject
 data class ErrorOverallWebSocketMessage(
     @JsonField(name = ["type"])
-    var type: String? = null,
+    override var type: String? = null,
     @JsonField(name = ["error"])
     var errorWebSocketMessage: ErrorWebSocketMessage? = null
-) : Parcelable {
+) : BaseWebSocketMessageInterface, Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
     constructor() : this(null, null)
 }

--- a/app/src/main/java/com/nextcloud/talk/models/json/websocket/ErrorOverallWebSocketMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/websocket/ErrorOverallWebSocketMessage.kt
@@ -15,11 +15,13 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 @JsonObject
 data class ErrorOverallWebSocketMessage(
+    @JsonField(name = ["id"])
+    override var id: String? = null,
     @JsonField(name = ["type"])
     override var type: String? = null,
     @JsonField(name = ["error"])
     var errorWebSocketMessage: ErrorWebSocketMessage? = null
 ) : BaseWebSocketMessageInterface, Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
-    constructor() : this(null, null)
+    constructor() : this(null, null, null)
 }

--- a/app/src/main/java/com/nextcloud/talk/models/json/websocket/EventOverallWebSocketMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/websocket/EventOverallWebSocketMessage.kt
@@ -19,11 +19,13 @@ import java.util.HashMap
 @JsonObject
 @TypeParceler<Any, AnyParceler>
 class EventOverallWebSocketMessage(
+    @JsonField(name = ["id"])
+    override var id: String? = null,
     @JsonField(name = ["type"])
     override var type: String? = null,
     @JsonField(name = ["event"])
     var eventMap: HashMap<String, Any>? = null
 ) : BaseWebSocketMessageInterface, Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
-    constructor() : this(null, null)
+    constructor() : this(null, null, null)
 }

--- a/app/src/main/java/com/nextcloud/talk/models/json/websocket/EventOverallWebSocketMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/websocket/EventOverallWebSocketMessage.kt
@@ -20,10 +20,10 @@ import java.util.HashMap
 @TypeParceler<Any, AnyParceler>
 class EventOverallWebSocketMessage(
     @JsonField(name = ["type"])
-    var type: String? = null,
+    override var type: String? = null,
     @JsonField(name = ["event"])
     var eventMap: HashMap<String, Any>? = null
-) : Parcelable {
+) : BaseWebSocketMessageInterface, Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
     constructor() : this(null, null)
 }

--- a/app/src/main/java/com/nextcloud/talk/models/json/websocket/HelloOverallWebSocketMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/websocket/HelloOverallWebSocketMessage.kt
@@ -16,10 +16,10 @@ import kotlinx.parcelize.Parcelize
 @JsonObject
 data class HelloOverallWebSocketMessage(
     @JsonField(name = ["type"])
-    var type: String? = null,
+    override var type: String? = null,
     @JsonField(name = ["hello"])
     var helloWebSocketMessage: HelloWebSocketMessage? = null
-) : Parcelable {
+) : BaseWebSocketMessageInterface, Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
     constructor() : this(null, null)
 }

--- a/app/src/main/java/com/nextcloud/talk/models/json/websocket/HelloOverallWebSocketMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/websocket/HelloOverallWebSocketMessage.kt
@@ -15,11 +15,13 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 @JsonObject
 data class HelloOverallWebSocketMessage(
+    @JsonField(name = ["id"])
+    override var id: String? = null,
     @JsonField(name = ["type"])
     override var type: String? = null,
     @JsonField(name = ["hello"])
     var helloWebSocketMessage: HelloWebSocketMessage? = null
 ) : BaseWebSocketMessageInterface, Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
-    constructor() : this(null, null)
+    constructor() : this(null, null, null)
 }

--- a/app/src/main/java/com/nextcloud/talk/models/json/websocket/HelloResponseOverallWebSocketMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/websocket/HelloResponseOverallWebSocketMessage.kt
@@ -16,10 +16,10 @@ import kotlinx.parcelize.Parcelize
 @JsonObject
 data class HelloResponseOverallWebSocketMessage(
     @JsonField(name = ["type"])
-    var type: String? = null,
+    override var type: String? = null,
     @JsonField(name = ["hello"])
     var helloResponseWebSocketMessage: HelloResponseWebSocketMessage? = null
-) : Parcelable {
+) : BaseWebSocketMessageInterface, Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
     constructor() : this(null, null)
 }

--- a/app/src/main/java/com/nextcloud/talk/models/json/websocket/HelloResponseOverallWebSocketMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/websocket/HelloResponseOverallWebSocketMessage.kt
@@ -15,11 +15,13 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 @JsonObject
 data class HelloResponseOverallWebSocketMessage(
+    @JsonField(name = ["id"])
+    override var id: String? = null,
     @JsonField(name = ["type"])
     override var type: String? = null,
     @JsonField(name = ["hello"])
     var helloResponseWebSocketMessage: HelloResponseWebSocketMessage? = null
 ) : BaseWebSocketMessageInterface, Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
-    constructor() : this(null, null)
+    constructor() : this(null, null, null)
 }

--- a/app/src/main/java/com/nextcloud/talk/models/json/websocket/JoinedRoomOverallWebSocketMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/websocket/JoinedRoomOverallWebSocketMessage.kt
@@ -15,11 +15,13 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 @JsonObject
 data class JoinedRoomOverallWebSocketMessage(
+    @JsonField(name = ["id"])
+    override var id: String? = null,
     @JsonField(name = ["type"])
     override var type: String? = null,
     @JsonField(name = ["room"])
     var roomWebSocketMessage: RoomWebSocketMessage? = null
 ) : BaseWebSocketMessageInterface, Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
-    constructor() : this(null, null)
+    constructor() : this(null, null, null)
 }

--- a/app/src/main/java/com/nextcloud/talk/models/json/websocket/JoinedRoomOverallWebSocketMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/websocket/JoinedRoomOverallWebSocketMessage.kt
@@ -16,10 +16,10 @@ import kotlinx.parcelize.Parcelize
 @JsonObject
 data class JoinedRoomOverallWebSocketMessage(
     @JsonField(name = ["type"])
-    var type: String? = null,
+    override var type: String? = null,
     @JsonField(name = ["room"])
     var roomWebSocketMessage: RoomWebSocketMessage? = null
-) : Parcelable {
+) : BaseWebSocketMessageInterface, Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
     constructor() : this(null, null)
 }

--- a/app/src/main/java/com/nextcloud/talk/models/json/websocket/RoomOverallWebSocketMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/websocket/RoomOverallWebSocketMessage.kt
@@ -16,10 +16,10 @@ import kotlinx.parcelize.Parcelize
 @JsonObject
 class RoomOverallWebSocketMessage(
     @JsonField(name = ["type"])
-    var type: String? = null,
+    override var type: String? = null,
     @JsonField(name = ["room"])
     var roomWebSocketMessage: RoomWebSocketMessage? = null
-) : Parcelable {
+) : BaseWebSocketMessageInterface, Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
     constructor() : this(null, null)
 }

--- a/app/src/main/java/com/nextcloud/talk/models/json/websocket/RoomOverallWebSocketMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/websocket/RoomOverallWebSocketMessage.kt
@@ -16,10 +16,12 @@ import kotlinx.parcelize.Parcelize
 @JsonObject
 class RoomOverallWebSocketMessage(
     @JsonField(name = ["type"])
+    override var id: String? = null,
+    @JsonField(name = ["type"])
     override var type: String? = null,
     @JsonField(name = ["room"])
     var roomWebSocketMessage: RoomWebSocketMessage? = null
 ) : BaseWebSocketMessageInterface, Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
-    constructor() : this(null, null)
+    constructor() : this(null, null, null)
 }

--- a/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketInstance.kt
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketInstance.kt
@@ -326,7 +326,7 @@ class WebSocketInstance internal constructor(
             hasMCU = helloResponseWebSocketMessage1.serverHasMCUSupport()
         }
         for (i in messagesQueue.indices) {
-            webSocket.send(messagesQueue[i])
+            webSocket.send(LoganSquare.serialize(messagesQueue[i]))
         }
         messagesQueue = ArrayList()
         val helloHashMap = HashMap<String, String?>()

--- a/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketInstance.kt
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketInstance.kt
@@ -150,7 +150,7 @@ class WebSocketInstance internal constructor(
         if (webSocket === internalWebSocket) {
             Log.d(TAG, "Receiving : $webSocket $text")
             try {
-                val (messageType) = LoganSquare.parse(text, BaseWebSocketMessage::class.java)
+                val (_, messageType) = LoganSquare.parse(text, BaseWebSocketMessage::class.java)
                 if (messageType != null) {
                     when (messageType) {
                         "hello" -> processHelloMessage(webSocket, text)
@@ -176,7 +176,7 @@ class WebSocketInstance internal constructor(
 
     @Throws(IOException::class)
     private fun processMessage(text: String) {
-        val (_, callWebSocketMessage) = LoganSquare.parse(text, CallOverallWebSocketMessage::class.java)
+        val (_, _, callWebSocketMessage) = LoganSquare.parse(text, CallOverallWebSocketMessage::class.java)
         if (callWebSocketMessage != null) {
             val ncSignalingMessage = callWebSocketMessage.ncSignalingMessage
 
@@ -285,7 +285,7 @@ class WebSocketInstance internal constructor(
 
     @Throws(IOException::class)
     private fun processJoinedRoomMessage(text: String) {
-        val (_, roomWebSocketMessage) = LoganSquare.parse(text, JoinedRoomOverallWebSocketMessage::class.java)
+        val (_, _, roomWebSocketMessage) = LoganSquare.parse(text, JoinedRoomOverallWebSocketMessage::class.java)
         if (roomWebSocketMessage != null) {
             currentRoomToken = roomWebSocketMessage.roomId
             if (roomWebSocketMessage.roomPropertiesWebSocketMessage != null && !TextUtils.isEmpty(currentRoomToken)) {
@@ -297,7 +297,7 @@ class WebSocketInstance internal constructor(
     @Throws(IOException::class)
     private fun processErrorMessage(webSocket: WebSocket, text: String) {
         Log.e(TAG, "Received error: $text")
-        val (_, message) = LoganSquare.parse(text, ErrorOverallWebSocketMessage::class.java)
+        val (_, _, message) = LoganSquare.parse(text, ErrorOverallWebSocketMessage::class.java)
         if (message != null) {
             if ("no_such_session" == message.code) {
                 Log.d(TAG, "WebSocket " + webSocket.hashCode() + " resumeID " + resumeId + " expired")
@@ -316,7 +316,7 @@ class WebSocketInstance internal constructor(
         isConnected = true
         reconnecting = false
         val oldResumeId = resumeId
-        val (_, helloResponseWebSocketMessage1) = LoganSquare.parse(
+        val (_, _, helloResponseWebSocketMessage1) = LoganSquare.parse(
             text,
             HelloResponseOverallWebSocketMessage::class.java
         )

--- a/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketInstance.kt
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketInstance.kt
@@ -165,7 +165,6 @@ class WebSocketInstance internal constructor(
                     when (messageType) {
                         "hello" -> processHelloMessage(webSocket, text)
                         "error" -> processErrorMessage(webSocket, text)
-                        "room" -> processJoinedRoomMessage(text)
                         "event" -> processEventMessage(text)
                         "message" -> processMessage(text)
                         "bye" -> {
@@ -396,11 +395,14 @@ class WebSocketInstance internal constructor(
         Log.d(TAG, "   session: $normalBackendSession")
         try {
             val message = webSocketConnectionHelper.getAssembledJoinOrLeaveRoomModel(roomToken, normalBackendSession, federation)
+            val processJoinedRoomMessageCallback = { text: String ->
+                processJoinedRoomMessage(text)
+            }
             if (roomToken == "") {
                 Log.d(TAG, "sending 'leave room' via websocket")
                 currentNormalBackendSession = ""
                 currentFederation = null
-                sendMessage(message)
+                sendMessage(message, processJoinedRoomMessageCallback)
             } else if (
                 roomToken == currentRoomToken &&
                 normalBackendSession == currentNormalBackendSession &&
@@ -413,7 +415,7 @@ class WebSocketInstance internal constructor(
                 Log.d(TAG, "Sending join room message via websocket")
                 currentNormalBackendSession = normalBackendSession
                 currentFederation = federation
-                sendMessage(message)
+                sendMessage(message, processJoinedRoomMessageCallback)
             }
         } catch (e: IOException) {
             Log.e(TAG, "Failed to serialize signaling message", e)

--- a/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketInstance.kt
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketInstance.kt
@@ -424,11 +424,13 @@ class WebSocketInstance internal constructor(
             if (!reconnecting) {
                 restartWebSocket()
             }
-        } else {
-            if (!internalWebSocket!!.send(message)) {
-                messagesQueue.add(message)
-                restartWebSocket()
-            }
+
+            return
+        }
+
+        if (!internalWebSocket!!.send(message)) {
+            messagesQueue.add(message)
+            restartWebSocket()
         }
     }
 


### PR DESCRIPTION
Fixes #4635

:warning: :warning: :warning: WIP, it seems that sometimes it does not work as expected, so it still needs further development :warning: :warning: :warning:

When the external signaling server is used it is possible to assign an id to a message to then be able to identify the response in the messages sent by the signaling server. For example, [when joining a room, the signaling server confirms that joining the room was successful with a `room` message](https://github.com/strukturag/nextcloud-spreed-signaling/blob/6b04363faf8629cee3f42bebcfc1fa3355aaf8a2/docs/standalone-signaling-api-v1.md#join-room).

Until now the Android app assumed that `room` messages were sent only in that case, but a `room` message can be sent also if the properties of the room change. When the room is joined and the call activity is active [the call is also joined](https://github.com/nextcloud/talk-android/blob/c8b33a380ab1d7b6193dd53fa613e974469a225e/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt#L1962-L1968), so if the properties of the room changed while in a call, the Android app rejoined the call. However, this was not done in a clean way; [previous event handlers were replaced without tearing down them first](https://github.com/nextcloud/talk-android/blob/c8b33a380ab1d7b6193dd53fa613e974469a225e/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt#L1728-L1729), and that caused strange issues. For example, when a recording started additional guests appeared in the UI. That would be the most common/visible case, but there could be others too when something caused a `room` message to be sent while in a call.

To solve that now only the `room` event that is sent as a response of joining a room is treated as such. Currently other `room` messages are ignored, although they could be used to update the properties of the room and things like that, but that would be a future improvement.

## TODO
- [ ] Check why the join room message is sent twice when joining a call, was it introduced by these changes or was it happening already?
- [ ] Test thoroughly (including federation)
- [ ] Check other messages that could require a callback besides joining a room (for example, hello responses)
- [ ] Guard against joining a call while already in a call? Or properly replace the event handlers? This would be just a safety measure, although not really needed after the fix.

## How to test

- Setup an HPB
- Setup a recording server
- In the WebUI, create a conversation
- Invite the user of the Android app
- Start a call
- In the Android app, join the call
- In the WebUI, start a recording

### Result with this pull request

Nothing strange happens in the Android app

### Result without this pull request

A guest user appears in the call view of the Android app
