### PR TITLE
use default http client specs

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/dagger/modules/RestModule.java
+++ b/app/src/main/java/com/nextcloud/talk/dagger/modules/RestModule.java
@@ -219,16 +219,6 @@ public class RestModule {
 
         httpClient.addInterceptor(new HeadersInterceptor());
 
-        List<ConnectionSpec> specs = new ArrayList<>();
-        if (BuildConfig.DEBUG) {
-            specs.add(ConnectionSpec.COMPATIBLE_TLS);
-            specs.add(ConnectionSpec.CLEARTEXT);
-            httpClient.connectionSpecs(specs);
-        } else {
-            specs.add(ConnectionSpec.COMPATIBLE_TLS);
-            httpClient.connectionSpecs(specs);
-        }
-
         if (BuildConfig.DEBUG && !context.getResources().getBoolean(R.bool.nc_is_debug)) {
             HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor();
             loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);


### PR DESCRIPTION
this reverts https://github.com/nextcloud/talk-android/pull/5215/files#diff-811b0de61c452d37c2edee9ec1a051d2300347c4ae179f2f949c3f238cb7767aR222-R231

which was left over from the first attempt to implement loginv2.

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)