### PR TITLE
fix(a11y): Make hint text the same color as the icons 

### DIFF
--- a/app/src/main/res/layout/fragment_message_input.xml
+++ b/app/src/main/res/layout/fragment_message_input.xml
@@ -71,6 +71,7 @@
         app:inputButtonMargin="0dp"
         app:inputButtonWidth="48dp"
         app:inputHint="@string/nc_hint_enter_a_message"
+        app:inputHintColor="?attr/colorControlNormal"
         app:inputTextColor="@color/nc_incoming_text_default"
         app:inputTextSize="16sp"
         app:showAttachmentButton="true" />


### PR DESCRIPTION
for proper contrast

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1080" height="2376" alt="before_light" src="https://github.com/user-attachments/assets/4b53fdad-6811-4005-b273-b9701e6eacc1" />|<img width="1080" height="2376" alt="after_light" src="https://github.com/user-attachments/assets/31df7a6f-dff5-47c2-b1dc-d96f5acefd6b" />
<img width="1080" height="2376" alt="before_dark" src="https://github.com/user-attachments/assets/77b1bb0b-371a-4ce3-a085-122da3eae5d8" />|<img width="1080" height="2376" alt="after_dark" src="https://github.com/user-attachments/assets/beadaa99-bc0c-4a62-99a2-8bbde9a56bb6" />

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)