### PR TITLE
Read status/Typing status setting is misconfigured

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -1410,10 +1410,6 @@ class SettingsActivity :
                                     json.toRequestBody("application/json".toMediaTypeOrNull())
                                 )
                             }
-                            withContext(Dispatchers.Main) {
-                                loadCapabilitiesAndUpdateSettings()
-                                Log.i(TAG, "typing status set")
-                            }
                         } catch (e: Exception) {
                             withContext(Dispatchers.Main) {
                                 appPreferences.typingStatus = !newBoolean


### PR DESCRIPTION
fix #4902 


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)