### PR TITLE
Dark mode fixes to Pinned Message

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/ComposeChatAdapter.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/ComposeChatAdapter.kt
@@ -224,6 +224,7 @@ class ComposeChatAdapter(
     } else {
         Color.Black.toArgb()
     }
+    val highEmphasisColor = Color(highEmphasisColorInt)
 
     fun addMessages(messages: MutableList<ChatMessage>, append: Boolean) {
         if (messages.isEmpty()) return
@@ -307,7 +308,7 @@ class ComposeChatAdapter(
                 } else {
                     val timestamp = items[listState.firstVisibleItemIndex].timestamp
                     val dateString = formatTime(timestamp * LONG_1000)
-                    val color = Color(highEmphasisColorInt)
+                    val color = highEmphasisColor
                     val backgroundColor =
                         LocalResources.current.getColor(R.color.bg_message_list_incoming_bubble, null)
                     Row(
@@ -521,7 +522,11 @@ class ComposeChatAdapter(
                     }
 
                     if (incoming) {
-                        Text(message.actorDisplayName.toString(), fontSize = AUTHOR_TEXT_SIZE)
+                        Text(
+                            message.actorDisplayName.toString(),
+                            fontSize = AUTHOR_TEXT_SIZE,
+                            color = highEmphasisColor
+                        )
                     }
 
                     ThreadTitle(message)
@@ -574,7 +579,8 @@ class ComposeChatAdapter(
         Text(
             timeString,
             fontSize = TIME_TEXT_SIZE,
-            textAlign = TextAlign.Center
+            textAlign = TextAlign.Center,
+            color = highEmphasisColor
         )
     }
 
@@ -587,7 +593,8 @@ class ComposeChatAdapter(
                 "",
                 modifier = Modifier
                     .padding(start = 4.dp)
-                    .size(16.dp)
+                    .size(16.dp),
+                tint = highEmphasisColor
             )
         }
     }
@@ -786,7 +793,7 @@ class ComposeChatAdapter(
             Text(
                 text,
                 fontSize = AUTHOR_TEXT_SIZE,
-                color = Color(highEmphasisColorInt)
+                color = highEmphasisColor
             )
         }
     }

--- a/app/src/main/java/com/nextcloud/talk/ui/PinnedMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/PinnedMessage.kt
@@ -1,0 +1,224 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Julius Linus <juliuslinus1@gmail.com>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.nextcloud.talk.ui
+
+import android.text.format.DateFormat
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material3.Divider
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.nextcloud.talk.R
+import com.nextcloud.talk.chat.data.model.ChatMessage
+import com.nextcloud.talk.models.domain.ConversationModel
+import com.nextcloud.talk.ui.theme.ViewThemeUtils
+import com.nextcloud.talk.utils.ConversationUtils
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+const val SPACE_16 = 16
+const val CORNER_RADIUS = 16
+const val ICON_SIZE = 24
+const val ELEVATION = 4
+const val MAX_HEIGHT = 100
+
+@Suppress("LongMethod", "LongParameterList")
+@Composable
+fun PinnedMessageView(
+    message: ChatMessage,
+    viewThemeUtils: ViewThemeUtils,
+    currentConversation: ConversationModel?,
+    scrollToMessageWithIdWithOffset: (String) -> Unit,
+    hidePinnedMessage: (ChatMessage) -> Unit,
+    unPinMessage: (ChatMessage) -> Unit
+) {
+    message.incoming = true
+
+    val pinnedBy = stringResource(R.string.pinned_by)
+
+    message.actorDisplayName = remember(message.pinnedActorDisplayName) {
+        "${message.actorDisplayName}\n$pinnedBy ${message.pinnedActorDisplayName}"
+    }
+    val scrollState = rememberScrollState()
+
+    val context = LocalContext.current
+
+    val outgoingBubbleColor = remember {
+        val colorInt = viewThemeUtils.talk
+            .getOutgoingMessageBubbleColor(context, message.isDeleted, false)
+
+        Color(colorInt)
+    }
+
+    val colorScheme = remember {
+        viewThemeUtils.getColorScheme(context)
+    }
+
+    val highEmphasisColor = colorScheme.onSurfaceVariant
+
+    val incomingBubbleColor = colorResource(R.color.bg_message_list_incoming_bubble)
+
+    val canPin = remember {
+        message.isOneToOneConversation ||
+            ConversationUtils.isParticipantOwnerOrModerator(currentConversation!!)
+    }
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy((-SPACE_16).dp),
+        modifier = Modifier
+    ) {
+        Box(
+            modifier = Modifier
+                .shadow(ELEVATION.dp, shape = RoundedCornerShape(CORNER_RADIUS.dp))
+                .background(incomingBubbleColor, RoundedCornerShape(CORNER_RADIUS.dp))
+                .padding(SPACE_16.dp)
+                .heightIn(max = MAX_HEIGHT.dp)
+                .verticalScroll(scrollState)
+                .clickable {
+                    scrollToMessageWithIdWithOffset(message.id)
+                }
+
+        ) {
+            ComposeChatAdapter().GetComposableForMessage(message)
+        }
+
+        var expanded by remember { mutableStateOf(false) }
+
+        val pinnedUntilStr = stringResource(R.string.pinned_until)
+        val untilUnpin = stringResource(R.string.until_unpin)
+        val pinnedText = remember(message.pinnedUntil) {
+            message.pinnedUntil?.let {
+                val format = if (DateFormat.is24HourFormat(context)) {
+                    "MMM dd yyyy, HH:mm"
+                } else {
+                    "MMM dd yyyy, hh:mm a"
+                }
+
+                val localDateTime = Instant.ofEpochSecond(it)
+                    .atZone(ZoneId.systemDefault())
+                    .toLocalDateTime()
+
+                val timeString = localDateTime.format(DateTimeFormatter.ofPattern(format))
+
+                "$pinnedUntilStr $timeString"
+            } ?: untilUnpin
+        }
+
+        Box(
+            modifier = Modifier
+                .offset(SPACE_16.dp, 0.dp)
+                .background(outgoingBubbleColor, RoundedCornerShape(CORNER_RADIUS.dp))
+        ) {
+            IconButton(onClick = { expanded = true }) {
+                Icon(
+                    imageVector = Icons.Default.Menu, // Or use a Pin icon here
+                    contentDescription = "Pinned Message Options",
+                    tint = highEmphasisColor
+                )
+            }
+
+            DropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
+                modifier = Modifier.background(outgoingBubbleColor)
+            ) {
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = pinnedText,
+                            color = highEmphasisColor
+                        )
+                    },
+                    onClick = { /* No-op or toggle expansion */ },
+                    enabled = false // Visually distinct as information, not action
+                )
+
+                Divider()
+
+                DropdownMenuItem(
+                    text = { Text("Go to message", color = highEmphasisColor) },
+                    leadingIcon = {
+                        Icon(
+                            painter = painterResource(R.drawable.baseline_chat_bubble_outline_24),
+                            contentDescription = null,
+                            modifier = Modifier.size(ICON_SIZE.dp),
+                            tint = highEmphasisColor
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        scrollToMessageWithIdWithOffset(message.id)
+                    }
+                )
+
+                DropdownMenuItem(
+                    text = { Text("Dismiss", color = highEmphasisColor) },
+                    leadingIcon = {
+                        Icon(
+                            painter = painterResource(R.drawable.ic_eye_off),
+                            contentDescription = null,
+                            modifier = Modifier.size(ICON_SIZE.dp),
+                            tint = highEmphasisColor
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        hidePinnedMessage(message)
+                    }
+                )
+
+                if (canPin) {
+                    DropdownMenuItem(
+                        text = { Text("Unpin", color = highEmphasisColor) },
+                        leadingIcon = {
+                            Icon(
+                                painter = painterResource(R.drawable.keep_off_24px),
+                                contentDescription = null,
+                                modifier = Modifier.size(ICON_SIZE.dp),
+                                tint = highEmphasisColor
+                            )
+                        },
+                        onClick = {
+                            expanded = false
+                            unPinMessage(message)
+                        }
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- fixes #5717 

###
- Fixed UI for dark mode
- Moved the Pinned View to it's own file

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="369" height="319" alt="Screenshot 2026-01-21 at 8 36 26 AM" src="https://github.com/user-attachments/assets/3d29cd0e-51a9-4c48-ac06-c710d3bc6a4e" /> | <img width="369" height="319" alt="Screenshot 2026-01-21 at 8 28 06 AM" src="https://github.com/user-attachments/assets/a7c44ecc-73d1-4a20-bd5d-4f7fe6037b8c" />
<img width="369" height="319" alt="Screenshot 2026-01-21 at 8 35 51 AM" src="https://github.com/user-attachments/assets/f40a9abb-943a-463e-a688-60f6a789f23e" /> | <img width="369" height="319" alt="Screenshot 2026-01-21 at 8 29 01 AM" src="https://github.com/user-attachments/assets/86bb2c5d-83bd-4e3e-89c8-217b33d6a0c9" />

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)