### PR TITLE
improving the background of reactions with added contrast

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/Reaction.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/Reaction.kt
@@ -11,8 +11,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.TextView
-import com.nextcloud.talk.databinding.ReactionsInsideMessageBinding
 import com.nextcloud.talk.chat.data.model.ChatMessage
+import com.nextcloud.talk.databinding.ReactionsInsideMessageBinding
 import com.nextcloud.talk.ui.theme.ViewThemeUtils
 import com.nextcloud.talk.utils.DisplayUtils
 import com.vanniktech.emoji.EmojiTextView
@@ -98,27 +98,19 @@ class Reaction {
         emojiWithAmountWrapper.addView(getReactionCount(context, layoutInfo.textColor, amount, layoutInfo.amountParams))
         emojiWithAmountWrapper.layoutParams = layoutInfo.wrapperParams
 
-        if (layoutInfo.isSelfReaction) {
-            layoutInfo.viewThemeUtils.talk.setCheckedBackground(
-                emojiWithAmountWrapper,
-                layoutInfo.isOutgoingMessage,
-                isBubbled
-            )
+        layoutInfo.viewThemeUtils.talk.setReactionsBackground(
+            emojiWithAmountWrapper,
+            layoutInfo.isOutgoingMessage,
+            layoutInfo.isSelfReaction
+        )
 
-            emojiWithAmountWrapper.setPaddingRelative(
-                layoutInfo.paddingSide,
-                layoutInfo.paddingTop,
-                layoutInfo.paddingSide,
-                layoutInfo.paddingBottom
-            )
-        } else {
-            emojiWithAmountWrapper.setPaddingRelative(
-                0,
-                layoutInfo.paddingTop,
-                layoutInfo.paddingSide,
-                layoutInfo.paddingBottom
-            )
-        }
+        emojiWithAmountWrapper.setPaddingRelative(
+            layoutInfo.paddingSide,
+            layoutInfo.paddingTop,
+            layoutInfo.paddingSide,
+            layoutInfo.paddingBottom
+        )
+
         return emojiWithAmountWrapper
     }
 

--- a/app/src/main/java/com/nextcloud/talk/ui/theme/TalkSpecificViewThemeUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/theme/TalkSpecificViewThemeUtils.kt
@@ -176,19 +176,24 @@ class TalkSpecificViewThemeUtils @Inject constructor(
         }
     }
 
-    fun setCheckedBackground(linearLayout: LinearLayout, outgoing: Boolean, isBubbled: Boolean) {
+    fun setReactionsBackground(linearLayout: LinearLayout, outgoing: Boolean, isBubbled: Boolean) {
         withScheme(linearLayout) { scheme ->
             val drawable = AppCompatResources
                 .getDrawable(linearLayout.context, R.drawable.reaction_self_background)!!
                 .mutate()
-            val backgroundColor = if (outgoing && isBubbled) {
-                ContextCompat.getColor(
-                    linearLayout.context,
-                    R.color.bg_message_list_incoming_bubble
-                )
-            } else {
+            val backgroundColor = if (isBubbled) {
                 dynamicColor.primaryContainer().getArgb(scheme)
+            } else {
+                if (outgoing) {
+                    ContextCompat.getColor(
+                        linearLayout.context,
+                        R.color.bg_message_list_incoming_bubble
+                    )
+                } else {
+                    dynamicColor.surfaceVariant().getArgb(scheme)
+                }
             }
+
             DrawableCompat.setTintList(
                 drawable,
                 ColorStateList.valueOf(backgroundColor)


### PR DESCRIPTION
### 🖼️ Screenshots Before

Light  | Dark | |
---|---|---
<img width="361" height="264" alt="Screenshot 2025-12-02 at 7 57 13 AM" src="https://github.com/user-attachments/assets/cf4afa9f-2ee3-4275-9771-1107f4631ad4" /> | <img width="361" height="264" alt="Screenshot 2025-12-02 at 7 57 59 AM" src="https://github.com/user-attachments/assets/0883c130-ddd2-465c-95b3-ece13132dc35" /> | Outgoing
<img width="361" height="264" alt="Screenshot 2025-12-02 at 8 00 19 AM" src="https://github.com/user-attachments/assets/6be1f53c-3a50-4f78-be7b-069bf866ef86" /> | <img width="361" height="264" alt="Screenshot 2025-12-02 at 7 59 25 AM" src="https://github.com/user-attachments/assets/851b8db8-65ff-4ffc-85f6-2b61f773d60e" /> | Incoming

### 🖼️ Screenshots After

Light  | Dark | |
---|---|---
<img width="259" height="153" alt="Screenshot 2025-11-03 at 10 22 04 AM" src="https://github.com/user-attachments/assets/7e7afb59-d615-41b8-bc74-04cceaca9267" /> | <img width="259" height="153" alt="Screenshot 2025-11-03 at 10 22 46 AM" src="https://github.com/user-attachments/assets/898a9d98-40ef-4810-a9b1-e36a879cc2cd" /> | Outgoing
<img width="259" height="248" alt="Screenshot 2025-11-03 at 10 24 05 AM" src="https://github.com/user-attachments/assets/f6cc0723-cb15-44d3-bd28-18871de69fa0" /> | <img width="259" height="248" alt="Screenshot 2025-11-03 at 10 23 09 AM" src="https://github.com/user-attachments/assets/e0ef33de-760b-47e7-b1a6-409f6b672114" /> | Incoming

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)