### PR TITLE
fix crash caused by updateScheduledMessagesAvailability (e.g. by screen rotation)

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
@@ -697,6 +697,11 @@ class MessageInputFragment : Fragment() {
     }
 
     private fun handleButtonsVisibility() {
+        if (!this::binding.isInitialized) {
+            Log.w(TAG, "binding not initialized in handleButtonsVisibility")
+            return
+        }
+
         fun View.setVisible(isVisible: Boolean) {
             visibility = if (isVisible) View.VISIBLE else View.GONE
         }


### PR DESCRIPTION
binding was not initialized. crash:

```
2026-01-29 09:58:13.087  3875-3875  TransactionExecutor     com.nextcloud.talk2                  E  Failed to execute the transaction: tId:1538356034 ClientTransaction{
                                                                                                    tId:1538356034   transactionItems=[
                                                                                                    tId:1538356034     ConfigurationChangeItem{deviceId=0, config{1.0 ?mcc0mnc [en_DE,de_DE,ar_EG] ldltr sw434dp w964dp h434dp 450dpi nrml long layoutCompatNeeded land finger -keyb/v/h -nav/h winConfig={ mBounds=Rect(0, 0 - 2712, 1220) mAppBounds=Rect(0, 0 - 2712, 1220) mMaxBounds=Rect(0, 0 - 2712, 1220) mDisplayRotation=ROTATION_90 mWindowingMode=fullscreen mActivityType=undefined mAlwaysOnTop=undefined mRotation=ROTATION_90} as.2 s.3409 fontWeightAdjustment=0 ?spn ?gid}}
                                                                                                    tId:1538356034     ActivityRelaunchItem{mActivityToken=android.os.BinderProxy@db25a03,pendingResults=null,pendingNewIntents=null,config={mGlobalConfig={1.0 ?mcc0mnc [en_DE,de_DE,ar_EG] ldltr sw434dp w964dp h434dp 450dpi nrml long layoutCompatNeeded land finger -keyb/v/h -nav/h winConfig={ mBounds=Rect(0, 0 - 2712, 1220) mAppBounds=Rect(0, 0 - 2712, 1220) mMaxBounds=Rect(0, 0 - 2712, 1220) mDisplayRotation=ROTATION_90 mWindowingMode=fullscreen mActivityType=undefined mAlwaysOnTop=undefined mRotation=ROTATION_90} as.2 s.3409 fontWeightAdjustment=0 ?spn ?gid} mOverrideConfig={1.0 ?mcc0mnc [en_DE,de_DE,ar_EG] ldltr sw434dp w964dp h434dp 450dpi nrml long layoutCompatNeeded land finger -keyb/v/h -nav/h winConfig={ mBounds=Rect(0, 0 - 2712, 1220) mAppBounds=Rect(0, 0 - 2712, 1220) mMaxBounds=Rect(0, 0 - 2712, 1220) mDisplayRotation=ROTATION_90 mWindowingMode=fullscreen mActivityType=standard mAlwaysOnTop=undefined mRotation=ROTATION_90} as.2 s.3 fontWeightAdjustment=0 ?spn ?gid}},activityWindowInfo=ActivityWindowInfo{isEmbedded=false, taskBounds=Rect(0, 0 - 2712, 1220), taskFragmentBounds=Rect(0, 0 - 2712, 1220)},configChanges=1152,preserveWindow=false}
                                                                                                    tId:1538356034     Target activity: com.nextcloud.talk.chat.ChatActivity
                                                                                                    tId:1538356034     ResumeActivityItem{mActivityToken=android.os.BinderProxy@db25a03,procState=-1,isForward=false,shouldSendCompatFakeFocus=false}
                                                                                                    tId:1538356034     Target activity: com.nextcloud.talk.chat.ChatActivity
                                                                                                    tId:1538356034   ]
                                                                                                    tId:1538356034 }
2026-01-29 09:58:13.087  3875-3875  AndroidRuntime          com.nextcloud.talk2                  D  Shutting down VM
2026-01-29 09:58:13.090  3875-3875  AndroidRuntime          com.nextcloud.talk2                  E  FATAL EXCEPTION: main (Fix with AI)
                                                                                                    Process: com.nextcloud.talk2, PID: 3875
                                                                                                    kotlin.UninitializedPropertyAccessException: lateinit property binding has not been initialized
                                                                                                    	at com.nextcloud.talk.chat.MessageInputFragment.getBinding(MessageInputFragment.kt:128)
                                                                                                    	at com.nextcloud.talk.chat.MessageInputFragment.handleButtonsVisibility(MessageInputFragment.kt:704)
                                                                                                    	at com.nextcloud.talk.chat.MessageInputFragment.updateScheduledMessagesAvailability(MessageInputFragment.kt:756)
                                                                                                    	at com.nextcloud.talk.chat.ChatActivity.initObservers$lambda$6(ChatActivity.kt:979)
                                                                                                    	at com.nextcloud.talk.chat.ChatActivity.$r8$lambda$_QqnoIWSyNJn8ELB500xQ0ODlUk(Unknown Source:0)
                                                                                                    	at com.nextcloud.talk.chat.ChatActivity$$ExternalSyntheticLambda73.invoke(D8$$SyntheticClass:0)
                                                                                                    	at com.nextcloud.talk.chat.ChatActivity$sam$androidx_lifecycle_Observer$0.onChanged(Unknown Source:2)
                                                                                                    	at androidx.lifecycle.LiveData.considerNotify(LiveData.java:134)
                                                                                                    	at androidx.lifecycle.LiveData.dispatchingValue(LiveData.java:147)
                                                                                                    	at androidx.lifecycle.LiveData$ObserverWrapper.activeStateChanged(LiveData.java:482)
```

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)