### PR TITLE
Make wave form thicker

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingVoiceMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingVoiceMessageViewHolder.kt
@@ -173,11 +173,14 @@ class OutcomingVoiceMessageViewHolder(outcomingView: View) :
             else -> null
         }
 
-        readStatusDrawableInt?.let { drawableInt ->
-            AppCompatResources.getDrawable(context!!, drawableInt)?.let {
+        if (readStatusDrawableInt != null) {
+            AppCompatResources.getDrawable(context!!, readStatusDrawableInt)?.let {
                 binding.checkMark.setImageDrawable(it)
                 viewThemeUtils.talk.themeMessageCheckMark(binding.checkMark)
             }
+            binding.checkMark.visibility = View.VISIBLE
+        } else {
+            binding.checkMark.visibility = View.GONE
         }
 
         binding.checkMark.contentDescription = readStatusContentDescriptionString

--- a/app/src/main/java/com/nextcloud/talk/ui/WaveformSeekBar.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/WaveformSeekBar.kt
@@ -97,7 +97,7 @@ class WaveformSeekBar : AppCompatSeekBar {
         val usableWidth = width - paddingLeft - paddingRight
         val midpoint = usableHeight / 2f
         val maxHeight: Float = usableHeight / MAX_HEIGHT_DIVISOR
-        val barGap: Float = (usableWidth - waveData.size * DEFAULT_BAR_WIDTH) / (waveData.size - 1).toFloat()
+        val barGap: Float = (usableWidth - waveData.size * DEFAULT_BAR_WIDTH) / (waveData.size - 1).toFloat() + 1
 
         canvas?.apply {
             withSave {
@@ -114,9 +114,9 @@ class WaveformSeekBar : AppCompatSeekBar {
     }
 
     companion object {
-        private const val DEFAULT_BAR_WIDTH: Int = 2
-        private const val MAX_HEIGHT_DIVISOR: Float = 4.0f
-        private const val WIDTH_DIVISOR = 20f
+        private const val DEFAULT_BAR_WIDTH: Int = 3
+        private const val MAX_HEIGHT_DIVISOR: Float = 2.4f
+        private const val WIDTH_DIVISOR = 16f
         private const val VALUE_100 = 100
         private const val MINIMUM_WIDTH = 50
         private val Int.dp: Int

--- a/app/src/main/res/layout/item_custom_incoming_voice_message.xml
+++ b/app/src/main/res/layout/item_custom_incoming_voice_message.xml
@@ -47,7 +47,7 @@
         <com.google.android.flexbox.FlexboxLayout
             android:id="@id/bubble"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:orientation="vertical"
             app:alignContent="stretch"
             app:alignItems="stretch"
@@ -75,8 +75,8 @@
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/playPauseBtn"
                     style="@style/Widget.AppTheme.Button.IconButton"
-                    android:layout_width="48dp"
-                    android:layout_height="48dp"
+                    android:layout_width="@dimen/min_size_clickable_area"
+                    android:layout_height="@dimen/min_size_clickable_area"
                     android:contentDescription="@string/play_pause_voice_message"
                     android:visibility="visible"
                     app:cornerRadius="@dimen/button_corner_radius"
@@ -87,21 +87,25 @@
                 <com.nextcloud.talk.ui.WaveformSeekBar
                     android:id="@+id/seekbar"
                     android:layout_width="0dp"
-                    android:layout_height="70dp"
+                    android:layout_height="@dimen/min_size_clickable_area"
                     android:layout_weight="1"
+                    android:paddingStart="@dimen/standard_half_padding"
+                    android:paddingTop="@dimen/zero"
+                    android:paddingEnd="@dimen/standard_half_padding"
+                    android:paddingBottom="@dimen/zero"
                     android:thumb="@drawable/voice_message_outgoing_seek_bar_slider"
-                    tools:progress="50" />
+                    tools:progress="0" />
 
                 <com.nextcloud.talk.ui.PlaybackSpeedControl
                     android:id="@+id/playbackSpeedControlBtn"
                     style="@style/Widget.AppTheme.Button.IconButton"
                     android:layout_width="wrap_content"
-                    android:layout_height="48dp"
-                    android:layout_marginEnd="@dimen/standard_margin"
+                    android:layout_height="@dimen/min_size_clickable_area"
                     android:contentDescription="@string/playback_speed_control"
                     android:textColor="@color/black"
                     app:cornerRadius="@dimen/button_corner_radius"
-                    app:rippleColor="#1FFFFFFF" />
+                    app:rippleColor="#1FFFFFFF"
+                    tools:text="1,5x" />
 
             </LinearLayout>
 

--- a/app/src/main/res/layout/item_custom_outcoming_voice_message.xml
+++ b/app/src/main/res/layout/item_custom_outcoming_voice_message.xml
@@ -13,21 +13,21 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginLeft="16dp"
+    android:layout_marginStart="@dimen/zero"
     android:layout_marginTop="2dp"
-    android:layout_marginRight="16dp"
+    android:layout_marginEnd="@dimen/standard_margin"
     android:layout_marginBottom="2dp">
 
     <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_alignParentEnd="true"
         android:layout_marginStart="@dimen/message_outcoming_bubble_margin_left">
 
         <com.google.android.flexbox.FlexboxLayout
             android:id="@id/bubble"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             app:alignContent="stretch"
             app:alignItems="stretch"
             app:flexWrap="wrap"
@@ -56,8 +56,8 @@
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/playPauseBtn"
                     style="@style/Widget.AppTheme.Button.IconButton"
-                    android:layout_width="48dp"
-                    android:layout_height="48dp"
+                    android:layout_width="@dimen/min_size_clickable_area"
+                    android:layout_height="@dimen/min_size_clickable_area"
                     android:contentDescription="@string/play_pause_voice_message"
                     android:visibility="visible"
                     app:cornerRadius="@dimen/button_corner_radius"
@@ -66,25 +66,28 @@
                     app:iconTint="@color/high_emphasis_text"
                     app:rippleColor="#1FFFFFFF" />
 
-
                 <com.nextcloud.talk.ui.WaveformSeekBar
                     android:id="@+id/seekbar"
                     android:layout_width="0dp"
-                    android:layout_height="70dp"
+                    android:layout_height="@dimen/min_size_clickable_area"
                     android:layout_weight="1"
+                    android:paddingStart="@dimen/standard_half_padding"
+                    android:paddingTop="@dimen/zero"
+                    android:paddingEnd="@dimen/standard_half_padding"
+                    android:paddingBottom="@dimen/zero"
                     android:thumb="@drawable/voice_message_outgoing_seek_bar_slider"
-                    tools:progress="50" />
+                    tools:progress="0" />
 
                 <com.nextcloud.talk.ui.PlaybackSpeedControl
                     android:id="@+id/playbackSpeedControlBtn"
                     style="@style/Widget.AppTheme.Button.IconButton"
                     android:layout_width="wrap_content"
-                    android:layout_height="48dp"
-                    android:layout_marginEnd="@dimen/standard_margin"
+                    android:layout_height="@dimen/min_size_clickable_area"
                     android:contentDescription="@string/playback_speed_control"
                     android:textColor="@color/black"
                     app:cornerRadius="@dimen/button_corner_radius"
-                    app:rippleColor="#1FFFFFFF" />
+                    app:rippleColor="#1FFFFFFF"
+                    tools:text="1,5x" />
 
             </LinearLayout>
 
@@ -111,7 +114,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
-                    android:layout_marginStart="8dp"
+                    android:layout_marginStart="@dimen/standard_half_margin"
                     android:alpha="0.6"
                     android:textColor="@color/no_emphasis_text"
                     tools:text="10:35" />
@@ -121,7 +124,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="@dimen/message_bubble_checkmark_height"
                     android:layout_gravity="center"
-                    android:layout_marginStart="8dp"
+                    android:layout_marginStart="@dimen/standard_half_margin"
                     android:contentDescription="@null"
                     app:tint="@color/high_emphasis_text" />
             </LinearLayout>


### PR DESCRIPTION
Given that I am used to "thicker wave-forms" on other messengers, I played around with the values, see below.

I tend to prefer *3-fine*

### 🖼️ Screenshots

🏚️ Before (2) | 🏡 After (3) | 🏡 After (3-fine optimized) | 🏡 After (4) | 🏡 After (4-fine optimized)
---|---|---|---|---
<img width="747" height="664" alt="before" src="https://github.com/user-attachments/assets/25ee3a6a-b75d-4a4a-92ae-49c7c1be8a30" />|<img width="738" height="657" alt="width3" src="https://github.com/user-attachments/assets/e1aa7369-39d5-45fa-9302-e36fdd3447c8" />|<img width="787" height="522" alt="3fine" src="https://github.com/user-attachments/assets/3c984c2a-c952-4fba-9974-999621bd2a25" />|<img width="735" height="662" alt="after_new" src="https://github.com/user-attachments/assets/ac719927-959b-49ff-a7ec-4c20c8508ec2" />|<img width="781" height="528" alt="4fine" src="https://github.com/user-attachments/assets/448d53c4-0b7c-476d-af0e-3a09f7fe096b" />

### 🚧 TODO

- [ ] get design feedback

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)