### PR TITLE
Avoid CompositeException by migrating getOpenConversations to coroutine?

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/api/NcApi.java
+++ b/app/src/main/java/com/nextcloud/talk/api/NcApi.java
@@ -486,13 +486,6 @@ public interface NcApi {
     @DELETE
     Observable<GenericOverall> markRoomAsUnread(@Header("Authorization") String authorization, @Url String url);
 
-    /*
-    Server URL is: baseUrl + ocsApiVersion + spreedApiVersion + /listed-room
-    */
-    @GET
-    Observable<RoomsOverall> getOpenConversations(@Header("Authorization") String authorization, @Url String url,
-                                                  @Query("searchTerm") String searchTerm);
-
     @GET
     Observable<StatusOverall> status(@Header("Authorization") String authorization, @Url String url);
 

--- a/app/src/main/java/com/nextcloud/talk/api/NcApiCoroutines.kt
+++ b/app/src/main/java/com/nextcloud/talk/api/NcApiCoroutines.kt
@@ -13,6 +13,7 @@ import com.nextcloud.talk.models.json.autocomplete.AutocompleteOverall
 import com.nextcloud.talk.models.json.chat.ChatOverall
 import com.nextcloud.talk.models.json.chat.ChatOverallSingleMessage
 import com.nextcloud.talk.models.json.conversations.RoomOverall
+import com.nextcloud.talk.models.json.conversations.RoomsOverall
 import com.nextcloud.talk.models.json.generic.GenericOverall
 import com.nextcloud.talk.models.json.participants.AddParticipantOverall
 import com.nextcloud.talk.models.json.participants.TalkBan
@@ -307,4 +308,11 @@ interface NcApiCoroutines {
         @Url url: String,
         @Field("level") level: Int
     ): ThreadOverall
+
+    @GET
+    suspend fun getOpenConversations(
+        @Header("Authorization") authorization: String,
+        @Url url: String,
+        @Query("searchTerm") searchTerm: String?
+    ): RoomsOverall
 }

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/viewmodels/ConversationsListViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/viewmodels/ConversationsListViewModel.kt
@@ -16,6 +16,8 @@ import com.nextcloud.talk.conversationlist.data.OfflineConversationsRepository
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.invitation.data.InvitationsModel
 import com.nextcloud.talk.invitation.data.InvitationsRepository
+import com.nextcloud.talk.models.json.conversations.Conversation
+import com.nextcloud.talk.openconversations.data.OpenConversationsRepository
 import com.nextcloud.talk.threadsoverview.data.ThreadsRepository
 import com.nextcloud.talk.users.UserManager
 import com.nextcloud.talk.utils.ApiUtils
@@ -39,6 +41,7 @@ class ConversationsListViewModel @Inject constructor(
     private val repository: OfflineConversationsRepository,
     private val threadsRepository: ThreadsRepository,
     private val currentUserProvider: CurrentUserProviderNew,
+    private val openConversationsRepository: OpenConversationsRepository,
     var userManager: UserManager
 ) : ViewModel() {
 
@@ -62,6 +65,15 @@ class ConversationsListViewModel @Inject constructor(
 
     private val _threadsExistState = MutableStateFlow<ThreadsExistUiState>(ThreadsExistUiState.None)
     val threadsExistState: StateFlow<ThreadsExistUiState> = _threadsExistState
+
+    sealed class OpenConversationsUiState {
+        data object None : OpenConversationsUiState()
+        data class Success(val conversations: List<Conversation>) : OpenConversationsUiState()
+        data class Error(val exception: Throwable) : OpenConversationsUiState()
+    }
+
+    private val _openConversationsState = MutableStateFlow<OpenConversationsUiState>(OpenConversationsUiState.None)
+    val openConversationsState: StateFlow<OpenConversationsUiState> = _openConversationsState
 
     object GetRoomsStartState : ViewState
     object GetRoomsErrorState : ViewState
@@ -184,6 +196,29 @@ class ConversationsListViewModel @Inject constructor(
                 _threadsExistState.value = ThreadsExistUiState.Success(false)
                 Log.d(TAG, "already checked in the last 2 hours if followed threads exist. Skip check.")
             }
+        }
+    }
+
+    fun fetchOpenConversations() {
+        _openConversationsState.value = OpenConversationsUiState.None
+
+        if (!hasSpreedFeatureCapability(currentUser.capabilities?.spreedCapability, SpreedFeatures.LISTABLE_ROOMS)) {
+            return
+        }
+
+        viewModelScope.launch {
+            openConversationsRepository.fetchConversations("")
+                .onSuccess { conversations ->
+                    if (conversations.isEmpty()) {
+                        _openConversationsState.value = OpenConversationsUiState.None
+                    } else {
+                        _openConversationsState.value = OpenConversationsUiState.Success(conversations)
+                    }
+                }
+                .onFailure { exception ->
+                    Log.e(TAG, "Failed to fetch conversations", exception)
+                    _openConversationsState.value = OpenConversationsUiState.Error(exception)
+                }
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/dagger/modules/RepositoryModule.kt
+++ b/app/src/main/java/com/nextcloud/talk/dagger/modules/RepositoryModule.kt
@@ -124,9 +124,9 @@ class RepositoryModule {
 
     @Provides
     fun provideOpenConversationsRepository(
-        ncApi: NcApi,
+        ncApiCoroutines: NcApiCoroutines,
         userProvider: CurrentUserProviderNew
-    ): OpenConversationsRepository = OpenConversationsRepositoryImpl(ncApi, userProvider)
+    ): OpenConversationsRepository = OpenConversationsRepositoryImpl(ncApiCoroutines, userProvider)
 
     @Provides
     fun translateRepository(ncApi: NcApi): TranslateRepository = TranslateRepositoryImpl(ncApi)

--- a/app/src/main/java/com/nextcloud/talk/openconversations/data/OpenConversationsRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/openconversations/data/OpenConversationsRepository.kt
@@ -7,9 +7,8 @@
 package com.nextcloud.talk.openconversations.data
 
 import com.nextcloud.talk.models.json.conversations.Conversation
-import io.reactivex.Observable
 
 interface OpenConversationsRepository {
 
-    fun fetchConversations(searchTerm: String): Observable<List<Conversation>>
+    suspend fun fetchConversations(searchTerm: String): Result<List<Conversation>>
 }

--- a/app/src/main/java/com/nextcloud/talk/openconversations/data/OpenConversationsRepositoryImpl.kt
+++ b/app/src/main/java/com/nextcloud/talk/openconversations/data/OpenConversationsRepositoryImpl.kt
@@ -6,27 +6,29 @@
  */
 package com.nextcloud.talk.openconversations.data
 
-import com.nextcloud.talk.api.NcApi
+import com.nextcloud.talk.api.NcApiCoroutines
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.models.json.conversations.Conversation
 import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.database.user.CurrentUserProviderNew
-import io.reactivex.Observable
 
-class OpenConversationsRepositoryImpl(private val ncApi: NcApi, currentUserProvider: CurrentUserProviderNew) :
-    OpenConversationsRepository {
+class OpenConversationsRepositoryImpl(
+    private val ncApiCoroutines: NcApiCoroutines,
+    currentUserProvider: CurrentUserProviderNew
+) : OpenConversationsRepository {
 
     val currentUser: User = currentUserProvider.currentUser.blockingGet()
     val credentials: String = ApiUtils.getCredentials(currentUser.username, currentUser.token)!!
 
     val apiVersion = ApiUtils.getConversationApiVersion(currentUser, intArrayOf(ApiUtils.API_V4, ApiUtils.API_V3, 1))
 
-    override fun fetchConversations(searchTerm: String): Observable<List<Conversation>> {
-        val roomOverall = ncApi.getOpenConversations(
-            credentials,
-            ApiUtils.getUrlForOpenConversations(apiVersion, currentUser.baseUrl!!),
-            searchTerm
-        )
-        return roomOverall.map { it.ocs?.data!! }
-    }
+    override suspend fun fetchConversations(searchTerm: String): Result<List<Conversation>> =
+        runCatching {
+            val roomOverall = ncApiCoroutines.getOpenConversations(
+                credentials,
+                ApiUtils.getUrlForOpenConversations(apiVersion, currentUser.baseUrl!!),
+                searchTerm
+            )
+            roomOverall.ocs?.data.orEmpty()
+        }
 }


### PR DESCRIPTION
- Hopefully fix https://github.com/nextcloud/talk-android/issues/5461

My theory is that before this fix, the errorDialog was tried to be shown although the activity was already gone (-> CompositeException) because the disposable handling was wrong. 

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)