### PR TITLE
Hide thread container when message isn't a thread

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingPreviewMessageViewHolder.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingPreviewMessageViewHolder.java
@@ -16,10 +16,10 @@ import android.widget.ProgressBar;
 
 import com.google.android.material.card.MaterialCardView;
 import com.nextcloud.talk.R;
+import com.nextcloud.talk.chat.data.model.ChatMessage;
 import com.nextcloud.talk.databinding.ItemCustomIncomingPreviewMessageBinding;
 import com.nextcloud.talk.databinding.ItemThreadTitleBinding;
 import com.nextcloud.talk.databinding.ReactionsInsideMessageBinding;
-import com.nextcloud.talk.chat.data.model.ChatMessage;
 import com.nextcloud.talk.utils.TextMatchers;
 
 import java.util.HashMap;
@@ -89,6 +89,12 @@ public class IncomingPreviewMessageViewHolder extends PreviewMessageViewHolder {
                                                                 R.color.no_emphasis_text));
         binding.messageTime.setTextColor(ContextCompat.getColor(binding.messageText.getContext(),
                                                                 R.color.no_emphasis_text));
+
+        if(!message.isThread()) {
+            binding.threadTitleWrapperContainer.setVisibility(View.GONE);
+        } else {
+            binding.threadTitleWrapperContainer.setVisibility(View.VISIBLE);
+        }
     }
 
     @NonNull

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingPreviewMessageViewHolder.java
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingPreviewMessageViewHolder.java
@@ -89,6 +89,12 @@ public class OutcomingPreviewMessageViewHolder extends PreviewMessageViewHolder 
                                                                 R.color.no_emphasis_text));
         binding.messageTime.setTextColor(ContextCompat.getColor(binding.messageText.getContext(),
                                                                 R.color.no_emphasis_text));
+
+        if(!message.isThread()) {
+            binding.threadTitleWrapperContainer.setVisibility(View.GONE);
+        } else {
+            binding.threadTitleWrapperContainer.setVisibility(View.VISIBLE);
+        }
     }
 
     @NonNull

--- a/app/src/main/res/layout/item_custom_incoming_preview_message.xml
+++ b/app/src/main/res/layout/item_custom_incoming_preview_message.xml
@@ -55,6 +55,7 @@
         app:justifyContent="flex_end">
 
         <LinearLayout
+            android:id="@+id/threadTitleWrapperContainer"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:padding="16dp">

--- a/app/src/main/res/layout/item_custom_outcoming_preview_message.xml
+++ b/app/src/main/res/layout/item_custom_outcoming_preview_message.xml
@@ -32,6 +32,7 @@
         app:justifyContent="flex_end">
 
         <LinearLayout
+            android:id="@+id/threadTitleWrapperContainer"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:padding="16dp">


### PR DESCRIPTION
... only preview messages

### 🖼️ Screenshots

**Ignore the theming color difference, this is due to my testing (!)**

🏚️ Before | 🏡 After
---|---
<img width="1080" height="2376" alt="Screenshot_20251027_141909" src="https://github.com/user-attachments/assets/8cc300b6-f961-4f34-95cf-71fcabb27e1b" />|<img width="1080" height="2376" alt="Screenshot_20251027_142557" src="https://github.com/user-attachments/assets/0f3494b8-0571-425e-8ca4-41301d510a75" />
<img width="1080" height="2376" alt="Screenshot_20251027_141918" src="https://github.com/user-attachments/assets/7723d569-20cb-4685-aafd-4320dc69e4e5" />|<img width="1080" height="2376" alt="Screenshot_20251027_142537" src="https://github.com/user-attachments/assets/f5e07c1d-8446-4fc3-a958-399394b7ceac" />

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)