### PR TITLE
Able to reschedule messages with or without notifications

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -926,7 +926,8 @@ How to translate with transifex:
     <string name="nc_message_scheduled">Message scheduled</string>
     <string name="nc_message_scheduled_at">Message scheduled for %1$s</string>
     <string name="nc_scheduled_time">Scheduled time</string>
-    <string name="nc_reschedule_message">Reschedule</string>
+    <string name="nc_reschedule_message_with_notification">Reschedule with notification</string>
+    <string name="nc_reschedule_message_without_notification">Reschedule without notification</string>
     <string name="nc_send_now">Send now</string>
     <string name="nc_schedule_message_title">Schedule message</string>
     <string name="nc_scheduled_messages_empty">No scheduled messages</string>


### PR DESCRIPTION
Able to reschedule the schedule messages with or without notifications.

<img width="335" height="575" alt="Screenshot 2026-02-11 at 10 33 46" src="https://github.com/user-attachments/assets/b2d6f79a-3c83-42b4-9ea3-448c8aed99c5" />


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)