### PR TITLE
allow nullable for capabilities but log error

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -532,12 +532,12 @@ class CallActivity : CallBaseActivity() {
             )
         }
 
-        when (CapabilitiesUtil.getRecordingConsentType(conversationUser!!.capabilities!!.spreedCapability!!)) {
+        when (CapabilitiesUtil.getRecordingConsentType(conversationUser.capabilities!!.spreedCapability!!)) {
             CapabilitiesUtil.RECORDING_CONSENT_NOT_REQUIRED -> initiateCall()
             CapabilitiesUtil.RECORDING_CONSENT_REQUIRED -> askForRecordingConsent()
             CapabilitiesUtil.RECORDING_CONSENT_DEPEND_ON_CONVERSATION -> {
                 val getRoomApiVersion = ApiUtils.getConversationApiVersion(
-                    conversationUser!!,
+                    conversationUser,
                     intArrayOf(ApiUtils.API_V4, 1)
                 )
                 ncApi!!.getRoom(credentials, ApiUtils.getUrlForRoom(getRoomApiVersion, baseUrl, roomToken))

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -3255,7 +3255,8 @@ class ChatActivity :
             }
 
             val searchItem = menu.findItem(R.id.conversation_search)
-            searchItem.isVisible = CapabilitiesUtil.isUnifiedSearchAvailable(spreedCapabilities) &&
+            searchItem.isVisible =
+                hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.UNIFIED_SEARCH) &&
                 currentConversation!!.remoteServer.isNullOrEmpty() &&
                 !isChatThread()
 

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -89,6 +89,8 @@ import com.nextcloud.talk.contacts.ContactsActivity
 import com.nextcloud.talk.contacts.ContactsUiState
 import com.nextcloud.talk.contacts.ContactsViewModel
 import com.nextcloud.talk.contacts.RoomUiState
+import com.nextcloud.talk.contextchat.ContextChatView
+import com.nextcloud.talk.contextchat.ContextChatViewModel
 import com.nextcloud.talk.conversationlist.viewmodels.ConversationsListViewModel
 import com.nextcloud.talk.data.network.NetworkMonitor
 import com.nextcloud.talk.data.user.model.User
@@ -113,8 +115,6 @@ import com.nextcloud.talk.threadsoverview.ThreadsOverviewActivity
 import com.nextcloud.talk.ui.BackgroundVoiceMessageCard
 import com.nextcloud.talk.ui.dialog.ChooseAccountDialogFragment
 import com.nextcloud.talk.ui.dialog.ChooseAccountShareToDialogFragment
-import com.nextcloud.talk.contextchat.ContextChatView
-import com.nextcloud.talk.contextchat.ContextChatViewModel
 import com.nextcloud.talk.ui.dialog.ConversationsListBottomDialog
 import com.nextcloud.talk.ui.dialog.FilterConversationFragment
 import com.nextcloud.talk.ui.dialog.FilterConversationFragment.Companion.ARCHIVE
@@ -125,7 +125,6 @@ import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.BrandingUtils
 import com.nextcloud.talk.utils.CapabilitiesUtil.hasSpreedFeatureCapability
 import com.nextcloud.talk.utils.CapabilitiesUtil.isServerEOL
-import com.nextcloud.talk.utils.CapabilitiesUtil.isUnifiedSearchAvailable
 import com.nextcloud.talk.utils.ClosedInterfaceImpl
 import com.nextcloud.talk.utils.ConversationUtils
 import com.nextcloud.talk.utils.FileUtils
@@ -319,7 +318,7 @@ class ConversationsListActivity :
                 return
             }
             currentUser?.capabilities?.spreedCapability?.let { spreedCapabilities ->
-                if (isUnifiedSearchAvailable(spreedCapabilities)) {
+                if (hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.UNIFIED_SEARCH)) {
                     searchHelper = MessageSearchHelper(unifiedSearchRepository)
                 }
             }
@@ -1072,7 +1071,7 @@ class ConversationsListActivity :
     }
 
     private fun fetchPendingInvitations() {
-        if (hasSpreedFeatureCapability(currentUser!!.capabilities!!.spreedCapability!!, SpreedFeatures.FEDERATION_V1)) {
+        if (hasSpreedFeatureCapability(currentUser?.capabilities?.spreedCapability, SpreedFeatures.FEDERATION_V1)) {
             binding.conversationListHintInclude.conversationListHintLayout.setOnClickListener {
                 val intent = Intent(this, InvitationsActivity::class.java)
                 startActivity(intent)
@@ -1203,7 +1202,7 @@ class ConversationsListActivity :
         searchableConversationItems.clear()
         searchableConversationItems.addAll(conversationItemsWithHeader)
         if (hasSpreedFeatureCapability(
-                currentUser!!.capabilities!!.spreedCapability!!,
+                currentUser?.capabilities?.spreedCapability,
                 SpreedFeatures.LISTABLE_ROOMS
             )
         ) {
@@ -1464,7 +1463,11 @@ class ConversationsListActivity :
                 adapter?.filterItems()
             }
 
-            if (isUnifiedSearchAvailable(currentUser!!.capabilities!!.spreedCapability!!)) {
+            if (hasSpreedFeatureCapability(
+                    currentUser?.capabilities?.spreedCapability,
+                    SpreedFeatures.UNIFIED_SEARCH
+                )
+            ) {
                 startMessageSearch(filter)
             }
         } else {
@@ -1584,7 +1587,7 @@ class ConversationsListActivity :
         selectedConversation = conversation
         if (selectedConversation != null) {
             val hasChatPermission = ParticipantPermissions(
-                currentUser!!.capabilities!!.spreedCapability!!,
+                currentUser?.capabilities?.spreedCapability,
                 selectedConversation!!
             )
                 .hasChatPermission()
@@ -1612,11 +1615,11 @@ class ConversationsListActivity :
 
     private fun shouldShowLobby(conversation: ConversationModel): Boolean {
         val participantPermissions = ParticipantPermissions(
-            currentUser!!.capabilities?.spreedCapability!!,
+            currentUser?.capabilities?.spreedCapability,
             selectedConversation!!
         )
         return conversation.lobbyState == ConversationEnums.LobbyState.LOBBY_STATE_MODERATORS_ONLY &&
-            !ConversationUtils.canModerate(conversation, currentUser!!.capabilities!!.spreedCapability!!) &&
+            !ConversationUtils.canModerate(conversation, currentUser?.capabilities?.spreedCapability) &&
             !participantPermissions.canIgnoreLobby()
     }
 

--- a/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.kt
@@ -232,7 +232,7 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
             bundle.putInt(BundleKeys.KEY_CALL_FLAG, conversation.callFlag)
 
             val participantPermission = ParticipantPermissions(
-                userBeingCalled!!.capabilities!!.spreedCapability!!,
+                userBeingCalled?.capabilities?.spreedCapability,
                 conversation
             )
             bundle.putBoolean(

--- a/app/src/main/java/com/nextcloud/talk/profile/ProfileActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/profile/ProfileActivity.kt
@@ -244,7 +244,7 @@ class ProfileActivity : BaseActivity() {
                 binding.emptyList.root.visibility = View.GONE
                 binding.userinfoList.visibility = View.VISIBLE
                 if (CapabilitiesUtil.hasSpreedFeatureCapability(
-                        currentUser!!.capabilities!!.spreedCapability!!,
+                        currentUser?.capabilities?.spreedCapability,
                         SpreedFeatures.TEMP_USER_AVATAR_API
                     )
                 ) {

--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -945,7 +945,7 @@ class SettingsActivity :
             binding.settingsShowNotificationWarning.visibility = View.GONE
         }
 
-        if (CapabilitiesUtil.isReadStatusAvailable(currentUser!!.capabilities!!.spreedCapability!!)) {
+        if (CapabilitiesUtil.isReadStatusAvailable(currentUser?.capabilities?.spreedCapability)) {
             binding.settingsReadPrivacySwitch.isChecked = !CapabilitiesUtil.isReadStatusPrivate(currentUser!!)
         } else {
             binding.settingsReadPrivacy.visibility = View.GONE

--- a/app/src/main/java/com/nextcloud/talk/utils/CapabilitiesUtil.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/CapabilitiesUtil.kt
@@ -100,7 +100,12 @@ object CapabilitiesUtil {
     //region SpreedCapabilities
 
     @JvmStatic
-    fun hasSpreedFeatureCapability(spreedCapabilities: SpreedCapability, spreedFeatures: SpreedFeatures): Boolean {
+    fun hasSpreedFeatureCapability(spreedCapabilities: SpreedCapability?, spreedFeatures: SpreedFeatures): Boolean {
+        if (spreedCapabilities == null) {
+            Log.e(TAG, "spreedCapabilities were null when checking capability " + spreedFeatures.value)
+            return false
+        }
+
         if (spreedCapabilities.features != null) {
             return spreedCapabilities.features!!.contains(spreedFeatures.value)
         }
@@ -136,7 +141,12 @@ object CapabilitiesUtil {
         return CONVERSATION_DESCRIPTION_LENGTH_FOR_OLD_SERVER
     }
 
-    fun isReadStatusAvailable(spreedCapabilities: SpreedCapability): Boolean {
+    fun isReadStatusAvailable(spreedCapabilities: SpreedCapability?): Boolean {
+        if (spreedCapabilities == null) {
+            Log.e(TAG, "spreedCapabilities were null when checking capability isReadStatusAvailable")
+            return false
+        }
+
         if (spreedCapabilities.config?.containsKey("chat") == true) {
             val map: Map<String, Any>? = spreedCapabilities.config!!["chat"]
             return map != null && map.containsKey("read-privacy")
@@ -200,9 +210,6 @@ object CapabilitiesUtil {
 
     fun isConversationDescriptionEndpointAvailable(spreedCapabilities: SpreedCapability): Boolean =
         hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.ROOM_DESCRIPTION)
-
-    fun isUnifiedSearchAvailable(spreedCapabilities: SpreedCapability): Boolean =
-        hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.UNIFIED_SEARCH)
 
     fun isAbleToCall(spreedCapabilities: SpreedCapability): Boolean =
         if (

--- a/app/src/main/java/com/nextcloud/talk/utils/ConversationUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/ConversationUtils.kt
@@ -27,11 +27,11 @@ object ConversationUtils {
             Participant.ParticipantType.GUEST_MODERATOR == conversation.participantType ||
             Participant.ParticipantType.MODERATOR == conversation.participantType
 
-    fun isLockedOneToOne(conversation: ConversationModel, spreedCapabilities: SpreedCapability): Boolean =
+    fun isLockedOneToOne(conversation: ConversationModel, spreedCapabilities: SpreedCapability?): Boolean =
         conversation.type == ConversationEnums.ConversationType.ROOM_TYPE_ONE_TO_ONE_CALL &&
             CapabilitiesUtil.hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.LOCKED_ONE_TO_ONE)
 
-    fun canModerate(conversation: ConversationModel, spreedCapabilities: SpreedCapability): Boolean =
+    fun canModerate(conversation: ConversationModel, spreedCapabilities: SpreedCapability?): Boolean =
         isParticipantOwnerOrModerator(conversation) &&
             !isLockedOneToOne(conversation, spreedCapabilities) &&
             conversation.type != ConversationEnums.ConversationType.FORMER_ONE_TO_ONE &&

--- a/app/src/main/java/com/nextcloud/talk/utils/ParticipantPermissions.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/ParticipantPermissions.kt
@@ -14,7 +14,7 @@ import com.nextcloud.talk.models.json.capabilities.SpreedCapability
  * see https://nextcloud-talk.readthedocs.io/en/latest/constants/#attendee-permissions
  */
 class ParticipantPermissions(
-    private val spreedCapabilities: SpreedCapability,
+    private val spreedCapabilities: SpreedCapability?,
     private val conversation: ConversationModel
 ) {
     val isDefault = (conversation.permissions and DEFAULT) == DEFAULT


### PR DESCRIPTION
capabilities were sometimes null which caused e.g.:

```
Exception java.lang.RuntimeException:
  at android.app.ActivityThread.performResumeActivity (ActivityThread.java:5753)
  at android.app.ActivityThread.handleResumeActivity (ActivityThread.java:5786)
  at android.app.servertransaction.ResumeActivityItem.execute (ResumeActivityItem.java:57)
  at android.app.servertransaction.ActivityTransactionItem.execute (ActivityTransactionItem.java:60)
  at android.app.servertransaction.TransactionExecutor.executeLifecycleItem (TransactionExecutor.java:237)
  at android.app.servertransaction.TransactionExecutor.executeTransactionItems (TransactionExecutor.java:110)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:84)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2899)
  at android.os.Handler.dispatchMessage (Handler.java:107)
  at android.os.Looper.loopOnce (Looper.java:249)
  at android.os.Looper.loop (Looper.java:337)
  at android.app.ActivityThread.main (ActivityThread.java:9515)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:636)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1005)
Caused by java.lang.NullPointerException:
  at com.nextcloud.talk.conversationlist.ConversationsListActivity.fetchPendingInvitations (ConversationsListActivity.kt:1075)
  at com.nextcloud.talk.conversationlist.ConversationsListActivity.onResume (ConversationsListActivity.kt:340)
  at android.app.Instrumentation.callActivityOnResume (Instrumentation.java:1733)
  at android.app.Activity.performResume (Activity.java:9385)
  at android.app.ActivityThread.performResumeActivity (ActivityThread.java:5740)
```

  The root cause why they can be null is not fixed/found (race conditions?)

  For now it is logged when capabilities were passed as null. This should be extended with an error that is shown to the user.
  For now, it may happen that some features are hidden to the user (instead to have the crash).
  So when users report that feature xy is missing, remember that this may be caused by capabilities being null!


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)