### PR TITLE
Increase default chat message size

### DIFF
--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -25,7 +25,7 @@
     <dimen name="avatar_size_big">96dp</dimen>
     <dimen name="avatar_size_open_conversation_list">52dp</dimen>
 
-    <dimen name="chat_text_size">14sp</dimen>
+    <dimen name="chat_text_size">16sp</dimen>
     <dimen name="message_bubble_corners_radius">20dp</dimen>
     <dimen name="message_bubble_corners_horizontal_padding">16dp</dimen>
     <dimen name="message_bubble_corners_vertical_padding">12dp</dimen>


### PR DESCRIPTION
Resolves https://github.com/nextcloud/talk-android/issues/5207 and https://github.com/nextcloud/talk-android/issues/4984

This does not implement the ability to change the font size, however it does makes the default font size same as other messaging apps.

Telegram has 16sp as default as shown here
<img width="540" height="1212" alt="image" src="https://github.com/user-attachments/assets/7974d1bd-b400-4d42-923f-84b1a44a40d4" />

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="540" height="1212" alt="image" src="https://github.com/user-attachments/assets/0f1b09b7-014c-4a87-9c6b-f0ddf0753520" />  |  <img width="540" height="1212" alt="image" src="https://github.com/user-attachments/assets/dc5d0c12-ec29-42a9-a262-8a9b7db508f0" />


- [x] Changed default chat message size from 14sp to 16sp