### PR TITLE
Fix proxy push with multiple account

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/jobs/PushRegistrationWorker.java
+++ b/app/src/main/java/com/nextcloud/talk/jobs/PushRegistrationWorker.java
@@ -16,7 +16,7 @@ import androidx.work.Data;
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
 import autodagger.AutoInjector;
-import okhttp3.JavaNetCookieJar;
+import okhttp3.CookieJar;
 import okhttp3.OkHttpClient;
 import retrofit2.Retrofit;
 
@@ -57,7 +57,7 @@ public class PushRegistrationWorker extends Worker {
                 .newBuilder()
                 .client(okHttpClient
                             .newBuilder()
-                            .cookieJar(new JavaNetCookieJar(new CookieManager()))
+                            .cookieJar(CookieJar.NO_COOKIES)
                             .build())
                 .build()
                 .create(NcApi.class);


### PR DESCRIPTION
While implementing UnifiedPush, I got errors when trying to register for proxy push for multiple users on a same server. This was surprising as the `authorization` headers were correctly set.

I've added some debugging lines, and the server correctly sees the authorization header, but `$this->userSession->getUser() gived another one`

```
		$user = $this->userSession->getUser();
		$this->log->error("register proxy for " . $user->getDisplayName() . " auth= " . $_SERVER['HTTP_AUTHORIZATION']);
```
We get:
```
register proxy for **admin** auth= Basic YWRtaW46YTZMcXdCW[...] (**admin**:foo)
register proxy for **admin** auth= Basic ZGV2OnU5ZzNTaWlR[...] (**dev**:bar)
```
And a tcpdump gives the answer, a session cookie is set with both requests:

```
POST /ocs/v2.php/apps/notifications/api/v2/push HTTP/1.1
Authorization: Basic ZGV2OnU5ZzNTaW[...]
User-Agent: Mozilla/5.0 (Android) Nextcloud-Talk v23.0.0 Alpha 19
Accept: application/json
OCS-APIRequest: true
ngrok-skip-browser-warning: true
Content-Type: application/x-www-form-urlencoded
Content-Length: 736
Host: 10.0.2.2:9000
Connection: Keep-Alive
Accept-Encoding: gzip
Cookie: oc_sessionPassphrase=9%2B4VHo9%2FlnUM4Z9fFCFm6gLiKDawbahPa5lt1U%2FvMjUiUeSaLIPEOK2zT2G2a0VBbmVppln3V8U%2FySMdEXYvAybRiWCDmHSnEX93wfCXnmz%2FUjl5U0WN45ksobXkgtDn; nc_sameSiteCookielax=true; nc_sameSiteCookiestrict=true; oc0xcjzkw2p2=6febe315bbbc0327b28072272d61169b

devicePublicKey=[...]
POST /ocs/v2.php/apps/notifications/api/v2/push HTTP/1.1
Authorization: Basic YWRtaW46YTZMcXdCW[...]
User-Agent: Mozilla/5.0 (Android) Nextcloud-Talk v23.0.0 Alpha 19
Accept: application/json
OCS-APIRequest: true
ngrok-skip-browser-warning: true
Content-Type: application/x-www-form-urlencoded
Content-Length: 736
Host: 10.0.2.2:9000
Connection: Keep-Alive
Accept-Encoding: gzip
Cookie: oc_sessionPassphrase=9%2B4VHo9%2FlnUM4Z9fFCFm6gLiKDawbahPa5lt1U%2FvMjUiUeSaLIPEOK2zT2G2a0VBbmVppln3V8U%2FySMdEXYvAybRiWCDmHSnEX93wfCXnmz%2FUjl5U0WN45ksobXkgtDn; nc_sameSiteCookielax=true; nc_sameSiteCookiestrict=true; oc0xcjzkw2p2=6febe315bbbc0327b28072272d61169b

devicePublicKey=[...]
```

Probably related:
- https://github.com/nextcloud/talk-android/issues/4631
- https://github.com/nextcloud/talk-android/issues/4382

---

**Reason:**
The ncApi is used accross different accounts, and stores cookies linked to users' session. When a second user of a same server registers for proxy push, the authorization is correctly set but the cookie, linked to the previous user, takes precedence. The server sends the previous user public key and the second user is never registered on the proxy side.

We don't need any cookie as all requests are authorized using basic authorization.

It would be worth using `CookieJar.NO_COOKIES` everywhere we use a basic authorization