### PR TITLE
Make thread icon dark/light aware 

### DIFF
--- a/app/src/main/res/layout/item_thread_title.xml
+++ b/app/src/main/res/layout/item_thread_title.xml
@@ -22,7 +22,8 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:contentDescription="@null"
-        android:src="@drawable/outline_forum_24" />
+        android:src="@drawable/outline_forum_24"
+        app:tint="@color/no_emphasis_text" />
 
     <androidx.emoji2.widget.EmojiTextView
         android:id="@+id/threadTitle"
@@ -34,6 +35,7 @@
         android:textAlignment="viewStart"
         android:textColor="@color/no_emphasis_text"
         android:textIsSelectable="false"
+        android:textSize="@dimen/chat_text_size"
         android:textStyle="bold"
         tools:text="The thread title" />
 


### PR DESCRIPTION
and title size matching the messages

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)