### PR TITLE
Place ongoing calls into foreground service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,6 +42,8 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.WRITE_CONTACTS" />
     <uses-permission android:name="android.permission.READ_PROFILE" />
@@ -300,6 +302,11 @@
                 android:name="android.accounts.AccountAuthenticator"
                 android:resource="@xml/auth" />
         </service>
+
+        <service
+            android:name=".services.CallForegroundService"
+            android:exported="false"
+            android:foregroundServiceType="phoneCall|microphone|camera" />
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -96,6 +96,7 @@ import com.nextcloud.talk.models.json.signaling.settings.SignalingSettingsOveral
 import com.nextcloud.talk.raisehand.viewmodel.RaiseHandViewModel
 import com.nextcloud.talk.raisehand.viewmodel.RaiseHandViewModel.LoweredHandState
 import com.nextcloud.talk.raisehand.viewmodel.RaiseHandViewModel.RaisedHandState
+import com.nextcloud.talk.services.CallForegroundService
 import com.nextcloud.talk.signaling.SignalingMessageReceiver
 import com.nextcloud.talk.signaling.SignalingMessageReceiver.CallParticipantMessageListener
 import com.nextcloud.talk.signaling.SignalingMessageReceiver.LocalParticipantMessageListener
@@ -382,6 +383,7 @@ class CallActivity : CallBaseActivity() {
         setContentView(binding!!.root)
         hideNavigationIfNoPipAvailable()
         processExtras(intent.extras!!)
+        CallForegroundService.start(applicationContext, conversationName, intent.extras)
 
         conversationUser = currentUserProvider.currentUser.blockingGet()
 
@@ -1460,6 +1462,7 @@ class CallActivity : CallBaseActivity() {
         if (currentCallStatus !== CallStatus.LEAVING) {
             hangup(true, false)
         }
+        CallForegroundService.stop(applicationContext)
         powerManagerUtils!!.updatePhoneState(PowerManagerUtils.PhoneState.IDLE)
         super.onDestroy()
     }

--- a/app/src/main/java/com/nextcloud/talk/services/CallForegroundService.kt
+++ b/app/src/main/java/com/nextcloud/talk/services/CallForegroundService.kt
@@ -1,0 +1,128 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.services
+
+import android.app.Notification
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.Bundle
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE
+import androidx.core.content.ContextCompat
+import com.nextcloud.talk.R
+import com.nextcloud.talk.activities.CallActivity
+import com.nextcloud.talk.application.NextcloudTalkApplication
+import com.nextcloud.talk.utils.NotificationUtils
+import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_CALL_VOICE_ONLY
+import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_PARTICIPANT_PERMISSION_CAN_PUBLISH_VIDEO
+
+class CallForegroundService : Service() {
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val conversationName = intent?.getStringExtra(EXTRA_CONVERSATION_NAME)
+        val callExtras = intent?.getBundleExtra(EXTRA_CALL_INTENT_EXTRAS)
+        val notification = buildNotification(conversationName, callExtras)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(
+                NOTIFICATION_ID,
+                notification,
+                resolveForegroundServiceType(callExtras)
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
+
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        super.onDestroy()
+    }
+
+    private fun buildNotification(conversationName: String?, callExtras: Bundle?): Notification {
+        val channelId = NotificationUtils.NotificationChannels.NOTIFICATION_CHANNEL_CALLS_V4.name
+        ensureNotificationChannel()
+
+        val contentTitle = conversationName?.takeIf { it.isNotBlank() }
+            ?: getString(R.string.nc_call_ongoing_notification_default_title)
+        val pendingIntent = createContentIntent(callExtras)
+
+        return NotificationCompat.Builder(this, channelId)
+            .setContentTitle(contentTitle)
+            .setContentText(getString(R.string.nc_call_ongoing_notification_content))
+            .setSmallIcon(R.drawable.ic_call_white_24dp)
+            .setOngoing(true)
+            .setCategory(NotificationCompat.CATEGORY_CALL)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setForegroundServiceBehavior(FOREGROUND_SERVICE_IMMEDIATE)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .setContentIntent(pendingIntent)
+            .setShowWhen(false)
+            .build()
+    }
+
+    private fun ensureNotificationChannel() {
+        val app = NextcloudTalkApplication.sharedApplication ?: return
+        NotificationUtils.registerNotificationChannels(applicationContext, app.appPreferences)
+    }
+
+    private fun createContentIntent(callExtras: Bundle?): PendingIntent {
+        val intent = Intent(this, CallActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            callExtras?.let { putExtras(Bundle(it)) }
+        }
+
+        val flags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        return PendingIntent.getActivity(this, 0, intent, flags)
+    }
+
+    private fun resolveForegroundServiceType(callExtras: Bundle?): Int {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            return 0
+        }
+
+        var serviceType = ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+        val isVoiceOnlyCall = callExtras?.getBoolean(KEY_CALL_VOICE_ONLY, false) ?: false
+        val canPublishVideo = callExtras?.getBoolean(
+            KEY_PARTICIPANT_PERMISSION_CAN_PUBLISH_VIDEO,
+            false
+        ) ?: false
+
+        if (!isVoiceOnlyCall && canPublishVideo) {
+            serviceType = serviceType or ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA
+        }
+
+        return serviceType
+    }
+
+    companion object {
+        private const val NOTIFICATION_ID = 47001
+        private const val EXTRA_CONVERSATION_NAME = "extra_conversation_name"
+        private const val EXTRA_CALL_INTENT_EXTRAS = "extra_call_intent_extras"
+
+        fun start(context: Context, conversationName: String?, callIntentExtras: Bundle?) {
+            val serviceIntent = Intent(context, CallForegroundService::class.java).apply {
+                putExtra(EXTRA_CONVERSATION_NAME, conversationName)
+                callIntentExtras?.let { putExtra(EXTRA_CALL_INTENT_EXTRAS, Bundle(it)) }
+            }
+            ContextCompat.startForegroundService(context, serviceIntent)
+        }
+
+        fun stop(context: Context) {
+            context.stopService(Intent(context, CallForegroundService::class.java))
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -318,6 +318,8 @@ How to translate with transifex:
     <string name="nc_call_state_with_phone">%1$s with phone</string>
     <string name="nc_call_state_with_video">%1$s with video</string>
     <string name="nc_missed_call">You missed a call from %s</string>
+    <string name="nc_call_ongoing_notification_default_title">Call in progress</string>
+    <string name="nc_call_ongoing_notification_content">Tap to return to your call.</string>
     <string name="nc_call_button_content_description_pip">Open picture-in-picture mode</string>
     <string name="nc_call_button_content_description_audio_output">Change audio output</string>
     <string name="nc_call_button_content_description_camera">Toggle camera</string>


### PR DESCRIPTION
As per issue #869 , there is a bug where bringing a call away from focus results in deactivating the microphone. This is the result of the call not being started with `FOREGROUND_SERVICE_TYPE_PHONE_CALL` . This fix was initially implemented by the [Jami client](https://git.jami.net/savoirfairelinux/jami-client-android/-/issues/1612), which gave me a good starting point.

This pull request does the following solves this bug by doing the following:

* Declare all call foreground service types
* Handle call foreground service permissions without dialer role
* Use microphone foreground service type for calls
* Start calls in a phone-call foreground service
* Add foreground service for ongoing calls

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)