### PR TITLE
fix to initialize messageInputFragment only when user is known

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -539,28 +539,31 @@ class ChatActivity :
                         )
                         chatViewModel.getThread(credentials, threadUrl)
                     }
+
+                    messageInputFragment = getMessageInputFragment()
+                    messageInputViewModel =
+                        ViewModelProvider(this@ChatActivity, viewModelFactory)[
+                            MessageInputViewModel::class
+                                .java
+                        ]
+                    messageInputViewModel.setData(chatViewModel.getChatRepository())
+
+                    initObservers()
+
+                    pickMultipleMedia = registerForActivityResult(
+                        ActivityResultContracts.PickMultipleVisualMedia(MAX_AMOUNT_MEDIA_FILE_PICKER)
+                    ) { uris ->
+                        if (uris.isNotEmpty()) {
+                            onChooseFileResult(uris)
+                        }
+                    }
                 }
                 .onFailure {
                     Snackbar.make(binding.root, R.string.nc_common_error_sorry, Snackbar.LENGTH_LONG).show()
                 }
         }
-        messageInputFragment = getMessageInputFragment()
-        messageInputViewModel = ViewModelProvider(this, viewModelFactory)[MessageInputViewModel::class.java]
-        messageInputViewModel.setData(chatViewModel.getChatRepository())
-
         binding.progressBar.visibility = View.VISIBLE
-
         onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
-
-        initObservers()
-
-        pickMultipleMedia = registerForActivityResult(
-            ActivityResultContracts.PickMultipleVisualMedia(MAX_AMOUNT_MEDIA_FILE_PICKER)
-        ) { uris ->
-            if (uris.isNotEmpty()) {
-                onChooseFileResult(uris)
-            }
-        }
     }
 
     private fun getMessageInputFragment(): MessageInputFragment {


### PR DESCRIPTION
see commit message

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)