### PR TITLE
fix to not wipe message input

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
@@ -45,9 +45,6 @@ import androidx.emoji2.widget.EmojiTextView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import autodagger.AutoInjector
@@ -179,20 +176,6 @@ class MessageInputFragment : Fragment() {
         }
     }
 
-    // https://stackoverflow.com/a/54648758/14183836
-    // Would be easier to move the capabilities observability to kotlin flows/suspend
-    fun <T> LiveData<T>.observeOnce(lifecycleOwner: LifecycleOwner, observer: Observer<T>) {
-        observe(
-            lifecycleOwner,
-            object : Observer<T> {
-                override fun onChanged(value: T) {
-                    observer.onChanged(value)
-                    removeObserver(this)
-                }
-            }
-        )
-    }
-
     private fun initObservers() {
         Log.d(TAG, "LifeCyclerOwner is: ${viewLifecycleOwner.lifecycle}")
         chatActivity.chatViewModel.getCapabilitiesViewState.observe(viewLifecycleOwner) { state ->
@@ -203,7 +186,7 @@ class MessageInputFragment : Fragment() {
                     setupMentionAutocomplete()
                     initVoiceRecordButton()
                     initThreadHandling()
-                    restoreState()
+                    updateScheduledMessagesAvailability(hasScheduledMessages)
                 }
 
                 is ChatViewModel.GetCapabilitiesInitialLoadState -> {
@@ -212,8 +195,8 @@ class MessageInputFragment : Fragment() {
                     setupMentionAutocomplete()
                     initVoiceRecordButton()
                     initThreadHandling()
-                    restoreState()
                     updateScheduledMessagesAvailability(hasScheduledMessages)
+                    restoreState()
                 }
 
                 else -> {}


### PR DESCRIPTION
Related commits that will be fixed by this PR are:
- 3cf5d4e9ad640cbbf1b5df0a5ba467657b58f22d
- 30cf6f1e44e2e9adecae9950a32c0f589c5fb72d
- 6c9b8ab02dc86dd32962b6a9059c0ee6d8542ff4



restoreState() must not be triggered by GetCapabilitiesUpdateState

However, way too many things rely on getCapabilitiesViewState here which is not necessary and should be changed. Also LiveData should be replaced with flow. I wont do this now to keep changes for RC2 minimal.



This PR will also fix the following bug:
1. start permanent voice recording
2. cancel it 
3. bug: message input buttons not clickable anymore


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)