### PR TITLE
reply to a thread should navigate to a thread

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -1867,8 +1867,10 @@ class ChatActivity :
                 this,
                 object : MessageSwipeActions {
                     override fun showReplyUI(position: Int) {
-                        val chatMessage = adapter?.items?.getOrNull(position)?.item as ChatMessage?
-                        if (chatMessage != null) {
+                        val chatMessage = adapter?.items?.getOrNull(position)?.item as ChatMessage? ?: return
+                        if (chatMessage.isThread && conversationThreadId == null) {
+                            openThread(chatMessage)
+                        } else {
                             messageInputViewModel.reply(chatMessage)
                         }
                     }

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
@@ -498,7 +498,11 @@ class MessageActionsDialog(
     private fun initMenuReplyToMessage(visible: Boolean) {
         if (visible) {
             dialogMessageActionsBinding.menuReplyToMessage.setOnClickListener {
-                chatActivity.messageInputViewModel.reply(message)
+                if (message.isThread && chatActivity.conversationThreadId == null) {
+                    chatActivity.openThread(message)
+                } else {
+                    chatActivity.messageInputViewModel.reply(message)
+                }
                 dismiss()
             }
         }


### PR DESCRIPTION
fix #5832 

There should be no option to quote a thread. Reply to a thread should navigate to the thread (same behavior is seen in ioS and web). 

Had to fix this because it impacts scheduled message. Quote to a thread should not be scheduled or sent (both cases will cause unnecessary network call to schedule endpoint or send endpoint).


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)