### PR TITLE
[issue 5299] fix text color of additional hint explaining why the 'typing status' setting is disabled when no high-performance backend is used

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -1071,7 +1071,6 @@ class SettingsActivity :
             binding.settingsTypingStatusSwitch.isChecked = false
             binding.settingsTypingStatusOnlyWithHpb.visibility = View.VISIBLE
             binding.settingsTypingStatus.isEnabled = false
-            binding.settingsTypingStatusOnlyWithHpb.alpha = DISABLED_ALPHA
             binding.settingsTypingStatus.alpha = DISABLED_ALPHA
         }
     }

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -616,7 +616,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="@dimen/standard_half_margin"
-                            android:hint="@string/nc_settings_typing_status_hpb_description"/>
+                            android:text="@string/nc_settings_typing_status_hpb_description"/>
                     </LinearLayout>
 
                     <com.google.android.material.materialswitch.MaterialSwitch


### PR DESCRIPTION
- fix #5299

Fixes the color of the additional hint that explains why the 'typing status' settings toggle is disabled in case no high-performance backend is used. 

Previously the existing hint's alpha channel was set to 'disabled'. However since the whole container already has a changed alpha channel due to being disabled this lead to a color barely readable against the background. 

This PR changes the hint into a text element and removes the change of the alpha channel. So the hint has the same appearance as the disabled text of the toggle switch. 

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="375" height="313" alt="Screenshot_talk-issue-5299_before" src="https://github.com/user-attachments/assets/d71961a9-aaa4-4221-8316-c8d59253f17b" /> | <img width="375" height="313" alt="Screenshot_talk-issue-5299-after" src="https://github.com/user-attachments/assets/c13c3001-1b24-4e60-b9bc-a4071ab9a5c8" /> 



### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)