### PR TITLE
hide attachment button in edit mode

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
@@ -681,7 +681,7 @@ class MessageInputFragment : Fragment() {
                     messageSendButton.setVisible(false)
                     recordAudioButton.setVisible(false)
                     submitThreadButton.setVisible(false)
-                    attachmentButton.setVisible(true)
+                    attachmentButton.setVisible(false)
                 }
 
                 isThreadCreateModeActive -> {


### PR DESCRIPTION
fix #5676

(All other messaging apps does this - more space is available for the message and improves readability especially for long messages).

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="448" height="179" alt="show attachment icon" src="https://github.com/user-attachments/assets/63ef70a5-fe84-41df-9aaf-a5663c801b49" />|<img width="443" height="191" alt="hide attachment icon" src="https://github.com/user-attachments/assets/d680fa6d-398f-40f1-91d7-815bc846beda" />






### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)