### PR TITLE
fix NumberFormatException in getContextForChatMessages

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/contextchat/ContextChatViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/contextchat/ContextChatViewModel.kt
@@ -60,7 +60,7 @@ class ContextChatViewModel @Inject constructor(private val chatNetworkDataSource
                 token = token,
                 messageId = messageId,
                 limit = LIMIT,
-                threadId = threadId?.toInt()
+                threadId = threadId?.toIntOrNull()
             )
 
             if (threadId.isNullOrEmpty()) {


### PR DESCRIPTION
- fix https://github.com/nextcloud/talk-android/issues/5436

root cause why string "null" is received was not yet investigated.

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)