### PR TITLE
open threads via notification

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -205,6 +205,7 @@ import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_FILE_PATHS
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_INTERNAL_USER_ID
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_IS_BREAKOUT_ROOM
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_IS_MODERATOR
+import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_OPENED_VIA_NOTIFICATION
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_RECORDING_STATE
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_ROOM_TOKEN
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_START_CALL_AFTER_ROOM_SWITCH
@@ -367,6 +368,7 @@ class ChatActivity :
     var sessionIdAfterRoomJoined: String? = null
     lateinit var roomToken: String
     var conversationThreadId: Long? = null
+    var openedViaNotification: Boolean = false
     var conversationThreadInfo: ThreadInfo? = null
     var conversationUser: User? = null
     lateinit var spreedCapabilities: SpreedCapability
@@ -409,10 +411,9 @@ class ChatActivity :
 
     private val onBackPressedCallback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
-            if (isChatThread()) {
-                val intent = Intent(this@ChatActivity, ChatActivity::class.java)
-                intent.putExtra(KEY_ROOM_TOKEN, roomToken)
-                startActivity(intent)
+            if (!openedViaNotification && isChatThread()) {
+                isEnabled = false
+                onBackPressedDispatcher.onBackPressed()
             } else {
                 val intent = Intent(this@ChatActivity, ConversationsListActivity::class.java)
                 startActivity(intent)
@@ -594,6 +595,8 @@ class ChatActivity :
         } else {
             null
         }
+
+        openedViaNotification = extras?.getBoolean(KEY_OPENED_VIA_NOTIFICATION) ?: false
 
         sharedText = extras?.getString(BundleKeys.KEY_SHARED_TEXT).orEmpty()
 

--- a/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.kt
@@ -86,6 +86,7 @@ import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_ROOM_TOKEN
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_SHARE_RECORDING_TO_CHAT_URL
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_SYSTEM_NOTIFICATION_ID
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_THREAD_ID
+import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_OPENED_VIA_NOTIFICATION
 import com.nextcloud.talk.utils.preferences.AppPreferences
 import io.reactivex.Observable
 import io.reactivex.Observer
@@ -989,6 +990,7 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
         val bundle = Bundle()
         bundle.putString(KEY_ROOM_TOKEN, pushMessage.id)
         bundle.putLong(KEY_INTERNAL_USER_ID, signatureVerification.user!!.id!!)
+        bundle.putBoolean(KEY_OPENED_VIA_NOTIFICATION, true)
         intent.putExtras(bundle)
         return intent
     }

--- a/app/src/main/java/com/nextcloud/talk/utils/bundle/BundleKeys.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/bundle/BundleKeys.kt
@@ -84,4 +84,5 @@ object BundleKeys {
     const val KEY_FOCUS_INPUT: String = "KEY_FOCUS_INPUT"
     const val KEY_THREAD_ID = "KEY_THREAD_ID"
     const val KEY_FROM_QR: String = "KEY_FROM_QR"
+    const val KEY_OPENED_VIA_NOTIFICATION: String = "KEY_OPENED_VIA_NOTIFICATION"
 }


### PR DESCRIPTION
- more progress to resolve https://github.com/nextcloud/talk-android/issues/3074

This PR will add the possibility to open threads via notification
(while keeping the behavior that backpress in thread that was opened via the threads-list should open the list again)

While it's tempting to do refactoring in the touched code parts, i won't do it now to avoid too many changes regarding the release of 22.0.0

Just some thoughts for later:
- is overriding handleOnBackPressed with own logic the best solution? 
   - take a closer look at Jetpack's Navigation component
   - or should backstack regarding ChatActivity be handled via activity flags again (as intermediate solution if there will be more scenarios to consider?)?
- MainActivity might be removed in the future (redirecting could be done differently?, it only still exists as remnant from conductor architechture). This will also allow easier backstack handling (e.g. without the `openedViaNotification` solution in this PR, the old code 
  ```
              if (isChatThread()) {
                  isEnabled = false
                  onBackPressedDispatcher.onBackPressed()
              } 
  ```
   ended up in showing the MainActivity (which should never be displayed besides when redirecting).

- NotificationWorker needs to be refactored. E.g. passing intents/bundles through the whole class is confusing...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)