### PR TITLE
Prevent Picture-in-Picture calls from ending when screen turns off

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallBaseActivity.java
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallBaseActivity.java
@@ -14,6 +14,7 @@ import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.PowerManager;
 import android.util.Log;
 import android.util.Rational;
 import android.view.View;
@@ -97,7 +98,7 @@ public abstract class CallBaseActivity extends BaseActivity {
     @Override
     public void onStop() {
         super.onStop();
-        if (isInPipMode) {
+        if (shouldFinishOnStop()) {
             finish();
         }
     }
@@ -139,6 +140,24 @@ public abstract class CallBaseActivity extends BaseActivity {
                 android.os.Process.myUid(),
                 BuildConfig.APPLICATION_ID) == AppOpsManager.MODE_ALLOWED;
             return deviceHasPipFeature && isPipFeatureGranted;
+    }
+
+    private boolean shouldFinishOnStop() {
+        if (!isInPipMode) {
+            return false;
+        }
+
+        PowerManager powerManager = (PowerManager) getSystemService(Context.POWER_SERVICE);
+        if (powerManager == null) {
+            return true;
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) {
+            return powerManager.isInteractive();
+        } else {
+            //noinspection deprecation
+            return powerManager.isScreenOn();
+        }
     }
 
     public abstract void updateUiForPipMode();


### PR DESCRIPTION
This PR solves the bug in issue #5466 , and is related to bug #869 and PR #5465 . With these two PRs, calls work normally when in background.