### PR TITLE
Make message input chat-bubble styled

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
@@ -1045,6 +1045,14 @@ class MessageInputFragment : Fragment() {
     }
 
     private fun themeMessageInputView() {
+        binding.messageInputContainer.apply {
+            viewThemeUtils.talk.themeCardView(this)
+        }
+
+        binding.fragmentMessageInputView.findViewById<ImageView>(R.id.microphoneEnabledInfoBackground)?.let {
+            viewThemeUtils.platform.themeViewBackground(it, ColorRole.SURFACE_VARIANT)
+        }
+
         binding.fragmentMessageInputView.button?.let { viewThemeUtils.platform.colorImageView(it, ColorRole.PRIMARY) }
 
         binding.fragmentMessageInputView.findViewById<ImageButton>(R.id.cancelReplyButton)?.let {

--- a/app/src/main/java/com/nextcloud/talk/ui/theme/TalkSpecificViewThemeUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/theme/TalkSpecificViewThemeUtils.kt
@@ -70,6 +70,13 @@ class TalkSpecificViewThemeUtils @Inject constructor(
     private val appcompat: AndroidXViewThemeUtils
 ) : ViewThemeUtilsBase(schemes) {
     private val dynamicColor = MaterialDynamicColors()
+
+    fun themeCardView(cardView: MaterialCardView) {
+        withScheme(cardView) { scheme ->
+            cardView.backgroundTintList = ColorStateList.valueOf(dynamicColor.surfaceVariant().getArgb(scheme))
+        }
+    }
+
     fun themeIncomingMessageBubble(bubble: View, grouped: Boolean, deleted: Boolean, isPlayed: Boolean = false) {
         val resources = bubble.resources
 

--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -254,12 +254,6 @@
             android:layout_marginBottom="-19dp"
             android:orientation="vertical">
 
-            <View
-                android:id="@+id/separator_1"
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:background="@color/chat_separator" />
-
             <TextView
                 android:id="@+id/typing_indicator"
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/create_thread_view.xml
+++ b/app/src/main/res/layout/create_thread_view.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Nextcloud Talk - Android Client
   ~
+  ~ SPDX-FileCopyrightText: 2025 Andy Scherzinger <info@andy-scherzinger.de>
   ~ SPDX-FileCopyrightText: 2025 Marcel Hibbe <dev@mhibbe.de>
   ~ SPDX-License-Identifier: GPL-3.0-or-later
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-
     android:id="@+id/createThreadView"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -16,22 +15,24 @@
     <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/standard_half_margin"
         android:layout_weight="1"
         android:orientation="vertical"
-        android:paddingStart="50dp"
         tools:ignore="RtlSymmetry">
 
         <TextView
             android:id="@+id/createThreadTitle"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginStart="49dp"
             android:text="@string/thread_title"
-            android:textColor="@color/grey_600" />
+            android:textColor="?attr/colorControlNormal" />
 
         <com.nextcloud.talk.utils.EmojiTextInputEditText
             android:id="@+id/createThreadInput"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginStart="45dp"
             android:imeOptions="actionDone"
             android:inputType="textUri"
             android:singleLine="true"

--- a/app/src/main/res/layout/edit_message_view.xml
+++ b/app/src/main/res/layout/edit_message_view.xml
@@ -2,64 +2,61 @@
 <!--
   ~ Nextcloud Talk - Android Client
   ~
+  ~ SPDX-FileCopyrightText: 2025 Andy Scherzinger <info@andy-scherzinger.de>
   ~ SPDX-FileCopyrightText: 2024 Sowjanya Kota <sowjanya.kch@gmail.com>
   ~ SPDX-License-Identifier: GPL-3.0-or-later
 -->
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-
+    android:id="@+id/editMessageView"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:id = "@+id/editMessageView"
-    android:orientation = "horizontal">
+    android:layout_marginTop="@dimen/standard_half_margin"
+    android:orientation="horizontal">
 
     <ImageView
-        android:id = "@+id/editIcon"
-        android:layout_width="48dp"
-        android:layout_height="48dp"
-        android:padding = "12dp"
-        android:src = "@drawable/ic_edit_24"
-        android:layout_gravity = "start|top"
-        android:contentDescription= "@string/nc_edit_icon"
-        app:tint="@color/grey_600">
+        android:id="@+id/editIcon"
+        android:layout_width="@dimen/min_size_clickable_area"
+        android:layout_height="@dimen/min_size_clickable_area"
+        android:layout_gravity="start|top"
+        android:contentDescription="@string/nc_edit_icon"
+        android:padding="12dp"
+        android:src="@drawable/ic_edit_24"
+        app:tint="?attr/colorControlNormal">
 
     </ImageView>
 
     <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight = "1"
-        android:orientation = "vertical">
+        android:layout_weight="1"
+        android:orientation="vertical">
 
         <TextView
-            android:id = "@+id/editMessageTitle"
+            android:id="@+id/editMessageTitle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor = "@color/grey_600"
-            android:text = "@string/nc_edit_message_text">
-        </TextView>
+            android:text="@string/nc_edit_message_text"
+            android:textColor="?attr/colorControlNormal" />
 
         <TextView
-            android:id = "@+id/editMessage"
+            android:id="@+id/editMessage"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:ellipsize="end"
-            android:maxLines = "1"
-            tools:text = "Edit message very very very very very very very very very very long">
-        </TextView>
+            android:maxLines="1"
+            tools:text="Edit message very very very very very very very very very very long" />
 
     </LinearLayout>
 
     <ImageView
-        android:id = "@+id/clearEdit"
-        android:layout_width="48dp"
-        android:layout_height="48dp"
-        android:padding = "12dp"
-        android:src = "@drawable/ic_clear_24"
+        android:id="@+id/clearEdit"
+        android:layout_width="@dimen/min_size_clickable_area"
+        android:layout_height="@dimen/min_size_clickable_area"
         android:contentDescription="@string/nc_clear_edit_button"
-        android:gravity = "top|end">
-    </ImageView>
+        android:gravity="top|end"
+        android:padding="12dp"
+        android:src="@drawable/ic_clear_24" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_message_input.xml
+++ b/app/src/main/res/layout/fragment_message_input.xml
@@ -1,78 +1,90 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Nextcloud Talk - Android Client
   ~
+  ~ SPDX-FileCopyrightText: 2025 Andy Scherzinger <info@andy-scherzinger.de>
   ~ SPDX-FileCopyrightText: 2024 Julius Linus <juliuslinus1@gmail.com>
   ~ SPDX-License-Identifier: GPL-3.0-or-later
 -->
-
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical">
 
-
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/fragment_connection_lost"
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/messageInputContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:gravity="center"
-        android:text="@string/connection_lost_sent_messages_are_queued"
-        android:textColor="@color/white"
-        android:background="@color/hwSecurityRed"
-        android:visibility="gone"
-        tools:visibility="visible" />
+        android:layout_marginHorizontal="@dimen/standard_half_margin"
+        android:layout_marginBottom="@dimen/standard_half_margin"
+        app:cardBackgroundColor="@color/bg_message_list_incoming_bubble"
+        app:cardCornerRadius="@dimen/button_corner_radius"
+        app:cardElevation="@dimen/zero"
+        app:strokeWidth="@dimen/zero">
 
-    <include
-        android:id="@+id/fragment_call_started"
-        layout="@layout/call_started_message"
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent"
-        android:layout_marginVertical="@dimen/standard_margin"
-        android:layout_marginHorizontal="@dimen/standard_quarter_margin"
-        android:visibility="gone"/>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
-    <include
-        android:id="@+id/fragment_editView"
-        layout="@layout/edit_message_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="6dp">
-    </include>
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/fragment_connection_lost"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/hwSecurityRed"
+                android:gravity="center"
+                android:text="@string/connection_lost_sent_messages_are_queued"
+                android:textColor="@color/white"
+                android:visibility="gone"
+                tools:visibility="visible" />
 
-    <include
-        android:id="@+id/fragment_create_thread_view"
-        layout="@layout/create_thread_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="6dp">
-    </include>
+            <include
+                android:id="@+id/fragment_call_started"
+                layout="@layout/call_started_message"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/standard_quarter_margin"
+                android:layout_marginVertical="@dimen/standard_margin"
+                android:visibility="gone" />
 
-    <com.nextcloud.talk.ui.MessageInput
-        android:id="@+id/fragment_message_input_view"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:animateLayoutChanges="true"
-        android:inputType="textLongMessage|textAutoComplete"
-        android:maxLength="1000"
-        app:attachmentButtonBackground="@color/transparent"
-        app:attachmentButtonHeight="48dp"
-        app:attachmentButtonIcon="@drawable/ic_baseline_attach_file_24"
-        app:attachmentButtonMargin="0dp"
-        app:attachmentButtonWidth="48dp"
-        app:delayTypingStatus="200"
-        app:inputButtonDefaultBgColor="@color/transparent"
-        app:inputButtonDefaultBgDisabledColor="@color/transparent"
-        app:inputButtonDefaultBgPressedColor="@color/transparent"
-        app:inputButtonDefaultIconColor="@color/colorPrimary"
-        app:inputButtonHeight="48dp"
-        app:inputButtonMargin="0dp"
-        app:inputButtonWidth="48dp"
-        app:inputHint="@string/nc_hint_enter_a_message"
-        app:inputHintColor="?attr/colorControlNormal"
-        app:inputTextColor="@color/nc_incoming_text_default"
-        app:inputTextSize="16sp"
-        app:showAttachmentButton="true" />
+            <include
+                android:id="@+id/fragment_editView"
+                layout="@layout/edit_message_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <include
+                android:id="@+id/fragment_create_thread_view"
+                layout="@layout/create_thread_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <com.nextcloud.talk.ui.MessageInput
+                android:id="@+id/fragment_message_input_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:animateLayoutChanges="true"
+                android:inputType="textLongMessage|textAutoComplete"
+                android:maxLength="1000"
+                app:attachmentButtonBackground="@color/transparent"
+                app:attachmentButtonHeight="48dp"
+                app:attachmentButtonIcon="@drawable/ic_baseline_attach_file_24"
+                app:attachmentButtonMargin="0dp"
+                app:attachmentButtonWidth="48dp"
+                app:delayTypingStatus="200"
+                app:inputButtonDefaultBgColor="@color/transparent"
+                app:inputButtonDefaultBgDisabledColor="@color/transparent"
+                app:inputButtonDefaultBgPressedColor="@color/transparent"
+                app:inputButtonDefaultIconColor="@color/colorPrimary"
+                app:inputButtonHeight="48dp"
+                app:inputButtonMargin="0dp"
+                app:inputButtonWidth="48dp"
+                app:inputHint="@string/nc_hint_enter_a_message"
+                app:inputHintColor="@color/nc_incoming_text_default"
+                app:inputTextColor="@color/nc_incoming_text_default"
+                app:inputTextSize="16sp"
+                app:showAttachmentButton="true" />
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
 </LinearLayout>

--- a/app/src/main/res/layout/item_message_quote.xml
+++ b/app/src/main/res/layout/item_message_quote.xml
@@ -12,12 +12,12 @@
     android:id="@+id/quotedChatMessageView"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginBottom="8dp"
     android:background="@drawable/reply_background"
     android:paddingStart="12dp"
-    android:paddingEnd="12dp"
-    android:paddingBottom="4dp"
     android:paddingTop="4dp"
-    android:layout_marginBottom="8dp">
+    android:paddingEnd="4dp"
+    android:paddingBottom="4dp">
 
     <androidx.emoji2.widget.EmojiTextView
         android:id="@+id/quotedMessageAuthor"
@@ -84,9 +84,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentEnd="true"
-        android:layout_centerVertical="true"
         android:layout_marginStart="8dp"
-        android:layout_marginEnd="8dp"
+        android:layout_marginEnd="@dimen/zero"
         android:background="@color/transparent"
         android:contentDescription="@string/nc_message_quote_cancel_reply"
         android:src="@drawable/ic_cancel_black_24dp"

--- a/app/src/main/res/layout/view_message_input.xml
+++ b/app/src/main/res/layout/view_message_input.xml
@@ -1,8 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Nextcloud Talk - Android Client
   ~
-  ~ SPDX-FileCopyrightText: 2021 Andy Scherzinger <info@andy-scherzinger.de>
+  ~ SPDX-FileCopyrightText: 2021-2025 Andy Scherzinger <info@andy-scherzinger.de>
   ~ SPDX-FileCopyrightText: 2021 Marcel Hibbe <dev@mhibbe.de>
   ~ SPDX-FileCopyrightText: 2017-2018 Mario Danic <mario@lovelyhq.com>
   ~ SPDX-License-Identifier: GPL-3.0-or-later
@@ -13,255 +12,254 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <RelativeLayout
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="4dp"
-        android:layoutDirection="ltr">
+        android:layoutDirection="ltr"
+        android:orientation="vertical">
 
-        <include layout="@layout/item_message_quote"
+        <include
+            layout="@layout/item_message_quote"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="4dp"
-            android:visibility="gone"/>
-
-        <ImageButton
-            android:id="@id/attachmentButton"
-            android:layout_width="48dp"
-            android:layout_height="48dp"
-            android:padding="12dp"
-            android:layout_below="@id/quotedChatMessageView"
-            android:background="@color/transparent"
-            android:src="@drawable/ic_baseline_attach_file_24"
-            app:tint="?attr/colorControlNormal"
-            android:scaleType="centerCrop"
-            android:contentDescription="@string/nc_add_attachment" />
-
-        <ImageButton
-            android:id="@+id/smileyButton"
-            android:layout_width="48dp"
-            android:layout_height="48dp"
-            android:padding="12dp"
-            android:layout_below="@id/quotedChatMessageView"
-            android:layout_toEndOf="@id/attachmentButton"
-            android:background="@color/transparent"
-            android:src="@drawable/ic_insert_emoticon_black_24dp"
-            android:scaleType="centerCrop"
-            app:tint="?attr/colorControlNormal"
-            android:contentDescription="@string/nc_add_emojis" />
-
-        <com.nextcloud.talk.utils.ImageEmojiEditText
-            android:id="@id/messageInput"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_below="@+id/quotedChatMessageView"
-            android:layout_centerHorizontal="true"
-            android:layout_marginEnd = "48dp"
-            android:layout_toEndOf="@id/smileyButton"
-            android:imeOptions="actionDone"
-            android:inputType="textAutoCorrect|textMultiLine|textCapSentences"
-            android:lineSpacingMultiplier="1.2"
-            android:minHeight="48dp"
-            android:textAlignment="viewStart"
-            android:layoutDirection="locale"
-            tools:hint="@string/nc_hint_enter_a_message" />
-
-        <TextView
-            android:id="@+id/slideToCancelDescription"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_below="@id/quotedChatMessageView"
-            android:layout_centerInParent="true"
-            android:layout_toStartOf="@id/recordAudioButton"
-            android:layout_toEndOf="@id/audioRecordDuration"
-            android:text="@string/nc_voice_message_slide_to_cancel"
-            android:textAlignment="viewStart"
-            android:textColor="@color/low_emphasis_text"
-            android:textSize="16sp"
-            android:textStyle="bold"
+            android:layout_marginStart="10dp"
+            android:layout_marginTop="10dp"
+            android:layout_marginEnd="10dp"
             android:visibility="gone"
             tools:visibility="visible" />
 
-        <ImageView
-            android:id="@+id/microphoneEnabledInfoBackground"
-            android:layout_width="48dp"
-            android:layout_height="48dp"
-            android:layout_below="@id/quotedChatMessageView"
-            android:scaleType="centerInside"
-            android:layout_alignParentStart="true"
-            android:background="@color/bg_default"
-            android:visibility="gone"
-            tools:visibility="gone"
-            android:contentDescription="@null" />
-
-        <com.nextcloud.talk.ui.MicInputCloud
-            android:id="@+id/micInputCloud"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_below="@id/audioRecordDuration"
-            android:layout_centerInParent="true"
-            app:playIcon="@drawable/ic_refresh"
-            app:pauseIcon="@drawable/baseline_stop_24"
-            android:background="?android:attr/selectableItemBackgroundBorderless"
-            android:visibility="gone" />
-
-        <ImageView
-            android:id="@+id/deleteVoiceRecording"
-            android:layout_width="48dp"
-            android:layout_height="48dp"
-            android:layout_alignParentStart="true"
-            android:layout_alignBottom="@id/micInputCloud"
-            android:layout_below="@id/audioRecordDuration"
-            android:layout_marginVertical="@dimen/standard_margin"
-            android:layout_marginStart="@dimen/standard_double_margin"
-            android:scaleType="centerInside"
-            android:src="@drawable/ic_delete"
-            android:contentDescription="@string/delete_voice_recording"
-            android:background="?android:attr/selectableItemBackgroundBorderless"
-            android:visibility="gone" />
-
-        <ImageView
-            android:id="@+id/sendVoiceRecording"
-            android:layout_width="48dp"
-            android:layout_height="48dp"
-            android:layout_alignParentEnd="true"
-            android:layout_alignBottom="@id/micInputCloud"
-            android:layout_below="@id/audioRecordDuration"
-            android:layout_marginVertical="@dimen/standard_margin"
-            android:layout_marginEnd="@dimen/standard_double_margin"
-            android:scaleType="centerInside"
-            android:src="@drawable/ic_send"
-            android:contentDescription="@string/nc_send_voice_recording"
-            android:background="?android:attr/selectableItemBackgroundBorderless"
-            android:visibility="gone" />
-
-        <!-- the height of this ImageView is used to define the overall height of the
-         parent layout whenever the voice recording mode is enabled. parent layout has
-         height=wrap_content because it must enlarge whenever user types a message with
-          linebreaks. -->
-        <ImageView
-            android:id="@+id/microphoneEnabledInfo"
-            android:layout_width="48dp"
-            android:layout_height="48dp"
-            android:layout_below="@id/quotedChatMessageView"
-            android:scaleType="centerInside"
-            android:layout_alignParentStart="true"
-            android:src="@drawable/ic_baseline_mic_red_24"
-            android:contentDescription="@string/nc_microphone_enabled_audio_recording"
-            android:visibility="gone"
-            tools:visibility="gone" />
-
-        <LinearLayout
-            android:id="@+id/voice_preview_container"
+        <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@id/quotedChatMessageView"
-            android:layout_marginTop="@dimen/standard_margin"
-            android:gravity="center"
-            android:orientation="horizontal"
-            android:layout_marginHorizontal="@dimen/standard_margin"
-            android:background="@drawable/shape_grouped_outcoming_message">
+            android:layoutDirection="ltr">
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/playPauseBtn"
-                style="@style/Widget.AppTheme.Button.IconButton"
-                android:layout_width="48dp"
-                android:layout_height="48dp"
-                android:layout_marginStart="@dimen/standard_margin"
-                android:contentDescription="@string/play_pause_voice_message"
-                android:visibility="gone"
-                app:cornerRadius="@dimen/button_corner_radius"
-                app:icon="@drawable/ic_baseline_play_arrow_voice_message_24"
-                app:iconSize="30dp"
-                app:iconTint="@color/high_emphasis_text"
-                app:rippleColor="#1FFFFFFF" />
+            <ImageButton
+                android:id="@id/attachmentButton"
+                android:layout_width="@dimen/min_size_clickable_area"
+                android:layout_height="@dimen/min_size_clickable_area"
+                android:layout_alignBottom="@id/messageInput"
+                android:background="@color/transparent"
+                android:contentDescription="@string/nc_add_attachment"
+                android:gravity="bottom"
+                android:src="@drawable/ic_baseline_attach_file_24"
+                app:tint="?attr/colorControlNormal" />
 
-            <SeekBar
-                android:id="@+id/seekbar"
-                style="@style/Nextcloud.Material.Outgoing.SeekBar"
+            <ImageButton
+                android:id="@+id/smileyButton"
+                android:layout_width="@dimen/min_size_clickable_area"
+                android:layout_height="@dimen/min_size_clickable_area"
+                android:layout_alignBottom="@id/messageInput"
+                android:layout_toEndOf="@id/attachmentButton"
+                android:background="@color/transparent"
+                android:contentDescription="@string/nc_add_emojis"
+                android:gravity="bottom"
+                android:src="@drawable/ic_insert_emoticon_black_24dp"
+                app:tint="?attr/colorControlNormal" />
+
+            <com.nextcloud.talk.utils.ImageEmojiEditText
+                android:id="@id/messageInput"
                 android:layout_width="match_parent"
-                android:layout_height="30dp"
-                android:layout_marginEnd="@dimen/standard_margin"
-                android:thumb="@drawable/voice_message_outgoing_seek_bar_slider"
+                android:layout_height="wrap_content"
+                android:layout_centerHorizontal="true"
+                android:layout_marginEnd="48dp"
+                android:layout_toEndOf="@id/smileyButton"
+                android:imeOptions="actionDone"
+                android:inputType="textAutoCorrect|textMultiLine|textCapSentences"
+                android:layoutDirection="locale"
+                android:lineSpacingMultiplier="1.2"
+                android:minHeight="@dimen/min_size_clickable_area"
+                android:paddingHorizontal="@dimen/zero"
+                android:textAlignment="viewStart"
+                tools:hint="@string/nc_hint_enter_a_message" />
+
+            <TextView
+                android:id="@+id/slideToCancelDescription"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true"
+                android:layout_toStartOf="@id/recordAudioButton"
+                android:layout_toEndOf="@id/audioRecordDuration"
+                android:text="@string/nc_voice_message_slide_to_cancel"
+                android:textAlignment="viewStart"
+                android:textColor="?attr/colorControlNormal"
+                android:textSize="16sp"
+                android:textStyle="bold"
                 android:visibility="gone"
-                tools:progress="50" />
-        </LinearLayout>
+                tools:visibility="visible" />
 
-        <Chronometer
-            android:id="@+id/audioRecordDuration"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_below="@id/quotedChatMessageView"
-            android:layout_toEndOf="@id/microphoneEnabledInfo"
-            android:layout_centerVertical="true"
-            android:textSize="16sp"
-            android:textStyle="bold"
-            android:textColor="@color/low_emphasis_text"
-            android:paddingStart="5dp"
-            android:paddingEnd="5dp"
-            android:background="@color/bg_default"
-            android:visibility="gone"
-            tools:visibility="gone" />
+            <ImageView
+                android:id="@+id/microphoneEnabledInfoBackground"
+                android:layout_width="@dimen/min_size_clickable_area"
+                android:layout_height="@dimen/min_size_clickable_area"
+                android:layout_alignParentStart="true"
+                android:background="@color/bg_message_list_incoming_bubble"
+                android:contentDescription="@null"
+                android:scaleType="centerInside"
+                android:visibility="gone"
+                tools:visibility="gone" />
 
-        <ImageButton
-            android:id="@id/messageSendButton"
-            android:layout_width="48dp"
-            android:layout_height="48dp"
-            android:padding="12dp"
-            android:layout_below="@id/quotedChatMessageView"
-            android:layout_alignParentEnd="true"
-            android:adjustViewBounds="true"
-            android:scaleType="centerInside"
-            android:contentDescription="@string/nc_description_send_message_button" />
+            <com.nextcloud.talk.ui.MicInputCloud
+                android:id="@+id/micInputCloud"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/audioRecordDuration"
+                android:layout_centerInParent="true"
+                android:background="?android:attr/selectableItemBackgroundBorderless"
+                android:visibility="gone"
+                app:pauseIcon="@drawable/baseline_stop_24"
+                app:playIcon="@drawable/ic_refresh" />
 
+            <ImageView
+                android:id="@+id/deleteVoiceRecording"
+                android:layout_width="@dimen/min_size_clickable_area"
+                android:layout_height="@dimen/min_size_clickable_area"
+                android:layout_below="@id/audioRecordDuration"
+                android:layout_alignBottom="@id/micInputCloud"
+                android:layout_alignParentStart="true"
+                android:layout_marginVertical="@dimen/standard_margin"
+                android:layout_marginStart="@dimen/standard_double_margin"
+                android:background="?android:attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/delete_voice_recording"
+                android:scaleType="centerInside"
+                android:src="@drawable/ic_delete"
+                android:visibility="gone" />
 
-        <ImageButton
-            android:id="@+id/recordAudioButton"
-            android:layout_width="48dp"
-            android:layout_height="48dp"
-            android:layout_below="@id/quotedChatMessageView"
-            android:layout_alignParentEnd="true"
-            android:background="@color/transparent"
-            android:src="@drawable/ic_baseline_mic_24"
-            android:contentDescription="@string/nc_description_record_voice" />
+            <ImageView
+                android:id="@+id/sendVoiceRecording"
+                android:layout_width="@dimen/min_size_clickable_area"
+                android:layout_height="@dimen/min_size_clickable_area"
+                android:layout_below="@id/audioRecordDuration"
+                android:layout_alignBottom="@id/micInputCloud"
+                android:layout_alignParentEnd="true"
+                android:layout_marginVertical="@dimen/standard_margin"
+                android:layout_marginEnd="@dimen/standard_double_margin"
+                android:background="?android:attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/nc_send_voice_recording"
+                android:scaleType="centerInside"
+                android:src="@drawable/ic_send"
+                android:visibility="gone" />
 
-        <ImageButton
-            android:id="@+id/submitThreadButton"
-            android:layout_width="48dp"
-            android:layout_height="48dp"
-            android:layout_below="@id/quotedChatMessageView"
-            android:layout_alignParentEnd="true"
-            android:background="@color/transparent"
-            android:contentDescription="@string/start_thread"
-            android:src="@drawable/outline_forum_24"
-            app:tint="@color/grey_600" />
+            <!-- the height of this ImageView is used to define the overall height of the
+             parent layout whenever the voice recording mode is enabled. parent layout has
+             height=wrap_content because it must enlarge whenever user types a message with
+              linebreaks. -->
+            <ImageView
+                android:id="@+id/microphoneEnabledInfo"
+                android:layout_width="@dimen/min_size_clickable_area"
+                android:layout_height="@dimen/min_size_clickable_area"
+                android:layout_alignParentStart="true"
+                android:contentDescription="@string/nc_microphone_enabled_audio_recording"
+                android:scaleType="centerInside"
+                android:src="@drawable/ic_baseline_mic_red_24"
+                android:visibility="gone"
+                tools:visibility="gone" />
 
-        <ImageButton
-            android:id="@+id/editMessageButton"
-            android:layout_width="48dp"
-            android:layout_height="48dp"
-            android:layout_below="@id/quotedChatMessageView"
-            android:layout_alignParentEnd="true"
-            android:background="@color/transparent"
-            android:src="@drawable/ic_check_24"
-            android:visibility = "gone"
-            tools:visibility = "visible"
-            android:contentDescription="@string/nc_send_edit_message" />
+            <LinearLayout
+                android:id="@+id/voice_preview_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/standard_margin"
+                android:layout_marginTop="@dimen/standard_margin"
+                android:background="@drawable/shape_grouped_outcoming_message"
+                android:gravity="center"
+                android:orientation="horizontal">
 
-        <Space
-            android:id="@id/attachmentButtonSpace"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_below="@id/quotedChatMessageView"
-            android:layout_toEndOf="@id/attachmentButton"
-            android:visibility="gone"/>
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/playPauseBtn"
+                    style="@style/Widget.AppTheme.Button.IconButton"
+                    android:layout_width="@dimen/min_size_clickable_area"
+                    android:layout_height="@dimen/min_size_clickable_area"
+                    android:layout_marginStart="@dimen/standard_margin"
+                    android:contentDescription="@string/play_pause_voice_message"
+                    android:visibility="gone"
+                    app:cornerRadius="@dimen/button_corner_radius"
+                    app:icon="@drawable/ic_baseline_play_arrow_voice_message_24"
+                    app:iconSize="30dp"
+                    app:iconTint="@color/high_emphasis_text"
+                    app:rippleColor="#1FFFFFFF" />
 
-        <Space
-            android:id="@id/sendButtonSpace"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_below="@id/quotedChatMessageView"
-            android:layout_toStartOf="@id/smileyButton" />
-    </RelativeLayout>
+                <SeekBar
+                    android:id="@+id/seekbar"
+                    style="@style/Nextcloud.Material.Outgoing.SeekBar"
+                    android:layout_width="match_parent"
+                    android:layout_height="30dp"
+                    android:layout_marginEnd="@dimen/standard_margin"
+                    android:thumb="@drawable/voice_message_outgoing_seek_bar_slider"
+                    android:visibility="gone"
+                    tools:progress="50" />
+            </LinearLayout>
+
+            <Chronometer
+                android:id="@+id/audioRecordDuration"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:layout_toEndOf="@id/microphoneEnabledInfo"
+                android:paddingStart="5dp"
+                android:paddingEnd="5dp"
+                android:textColor="?attr/colorControlNormal"
+                android:textSize="16sp"
+                android:textStyle="bold"
+                android:visibility="gone"
+                tools:visibility="gone" />
+
+            <ImageButton
+                android:id="@id/messageSendButton"
+                android:layout_width="@dimen/min_size_clickable_area"
+                android:layout_height="@dimen/min_size_clickable_area"
+                android:layout_alignBottom="@id/messageInput"
+                android:layout_alignParentEnd="true"
+                android:layout_gravity="bottom"
+                android:adjustViewBounds="true"
+                android:contentDescription="@string/nc_description_send_message_button"
+                android:padding="12dp"
+                android:scaleType="centerInside" />
+
+            <ImageButton
+                android:id="@+id/recordAudioButton"
+                android:layout_width="@dimen/min_size_clickable_area"
+                android:layout_height="@dimen/min_size_clickable_area"
+                android:layout_alignParentEnd="true"
+                android:background="@color/transparent"
+                android:contentDescription="@string/nc_description_record_voice"
+                android:src="@drawable/ic_baseline_mic_24" />
+
+            <ImageButton
+                android:id="@+id/submitThreadButton"
+                android:layout_width="@dimen/min_size_clickable_area"
+                android:layout_height="@dimen/min_size_clickable_area"
+                android:layout_alignParentEnd="true"
+                android:background="@color/transparent"
+                android:contentDescription="@string/start_thread"
+                android:src="@drawable/outline_forum_24"
+                app:tint="?attr/colorControlNormal" />
+
+            <ImageButton
+                android:id="@+id/editMessageButton"
+                android:layout_width="@dimen/min_size_clickable_area"
+                android:layout_height="@dimen/min_size_clickable_area"
+                android:layout_alignBottom="@id/messageInput"
+                android:layout_alignParentEnd="true"
+                android:background="@color/transparent"
+                android:contentDescription="@string/nc_send_edit_message"
+                android:src="@drawable/ic_check_24"
+                android:visibility="gone"
+                tools:visibility="visible" />
+
+            <Space
+                android:id="@id/attachmentButtonSpace"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_toEndOf="@id/attachmentButton"
+                android:visibility="gone" />
+
+            <Space
+                android:id="@id/sendButtonSpace"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_toStartOf="@id/smileyButton" />
+        </RelativeLayout>
+
+    </LinearLayout>
 
 </merge>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -37,8 +37,6 @@
     <color name="conversation_unread_bubble">#373737</color>
     <color name="conversation_unread_bubble_text">#D8D8D8</color>
 
-    <color name="chat_separator">#484848</color>
-
     <!-- Background for replied messages -->
     <color name="reply_background">#33000000</color>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -38,7 +38,7 @@
     <!-- Text color of received messages -->
     <color name="nc_incoming_text_default">@color/high_emphasis_text</color>
     <!-- Background for replied messages -->
-    <color name="reply_background">#55FFFFFF</color>
+    <color name="reply_background">#11000000</color>
 
     <!-- Name of person or group for the chat conversation -->
     <color name="conversation_item_header">@color/high_emphasis_text</color>
@@ -48,7 +48,6 @@
     <color name="nc_darkRed">#D32F2F</color>
     <color name="nc_darkYellow">#FF9800</color>
     <color name="nc_darkGreen">#006400</color>
-    <color name="chat_separator">#E8E8E8</color>
     <color name="grey_600">#757575</color>
     <color name="nc_grey">#D5D5D5</color>
     <color name="black">#000000</color>


### PR DESCRIPTION
* 💡 Beware the input "bubble is wider than the chat. I did this to not loose more space since the buttons (attachment, emoji and send/mic are 48dp in height/width for a11y reasons) if I add another 8dp on each side of the bubble the message input text field "looses" another 16dp in width
* Input field buttons are now bottom-aligned like in other messengers
* paddings and margins are more unified across the chat input elements in general, same for the grey tones in use

### 🖼️ Screenshots

🏚️ Before 🌞 | 🏚️ Before 🌑  |🏡 After 🌞 | 🏡 After 🌑
---|---|---|---
<img width="1080" height="2376" alt="before_light" src="https://github.com/user-attachments/assets/cad56736-1e58-4c52-8be0-036356ce996c" />|<img width="1080" height="2376" alt="before_dark" src="https://github.com/user-attachments/assets/ee8a47a1-471c-4992-b02d-be83b2a9ed48" />|<img width="1080" height="2376" alt="after_light" src="https://github.com/user-attachments/assets/7efa8061-fd6f-4adf-95d4-3046d0be475d" />|<img width="1080" height="2376" alt="after_dark" src="https://github.com/user-attachments/assets/998bfdd0-f927-4ba5-b960-6805f9dd49c8" />
<img width="1080" height="2376" alt="before_single_line" src="https://github.com/user-attachments/assets/7b838695-8276-47d5-b7d4-12a3825b1e4d" />|<img width="1080" height="2376" alt="before_single_line_dark" src="https://github.com/user-attachments/assets/1521e436-ec3e-45c9-8ad0-06b8da156a59" />|<img width="1080" height="2376" alt="after_single_line" src="https://github.com/user-attachments/assets/23c32e1e-9a4e-4ef3-b7b0-a4a8577d3f4d" />|<img width="1080" height="2376" alt="after_single_line_dark" src="https://github.com/user-attachments/assets/54a61d25-147d-44f2-85ba-d61c8a5b904f" />
<img width="1080" height="2376" alt="before_multi_line" src="https://github.com/user-attachments/assets/0274c31e-f8dd-4181-b3c3-7c66134f186a" />|<img width="1080" height="2376" alt="before_multi_line_dark" src="https://github.com/user-attachments/assets/2d70cd8f-aae6-4710-a608-1208fca5a3b8" />|<img width="1080" height="2376" alt="after_multi_line" src="https://github.com/user-attachments/assets/5077ef34-9603-4082-a47d-5622abe5e2ba" />|<img width="1080" height="2376" alt="after_multi_line_dark" src="https://github.com/user-attachments/assets/a81a1f65-e766-40af-87df-48f2078b83bf" />
<img width="1080" height="2376" alt="before_edit" src="https://github.com/user-attachments/assets/f7e2e99f-9db3-487e-8467-81a4b09b59b5" />|<img width="1080" height="2376" alt="before_edit_dark" src="https://github.com/user-attachments/assets/dcb8306a-72e5-48c0-b112-74c3e6300057" />|<img width="1080" height="2376" alt="after_edit" src="https://github.com/user-attachments/assets/f31997a8-6cfd-443c-afd5-4265fe800693" />|<img width="1080" height="2376" alt="after_edit_dark" src="https://github.com/user-attachments/assets/c599a0d4-2a28-4685-94ee-1c843e550036" />
<img width="1080" height="2376" alt="before_reply" src="https://github.com/user-attachments/assets/ec49f40e-cb93-4dd2-8691-55483c011e37" />|<img width="1080" height="2376" alt="before_reply_dark" src="https://github.com/user-attachments/assets/ef479f69-7d37-4e9c-857a-74f3884356b1" />|<img width="1080" height="2376" alt="after_reply" src="https://github.com/user-attachments/assets/8a206cc0-af5a-4d71-9ec4-abb34b33707c" />|<img width="1080" height="2376" alt="after_reply_dark" src="https://github.com/user-attachments/assets/f52f9f77-7748-4658-b7c2-0eecdf41c717" />
<img width="1080" height="2376" alt="before_thread" src="https://github.com/user-attachments/assets/225f9edc-7d6a-4fec-a52e-52d8014824d2" />|<img width="1080" height="2376" alt="before_thread_dark" src="https://github.com/user-attachments/assets/cc20b2cc-7ef1-40fe-8f88-fec5d909a076" />|<img width="1080" height="2376" alt="after_thread" src="https://github.com/user-attachments/assets/fbf46349-fe0f-4c4b-861f-7afc4fa1f7a6" />|<img width="1080" height="2376" alt="after_thread_dark" src="https://github.com/user-attachments/assets/2cedc1cd-5629-47b7-b6a1-b594188c4ec9" />


### 🚧 TODO

- [ ] Design review
- [ ] Code review

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)