### PR TITLE
change concurrency settings (try to avoid "Error: The operation was canceled.")

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -21,7 +21,7 @@ permissions:
     contents: write
 
 concurrency:
-    group: analysis-wrapper-${{ github.head_ref || github.run_id }}
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/assembleFlavors.yml
+++ b/.github/workflows/assembleFlavors.yml
@@ -11,7 +11,7 @@ on:
 permissions: read-all
 
 concurrency:
-  group: assemble-flavors-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/autoApproveSync.yml
+++ b/.github/workflows/autoApproveSync.yml
@@ -17,7 +17,7 @@ on:
       - labeled
 
 concurrency:
-  group: sync-approve-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ on:
 permissions: read-all
 
 concurrency:
-  group: check-kotlin-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/detectNewJavaFiles.yml
+++ b/.github/workflows/detectNewJavaFiles.yml
@@ -15,7 +15,7 @@ on:
 permissions: read-all
 
 concurrency:
-  group: detect-new-java-files-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/fixup.yml
+++ b/.github/workflows/fixup.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: fixup-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: qa-build-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/renovate-approve-merge.yml
+++ b/.github/workflows/renovate-approve-merge.yml
@@ -19,7 +19,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: renovate-approve-merge-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -58,4 +58,4 @@ jobs:
         run: gh pr merge --merge --auto
         env:
           GH_TOKEN: ${{ secrets.AUTOMERGE }}
-          
+

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,8 +15,8 @@ on:
 # Declare default permissions as read only.
 permissions: read-all
 
-concurrency: 
-  group: scorecard-supply-chain-security-${{ github.head_ref || github.run_id }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ permissions:
     pull-requests: write
 
 concurrency:
-    group: unit-tests-${{ github.head_ref || github.run_id }}
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
followup of (or maybe should replace?) https://github.com/nextcloud/talk-android/pull/5587

Not sure if it helps. Just testing..


Keep in mind also if it solves the "Error: The operation was canceled." issue:

This would change the behavior for builds on master.

## Before:
`analysis-wrapper-${{ github.head_ref || github.run_id }}`

> "The following concurrency group cancels in-progress jobs or runs on pull_request events only"

https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency#example-using-a-fallback-value

## After:

`${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`

`${{ github.workflow }}` is just used for convenience. 
The important parts are  `github.head_ref || github.run_id` vs `github.event.pull_request.number || github.ref`

same as iOS talk uses.
Modified version of https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency#example-using-concurrency-and-the-default-behavior


### 🚧 TODO

- [ ] keep an eye on if "Error: The operation was canceled." happens on other branches without these changes
- [ ] keep an eye on if "Error: The operation was canceled." still happens in this branch (retrigger builds again..?)
- [ ] if it's merged, also do the changes in config repo

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)