### PR TITLE
Fixing race condition in Message Input Fragment

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
@@ -169,9 +169,12 @@ class MessageInputFragment : Fragment() {
 
     private fun initObservers() {
         Log.d(TAG, "LifeCyclerOwner is: ${viewLifecycleOwner.lifecycle}")
-        // FIXME conversation state not saved on orientation change
         chatActivity.chatViewModel.getCapabilitiesViewState.observe(viewLifecycleOwner) { state ->
             when (state) {
+                is ChatViewModel.GetCapabilitiesUpdateState -> {
+                    restoreState()
+                }
+
                 is ChatViewModel.GetCapabilitiesInitialLoadState -> {
                     initMessageInputView(state.spreedCapabilities)
                     initSmileyKeyboardToggler()


### PR DESCRIPTION
- fixes #5603 

### 🚧 TODO

- [x] spreed capabilities guaranteed not null
- [x] Fix message drafts not saving on orientation changes

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)