### PR TITLE
feat: Add deep link and launcher shortcut support for conversations

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -127,6 +127,33 @@
             <meta-data
                 android:name="android.app.shortcuts"
                 android:resource="@xml/shortcuts" />
+
+            <!-- Custom URI scheme for opening conversations from external apps/launchers -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="nctalk" />
+            </intent-filter>
+
+            <!-- HTTP/HTTPS deep links for opening Talk conversation links -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" />
+                <data android:host="*" />
+                <data android:pathPrefix="/call/" />
+            </intent-filter>
+
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" />
+                <data android:host="*" />
+                <data android:pathPrefix="/index.php/call/" />
+            </intent-filter>
         </activity>
 
         <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -133,26 +133,7 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="nctalk" />
-            </intent-filter>
-
-            <!-- HTTP/HTTPS deep links for opening Talk conversation links -->
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="https" />
-                <data android:host="*" />
-                <data android:pathPrefix="/call/" />
-            </intent-filter>
-
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="https" />
-                <data android:host="*" />
-                <data android:pathPrefix="/index.php/call/" />
+                <data android:scheme="nextcloudtalk" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
@@ -306,8 +306,6 @@ class MainActivity :
     private fun handleDeepLink(intent: Intent): Boolean {
         val deepLinkResult = intent.data?.let { DeepLinkHandler.parseDeepLink(it) } ?: return false
 
-        Log.d(TAG, "Handling deep link: token=${deepLinkResult.roomToken}, server=${deepLinkResult.serverUrl}")
-
         val disposable = userManager.users
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
@@ -347,6 +345,7 @@ class MainActivity :
                         // Open conversation list first so back press shows correct user's conversations
                         val listIntent = Intent(context, ConversationsListActivity::class.java)
                         listIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                        listIntent.putExtra(BundleKeys.KEY_INTERNAL_USER_ID, targetUser.id)
 
                         val chatIntent = Intent(context, ChatActivity::class.java)
                         chatIntent.putExtra(KEY_ROOM_TOKEN, deepLinkResult.roomToken)

--- a/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
@@ -344,10 +344,15 @@ class MainActivity :
 
                         if (isFinishing || isDestroyed) return@subscribe
 
+                        // Open conversation list first so back press shows correct user's conversations
+                        val listIntent = Intent(context, ConversationsListActivity::class.java)
+                        listIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+
                         val chatIntent = Intent(context, ChatActivity::class.java)
                         chatIntent.putExtra(KEY_ROOM_TOKEN, deepLinkResult.roomToken)
                         chatIntent.putExtra(BundleKeys.KEY_INTERNAL_USER_ID, targetUser.id)
-                        startActivity(chatIntent)
+
+                        startActivities(arrayOf(listIntent, chatIntent))
                     } else {
                         Toast.makeText(
                             context,

--- a/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
@@ -37,8 +37,10 @@ import com.nextcloud.talk.models.json.conversations.RoomOverall
 import com.nextcloud.talk.users.UserManager
 import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.ClosedInterfaceImpl
+import com.nextcloud.talk.utils.DeepLinkHandler
 import com.nextcloud.talk.utils.SecurityUtils
 import com.nextcloud.talk.utils.UnifiedPushUtils
+import com.nextcloud.talk.utils.ShortcutManagerHelper
 import com.nextcloud.talk.utils.bundle.BundleKeys
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_ROOM_TOKEN
 import io.reactivex.Observer
@@ -233,6 +235,11 @@ class MainActivity :
     }
 
     private fun handleIntent(intent: Intent) {
+        // Handle deep links first (nctalk:// scheme and https:// web links)
+        if (handleDeepLink(intent)) {
+            return
+        }
+
         handleActionFromContact(intent)
 
         val internalUserId = intent.extras?.getLong(BundleKeys.KEY_INTERNAL_USER_ID)
@@ -286,6 +293,113 @@ class MainActivity :
                 }
             })
         }
+    }
+
+    /**
+     * Handles deep link URIs for opening conversations.
+     *
+     * Supports:
+     * - nctalk://conversation/{token}?user={userId}
+     * - https://{server}/call/{token}
+     * - https://{server}/index.php/call/{token}
+     *
+     * @param intent The intent to process
+     * @return true if the intent was handled as a deep link, false otherwise
+     */
+    private fun handleDeepLink(intent: Intent): Boolean {
+        val uri = intent.data ?: return false
+        val deepLinkResult = DeepLinkHandler.parseDeepLink(uri) ?: return false
+
+        Log.d(TAG, "Handling deep link: $uri -> token=${deepLinkResult.roomToken}")
+
+        userManager.users.subscribe(object : SingleObserver<List<User>> {
+            override fun onSubscribe(d: Disposable) {
+                // unused atm
+            }
+
+            override fun onSuccess(users: List<User>) {
+                if (users.isEmpty()) {
+                    runOnUiThread {
+                        launchServerSelection()
+                    }
+                    return
+                }
+
+                val targetUser = resolveTargetUser(users, deepLinkResult)
+
+                if (targetUser == null) {
+                    runOnUiThread {
+                        Toast.makeText(
+                            context,
+                            context.resources.getString(R.string.nc_no_account_for_server),
+                            Toast.LENGTH_LONG
+                        ).show()
+                        openConversationList()
+                    }
+                    return
+                }
+
+                if (userManager.setUserAsActive(targetUser).blockingGet()) {
+                    // Report shortcut usage for ranking
+                    ShortcutManagerHelper.reportShortcutUsed(
+                        context,
+                        deepLinkResult.roomToken,
+                        targetUser.id!!
+                    )
+
+                    runOnUiThread {
+                        val chatIntent = Intent(context, ChatActivity::class.java)
+                        chatIntent.putExtra(KEY_ROOM_TOKEN, deepLinkResult.roomToken)
+                        chatIntent.putExtra(BundleKeys.KEY_INTERNAL_USER_ID, targetUser.id)
+                        startActivity(chatIntent)
+                    }
+                }
+            }
+
+            override fun onError(e: Throwable) {
+                Log.e(TAG, "Error loading users for deep link", e)
+                runOnUiThread {
+                    Toast.makeText(
+                        context,
+                        context.resources.getString(R.string.nc_common_error_sorry),
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+            }
+        })
+
+        return true
+    }
+
+    /**
+     * Resolves which user account to use for a deep link.
+     *
+     * Priority:
+     * 1. User ID specified in deep link (for nctalk:// URIs)
+     * 2. User matching the server URL (for https:// web links)
+     * 3. Current active user as fallback
+     */
+    private fun resolveTargetUser(
+        users: List<User>,
+        deepLinkResult: DeepLinkHandler.DeepLinkResult
+    ): User? {
+        // If user ID is specified, use that user
+        deepLinkResult.internalUserId?.let { userId ->
+            return userManager.getUserWithId(userId).blockingGet()
+        }
+
+        // If server URL is specified, find matching account
+        deepLinkResult.serverUrl?.let { serverUrl ->
+            val matchingUser = users.find { user ->
+                user.baseUrl?.lowercase()?.contains(serverUrl.lowercase()) == true
+            }
+            if (matchingUser != null) {
+                return matchingUser
+            }
+        }
+
+        // Fall back to current user
+        return currentUserProviderOld.currentUser.blockingGet()
     }
 
     companion object {

--- a/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
@@ -43,8 +43,10 @@ import com.nextcloud.talk.utils.UnifiedPushUtils
 import com.nextcloud.talk.utils.ShortcutManagerHelper
 import com.nextcloud.talk.utils.bundle.BundleKeys
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_ROOM_TOKEN
+import io.reactivex.SingleObserver
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
 import javax.inject.Inject
 

--- a/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
@@ -11,6 +11,7 @@ package com.nextcloud.talk.activities
 
 import android.app.KeyguardManager
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.provider.ContactsContract
 import android.text.TextUtils
@@ -33,7 +34,6 @@ import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.databinding.ActivityMainBinding
 import com.nextcloud.talk.invitation.InvitationsActivity
 import com.nextcloud.talk.lock.LockedActivity
-import com.nextcloud.talk.models.json.conversations.RoomOverall
 import com.nextcloud.talk.users.UserManager
 import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.ClosedInterfaceImpl
@@ -43,10 +43,8 @@ import com.nextcloud.talk.utils.UnifiedPushUtils
 import com.nextcloud.talk.utils.ShortcutManagerHelper
 import com.nextcloud.talk.utils.bundle.BundleKeys
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_ROOM_TOKEN
-import io.reactivex.Observer
-import io.reactivex.SingleObserver
 import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.disposables.Disposable
+import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
 import javax.inject.Inject
 
@@ -62,6 +60,8 @@ class MainActivity :
 
     @Inject
     lateinit var userManager: UserManager
+
+    private val disposables = CompositeDisposable()
 
     private val onBackPressedCallback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
@@ -92,6 +92,11 @@ class MainActivity :
         handleIntent(intent)
 
         onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        disposables.dispose()
     }
 
     fun lockScreenIfConditionsApply() {
@@ -169,7 +174,8 @@ class MainActivity :
                     val user = userId.substringBeforeLast("@")
                     val baseUrl = userId.substringAfterLast("@")
 
-                    if (currentUserProviderOld.currentUser.blockingGet()?.baseUrl!!.endsWith(baseUrl) == true) {
+                    val currentUser = currentUserProviderOld.currentUser.blockingGet()
+                    if (currentUser?.baseUrl?.endsWith(baseUrl) == true) {
                         startConversation(user)
                     } else {
                         Snackbar.make(
@@ -197,35 +203,28 @@ class MainActivity :
             invite = userId
         )
 
-        ncApi.createRoom(
+        val disposable = ncApi.createRoom(
             credentials,
             retrofitBucket.url,
             retrofitBucket.queryMap
         )
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
-            .subscribe(object : Observer<RoomOverall> {
-                override fun onSubscribe(d: Disposable) {
-                    // unused atm
-                }
-
-                override fun onNext(roomOverall: RoomOverall) {
+            .subscribe(
+                { roomOverall ->
+                    if (isFinishing || isDestroyed) return@subscribe
                     val bundle = Bundle()
                     bundle.putString(KEY_ROOM_TOKEN, roomOverall.ocs!!.data!!.token)
 
                     val chatIntent = Intent(context, ChatActivity::class.java)
                     chatIntent.putExtras(bundle)
                     startActivity(chatIntent)
+                },
+                { e ->
+                    Log.e(TAG, "Error creating room", e)
                 }
-
-                override fun onError(e: Throwable) {
-                    // unused atm
-                }
-
-                override fun onComplete() {
-                    // unused atm
-                }
-            })
+            )
+        disposables.add(disposable)
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -235,7 +234,7 @@ class MainActivity :
     }
 
     private fun handleIntent(intent: Intent) {
-        // Handle deep links first (nctalk:// scheme and https:// web links)
+        // Handle deep links first (nextcloudtalk:// scheme)
         if (handleDeepLink(intent)) {
             return
         }
@@ -245,7 +244,7 @@ class MainActivity :
         val internalUserId = intent.extras?.getLong(BundleKeys.KEY_INTERNAL_USER_ID)
 
         var user: User? = null
-        if (internalUserId != null) {
+        if (internalUserId != null && internalUserId != 0L) {
             user = userManager.getUserWithId(internalUserId).blockingGet()
         }
 
@@ -299,74 +298,75 @@ class MainActivity :
      * Handles deep link URIs for opening conversations.
      *
      * Supports:
-     * - nctalk://conversation/{token}?user={userId}
-     * - https://{server}/call/{token}
-     * - https://{server}/index.php/call/{token}
+     * - nextcloudtalk://[user@]server/call/token
      *
      * @param intent The intent to process
      * @return true if the intent was handled as a deep link, false otherwise
      */
     private fun handleDeepLink(intent: Intent): Boolean {
-        val uri = intent.data ?: return false
-        val deepLinkResult = DeepLinkHandler.parseDeepLink(uri) ?: return false
+        val deepLinkResult = intent.data?.let { DeepLinkHandler.parseDeepLink(it) } ?: return false
 
-        Log.d(TAG, "Handling deep link: $uri -> token=${deepLinkResult.roomToken}")
+        Log.d(TAG, "Handling deep link: token=${deepLinkResult.roomToken}, server=${deepLinkResult.serverUrl}")
 
-        userManager.users.subscribe(object : SingleObserver<List<User>> {
-            override fun onSubscribe(d: Disposable) {
-                // unused atm
-            }
+        val disposable = userManager.users
+            .subscribeOn(Schedulers.io())
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe(
+                { users ->
+                    if (isFinishing || isDestroyed) return@subscribe
 
-            override fun onSuccess(users: List<User>) {
-                if (users.isEmpty()) {
-                    runOnUiThread {
+                    if (users.isEmpty()) {
                         launchServerSelection()
+                        return@subscribe
                     }
-                    return
-                }
 
-                val targetUser = resolveTargetUser(users, deepLinkResult)
+                    val targetUser = resolveTargetUser(users, deepLinkResult)
 
-                if (targetUser == null) {
-                    runOnUiThread {
+                    if (targetUser == null) {
                         Toast.makeText(
                             context,
                             context.resources.getString(R.string.nc_no_account_for_server),
                             Toast.LENGTH_LONG
                         ).show()
                         openConversationList()
+                        return@subscribe
                     }
-                    return
-                }
 
-                if (userManager.setUserAsActive(targetUser).blockingGet()) {
-                    // Report shortcut usage for ranking
-                    ShortcutManagerHelper.reportShortcutUsed(
-                        context,
-                        deepLinkResult.roomToken,
-                        targetUser.id!!
-                    )
+                    if (userManager.setUserAsActive(targetUser).blockingGet()) {
+                        // Report shortcut usage for ranking
+                        targetUser.id?.let { userId ->
+                            ShortcutManagerHelper.reportShortcutUsed(
+                                context,
+                                deepLinkResult.roomToken,
+                                userId
+                            )
+                        }
 
-                    runOnUiThread {
+                        if (isFinishing || isDestroyed) return@subscribe
+
                         val chatIntent = Intent(context, ChatActivity::class.java)
                         chatIntent.putExtra(KEY_ROOM_TOKEN, deepLinkResult.roomToken)
                         chatIntent.putExtra(BundleKeys.KEY_INTERNAL_USER_ID, targetUser.id)
                         startActivity(chatIntent)
+                    } else {
+                        Toast.makeText(
+                            context,
+                            context.resources.getString(R.string.nc_common_error_sorry),
+                            Toast.LENGTH_SHORT
+                        ).show()
                     }
-                }
-            }
-
-            override fun onError(e: Throwable) {
-                Log.e(TAG, "Error loading users for deep link", e)
-                runOnUiThread {
+                },
+                { e ->
+                    Log.e(TAG, "Error loading users for deep link", e)
+                    if (isFinishing || isDestroyed) return@subscribe
                     Toast.makeText(
                         context,
                         context.resources.getString(R.string.nc_common_error_sorry),
                         Toast.LENGTH_SHORT
                     ).show()
                 }
-            }
-        })
+            )
+        disposables.add(disposable)
 
         return true
     }
@@ -375,31 +375,38 @@ class MainActivity :
      * Resolves which user account to use for a deep link.
      *
      * Priority:
-     * 1. User ID specified in deep link (for nctalk:// URIs)
-     * 2. User matching the server URL (for https:// web links)
-     * 3. Current active user as fallback
+     * 1. User matching both username and server URL
+     * 2. User matching the server URL only
+     * 3. Current active user as fallback (if server matches)
      */
-    private fun resolveTargetUser(
-        users: List<User>,
-        deepLinkResult: DeepLinkHandler.DeepLinkResult
-    ): User? {
-        // If user ID is specified, use that user
-        deepLinkResult.internalUserId?.let { userId ->
-            return userManager.getUserWithId(userId).blockingGet()
+    private fun resolveTargetUser(users: List<User>, deepLinkResult: DeepLinkHandler.DeepLinkResult): User? {
+        val deepLinkHost = Uri.parse(deepLinkResult.serverUrl).host?.lowercase()
+        if (deepLinkHost.isNullOrBlank()) {
+            return currentUserProviderOld.currentUser.blockingGet()
         }
 
-        // If server URL is specified, find matching account
-        deepLinkResult.serverUrl?.let { serverUrl ->
-            val matchingUser = users.find { user ->
-                user.baseUrl?.lowercase()?.contains(serverUrl.lowercase()) == true
+        // Priority: exact match (username + server) > server match > current user fallback
+        val username = deepLinkResult.username
+        val exactMatch = if (username != null) {
+            users.find { user ->
+                val userHost = user.baseUrl?.let { Uri.parse(it).host?.lowercase() }
+                userHost == deepLinkHost && user.username?.lowercase() == username.lowercase()
             }
-            if (matchingUser != null) {
-                return matchingUser
-            }
+        } else {
+            null
         }
 
-        // Fall back to current user
-        return currentUserProviderOld.currentUser.blockingGet()
+        val serverMatch = users.find { user ->
+            val userHost = user.baseUrl?.let { Uri.parse(it).host?.lowercase() }
+            userHost == deepLinkHost
+        }
+
+        val currentUser = currentUserProviderOld.currentUser.blockingGet()
+        val currentUserMatch = currentUser?.takeIf {
+            it.baseUrl?.let { url -> Uri.parse(url).host?.lowercase() } == deepLinkHost
+        }
+
+        return exactMatch ?: serverMatch ?: currentUserMatch
     }
 
     companion object {

--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
@@ -90,6 +90,7 @@ import com.nextcloud.talk.utils.ConversationUtils
 import com.nextcloud.talk.utils.DateConstants
 import com.nextcloud.talk.utils.DateUtils
 import com.nextcloud.talk.utils.ShareUtils
+import com.nextcloud.talk.utils.ShortcutManagerHelper
 import com.nextcloud.talk.utils.SpreedFeatures
 import com.nextcloud.talk.utils.bundle.BundleKeys
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_ROOM_TOKEN
@@ -1013,6 +1014,14 @@ class ConversationInfoActivity : BaseActivity() {
                     if (workInfo != null) {
                         when (workInfo.state) {
                             WorkInfo.State.SUCCEEDED -> {
+                                conversationUser.id?.let { userId ->
+                                    ShortcutManagerHelper.disableConversationShortcut(
+                                        context,
+                                        conversationToken,
+                                        userId,
+                                        context.resources.getString(R.string.nc_shortcut_conversation_deleted)
+                                    )
+                                }
                                 val intent = Intent(context, MainActivity::class.java)
                                 intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
                                 startActivity(intent)
@@ -1088,6 +1097,14 @@ class ConversationInfoActivity : BaseActivity() {
                     DeleteConversationWorker::class.java
                 ).setInputData(it).build()
             )
+            conversationUser.id?.let { userId ->
+                ShortcutManagerHelper.disableConversationShortcut(
+                    context,
+                    conversationToken,
+                    userId,
+                    context.resources.getString(R.string.nc_shortcut_conversation_deleted)
+                )
+            }
             val intent = Intent(context, MainActivity::class.java)
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
             startActivity(intent)

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -179,7 +179,12 @@ class ConversationsListActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
         NextcloudTalkApplication.sharedApplication!!.componentApplication.inject(this)
 
-        currentUser = currentUserProviderOld.currentUser.blockingGet()
+        val targetUserId = intent.getLongExtra(KEY_INTERNAL_USER_ID, 0L)
+        currentUser = if (targetUserId != 0L) {
+            userManager.getUserWithId(targetUserId).blockingGet()
+        } else {
+            currentUserProviderOld.currentUser.blockingGet()
+        }
 
         conversationsListViewModel = ViewModelProvider(this, viewModelFactory)[ConversationsListViewModel::class.java]
         contextChatViewModel = ViewModelProvider(this, viewModelFactory)[ContextChatViewModel::class.java]
@@ -978,6 +983,7 @@ class ConversationsListActivity : BaseActivity() {
             is ConversationOpsAction.ShareLink -> shareConversationLink(conversation)
             is ConversationOpsAction.Rename -> renameConversation(conversation)
             is ConversationOpsAction.ToggleArchive -> handleArchiving(conversation)
+            is ConversationOpsAction.AddToHomeScreen -> addConversationToHomeScreen(conversation)
             is ConversationOpsAction.Leave -> leaveConversation(conversation)
             is ConversationOpsAction.Delete -> showDeleteConversationDialog(conversation)
         }
@@ -992,6 +998,16 @@ class ConversationsListActivity : BaseActivity() {
             conversation.name,
             canGeneratePrettyURL
         )
+    }
+
+    private fun addConversationToHomeScreen(conversation: ConversationModel) {
+        val user = currentUser ?: return
+        val success = ShortcutManagerHelper.requestPinShortcut(this, conversation, user)
+        if (success) {
+            showSnackbar(resources.getString(R.string.nc_shortcut_created))
+        } else {
+            showSnackbar(resources.getString(R.string.nc_common_error_sorry))
+        }
     }
 
     @Suppress("Detekt.TooGenericExceptionCaught", "TooGenericExceptionCaught")
@@ -1080,6 +1096,14 @@ class ConversationsListActivity : BaseActivity() {
         WorkManager.getInstance(this).getWorkInfoByIdLiveData(worker.id).observeForever { workInfo ->
             when (workInfo?.state) {
                 WorkInfo.State.SUCCEEDED -> {
+                    currentUser?.id?.let { userId ->
+                        ShortcutManagerHelper.disableConversationShortcut(
+                            this,
+                            conversation.token,
+                            userId,
+                            resources.getString(R.string.nc_shortcut_conversation_deleted)
+                        )
+                    }
                     showSnackbar(
                         String.format(resources.getString(R.string.left_conversation), conversation.displayName)
                     )

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -1293,6 +1293,14 @@ class ConversationsListActivity : BaseActivity() {
                 if (workInfo != null) {
                     when (workInfo.state) {
                         WorkInfo.State.SUCCEEDED -> {
+                            currentUser?.id?.let { userId ->
+                                ShortcutManagerHelper.disableConversationShortcut(
+                                    context,
+                                    conversation.token,
+                                    userId,
+                                    context.resources.getString(R.string.nc_shortcut_conversation_deleted)
+                                )
+                            }
                             showSnackbar(
                                 String.format(
                                     context.resources.getString(R.string.deleted_conversation),

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -83,6 +83,7 @@ import com.nextcloud.talk.utils.Mimetype
 import com.nextcloud.talk.utils.NotificationUtils
 import com.nextcloud.talk.utils.ParticipantPermissions
 import com.nextcloud.talk.utils.ShareUtils
+import com.nextcloud.talk.utils.ShortcutManagerHelper
 import com.nextcloud.talk.utils.SpreedFeatures
 import com.nextcloud.talk.utils.UserIdUtils
 import com.nextcloud.talk.utils.bundle.BundleKeys
@@ -419,6 +420,11 @@ class ConversationsListActivity : BaseActivity() {
                         pendingDirectShareToken = null
                         val conversation = list.firstOrNull { it.token == token }
                         if (conversation != null) handleConversation(conversation)
+                    }
+
+                    // Update dynamic shortcuts for frequent/favorite conversations
+                    currentUser?.let { user ->
+                        ShortcutManagerHelper.updateDynamicShortcuts(context, list, user)
                     }
 
                     if (!scrollPositionRestored) {

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ui/ConversationOperationsSheet.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ui/ConversationOperationsSheet.kt
@@ -53,6 +53,7 @@ private data class ConversationOpsVisibility(
     val showShareLink: Boolean,
     val showRename: Boolean,
     val isArchived: Boolean,
+    val showAddToHomeScreen: Boolean,
     val showLeave: Boolean,
     val showDelete: Boolean
 )
@@ -70,6 +71,7 @@ private fun computeVisibility(conversation: ConversationModel, user: User): Conv
         showShareLink = !ConversationUtils.isNoteToSelfConversation(conversation),
         showRename = spreedCap != null && ConversationUtils.isNameEditable(conversation, spreedCap),
         isArchived = conversation.hasArchived,
+        showAddToHomeScreen = true,
         showLeave = conversation.canLeaveConversation,
         showDelete = conversation.canDeleteConversation
     )
@@ -165,6 +167,12 @@ private fun ConversationOpsManageGroup(
         stringResource(R.string.archive_conversation)
     }
     ConversationOpsMenuItem(archiveIcon, archiveLabel) { onAction(ConversationOpsAction.ToggleArchive) }
+    if (visibility.showAddToHomeScreen) {
+        ConversationOpsMenuItem(
+            R.drawable.ic_home,
+            stringResource(R.string.nc_add_to_home_screen)
+        ) { onAction(ConversationOpsAction.AddToHomeScreen) }
+    }
     if (visibility.showLeave) {
         ConversationOpsMenuItem(
             R.drawable.ic_exit_to_app_black_24dp,

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ui/ConversationOpsAction.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ui/ConversationOpsAction.kt
@@ -15,6 +15,7 @@ sealed class ConversationOpsAction {
     object ShareLink : ConversationOpsAction()
     object Rename : ConversationOpsAction()
     object ToggleArchive : ConversationOpsAction()
+    object AddToHomeScreen : ConversationOpsAction()
     object Leave : ConversationOpsAction()
     object Delete : ConversationOpsAction()
 }

--- a/app/src/main/java/com/nextcloud/talk/utils/DeepLinkHandler.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/DeepLinkHandler.kt
@@ -11,32 +11,32 @@ import android.net.Uri
 /**
  * Handles parsing of deep links for opening conversations.
  *
- * Supported URI formats:
- * - nctalk://conversation/{token}
- * - nctalk://conversation/{token}?user={internalUserId}
- * - https://{server}/call/{token}
- * - https://{server}/index.php/call/{token}
+ * Supported URI format (per https://github.com/nextcloud/spreed/issues/16354):
+ * - nextcloudtalk://[userid@]server_host/[server_base/]call/token
+ *
+ * Examples:
+ * - nextcloudtalk://cloud.example.com/call/abc123
+ * - nextcloudtalk://user1@cloud.example.com/call/abc123
+ * - nextcloudtalk://cloud.example.com/nextcloud/call/abc123
+ * - nextcloudtalk://user1@cloud.example.com/index.php/call/abc123
  */
 object DeepLinkHandler {
 
-    private const val SCHEME_NCTALK = "nctalk"
-    private const val HOST_CONVERSATION = "conversation"
-    private const val QUERY_PARAM_USER = "user"
+    private const val SCHEME_NEXTCLOUD_TALK = "nextcloudtalk"
     private const val PATH_CALL = "call"
     private const val PATH_INDEX_PHP = "index.php"
+
+    // Token validation: alphanumeric characters, reasonable length
+    private val TOKEN_PATTERN = Regex("^[a-zA-Z0-9]{4,32}$")
 
     /**
      * Result of parsing a deep link URI.
      *
      * @property roomToken The conversation/room token to open
-     * @property internalUserId Optional internal user ID for multi-account support
-     * @property serverUrl Optional server URL extracted from web links
+     * @property serverUrl The server URL extracted from the deep link
+     * @property username Optional username from the URI authority (user@host format)
      */
-    data class DeepLinkResult(
-        val roomToken: String,
-        val internalUserId: Long? = null,
-        val serverUrl: String? = null
-    )
+    data class DeepLinkResult(val roomToken: String, val serverUrl: String, val username: String? = null)
 
     /**
      * Parses a deep link URI and extracts conversation information.
@@ -45,80 +45,88 @@ object DeepLinkHandler {
      * @return DeepLinkResult if the URI is valid, null otherwise
      */
     fun parseDeepLink(uri: Uri): DeepLinkResult? {
-        return when (uri.scheme?.lowercase()) {
-            SCHEME_NCTALK -> parseNcTalkUri(uri)
-            "http", "https" -> parseWebUri(uri)
-            else -> null
+        if (uri.scheme?.lowercase() != SCHEME_NEXTCLOUD_TALK) {
+            return null
         }
+        return parseNextcloudTalkUri(uri)
     }
 
     /**
-     * Parses a custom scheme URI (nctalk://conversation/{token}).
+     * Parses a nextcloudtalk:// URI.
+     * Format: nextcloudtalk://[userid@]server_host/[server_base/]call/token
      */
-    private fun parseNcTalkUri(uri: Uri): DeepLinkResult? {
-        if (uri.host?.lowercase() != HOST_CONVERSATION) {
-            return null
-        }
-
-        val pathSegments = uri.pathSegments
-        if (pathSegments.isEmpty()) {
-            return null
-        }
-
-        val token = pathSegments[0]
-        if (token.isBlank()) {
-            return null
-        }
-
-        val userId = uri.getQueryParameter(QUERY_PARAM_USER)?.toLongOrNull()
-
-        return DeepLinkResult(
-            roomToken = token,
-            internalUserId = userId
-        )
-    }
-
-    /**
-     * Parses a web URL (https://{server}/call/{token} or https://{server}/index.php/call/{token}).
-     */
-    private fun parseWebUri(uri: Uri): DeepLinkResult? {
+    @Suppress("ReturnCount")
+    private fun parseNextcloudTalkUri(uri: Uri): DeepLinkResult? {
+        val authority = uri.authority ?: return null
         val path = uri.path ?: return null
-        val host = uri.host ?: return null
+        val (username, serverHost) = parseAuthority(authority)
+        val token = extractTokenFromPath(path)
 
-        // Match /call/{token} or /index.php/call/{token}
-        val tokenRegex = Regex("^(?:/$PATH_INDEX_PHP)?/$PATH_CALL/([^/]+)/?$")
-        val match = tokenRegex.find(path) ?: return null
-        val token = match.groupValues[1]
+        return if (serverHost.isBlank() || token == null || !isValidToken(token)) {
+            null
+        } else {
+            DeepLinkResult(roomToken = token, serverUrl = "https://$serverHost", username = username)
+        }
+    }
 
-        if (token.isBlank()) {
-            return null
+    /**
+     * Parses the authority part to extract optional username and server host.
+     * Format: [userid@]server_host
+     *
+     * @return Pair of (username or null, serverHost)
+     */
+    private fun parseAuthority(authority: String): Pair<String?, String> =
+        if (authority.contains("@")) {
+            val parts = authority.split("@", limit = 2)
+            val username = parts[0].takeIf { it.isNotBlank() }
+            val host = parts.getOrElse(1) { "" }
+            Pair(username, host)
+        } else {
+            Pair(null, authority)
         }
 
-        val serverUrl = "${uri.scheme}://$host"
-
-        return DeepLinkResult(
-            roomToken = token,
-            serverUrl = serverUrl
-        )
+    /**
+     * Extracts the room token from the path.
+     * Matches /call/{token} or /[anything]/call/{token} patterns.
+     */
+    private fun extractTokenFromPath(path: String): String? {
+        // Match patterns like /call/token or /base/call/token or /index.php/call/token
+        val tokenRegex = Regex("/$PATH_CALL/([^/]+)/?$")
+        val match = tokenRegex.find(path) ?: return null
+        return match.groupValues[1].takeIf { it.isNotBlank() }
     }
+
+    /**
+     * Validates that a token matches the expected format.
+     * Tokens should be alphanumeric and between 4-32 characters.
+     */
+    private fun isValidToken(token: String): Boolean = TOKEN_PATTERN.matches(token)
 
     /**
      * Creates a custom scheme URI for a conversation.
      *
      * @param roomToken The conversation token
-     * @param internalUserId Optional user ID for multi-account support
-     * @return URI in the format nctalk://conversation/{token}?user={userId}
+     * @param serverUrl The server base URL (e.g., "https://cloud.example.com")
+     * @param username Optional username for multi-account support
+     * @return URI in the format nextcloudtalk://[user@]host/call/token
      */
-    fun createConversationUri(roomToken: String, internalUserId: Long? = null): Uri {
-        val builder = Uri.Builder()
-            .scheme(SCHEME_NCTALK)
-            .authority(HOST_CONVERSATION)
-            .appendPath(roomToken)
+    fun createConversationUri(roomToken: String, serverUrl: String, username: String? = null): Uri {
+        // Extract host from server URL
+        val serverUri = Uri.parse(serverUrl)
+        val host = serverUri.host ?: return Uri.EMPTY
 
-        internalUserId?.let {
-            builder.appendQueryParameter(QUERY_PARAM_USER, it.toString())
+        // Build authority with optional username
+        val authority = if (username != null) {
+            "$username@$host"
+        } else {
+            host
         }
 
-        return builder.build()
+        return Uri.Builder()
+            .scheme(SCHEME_NEXTCLOUD_TALK)
+            .authority(authority)
+            .appendPath(PATH_CALL)
+            .appendPath(roomToken)
+            .build()
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/utils/DeepLinkHandler.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/DeepLinkHandler.kt
@@ -1,0 +1,124 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.utils
+
+import android.net.Uri
+
+/**
+ * Handles parsing of deep links for opening conversations.
+ *
+ * Supported URI formats:
+ * - nctalk://conversation/{token}
+ * - nctalk://conversation/{token}?user={internalUserId}
+ * - https://{server}/call/{token}
+ * - https://{server}/index.php/call/{token}
+ */
+object DeepLinkHandler {
+
+    private const val SCHEME_NCTALK = "nctalk"
+    private const val HOST_CONVERSATION = "conversation"
+    private const val QUERY_PARAM_USER = "user"
+    private const val PATH_CALL = "call"
+    private const val PATH_INDEX_PHP = "index.php"
+
+    /**
+     * Result of parsing a deep link URI.
+     *
+     * @property roomToken The conversation/room token to open
+     * @property internalUserId Optional internal user ID for multi-account support
+     * @property serverUrl Optional server URL extracted from web links
+     */
+    data class DeepLinkResult(
+        val roomToken: String,
+        val internalUserId: Long? = null,
+        val serverUrl: String? = null
+    )
+
+    /**
+     * Parses a deep link URI and extracts conversation information.
+     *
+     * @param uri The URI to parse
+     * @return DeepLinkResult if the URI is valid, null otherwise
+     */
+    fun parseDeepLink(uri: Uri): DeepLinkResult? {
+        return when (uri.scheme?.lowercase()) {
+            SCHEME_NCTALK -> parseNcTalkUri(uri)
+            "http", "https" -> parseWebUri(uri)
+            else -> null
+        }
+    }
+
+    /**
+     * Parses a custom scheme URI (nctalk://conversation/{token}).
+     */
+    private fun parseNcTalkUri(uri: Uri): DeepLinkResult? {
+        if (uri.host?.lowercase() != HOST_CONVERSATION) {
+            return null
+        }
+
+        val pathSegments = uri.pathSegments
+        if (pathSegments.isEmpty()) {
+            return null
+        }
+
+        val token = pathSegments[0]
+        if (token.isBlank()) {
+            return null
+        }
+
+        val userId = uri.getQueryParameter(QUERY_PARAM_USER)?.toLongOrNull()
+
+        return DeepLinkResult(
+            roomToken = token,
+            internalUserId = userId
+        )
+    }
+
+    /**
+     * Parses a web URL (https://{server}/call/{token} or https://{server}/index.php/call/{token}).
+     */
+    private fun parseWebUri(uri: Uri): DeepLinkResult? {
+        val path = uri.path ?: return null
+        val host = uri.host ?: return null
+
+        // Match /call/{token} or /index.php/call/{token}
+        val tokenRegex = Regex("^(?:/$PATH_INDEX_PHP)?/$PATH_CALL/([^/]+)/?$")
+        val match = tokenRegex.find(path) ?: return null
+        val token = match.groupValues[1]
+
+        if (token.isBlank()) {
+            return null
+        }
+
+        val serverUrl = "${uri.scheme}://$host"
+
+        return DeepLinkResult(
+            roomToken = token,
+            serverUrl = serverUrl
+        )
+    }
+
+    /**
+     * Creates a custom scheme URI for a conversation.
+     *
+     * @param roomToken The conversation token
+     * @param internalUserId Optional user ID for multi-account support
+     * @return URI in the format nctalk://conversation/{token}?user={userId}
+     */
+    fun createConversationUri(roomToken: String, internalUserId: Long? = null): Uri {
+        val builder = Uri.Builder()
+            .scheme(SCHEME_NCTALK)
+            .authority(HOST_CONVERSATION)
+            .appendPath(roomToken)
+
+        internalUserId?.let {
+            builder.appendQueryParameter(QUERY_PARAM_USER, it.toString())
+        }
+
+        return builder.build()
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/utils/DeepLinkHandler.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/DeepLinkHandler.kt
@@ -76,9 +76,8 @@ object DeepLinkHandler {
      */
     private fun parseAuthority(authority: String): Pair<String?, String> =
         if (authority.contains("@")) {
-            val parts = authority.split("@", limit = 2)
-            val username = parts[0].takeIf { it.isNotBlank() }
-            val host = parts.getOrElse(1) { "" }
+            val username = authority.substringBeforeLast("@").takeIf { it.isNotBlank() }
+            val host = authority.substringAfterLast("@").takeIf { it.isNotBlank() } ?: ""
             Pair(username, host)
         } else {
             Pair(null, authority)

--- a/app/src/main/java/com/nextcloud/talk/utils/DeepLinkHandler.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/DeepLinkHandler.kt
@@ -24,7 +24,6 @@ object DeepLinkHandler {
 
     private const val SCHEME_NEXTCLOUD_TALK = "nextcloudtalk"
     private const val PATH_CALL = "call"
-    private const val PATH_INDEX_PHP = "index.php"
 
     // Token validation: alphanumeric characters, reasonable length
     private val TOKEN_PATTERN = Regex("^[a-zA-Z0-9]{4,32}$")

--- a/app/src/main/java/com/nextcloud/talk/utils/ShortcutManagerHelper.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/ShortcutManagerHelper.kt
@@ -1,0 +1,234 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.utils
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
+import com.nextcloud.talk.R
+import com.nextcloud.talk.activities.MainActivity
+import com.nextcloud.talk.data.user.model.User
+import com.nextcloud.talk.models.domain.ConversationModel
+import com.nextcloud.talk.utils.bundle.BundleKeys
+
+/**
+ * Helper class for managing Android shortcuts for conversations.
+ *
+ * Provides methods to create, update, and manage dynamic shortcuts that allow
+ * users to quickly access conversations from their launcher.
+ */
+object ShortcutManagerHelper {
+
+    private const val MAX_DYNAMIC_SHORTCUTS = 4
+    private const val CONVERSATION_SHORTCUT_PREFIX = "conversation_"
+
+    /**
+     * Creates a shortcut for a conversation.
+     *
+     * @param context Application context
+     * @param conversation The conversation to create a shortcut for
+     * @param user The user account associated with the conversation
+     * @return ShortcutInfoCompat ready to be added via ShortcutManagerCompat
+     */
+    fun createConversationShortcut(
+        context: Context,
+        conversation: ConversationModel,
+        user: User
+    ): ShortcutInfoCompat {
+        val shortcutId = getShortcutId(conversation.token, user.id!!)
+        val displayName = conversation.displayName.ifBlank { conversation.name }
+
+        // Use custom URI scheme for the intent
+        val uri = DeepLinkHandler.createConversationUri(conversation.token, user.id)
+        val intent = Intent(Intent.ACTION_VIEW, uri).apply {
+            setPackage(context.packageName)
+        }
+
+        // Use the app icon as the shortcut icon - avatar loading would require async operations
+        val icon = IconCompat.createWithResource(context, R.drawable.baseline_chat_bubble_outline_24)
+
+        return ShortcutInfoCompat.Builder(context, shortcutId)
+            .setShortLabel(displayName)
+            .setLongLabel(displayName)
+            .setIcon(icon)
+            .setIntent(intent)
+            .build()
+    }
+
+    /**
+     * Creates a shortcut using bundle extras (alternative to URI scheme).
+     * This matches the existing Note To Self shortcut pattern.
+     *
+     * @param context Application context
+     * @param conversation The conversation to create a shortcut for
+     * @param user The user account associated with the conversation
+     * @return ShortcutInfoCompat ready to be added via ShortcutManagerCompat
+     */
+    fun createConversationShortcutWithBundle(
+        context: Context,
+        conversation: ConversationModel,
+        user: User
+    ): ShortcutInfoCompat {
+        val shortcutId = getShortcutId(conversation.token, user.id!!)
+        val displayName = conversation.displayName.ifBlank { conversation.name }
+
+        val bundle = Bundle().apply {
+            putString(BundleKeys.KEY_ROOM_TOKEN, conversation.token)
+            putLong(BundleKeys.KEY_INTERNAL_USER_ID, user.id!!)
+        }
+
+        val intent = Intent(context, MainActivity::class.java).apply {
+            action = Intent.ACTION_VIEW
+            putExtras(bundle)
+        }
+
+        val icon = IconCompat.createWithResource(context, R.drawable.baseline_chat_bubble_outline_24)
+
+        return ShortcutInfoCompat.Builder(context, shortcutId)
+            .setShortLabel(displayName)
+            .setLongLabel(displayName)
+            .setIcon(icon)
+            .setIntent(intent)
+            .build()
+    }
+
+    /**
+     * Updates dynamic shortcuts with the user's top conversations.
+     * Excludes Note To Self (handled separately) and archived conversations.
+     *
+     * @param context Application context
+     * @param conversations List of all conversations
+     * @param user The current user
+     */
+    fun updateDynamicShortcuts(
+        context: Context,
+        conversations: List<ConversationModel>,
+        user: User
+    ) {
+        // Remove existing conversation shortcuts (keep Note To Self shortcut)
+        val existingShortcuts = ShortcutManagerCompat.getDynamicShortcuts(context)
+        val conversationShortcutIds = existingShortcuts
+            .filter { it.id.startsWith(CONVERSATION_SHORTCUT_PREFIX) }
+            .map { it.id }
+
+        if (conversationShortcutIds.isNotEmpty()) {
+            ShortcutManagerCompat.removeDynamicShortcuts(context, conversationShortcutIds)
+        }
+
+        // Get top conversations: favorites first, then by last activity
+        val topConversations = conversations
+            .filter { !it.hasArchived }
+            .filter { !ConversationUtils.isNoteToSelfConversation(it) }
+            .sortedWith(compareByDescending<ConversationModel> { it.favorite }.thenByDescending { it.lastActivity })
+            .take(MAX_DYNAMIC_SHORTCUTS)
+
+        // Create and push shortcuts
+        topConversations.forEach { conversation ->
+            val shortcut = createConversationShortcutWithBundle(context, conversation, user)
+            ShortcutManagerCompat.pushDynamicShortcut(context, shortcut)
+        }
+    }
+
+    /**
+     * Requests to pin a shortcut to the home screen.
+     *
+     * @param context Application context
+     * @param conversation The conversation to create a pinned shortcut for
+     * @param user The user account associated with the conversation
+     * @return true if the pin request was successfully sent, false otherwise
+     */
+    fun requestPinShortcut(
+        context: Context,
+        conversation: ConversationModel,
+        user: User
+    ): Boolean {
+        if (!ShortcutManagerCompat.isRequestPinShortcutSupported(context)) {
+            // Fall back to legacy shortcut broadcast
+            return createLegacyShortcut(context, conversation, user)
+        }
+
+        val shortcut = createConversationShortcutWithBundle(context, conversation, user)
+        return ShortcutManagerCompat.requestPinShortcut(context, shortcut, null)
+    }
+
+    /**
+     * Creates a shortcut using the legacy broadcast method for older launchers.
+     *
+     * @param context Application context
+     * @param conversation The conversation to create a shortcut for
+     * @param user The user account associated with the conversation
+     * @return true if the broadcast was sent successfully
+     */
+    @Suppress("DEPRECATION")
+    private fun createLegacyShortcut(
+        context: Context,
+        conversation: ConversationModel,
+        user: User
+    ): Boolean {
+        val displayName = conversation.displayName.ifBlank { conversation.name }
+
+        val bundle = Bundle().apply {
+            putString(BundleKeys.KEY_ROOM_TOKEN, conversation.token)
+            putLong(BundleKeys.KEY_INTERNAL_USER_ID, user.id!!)
+        }
+
+        val launchIntent = Intent(context, MainActivity::class.java).apply {
+            action = Intent.ACTION_VIEW
+            putExtras(bundle)
+        }
+
+        val shortcutIntent = Intent("com.android.launcher.action.INSTALL_SHORTCUT").apply {
+            putExtra(Intent.EXTRA_SHORTCUT_NAME, displayName)
+            putExtra(Intent.EXTRA_SHORTCUT_INTENT, launchIntent)
+            putExtra(
+                Intent.EXTRA_SHORTCUT_ICON_RESOURCE,
+                Intent.ShortcutIconResource.fromContext(context, R.mipmap.ic_launcher)
+            )
+        }
+
+        return try {
+            context.sendBroadcast(shortcutIntent)
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    /**
+     * Reports that a shortcut has been used (helps with shortcut ranking).
+     *
+     * @param context Application context
+     * @param roomToken The conversation token
+     * @param userId The user ID
+     */
+    fun reportShortcutUsed(context: Context, roomToken: String, userId: Long) {
+        val shortcutId = getShortcutId(roomToken, userId)
+        ShortcutManagerCompat.reportShortcutUsed(context, shortcutId)
+    }
+
+    /**
+     * Removes a specific conversation shortcut.
+     *
+     * @param context Application context
+     * @param roomToken The conversation token
+     * @param userId The user ID
+     */
+    fun removeConversationShortcut(context: Context, roomToken: String, userId: Long) {
+        val shortcutId = getShortcutId(roomToken, userId)
+        ShortcutManagerCompat.removeDynamicShortcuts(context, listOf(shortcutId))
+    }
+
+    /**
+     * Generates a unique shortcut ID for a conversation.
+     */
+    private fun getShortcutId(roomToken: String, userId: Long): String {
+        return "${CONVERSATION_SHORTCUT_PREFIX}${userId}_$roomToken"
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/utils/ShortcutManagerHelper.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/ShortcutManagerHelper.kt
@@ -128,7 +128,8 @@ object ShortcutManagerHelper {
      */
     @Suppress("DEPRECATION")
     private fun createLegacyShortcut(context: Context, conversation: ConversationModel, user: User): Boolean {
-        if (user.id == null || user.baseUrl == null) {
+        val baseUrl = user.baseUrl
+        if (user.id == null || baseUrl == null) {
             Log.w(TAG, "Cannot create legacy shortcut: user ID or base URL is null")
             return false
         }
@@ -137,7 +138,7 @@ object ShortcutManagerHelper {
 
         val uri = DeepLinkHandler.createConversationUri(
             roomToken = conversation.token,
-            serverUrl = user.baseUrl!!,
+            serverUrl = baseUrl,
             username = user.username
         )
 

--- a/app/src/main/java/com/nextcloud/talk/utils/ShortcutManagerHelper.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/ShortcutManagerHelper.kt
@@ -8,7 +8,7 @@ package com.nextcloud.talk.utils
 
 import android.content.Context
 import android.content.Intent
-import android.os.Bundle
+import android.net.Uri
 import android.util.Log
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
@@ -17,7 +17,6 @@ import com.nextcloud.talk.R
 import com.nextcloud.talk.activities.MainActivity
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.models.domain.ConversationModel
-import com.nextcloud.talk.utils.bundle.BundleKeys
 
 /**
  * Helper class for managing Android shortcuts for conversations.
@@ -32,8 +31,8 @@ object ShortcutManagerHelper {
     private const val CONVERSATION_SHORTCUT_PREFIX = "conversation_"
 
     /**
-     * Creates a shortcut for a conversation using bundle extras.
-     * This matches the existing Note To Self shortcut pattern.
+     * Creates a shortcut for a conversation using a nextcloudtalk:// deep link URI.
+     * This ensures proper multi-account user resolution when the shortcut is opened.
      *
      * @param context Application context
      * @param conversation The conversation to create a shortcut for
@@ -41,30 +40,24 @@ object ShortcutManagerHelper {
      * @return ShortcutInfoCompat ready to be added, or null if user ID is invalid
      */
     fun createConversationShortcut(context: Context, conversation: ConversationModel, user: User): ShortcutInfoCompat? {
-        val userId = user.id ?: run {
-            Log.w(TAG, "Cannot create shortcut: user ID is null")
-            return null
+        val userId = user.id
+        val baseUrl = user.baseUrl
+        val uri = baseUrl?.let {
+            DeepLinkHandler.createConversationUri(conversation.token, it, user.username)
+                .takeIf { built -> built != Uri.EMPTY }
         }
+        if (userId == null || uri == null) return null
 
-        val shortcutId = getShortcutId(conversation.token, userId)
         val displayName = conversation.displayName.ifBlank { conversation.name }
-
-        val bundle = Bundle().apply {
-            putString(BundleKeys.KEY_ROOM_TOKEN, conversation.token)
-            putLong(BundleKeys.KEY_INTERNAL_USER_ID, userId)
-        }
-
         val intent = Intent(context, MainActivity::class.java).apply {
             action = Intent.ACTION_VIEW
-            putExtras(bundle)
+            data = uri
         }
 
-        val icon = IconCompat.createWithResource(context, R.drawable.baseline_chat_bubble_outline_24)
-
-        return ShortcutInfoCompat.Builder(context, shortcutId)
+        return ShortcutInfoCompat.Builder(context, getShortcutId(conversation.token, userId))
             .setShortLabel(displayName)
             .setLongLabel(displayName)
-            .setIcon(icon)
+            .setIcon(IconCompat.createWithResource(context, R.drawable.baseline_chat_bubble_outline_24))
             .setIntent(intent)
             .build()
     }
@@ -135,21 +128,22 @@ object ShortcutManagerHelper {
      */
     @Suppress("DEPRECATION")
     private fun createLegacyShortcut(context: Context, conversation: ConversationModel, user: User): Boolean {
-        val userId = user.id ?: run {
-            Log.w(TAG, "Cannot create legacy shortcut: user ID is null")
+        if (user.id == null || user.baseUrl == null) {
+            Log.w(TAG, "Cannot create legacy shortcut: user ID or base URL is null")
             return false
         }
 
         val displayName = conversation.displayName.ifBlank { conversation.name }
 
-        val bundle = Bundle().apply {
-            putString(BundleKeys.KEY_ROOM_TOKEN, conversation.token)
-            putLong(BundleKeys.KEY_INTERNAL_USER_ID, userId)
-        }
+        val uri = DeepLinkHandler.createConversationUri(
+            roomToken = conversation.token,
+            serverUrl = user.baseUrl!!,
+            username = user.username
+        )
 
         val launchIntent = Intent(context, MainActivity::class.java).apply {
             action = Intent.ACTION_VIEW
-            putExtras(bundle)
+            data = uri
         }
 
         val shortcutIntent = Intent("com.android.launcher.action.INSTALL_SHORTCUT").apply {
@@ -186,15 +180,18 @@ object ShortcutManagerHelper {
     }
 
     /**
-     * Removes a specific conversation shortcut.
+     * Disables all shortcuts (dynamic and pinned) for a deleted conversation.
+     * Dynamic shortcuts are removed; pinned shortcuts are disabled with a message.
      *
      * @param context Application context
      * @param roomToken The conversation token
      * @param userId The user ID
+     * @param disabledMessage Message shown when a disabled pinned shortcut is tapped
      */
-    fun removeConversationShortcut(context: Context, roomToken: String, userId: Long) {
+    fun disableConversationShortcut(context: Context, roomToken: String, userId: Long, disabledMessage: String) {
         val shortcutId = getShortcutId(roomToken, userId)
         ShortcutManagerCompat.removeDynamicShortcuts(context, listOf(shortcutId))
+        ShortcutManagerCompat.disableShortcuts(context, listOf(shortcutId), disabledMessage)
     }
 
     /**

--- a/app/src/main/res/drawable/ic_home.xml
+++ b/app/src/main/res/drawable/ic_home.xml
@@ -1,0 +1,15 @@
+<!--
+  ~ Nextcloud Talk - Android Client
+  ~
+  ~ SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+  ~ SPDX-License-Identifier: GPL-3.0-or-later
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M10,20v-6h4v6h5v-8h3L12,3 2,12h3v8z"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,11 @@ How to translate with transifex:
     <string name="nc_common_copy_success">Copied to clipboard</string>
     <string name="nc_common_more_options">More options</string>
 
+    <!-- Shortcuts and Deep Links -->
+    <string name="nc_add_to_home_screen">Add to home screen</string>
+    <string name="nc_shortcut_created">Shortcut created</string>
+    <string name="nc_no_account_for_server">No account found for this server</string>
+
     <!-- Bottom Navigation -->
     <string name="nc_settings">Settings</string>
     <string name="add_participants">Add</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@ How to translate with transifex:
     <!-- Shortcuts and Deep Links -->
     <string name="nc_add_to_home_screen">Add to home screen</string>
     <string name="nc_shortcut_created">Shortcut created</string>
+    <string name="nc_shortcut_conversation_deleted">This conversation no longer exists</string>
     <string name="nc_no_account_for_server">No account found for this server</string>
 
     <!-- Bottom Navigation -->


### PR DESCRIPTION
- Add custom URI scheme (nctalk://conversation/{token}) for opening conversations from external launchers like KISS
- Add HTTPS deep link support for /call/{token} URLs (fixes #847)
- Add dynamic shortcuts for favorite/recent conversations
- Add "Add to home screen" menu option in conversation long-press dialog
- New DeepLinkHandler utility for parsing deep link URIs
- New ShortcutManagerHelper utility for managing conversation shortcuts

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)