### PR TITLE
Adding Migration Tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,6 +82,11 @@ android {
             }
         }
 
+        sourceSets {
+            // Adds exported schema location as test app assets.
+            getByName("androidTest").assets.srcDir("$projectDir/schemas")
+        }
+
         testInstrumentationRunnerArgument "TEST_SERVER_URL", "${NC_TEST_SERVER_BASEURL}"
         testInstrumentationRunnerArgument "TEST_SERVER_USERNAME", "${NC_TEST_SERVER_USERNAME}"
         testInstrumentationRunnerArgument "TEST_SERVER_PASSWORD", "${NC_TEST_SERVER_PASSWORD}"
@@ -179,6 +184,7 @@ configurations.configureEach {
 }
 
 dependencies {
+    implementation 'androidx.room:room-testing-android:2.7.2'
     spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.14.0'
     spotbugsPlugins 'com.mebigfatguy.fb-contrib:fb-contrib:7.6.13'
     detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.8")
@@ -350,6 +356,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.13.4'
+    testImplementation("androidx.room:room-testing:2.7.2")
 }
 
 tasks.register('installGitHooks', Copy) {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -184,7 +184,7 @@ configurations.configureEach {
 }
 
 dependencies {
-    implementation 'androidx.room:room-testing-android:2.7.2'
+    implementation "androidx.room:room-testing-android:${roomVersion}"
     spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.14.0'
     spotbugsPlugins 'com.mebigfatguy.fb-contrib:fb-contrib:7.6.13'
     detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.8")
@@ -356,7 +356,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.13.4'
-    testImplementation("androidx.room:room-testing:2.7.2")
+    testImplementation "androidx.room:room-testing:${roomVersion}"
 }
 
 tasks.register('installGitHooks', Copy) {

--- a/app/schemas/com.nextcloud.talk.data.source.local.TalkDatabase/10.json
+++ b/app/schemas/com.nextcloud.talk.data.source.local.TalkDatabase/10.json
@@ -1,709 +1,146 @@
 {
-  "formatVersion": 1,
-  "database": {
-    "version": 10,
-    "identityHash": "c07a2543aa583e08e7b3208f44fcc7ac",
-    "entities": [
-      {
-        "tableName": "User",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `userId` TEXT, `username` TEXT, `baseUrl` TEXT, `token` TEXT, `displayName` TEXT, `pushConfigurationState` TEXT, `capabilities` TEXT, `serverVersion` TEXT DEFAULT '', `clientCertificate` TEXT, `externalSignalingServer` TEXT, `current` INTEGER NOT NULL, `scheduledForDeletion` INTEGER NOT NULL)",
-        "fields": [
-          {
-            "fieldPath": "id",
-            "columnName": "id",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "userId",
-            "columnName": "userId",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "username",
-            "columnName": "username",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "baseUrl",
-            "columnName": "baseUrl",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "token",
-            "columnName": "token",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "displayName",
-            "columnName": "displayName",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "pushConfigurationState",
-            "columnName": "pushConfigurationState",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "capabilities",
-            "columnName": "capabilities",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "serverVersion",
-            "columnName": "serverVersion",
-            "affinity": "TEXT",
-            "notNull": false,
-            "defaultValue": "''"
-          },
-          {
-            "fieldPath": "clientCertificate",
-            "columnName": "clientCertificate",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "externalSignalingServer",
-            "columnName": "externalSignalingServer",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "current",
-            "columnName": "current",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "scheduledForDeletion",
-            "columnName": "scheduledForDeletion",
-            "affinity": "INTEGER",
-            "notNull": true
-          }
+    "formatVersion": 1,
+    "database": {
+        "version": 10,
+        "identityHash": "1b2dab0ea495c45c9c9ee6e64ba74039",
+        "entities": [
+            {
+                "tableName": "User",
+                "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `userId` TEXT, `username` TEXT, `baseUrl` TEXT, `token` TEXT, `displayName` TEXT, `pushConfigurationState` TEXT, `capabilities` TEXT, `serverVersion` TEXT DEFAULT '', `clientCertificate` TEXT, `externalSignalingServer` TEXT, `current` INTEGER NOT NULL, `scheduledForDeletion` INTEGER NOT NULL)",
+                "fields": [
+                    {
+                        "fieldPath": "id",
+                        "columnName": "id",
+                        "affinity": "INTEGER",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "userId",
+                        "columnName": "userId",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "username",
+                        "columnName": "username",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "baseUrl",
+                        "columnName": "baseUrl",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "token",
+                        "columnName": "token",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "displayName",
+                        "columnName": "displayName",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "pushConfigurationState",
+                        "columnName": "pushConfigurationState",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "capabilities",
+                        "columnName": "capabilities",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "serverVersion",
+                        "columnName": "serverVersion",
+                        "affinity": "TEXT",
+                        "notNull": false,
+                        "defaultValue": "''"
+                    },
+                    {
+                        "fieldPath": "clientCertificate",
+                        "columnName": "clientCertificate",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "externalSignalingServer",
+                        "columnName": "externalSignalingServer",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "current",
+                        "columnName": "current",
+                        "affinity": "INTEGER",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "scheduledForDeletion",
+                        "columnName": "scheduledForDeletion",
+                        "affinity": "INTEGER",
+                        "notNull": true
+                    }
+                ],
+                "primaryKey": {
+                    "autoGenerate": true,
+                    "columnNames": [
+                        "id"
+                    ]
+                },
+                "indices": [],
+                "foreignKeys": []
+            },
+            {
+                "tableName": "ArbitraryStorage",
+                "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountIdentifier` INTEGER NOT NULL, `key` TEXT NOT NULL, `object` TEXT, `value` TEXT, PRIMARY KEY(`accountIdentifier`, `key`))",
+                "fields": [
+                    {
+                        "fieldPath": "accountIdentifier",
+                        "columnName": "accountIdentifier",
+                        "affinity": "INTEGER",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "key",
+                        "columnName": "key",
+                        "affinity": "TEXT",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "storageObject",
+                        "columnName": "object",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "value",
+                        "columnName": "value",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    }
+                ],
+                "primaryKey": {
+                    "autoGenerate": false,
+                    "columnNames": [
+                        "accountIdentifier",
+                        "key"
+                    ]
+                },
+                "indices": [],
+                "foreignKeys": []
+            }
         ],
-        "primaryKey": {
-          "autoGenerate": true,
-          "columnNames": [
-            "id"
-          ]
-        },
-        "indices": [],
-        "foreignKeys": []
-      },
-      {
-        "tableName": "ArbitraryStorage",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`accountIdentifier` INTEGER NOT NULL, `key` TEXT NOT NULL, `object` TEXT, `value` TEXT, PRIMARY KEY(`accountIdentifier`, `key`))",
-        "fields": [
-          {
-            "fieldPath": "accountIdentifier",
-            "columnName": "accountIdentifier",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "key",
-            "columnName": "key",
-            "affinity": "TEXT",
-            "notNull": true
-          },
-          {
-            "fieldPath": "storageObject",
-            "columnName": "object",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "value",
-            "columnName": "value",
-            "affinity": "TEXT",
-            "notNull": false
-          }
-        ],
-        "primaryKey": {
-          "autoGenerate": false,
-          "columnNames": [
-            "accountIdentifier",
-            "key"
-          ]
-        },
-        "indices": [],
-        "foreignKeys": []
-      },
-      {
-        "tableName": "Conversations",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`internalId` TEXT NOT NULL, `accountId` INTEGER NOT NULL, `token` TEXT, `name` TEXT, `displayName` TEXT, `description` TEXT, `type` TEXT, `lastPing` INTEGER NOT NULL, `participantType` TEXT, `hasPassword` INTEGER NOT NULL, `sessionId` TEXT, `actorId` TEXT, `actorType` TEXT, `isFavorite` INTEGER NOT NULL, `lastActivity` INTEGER NOT NULL, `unreadMessages` INTEGER NOT NULL, `unreadMention` INTEGER NOT NULL, `lastMessageJson` TEXT, `objectType` TEXT, `notificationLevel` TEXT, `readOnly` TEXT, `lobbyState` TEXT, `lobbyTimer` INTEGER, `lastReadMessage` INTEGER NOT NULL, `lastCommonReadMessage` INTEGER NOT NULL, `hasCall` INTEGER NOT NULL, `callFlag` INTEGER NOT NULL, `canStartCall` INTEGER NOT NULL, `canLeaveConversation` INTEGER, `canDeleteConversation` INTEGER, `unreadMentionDirect` INTEGER, `notificationCalls` INTEGER, `permissions` INTEGER NOT NULL, `messageExpiration` INTEGER NOT NULL, `status` TEXT, `statusIcon` TEXT, `statusMessage` TEXT, `statusClearAt` INTEGER, `callRecording` INTEGER NOT NULL, `avatarVersion` TEXT, `isCustomAvatar` INTEGER, `callStartTime` INTEGER, `recordingConsent` INTEGER NOT NULL, `remoteServer` TEXT, `remoteToken` TEXT, PRIMARY KEY(`internalId`), FOREIGN KEY(`accountId`) REFERENCES `User`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
-        "fields": [
-          {
-            "fieldPath": "internalId",
-            "columnName": "internalId",
-            "affinity": "TEXT",
-            "notNull": true
-          },
-          {
-            "fieldPath": "accountId",
-            "columnName": "accountId",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "token",
-            "columnName": "token",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "name",
-            "columnName": "name",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "displayName",
-            "columnName": "displayName",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "description",
-            "columnName": "description",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "type",
-            "columnName": "type",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "lastPing",
-            "columnName": "lastPing",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "participantType",
-            "columnName": "participantType",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "hasPassword",
-            "columnName": "hasPassword",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "sessionId",
-            "columnName": "sessionId",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "actorId",
-            "columnName": "actorId",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "actorType",
-            "columnName": "actorType",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "favorite",
-            "columnName": "isFavorite",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "lastActivity",
-            "columnName": "lastActivity",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "unreadMessages",
-            "columnName": "unreadMessages",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "unreadMention",
-            "columnName": "unreadMention",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "lastMessageJson",
-            "columnName": "lastMessageJson",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "objectType",
-            "columnName": "objectType",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "notificationLevel",
-            "columnName": "notificationLevel",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "conversationReadOnlyState",
-            "columnName": "readOnly",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "lobbyState",
-            "columnName": "lobbyState",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "lobbyTimer",
-            "columnName": "lobbyTimer",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "lastReadMessage",
-            "columnName": "lastReadMessage",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "lastCommonReadMessage",
-            "columnName": "lastCommonReadMessage",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "hasCall",
-            "columnName": "hasCall",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "callFlag",
-            "columnName": "callFlag",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "canStartCall",
-            "columnName": "canStartCall",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "canLeaveConversation",
-            "columnName": "canLeaveConversation",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "canDeleteConversation",
-            "columnName": "canDeleteConversation",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "unreadMentionDirect",
-            "columnName": "unreadMentionDirect",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "notificationCalls",
-            "columnName": "notificationCalls",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "permissions",
-            "columnName": "permissions",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "messageExpiration",
-            "columnName": "messageExpiration",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "status",
-            "columnName": "status",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "statusIcon",
-            "columnName": "statusIcon",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "statusMessage",
-            "columnName": "statusMessage",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "statusClearAt",
-            "columnName": "statusClearAt",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "callRecording",
-            "columnName": "callRecording",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "avatarVersion",
-            "columnName": "avatarVersion",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "hasCustomAvatar",
-            "columnName": "isCustomAvatar",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "callStartTime",
-            "columnName": "callStartTime",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "recordingConsentRequired",
-            "columnName": "recordingConsent",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "remoteServer",
-            "columnName": "remoteServer",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "remoteToken",
-            "columnName": "remoteToken",
-            "affinity": "TEXT",
-            "notNull": false
-          }
-        ],
-        "primaryKey": {
-          "autoGenerate": false,
-          "columnNames": [
-            "internalId"
-          ]
-        },
-        "indices": [
-          {
-            "name": "index_Conversations_accountId",
-            "unique": false,
-            "columnNames": [
-              "accountId"
-            ],
-            "orders": [],
-            "createSql": "CREATE INDEX IF NOT EXISTS `index_Conversations_accountId` ON `${TABLE_NAME}` (`accountId`)"
-          }
-        ],
-        "foreignKeys": [
-          {
-            "table": "User",
-            "onDelete": "CASCADE",
-            "onUpdate": "CASCADE",
-            "columns": [
-              "accountId"
-            ],
-            "referencedColumns": [
-              "id"
-            ]
-          }
+        "views": [],
+        "setupQueries": [
+            "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+            "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1b2dab0ea495c45c9c9ee6e64ba74039')"
         ]
-      },
-      {
-        "tableName": "ChatMessages",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`internalId` TEXT NOT NULL, `accountId` INTEGER, `token` TEXT, `id` INTEGER NOT NULL, `internalConversationId` TEXT, `actorType` TEXT, `actorId` TEXT, `actorDisplayName` TEXT, `timestamp` INTEGER NOT NULL, `systemMessage` TEXT, `messageType` TEXT, `isReplyable` INTEGER NOT NULL, `message` TEXT, `messageParameters` TEXT, `expirationTimestamp` INTEGER NOT NULL, `parent` INTEGER, `reactions` TEXT, `reactionsSelf` TEXT, `markdown` INTEGER, `lastEditActorType` TEXT, `lastEditActorId` TEXT, `lastEditActorDisplayName` TEXT, `lastEditTimestamp` INTEGER, `deleted` INTEGER NOT NULL, PRIMARY KEY(`internalId`), FOREIGN KEY(`internalConversationId`) REFERENCES `Conversations`(`internalId`) ON UPDATE CASCADE ON DELETE CASCADE )",
-        "fields": [
-          {
-            "fieldPath": "internalId",
-            "columnName": "internalId",
-            "affinity": "TEXT",
-            "notNull": true
-          },
-          {
-            "fieldPath": "accountId",
-            "columnName": "accountId",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "token",
-            "columnName": "token",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "id",
-            "columnName": "id",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "internalConversationId",
-            "columnName": "internalConversationId",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "actorType",
-            "columnName": "actorType",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "actorId",
-            "columnName": "actorId",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "actorDisplayName",
-            "columnName": "actorDisplayName",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "timestamp",
-            "columnName": "timestamp",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "systemMessageType",
-            "columnName": "systemMessage",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "messageType",
-            "columnName": "messageType",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "replyable",
-            "columnName": "isReplyable",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "message",
-            "columnName": "message",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "messageParameters",
-            "columnName": "messageParameters",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "expirationTimestamp",
-            "columnName": "expirationTimestamp",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "parentMessageId",
-            "columnName": "parent",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "reactions",
-            "columnName": "reactions",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "reactionsSelf",
-            "columnName": "reactionsSelf",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "renderMarkdown",
-            "columnName": "markdown",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "lastEditActorType",
-            "columnName": "lastEditActorType",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "lastEditActorId",
-            "columnName": "lastEditActorId",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "lastEditActorDisplayName",
-            "columnName": "lastEditActorDisplayName",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "lastEditTimestamp",
-            "columnName": "lastEditTimestamp",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "deleted",
-            "columnName": "deleted",
-            "affinity": "INTEGER",
-            "notNull": true
-          }
-        ],
-        "primaryKey": {
-          "autoGenerate": false,
-          "columnNames": [
-            "internalId"
-          ]
-        },
-        "indices": [
-          {
-            "name": "index_ChatMessages_internalId",
-            "unique": true,
-            "columnNames": [
-              "internalId"
-            ],
-            "orders": [],
-            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_ChatMessages_internalId` ON `${TABLE_NAME}` (`internalId`)"
-          },
-          {
-            "name": "index_ChatMessages_internalConversationId",
-            "unique": false,
-            "columnNames": [
-              "internalConversationId"
-            ],
-            "orders": [],
-            "createSql": "CREATE INDEX IF NOT EXISTS `index_ChatMessages_internalConversationId` ON `${TABLE_NAME}` (`internalConversationId`)"
-          }
-        ],
-        "foreignKeys": [
-          {
-            "table": "Conversations",
-            "onDelete": "CASCADE",
-            "onUpdate": "CASCADE",
-            "columns": [
-              "internalConversationId"
-            ],
-            "referencedColumns": [
-              "internalId"
-            ]
-          }
-        ]
-      },
-      {
-        "tableName": "ChatBlocks",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `internalConversationId` TEXT NOT NULL, `accountId` INTEGER, `token` TEXT, `oldestMessageId` INTEGER NOT NULL, `newestMessageId` INTEGER NOT NULL, `hasHistory` INTEGER NOT NULL, FOREIGN KEY(`internalConversationId`) REFERENCES `Conversations`(`internalId`) ON UPDATE CASCADE ON DELETE CASCADE )",
-        "fields": [
-          {
-            "fieldPath": "id",
-            "columnName": "id",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "internalConversationId",
-            "columnName": "internalConversationId",
-            "affinity": "TEXT",
-            "notNull": true
-          },
-          {
-            "fieldPath": "accountId",
-            "columnName": "accountId",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "token",
-            "columnName": "token",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "oldestMessageId",
-            "columnName": "oldestMessageId",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "newestMessageId",
-            "columnName": "newestMessageId",
-            "affinity": "INTEGER",
-            "notNull": true
-          },
-          {
-            "fieldPath": "hasHistory",
-            "columnName": "hasHistory",
-            "affinity": "INTEGER",
-            "notNull": true
-          }
-        ],
-        "primaryKey": {
-          "autoGenerate": true,
-          "columnNames": [
-            "id"
-          ]
-        },
-        "indices": [],
-        "foreignKeys": [
-          {
-            "table": "Conversations",
-            "onDelete": "CASCADE",
-            "onUpdate": "CASCADE",
-            "columns": [
-              "internalConversationId"
-            ],
-            "referencedColumns": [
-              "internalId"
-            ]
-          }
-        ]
-      }
-    ],
-    "views": [],
-    "setupQueries": [
-      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c07a2543aa583e08e7b3208f44fcc7ac')"
-    ]
-  }
+    }
 }

--- a/app/src/androidTest/java/com/nextcloud/talk/data/database/migrations/MigrationsTest.kt
+++ b/app/src/androidTest/java/com/nextcloud/talk/data/database/migrations/MigrationsTest.kt
@@ -110,4 +110,13 @@ class MigrationsTest {
         }
         helper.runMigrationsAndValidate(TEST_DB, 16, true, Migrations.MIGRATION_15_16)
     }
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate17To19() {
+        helper.createDatabase(TEST_DB, 17).apply {
+            close()
+        }
+        helper.runMigrationsAndValidate(TEST_DB, 19, true, Migrations.MIGRATION_17_19)
+    }
 }

--- a/app/src/androidTest/java/com/nextcloud/talk/data/database/migrations/MigrationsTest.kt
+++ b/app/src/androidTest/java/com/nextcloud/talk/data/database/migrations/MigrationsTest.kt
@@ -34,6 +34,7 @@ class MigrationsTest {
 
     @Test
     @Throws(IOException::class)
+    @Suppress("SpreadOperator")
     fun migrateAll() {
         helper.createDatabase(TEST_DB, INIT_VERSION).apply {
             close()

--- a/app/src/androidTest/java/com/nextcloud/talk/data/database/migrations/MigrationsTest.kt
+++ b/app/src/androidTest/java/com/nextcloud/talk/data/database/migrations/MigrationsTest.kt
@@ -22,7 +22,7 @@ import java.io.IOException
 class MigrationsTest {
     companion object {
         private const val TEST_DB = "migration-test"
-        private const val INIT_VERSION = 8
+        private const val INIT_VERSION = 10 // last version before update to offline first
         private val TAG = MigrationsTest::class.java.simpleName
     }
 
@@ -35,7 +35,7 @@ class MigrationsTest {
     @Test
     @Throws(IOException::class)
     fun migrateAll() {
-        helper.createDatabase(TEST_DB, 8).apply {
+        helper.createDatabase(TEST_DB, INIT_VERSION).apply {
             close()
         }
 
@@ -46,15 +46,6 @@ class MigrationsTest {
         ).addMigrations(*TalkDatabase.MIGRATIONS).build().apply {
             openHelper.writableDatabase.close()
         }
-    }
-
-    @Test
-    @Throws(IOException::class)
-    fun migrate8To9() {
-        helper.createDatabase(TEST_DB, 8).apply {
-            close()
-        }
-        helper.runMigrationsAndValidate(TEST_DB, 9, true, Migrations.MIGRATION_8_9)
     }
 
     @Test

--- a/app/src/androidTest/java/com/nextcloud/talk/data/database/migrations/MigrationsTest.kt
+++ b/app/src/androidTest/java/com/nextcloud/talk/data/database/migrations/MigrationsTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2025 Julius Linus <juliuslinus1@email.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.nextcloud.talk.data.database.migrations
+
+import androidx.room.Room
+import androidx.room.testing.MigrationTestHelper
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.nextcloud.talk.data.source.local.Migrations
+import com.nextcloud.talk.data.source.local.TalkDatabase
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+
+@RunWith(AndroidJUnit4::class)
+class MigrationsTest {
+    companion object {
+        private const val TEST_DB = "migration-test"
+        private const val INIT_VERSION = 8
+        private val TAG = MigrationsTest::class.java.simpleName
+    }
+
+    @get:Rule
+    val helper: MigrationTestHelper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        TalkDatabase::class.java
+    )
+
+    @Test
+    @Throws(IOException::class)
+    fun migrateAll() {
+        helper.createDatabase(TEST_DB, 8).apply {
+            close()
+        }
+
+        Room.databaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            TalkDatabase::class.java,
+            TEST_DB
+        ).addMigrations(*TalkDatabase.MIGRATIONS).build().apply {
+            openHelper.writableDatabase.close()
+        }
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate8To9() {
+        helper.createDatabase(TEST_DB, 8).apply {
+            close()
+        }
+        helper.runMigrationsAndValidate(TEST_DB, 9, true, Migrations.MIGRATION_8_9)
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate10To11() {
+        helper.createDatabase(TEST_DB, 10).apply {
+            close()
+        }
+        helper.runMigrationsAndValidate(TEST_DB, 11, true, Migrations.MIGRATION_10_11)
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate11To12() {
+        helper.createDatabase(TEST_DB, 11).apply {
+            close()
+        }
+        helper.runMigrationsAndValidate(TEST_DB, 12, true, Migrations.MIGRATION_11_12)
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate12To13() {
+        helper.createDatabase(TEST_DB, 12).apply {
+            close()
+        }
+        helper.runMigrationsAndValidate(TEST_DB, 13, true, Migrations.MIGRATION_12_13)
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate13To14() {
+        helper.createDatabase(TEST_DB, 13).apply {
+            close()
+        }
+        helper.runMigrationsAndValidate(TEST_DB, 14, true, Migrations.MIGRATION_13_14)
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate14To15() {
+        helper.createDatabase(TEST_DB, 14).apply {
+            close()
+        }
+        helper.runMigrationsAndValidate(TEST_DB, 15, true, Migrations.MIGRATION_14_15)
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate15To16() {
+        helper.createDatabase(TEST_DB, 15).apply {
+            close()
+        }
+        helper.runMigrationsAndValidate(TEST_DB, 16, true, Migrations.MIGRATION_15_16)
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/data/source/local/TalkDatabase.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/source/local/TalkDatabase.kt
@@ -103,6 +103,7 @@ abstract class TalkDatabase : RoomDatabase() {
             Migrations.MIGRATION_17_19
         )
 
+        @Suppress("SpreadOperator")
         private fun build(context: Context): TalkDatabase {
             val passCharArray = context.getString(R.string.nc_talk_database_encryption_key).toCharArray()
             val passphrase: ByteArray = getBytesFromChars(passCharArray)
@@ -122,6 +123,7 @@ abstract class TalkDatabase : RoomDatabase() {
                 .databaseBuilder(context.applicationContext, TalkDatabase::class.java, dbName)
                 // comment out openHelperFactory to view the database entries in Android Studio for debugging
                 .openHelperFactory(factory)
+                .fallbackToDestructiveMigrationFrom(true, 18)
                 .addMigrations(*MIGRATIONS) // * converts migrations to vararg
                 .allowMainThreadQueries()
                 .addCallback(

--- a/app/src/main/java/com/nextcloud/talk/data/source/local/TalkDatabase.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/source/local/TalkDatabase.kt
@@ -89,6 +89,19 @@ abstract class TalkDatabase : RoomDatabase() {
                 instance ?: build(context).also { instance = it }
             }
 
+        // If editing the migrations, please add a test case in MigrationsTest under androidTest/data
+        val MIGRATIONS = arrayOf(
+            Migrations.MIGRATION_6_8,
+            Migrations.MIGRATION_7_8,
+            Migrations.MIGRATION_8_9,
+            Migrations.MIGRATION_10_11,
+            Migrations.MIGRATION_11_12,
+            Migrations.MIGRATION_12_13,
+            Migrations.MIGRATION_13_14,
+            Migrations.MIGRATION_14_15,
+            Migrations.MIGRATION_15_16
+        )
+
         private fun build(context: Context): TalkDatabase {
             val passCharArray = context.getString(R.string.nc_talk_database_encryption_key).toCharArray()
             val passphrase: ByteArray = getBytesFromChars(passCharArray)
@@ -108,21 +121,7 @@ abstract class TalkDatabase : RoomDatabase() {
                 .databaseBuilder(context.applicationContext, TalkDatabase::class.java, dbName)
                 // comment out openHelperFactory to view the database entries in Android Studio for debugging
                 .openHelperFactory(factory)
-                .fallbackToDestructiveMigrationFrom(true, 18)
-                .addMigrations(
-                    Migrations.MIGRATION_6_8,
-                    Migrations.MIGRATION_7_8,
-                    Migrations.MIGRATION_8_9,
-                    Migrations.MIGRATION_10_11,
-                    Migrations.MIGRATION_11_12,
-                    Migrations.MIGRATION_12_13,
-                    Migrations.MIGRATION_13_14,
-                    Migrations.MIGRATION_14_15,
-                    Migrations.MIGRATION_15_16,
-                    // do not provide migration 18 to 19 as 17 to 18 was buggy ->
-                    // fallbackToDestructiveMigration for everyone who has db v18 and did not reinstall or clear data
-                    Migrations.MIGRATION_17_19
-                )
+                .addMigrations(*MIGRATIONS) // * converts migrations to vararg
                 .allowMainThreadQueries()
                 .addCallback(
                     object : Callback() {

--- a/app/src/main/java/com/nextcloud/talk/data/source/local/TalkDatabase.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/source/local/TalkDatabase.kt
@@ -99,7 +99,8 @@ abstract class TalkDatabase : RoomDatabase() {
             Migrations.MIGRATION_12_13,
             Migrations.MIGRATION_13_14,
             Migrations.MIGRATION_14_15,
-            Migrations.MIGRATION_15_16
+            Migrations.MIGRATION_15_16,
+            Migrations.MIGRATION_17_19
         )
 
         private fun build(context: Context): TalkDatabase {


### PR DESCRIPTION
- fixes #5168

Includes explicit tests for all manual migrations, and a implicit test for all migrations from version 10 (last version before offline support).

> Schema 10.json was corrupted, which resulted in test
failing. It was from the offline support days, where the
database was updated, but not the version, which updated
10.json instead of 11.json. Replaced with proper schema
from the 9-10 auto migration.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)