### PR TITLE
Send data as POST param

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/api/NcApi.java
+++ b/app/src/main/java/com/nextcloud/talk/api/NcApi.java
@@ -281,11 +281,12 @@ public interface NcApi {
         Server URL is: baseUrl + ocsApiVersion + "/apps/notifications/api/v2/push
      */
 
+    @FormUrlEncoded
     @POST
     Observable<PushRegistrationOverall> registerDeviceForNotificationsWithNextcloud(
         @Header("Authorization") String authorization,
         @Url String url,
-        @QueryMap Map<String, String> options);
+        @FieldMap Map<String, String> options);
 
     @DELETE
     Observable<GenericOverall> unregisterDeviceForNotificationsWithNextcloud(


### PR DESCRIPTION
I found out while debugging #5715 that the parameters where send via GET params, and they should be sent as a POST