### PR TITLE
Better device details in login

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/account/BrowserLoginActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/account/BrowserLoginActivity.kt
@@ -34,6 +34,7 @@ import com.nextcloud.talk.databinding.ActivityWebViewLoginBinding
 import com.nextcloud.talk.jobs.AccountRemovalWorker
 import com.nextcloud.talk.models.LoginData
 import com.nextcloud.talk.users.UserManager
+import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.bundle.BundleKeys
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_BASE_URL
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_ORIGINAL_PROTOCOL
@@ -176,6 +177,7 @@ class BrowserLoginActivity : BaseActivity() {
             .url(url)
             .post(FormBody.Builder().build())
             .addHeader("Clear-Site-Data", "cookies")
+            .addHeader("User-Agent", ApiUtils.userAgent)
             .build()
 
         okHttpClient.newCall(request).execute().use { response ->


### PR DESCRIPTION
- fixes #5194 

 I forgot to add the `User-Agent` header

### 🖼️ Screenshots

<img width="352" height="488" alt="Screenshot 2025-07-29 at 11 03 27 AM" src="https://github.com/user-attachments/assets/a202377f-ffbf-4196-b85c-80aa3183779f" />


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)