### PR TITLE
Revert "fix(deps): update roomversion to v2.8.1"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -168,7 +168,7 @@ ext {
     parcelerVersion = "1.1.13"
     prismVersion = "2.0.0"
     retrofit2Version = "3.0.0"
-    roomVersion = "2.8.1"
+    roomVersion = "2.8.0"
     workVersion = "2.10.5"
     espressoVersion = "3.7.0"
     androidxTestVersion = "1.5.0"


### PR DESCRIPTION
This reverts commit 93573a3f (PR https://github.com/nextcloud/talk-android/pull/5412)

- this will fix #5422 for now, but the root cause needs to be fixed afterwards so the dependency can be updated
