### PR TITLE
Fixed text disappearing in Message Input Fragment

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
@@ -173,12 +173,15 @@ class MessageInputFragment : Fragment() {
     // https://stackoverflow.com/a/54648758/14183836
     // Would be easier to move the capabilities observability to kotlin flows/suspend
     fun <T> LiveData<T>.observeOnce(lifecycleOwner: LifecycleOwner, observer: Observer<T>) {
-        observe(lifecycleOwner, object : Observer<T> {
-            override fun onChanged(value: T) {
-                observer.onChanged(value)
-                removeObserver(this)
+        observe(
+            lifecycleOwner,
+            object : Observer<T> {
+                override fun onChanged(value: T) {
+                    observer.onChanged(value)
+                    removeObserver(this)
+                }
             }
-        })
+        )
     }
 
     private fun initObservers() {


### PR DESCRIPTION
This changes the observer to fire once, and remove itself, instead of continuously updating every time the capabilities is refreshed.

Todo
- [x] Test it a bit more

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)