### PR TITLE
handle markdown links

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingTextMessageViewHolder.kt
@@ -106,6 +106,10 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) :
                 viewThemeUtils
             )
 
+            message.message?.let {
+                messageUtils.hyperLinks(binding.messageText, message.message!!)
+            }
+
             val spansFromString: Array<Any> = processedMessageText!!.getSpans(
                 0,
                 processedMessageText.length,
@@ -135,6 +139,7 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) :
                 message,
                 itemView
             )
+
             val messageParameters = message.messageParameters
             if (
                 (messageParameters == null || messageParameters.size <= 0) &&

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
@@ -117,6 +117,10 @@ class OutcomingTextMessageViewHolder(itemView: View) :
                 viewThemeUtils
             )
 
+            message.message?.let {
+                messageUtils.hyperLinks(binding.messageText, message.message!!)
+            }
+
             val spansFromString: Array<Any> = processedMessageText!!.getSpans(
                 0,
                 processedMessageText.length,

--- a/app/src/main/java/com/nextcloud/talk/utils/MarkdownUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/MarkdownUtils.kt
@@ -9,7 +9,7 @@ package com.nextcloud.talk.utils
 
 import android.content.Context
 import android.content.Intent
-import android.text.method.ScrollingMovementMethod
+import android.util.Log
 import android.view.View
 import androidx.core.net.toUri
 import com.nextcloud.talk.R
@@ -19,12 +19,12 @@ import io.noties.markwon.Markwon
 import io.noties.markwon.MarkwonConfiguration
 import io.noties.markwon.core.MarkwonTheme
 import io.noties.markwon.ext.strikethrough.StrikethroughPlugin
+import io.noties.markwon.ext.tables.TablePlugin
 import io.noties.markwon.ext.tasklist.TaskListDrawable
 import io.noties.markwon.ext.tasklist.TaskListPlugin
-import io.noties.markwon.movement.MovementMethodPlugin
 
-object MarkwonUtils {
-    private const val TAG = "MarkwonUtils"
+object MarkdownUtils {
+    private const val TAG = "MarkdownUtils"
 
     fun build(context: Context, textColor: Int): Markwon {
         val drawable = TaskListDrawable(textColor, textColor, context.getColor(R.color.bg_default))
@@ -37,6 +37,7 @@ object MarkwonUtils {
                 override fun configureConfiguration(builder: MarkwonConfiguration.Builder) {
                     builder.linkResolver(object : LinkResolverDef() {
                         override fun resolve(view: View, link: String) {
+                            Log.i(TAG, "Link - $view / $link")
                             var linkToOpen = link
                             if (!(linkToOpen.contains("http://") || linkToOpen.contains("https://"))) {
                                 linkToOpen = "https://$link"
@@ -52,7 +53,7 @@ object MarkwonUtils {
             })
             .usePlugin(TaskListPlugin.create(drawable))
             .usePlugin(StrikethroughPlugin.create())
-            .usePlugin(MovementMethodPlugin.create(ScrollingMovementMethod.getInstance()))
+            .usePlugin(TablePlugin.create { _ -> })
             .build()
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/utils/MarkdownUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/MarkdownUtils.kt
@@ -1,7 +1,7 @@
 /*
  * Nextcloud Talk - Android Client
  *
- * SPDX-FileCopyrightText: 2025 Your Name <your@email.com>
+ * SPDX-FileCopyrightText: 2025 Sowjanya Kota <sowjanya.kch@gmail.com>
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/app/src/main/java/com/nextcloud/talk/utils/MarkwonUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/MarkwonUtils.kt
@@ -7,17 +7,22 @@
 
 package com.nextcloud.talk.utils
 
+import android.annotation.SuppressLint
 import android.content.Context
-import android.util.Log
+import android.content.Intent
+import android.text.method.ScrollingMovementMethod
 import android.view.View
+import androidx.core.net.toUri
 import com.nextcloud.talk.R
 import io.noties.markwon.AbstractMarkwonPlugin
+import io.noties.markwon.LinkResolverDef
 import io.noties.markwon.Markwon
 import io.noties.markwon.MarkwonConfiguration
 import io.noties.markwon.core.MarkwonTheme
 import io.noties.markwon.ext.strikethrough.StrikethroughPlugin
 import io.noties.markwon.ext.tasklist.TaskListDrawable
 import io.noties.markwon.ext.tasklist.TaskListPlugin
+import io.noties.markwon.movement.MovementMethodPlugin
 
 object MarkwonUtils {
     private const val TAG = "MarkwonUtils"
@@ -31,13 +36,28 @@ object MarkwonUtils {
                 }
 
                 override fun configureConfiguration(builder: MarkwonConfiguration.Builder) {
-                    builder.linkResolver { view: View?, link: String? ->
-                        Log.i(TAG, "Link action not implemented $view / $link")
-                    }
+                    builder.linkResolver(object : LinkResolverDef() {
+                        @SuppressLint("SuspiciousIndentation")
+                        override fun resolve(view: View, link: String) {
+                            var linkToOpen = link
+                            if (!(linkToOpen.contains("http://") || linkToOpen.contains("https://"))) {
+                                linkToOpen = "https://$link"
+                            } else {
+                                linkToOpen = link
+                            }
+
+                            val browserIntent = Intent(
+                                Intent.ACTION_VIEW,
+                                linkToOpen.toUri()
+                            )
+                            context.startActivity(browserIntent)
+                        }
+                    })
                 }
             })
             .usePlugin(TaskListPlugin.create(drawable))
             .usePlugin(StrikethroughPlugin.create())
+            .usePlugin(MovementMethodPlugin.create(ScrollingMovementMethod.getInstance()))
             .build()
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/utils/MarkwonUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/MarkwonUtils.kt
@@ -7,7 +7,6 @@
 
 package com.nextcloud.talk.utils
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.text.method.ScrollingMovementMethod
@@ -37,15 +36,11 @@ object MarkwonUtils {
 
                 override fun configureConfiguration(builder: MarkwonConfiguration.Builder) {
                     builder.linkResolver(object : LinkResolverDef() {
-                        @SuppressLint("SuspiciousIndentation")
                         override fun resolve(view: View, link: String) {
                             var linkToOpen = link
                             if (!(linkToOpen.contains("http://") || linkToOpen.contains("https://"))) {
                                 linkToOpen = "https://$link"
-                            } else {
-                                linkToOpen = link
                             }
-
                             val browserIntent = Intent(
                                 Intent.ACTION_VIEW,
                                 linkToOpen.toUri()

--- a/app/src/main/java/com/nextcloud/talk/utils/MarkwonUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/MarkwonUtils.kt
@@ -1,0 +1,43 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2025 Your Name <your@email.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.nextcloud.talk.utils
+
+import android.content.Context
+import android.util.Log
+import android.view.View
+import com.nextcloud.talk.R
+import io.noties.markwon.AbstractMarkwonPlugin
+import io.noties.markwon.Markwon
+import io.noties.markwon.MarkwonConfiguration
+import io.noties.markwon.core.MarkwonTheme
+import io.noties.markwon.ext.strikethrough.StrikethroughPlugin
+import io.noties.markwon.ext.tasklist.TaskListDrawable
+import io.noties.markwon.ext.tasklist.TaskListPlugin
+
+object MarkwonUtils {
+    private const val TAG = "MarkwonUtils"
+
+    fun build(context: Context, textColor: Int): Markwon {
+        val drawable = TaskListDrawable(textColor, textColor, context.getColor(R.color.bg_default))
+        return Markwon.builder(context)
+            .usePlugin(object : AbstractMarkwonPlugin() {
+                override fun configureTheme(builder: MarkwonTheme.Builder) {
+                    builder.isLinkUnderlined(true).headingBreakHeight(0)
+                }
+
+                override fun configureConfiguration(builder: MarkwonConfiguration.Builder) {
+                    builder.linkResolver { view: View?, link: String? ->
+                        Log.i(TAG, "Link action not implemented $view / $link")
+                    }
+                }
+            })
+            .usePlugin(TaskListPlugin.create(drawable))
+            .usePlugin(StrikethroughPlugin.create())
+            .build()
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/utils/message/MessageUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/message/MessageUtils.kt
@@ -20,7 +20,7 @@ import com.nextcloud.talk.R
 import com.nextcloud.talk.chat.data.model.ChatMessage
 import com.nextcloud.talk.ui.theme.ViewThemeUtils
 import com.nextcloud.talk.utils.DisplayUtils
-import com.nextcloud.talk.utils.MarkwonUtils
+import com.nextcloud.talk.utils.MarkdownUtils
 
 class MessageUtils(val context: Context) {
     fun enrichChatReplyMessageText(
@@ -196,7 +196,7 @@ class MessageUtils(val context: Context) {
     }
 
     fun getRenderedMarkdownText(context: Context, markdown: String, textColor: Int): Spanned {
-        val markwon = MarkwonUtils.build(context, textColor)
+        val markwon = MarkdownUtils.build(context, textColor)
         return markwon.toMarkdown(markdown)
     }
 

--- a/app/src/main/java/com/nextcloud/talk/utils/message/MessageUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/message/MessageUtils.kt
@@ -16,6 +16,7 @@ import android.text.Spanned
 import android.text.style.StyleSpan
 import android.util.Log
 import android.view.View
+import android.widget.TextView
 import com.nextcloud.talk.R
 import com.nextcloud.talk.chat.data.model.ChatMessage
 import com.nextcloud.talk.ui.theme.ViewThemeUtils
@@ -208,6 +209,19 @@ class MessageUtils(val context: Context) {
         return markwon.toMarkdown(markdown)
     }
 
+    fun isMarkdownInlineLink(text: String): Boolean {
+        val markdownLinkRegex = Regex("""\[([^\]]+?)]\((.*?)(?:\s+"[^"]*")?\)""")
+        return markdownLinkRegex.containsMatchIn(text)
+    }
+
+    fun hyperLinks(view: TextView, text: String) {
+        val isMarkdownLink = isMarkdownInlineLink(text)
+        if (isMarkdownLink) {
+            view.autoLinkMask = 0
+        } else {
+            view.autoLinkMask = 15
+        }
+    }
     companion object {
         private const val TAG = "MessageUtils"
         const val MAX_REPLY_LENGTH = 250

--- a/app/src/main/java/com/nextcloud/talk/utils/message/MessageUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/message/MessageUtils.kt
@@ -9,26 +9,17 @@ package com.nextcloud.talk.utils.message
 import android.content.Context
 import android.content.Intent
 import android.graphics.Typeface
-import android.net.Uri
 import android.text.SpannableString
 import android.text.SpannableStringBuilder
 import android.text.Spanned
 import android.text.style.StyleSpan
-import android.util.Log
 import android.view.View
 import android.widget.TextView
+import androidx.core.net.toUri
 import com.nextcloud.talk.R
 import com.nextcloud.talk.chat.data.model.ChatMessage
 import com.nextcloud.talk.ui.theme.ViewThemeUtils
 import com.nextcloud.talk.utils.DisplayUtils
-import io.noties.markwon.AbstractMarkwonPlugin
-import io.noties.markwon.Markwon
-import io.noties.markwon.MarkwonConfiguration
-import io.noties.markwon.core.MarkwonTheme
-import io.noties.markwon.ext.strikethrough.StrikethroughPlugin
-import io.noties.markwon.ext.tables.TablePlugin
-import io.noties.markwon.ext.tasklist.TaskListDrawable
-import io.noties.markwon.ext.tasklist.TaskListPlugin
 import com.nextcloud.talk.utils.MarkwonUtils
 
 class MessageUtils(val context: Context) {

--- a/app/src/main/java/com/nextcloud/talk/utils/message/MessageUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/message/MessageUtils.kt
@@ -9,13 +9,13 @@ package com.nextcloud.talk.utils.message
 import android.content.Context
 import android.content.Intent
 import android.graphics.Typeface
+import android.net.Uri
 import android.text.SpannableString
 import android.text.SpannableStringBuilder
 import android.text.Spanned
 import android.text.style.StyleSpan
 import android.util.Log
 import android.view.View
-import androidx.core.net.toUri
 import com.nextcloud.talk.R
 import com.nextcloud.talk.chat.data.model.ChatMessage
 import com.nextcloud.talk.ui.theme.ViewThemeUtils
@@ -28,6 +28,7 @@ import io.noties.markwon.ext.strikethrough.StrikethroughPlugin
 import io.noties.markwon.ext.tables.TablePlugin
 import io.noties.markwon.ext.tasklist.TaskListDrawable
 import io.noties.markwon.ext.tasklist.TaskListPlugin
+import com.nextcloud.talk.utils.MarkwonUtils
 
 class MessageUtils(val context: Context) {
     fun enrichChatReplyMessageText(
@@ -203,21 +204,7 @@ class MessageUtils(val context: Context) {
     }
 
     fun getRenderedMarkdownText(context: Context, markdown: String, textColor: Int): Spanned {
-        val drawable = TaskListDrawable(textColor, textColor, context.getColor(R.color.bg_default))
-        val markwon = Markwon.builder(context).usePlugin(object : AbstractMarkwonPlugin() {
-            override fun configureTheme(builder: MarkwonTheme.Builder) {
-                builder.isLinkUnderlined(true).headingBreakHeight(0)
-            }
-
-            override fun configureConfiguration(builder: MarkwonConfiguration.Builder) {
-                builder.linkResolver { view: View?, link: String? ->
-                    Log.i(TAG, "Link action not implemented $view / $link")
-                }
-            }
-        })
-            .usePlugin(TaskListPlugin.create(drawable))
-            .usePlugin(TablePlugin.create { _ -> })
-            .usePlugin(StrikethroughPlugin.create()).build()
+        val markwon = MarkwonUtils.build(context, textColor)
         return markwon.toMarkdown(markdown)
     }
 

--- a/app/src/main/java/com/nextcloud/talk/utils/message/MessageUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/message/MessageUtils.kt
@@ -208,13 +208,15 @@ class MessageUtils(val context: Context) {
     fun hyperLinks(view: TextView, text: String) {
         val isMarkdownLink = isMarkdownInlineLink(text)
         if (isMarkdownLink) {
-            view.autoLinkMask = 0
+            view.autoLinkMask = AUTO_LINK_NONE
         } else {
-            view.autoLinkMask = 15
+            view.autoLinkMask = AUTO_LINK_ALL
         }
     }
     companion object {
         private const val TAG = "MessageUtils"
         const val MAX_REPLY_LENGTH = 250
+        const val AUTO_LINK_NONE = 0
+        const val AUTO_LINK_ALL = 15
     }
 }


### PR DESCRIPTION
fix #4909

Note:  Only marked down links are handled when a message contains both marked down links and plain URL's are present in a message. 

### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)