### PR TITLE
fix(CallActivity): check participant's nextcloud session ids if not MCU

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -2123,11 +2123,12 @@ class CallActivity : CallBaseActivity() {
 
         for (participant in participantsInCall) {
             val inCallFlag = participant.inCall
-            if (participant.sessionId != currentSessionId) {
+            val participantSession = if (hasMCU) participant.sessionId else participant.nextcloudSessionId
+            if (participantSession != callSession) {
                 Log.d(
                     TAG,
                     "   inCallFlag of participant " +
-                        participant.sessionId!!.substring(0, SESSION_ID_PREFFIX_END) +
+                        participantSession!!.substring(0, SESSION_ID_PREFFIX_END) +
                         " : " +
                         inCallFlag
                 )

--- a/app/src/main/java/com/nextcloud/talk/call/CallParticipantList.java
+++ b/app/src/main/java/com/nextcloud/talk/call/CallParticipantList.java
@@ -128,6 +128,7 @@ public class CallParticipantList {
             copiedParticipant.setInternal(participant.getInternal());
             copiedParticipant.setLastPing(participant.getLastPing());
             copiedParticipant.setSessionId(participant.getSessionId());
+            copiedParticipant.setNextcloudSessionId(participant.getNextcloudSessionId());
             copiedParticipant.setType(participant.getType());
             copiedParticipant.setUserId(participant.getUserId());
 

--- a/app/src/main/java/com/nextcloud/talk/models/json/participants/Participant.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/participants/Participant.kt
@@ -53,6 +53,9 @@ data class Participant(
     @JsonField(name = ["sessionId"])
     var sessionId: String? = null,
 
+    @JsonField(name = ["nextcloudSessionId"])
+    var nextcloudSessionId: String? = null,
+
     @JsonField(name = ["sessionIds"])
     var sessionIds: ArrayList<String> = ArrayList(0),
 
@@ -80,7 +83,7 @@ data class Participant(
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
     constructor() : this(
         null, null, null, null, null, null, null, null, null,
-        0, null, ArrayList(0), 0, 0, null,
+        0, null, null, ArrayList(0), 0, 0, null,
         null, null
     )
 

--- a/app/src/main/java/com/nextcloud/talk/signaling/SignalingMessageReceiver.java
+++ b/app/src/main/java/com/nextcloud/talk/signaling/SignalingMessageReceiver.java
@@ -493,6 +493,7 @@ public abstract class SignalingMessageReceiver {
         participant.setInCall(Long.parseLong(participantMap.get("inCall").toString()));
         participant.setLastPing(Long.parseLong(participantMap.get("lastPing").toString()));
         participant.setSessionId(participantMap.get("sessionId").toString());
+        participant.setNextcloudSessionId(participantMap.get("nextcloudSessionId").toString());
 
         if (participantMap.get("userId") != null && !participantMap.get("userId").toString().isEmpty()) {
             participant.setUserId(participantMap.get("userId").toString());


### PR DESCRIPTION
The logic in CallActivity ends up comparing our nextcloud session id to the call session ID when handling a "call participants changed" message.  If hasMCU, then compare call session IDs, otherwise compare nextcloud session IDs.

See: #5452

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)