### PR TITLE
Suppress ForegroundServiceType warning (because lint fails to recognize them?)

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/services/CallForegroundService.kt
+++ b/app/src/main/java/com/nextcloud/talk/services/CallForegroundService.kt
@@ -6,6 +6,7 @@
  */
 package com.nextcloud.talk.services
 
+import android.annotation.SuppressLint
 import android.app.Notification
 import android.app.PendingIntent
 import android.app.Service
@@ -29,6 +30,7 @@ class CallForegroundService : Service() {
 
     override fun onBind(intent: Intent?): IBinder? = null
 
+    @SuppressLint("ForegroundServiceType")
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val conversationName = intent?.getStringExtra(EXTRA_CONVERSATION_NAME)
         val callExtras = intent?.getBundleExtra(EXTRA_CALL_INTENT_EXTRAS)


### PR DESCRIPTION
lint gives:

> "Missing foregroundServiceType attribute in manifest
To call Service.startForeground(), the <service> element of manifest file must have the foregroundServiceType attribute specified"

for the lines
CallForegroundService.kt:40
CallForegroundService.kt:42

However the AndroidManifest contains the foregroundServiceType for this class:

        <service
            android:name=".services.CallForegroundService"
            android:exported="false"
            android:foregroundServiceType="microphone|camera" />

For
`startForeground(NOTIFICATION_ID, notification, foregroundServiceType)`
i guess it's just a lint problem to not recognize that the service types are passed as variable.

For
`startForeground(NOTIFICATION_ID, notification)`
i guess lint is not able to take into account the android version check where it's not necessary to pass a service type.

So i will suppress the lint warnings.



### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)