### PR TITLE
fix that contact in search is clickable

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/items/ContactItem.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/ContactItem.kt
@@ -194,7 +194,6 @@ class ContactItem(
     }
 
     companion object {
-        const val VIEW_TYPE = FlexibleItemViewType.CONTACT_ITEM
         private const val FULLY_OPAQUE: Float = 1.0f
         private const val SEMI_TRANSPARENT: Float = 0.38f
     }

--- a/app/src/main/java/com/nextcloud/talk/adapters/items/FlexibleItemViewType.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/FlexibleItemViewType.kt
@@ -14,5 +14,4 @@ object FlexibleItemViewType {
     const val POLL_RESULT_HEADER_ITEM: Int = 1120391234
     const val POLL_RESULT_VOTER_ITEM: Int = 1120391235
     const val POLL_RESULT_VOTERS_OVERVIEW_ITEM: Int = 1120391236
-    const val CONTACT_ITEM: Int = 2131558687
 }

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -163,7 +163,6 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import retrofit2.HttpException
 import java.io.File
-import java.util.Objects
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
@@ -1481,10 +1480,9 @@ class ConversationsListActivity :
     override fun onItemClick(view: View, position: Int): Boolean {
         val item = adapter?.getItem(position)
         if (item != null) {
-            when (item.itemViewType) {
-                MessageResultItem.VIEW_TYPE -> {
-                    val messageItem: MessageResultItem = item as MessageResultItem
-                    val token = messageItem.messageEntry.conversationToken
+            when (item) {
+                is MessageResultItem -> {
+                    val token = item.messageEntry.conversationToken
                     val conversationName = (
                         conversationItems.first {
                             (it is ConversationItem) && it.model.token == token
@@ -1498,27 +1496,26 @@ class ConversationsListActivity :
                             bundle.putString(BundleKeys.KEY_CREDENTIALS, credentials!!)
                             bundle.putString(BundleKeys.KEY_BASE_URL, currentUser!!.baseUrl)
                             bundle.putString(KEY_ROOM_TOKEN, token)
-                            bundle.putString(BundleKeys.KEY_MESSAGE_ID, messageItem.messageEntry.messageId)
+                            bundle.putString(BundleKeys.KEY_MESSAGE_ID, item.messageEntry.messageId)
                             bundle.putString(BundleKeys.KEY_CONVERSATION_NAME, conversationName)
                             ContextChatCompose(bundle).GetDialogView(shouldDismiss, context)
                         }
                     }
                 }
 
-                LoadMoreResultsItem.VIEW_TYPE -> {
+                is LoadMoreResultsItem -> {
                     loadMoreMessages()
                 }
 
-                ConversationItem.VIEW_TYPE -> {
-                    handleConversation((Objects.requireNonNull(item) as ConversationItem).model)
+                is ConversationItem -> {
+                    handleConversation(item.model)
                 }
 
-                ContactItem.VIEW_TYPE -> {
-                    val contact = item as ContactItem
+                is ContactItem -> {
                     contactsViewModel.createRoom(
                         ROOM_TYPE_ONE_ONE,
                         null,
-                        contact.model.actorId!!,
+                        item.model.actorId!!,
                         null
                     )
                 }

--- a/app/src/main/java/com/nextcloud/talk/messagesearch/MessageSearchActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/messagesearch/MessageSearchActivity.kt
@@ -148,13 +148,12 @@ class MessageSearchActivity : BaseActivity() {
         adapter!!.addListener(object : FlexibleAdapter.OnItemClickListener {
             override fun onItemClick(view: View?, position: Int): Boolean {
                 val item = adapter!!.getItem(position)
-                when (item?.itemViewType) {
-                    LoadMoreResultsItem.VIEW_TYPE -> {
+                when (item) {
+                    is LoadMoreResultsItem -> {
                         viewModel.loadMore()
                     }
-                    MessageResultItem.VIEW_TYPE -> {
-                        val messageItem = item as MessageResultItem
-                        viewModel.selectMessage(messageItem.messageEntry)
+                    is MessageResultItem -> {
+                        viewModel.selectMessage(item.messageEntry)
                     }
                 }
                 return false


### PR DESCRIPTION
A contact (so not a conversation yet!) had the VIEW_TYPE 2131558677, but 2131558687 was expected to identify the type, see FlexibleViewType.kt

The checks in onItemClick are replaced to directly check the type via kotlin "is" method.

best solution for future: FlexibleAdapter should be removed!-> replace with Compose!


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)