### PR TITLE
fix app freeze

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/PinnedMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/PinnedMessage.kt
@@ -97,6 +97,10 @@ fun PinnedMessageView(
             ConversationUtils.isParticipantOwnerOrModerator(currentConversation!!)
     }
 
+    val adapter = remember {
+        ComposeChatAdapter()
+    }
+
     Column(
         verticalArrangement = Arrangement.spacedBy((-SPACE_16).dp),
         modifier = Modifier
@@ -113,7 +117,7 @@ fun PinnedMessageView(
                 }
 
         ) {
-            ComposeChatAdapter().GetComposableForMessage(message)
+            adapter.GetComposableForMessage(message)
         }
 
         var expanded by remember { mutableStateOf(false) }


### PR DESCRIPTION
fix https://github.com/nextcloud/talk-android/issues/5773

First of all:
The app is doing way too much work on the main thread and this needs to be investigated in general. The problem described here has certainly only caused the barrel to overflow.

**The problem:**

I realized that the app is freezing when pinning messages.
As i wont have more time today, could you please take over if possible @rapterjet2004  ? 


I debugged and found out this is happening because of 

`ComposeChatAdapter().GetComposableForMessage(message)`

in PinnedMessage.kt

Initializing a class like ComposeChatAdapter in a Composable is not a good idea. It does way too much work incl injections.
The log even shows needless repeating calls to 
`/ocs/v2.php/core/autocomplete/get`
when this is initialized.

I replaced it with a plain Text composable for now which seems to fix the freeze (please test and confirm!).

**Spoiler:** 
I already realized that the ComposeChatAdapter is a problem in the last days and i modify/delete it in https://github.com/nextcloud/talk-android/pull/5635
So there is no need to come up with a perfect solution but it should be good enough until https://github.com/nextcloud/talk-android/pull/5635 is merged (which will not be for v23.0).


So as we need to release 23.0RC1 (postponed to tomorrow i guess) we need a lightweight Composable that does no heavy work behind the scenes. Just the messages text and author name and and maybe avatar is fine i think.

Best will be: Do the heavy work elsewhere and pass the ready to use data into the Composable, also inside ChatActivity might be fine.


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)