### PR TITLE
Handles wrong image shown for some conversations

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.kt
@@ -22,6 +22,7 @@ import android.view.View
 import android.widget.RelativeLayout
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
+import coil.dispose
 import com.nextcloud.talk.R
 import com.nextcloud.talk.adapters.items.ConversationItem.ConversationItemViewHolder
 import com.nextcloud.talk.application.NextcloudTalkApplication.Companion.sharedApplication
@@ -182,8 +183,7 @@ class ConversationItem(
     }
 
     private fun showAvatar(holder: ConversationItemViewHolder) {
-        // reset before loading
-        holder.binding.dialogAvatar.setImageDrawable(null)
+        holder.binding.dialogAvatar.dispose()
         holder.binding.dialogAvatar.visibility = View.VISIBLE
 
         var shouldLoadAvatar = shouldLoadAvatar(holder)

--- a/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.kt
@@ -182,16 +182,16 @@ class ConversationItem(
     }
 
     private fun showAvatar(holder: ConversationItemViewHolder) {
+        // reset before loading
+        holder.binding.dialogAvatar.setImageDrawable(null)
         holder.binding.dialogAvatar.visibility = View.VISIBLE
+
         var shouldLoadAvatar = shouldLoadAvatar(holder)
         if (ConversationEnums.ConversationType.ROOM_SYSTEM == model.type) {
             holder.binding.dialogAvatar.loadSystemAvatar()
             shouldLoadAvatar = false
         }
         if (shouldLoadAvatar) {
-            // reset before loading
-            holder.binding.dialogAvatar.setImageDrawable(null)
-
             when (model.type) {
                 ConversationEnums.ConversationType.ROOM_TYPE_ONE_TO_ONE_CALL -> {
                     if (!TextUtils.isEmpty(model.name)) {

--- a/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.kt
@@ -189,6 +189,9 @@ class ConversationItem(
             shouldLoadAvatar = false
         }
         if (shouldLoadAvatar) {
+            // reset before loading
+            holder.binding.dialogAvatar.setImageDrawable(null)
+
             when (model.type) {
                 ConversationEnums.ConversationType.ROOM_TYPE_ONE_TO_ONE_CALL -> {
                     if (!TextUtils.isEmpty(model.name)) {


### PR DESCRIPTION
Aftermath of this https://github.com/nextcloud/talk-android/pull/5205

An unexpected side effect was reported: the "Note to Self" image randomly appears for different chats
https://github.com/nextcloud/talk-android/pull/5205#issuecomment-3187866026

Attempting to fix by explicitly removing the image from the viewholder before loading the new one.