### PR TITLE
bump compileSdkVersion and targetSdkVersion to Android 16 (api level 36)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,13 +29,13 @@ apply plugin: "org.jlleitschuh.gradle.ktlint"
 apply plugin: 'kotlinx-serialization'
 
 android {
-    compileSdkVersion 35
+    compileSdkVersion 36
 
     namespace = 'com.nextcloud.talk'
 
     defaultConfig {
         minSdkVersion 26
-        targetSdkVersion 35
+        targetSdkVersion 36
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         // mayor.minor.hotfix.increment (for increment: 01-50=Alpha / 51-89=RC / 90-99=stable)


### PR DESCRIPTION
All mandatory adaptions in
https://developer.android.com/about/versions/16/behavior-changes-16 are fulfilled.

Predictive back does not yet work for all screens. Further migration to Jetpack compose could fix this by the way.

Some optional required adaptions are not yet done but should be taken into account for the future. For Android Talk this might be:

- https://developer.android.com/about/versions/16/behavior-changes-16#new-intents-to-handle-bond-loss

- https://developer.android.com/about/versions/16/behavior-changes-16#safer-intents

- https://developer.android.com/about/versions/16/behavior-changes-16#local-network-permission


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)