### PR TITLE
Fix bugs in schedule message dialog

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -959,6 +959,7 @@ class ChatActivity :
                     val scheduledTimeText = dateUtils.getLocalDateTimeStringFromTimestamp(
                         scheduledAt * DateConstants.SECOND_DIVIDER
                     )
+                    messageInputFragment.onScheduledMessageSent()
                     Snackbar.make(
                         binding.root,
                         getString(R.string.nc_message_scheduled_at, scheduledTimeText),

--- a/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
@@ -374,6 +374,12 @@ class MessageInputFragment : Fragment() {
         }
     }
 
+    fun onScheduledMessageSent() {
+        binding.fragmentMessageInputView.inputEditText?.setText("")
+        cancelReply()
+        cancelCreateThread()
+    }
+
     private fun restoreState() {
         CoroutineScope(Dispatchers.IO).launch {
             if (!hasSharedText) {
@@ -804,15 +810,12 @@ class MessageInputFragment : Fragment() {
             if (message.isBlank()) {
                 return
             }
-            binding.fragmentMessageInputView.inputEditText?.setText("")
             chatActivity.showScheduleMessageDialog(
                 message = message,
                 sendWithoutNotification = sendWithoutNotification,
                 replyToMessageId = chatActivity.getReplyToMessageId(),
                 threadTitle = chatActivity.chatViewModel.messageDraft.threadTitle
             )
-            cancelReply()
-            cancelCreateThread()
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/chat/ScheduleMessageCompose.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ScheduleMessageCompose.kt
@@ -66,6 +66,7 @@ import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import java.time.temporal.TemporalAdjusters.nextOrSame
 
 class ScheduleMessageCompose(
@@ -79,7 +80,8 @@ class ScheduleMessageCompose(
     private val timeState = mutableStateOf(initialTime())
 
     private fun initialTime(): LocalDateTime {
-        val scheduled = initialScheduledAt ?: return LocalDateTime.now()
+        val scheduled = initialScheduledAt
+            ?: return LocalDateTime.now().truncatedTo(ChronoUnit.HOURS).plusHours(1)
         return LocalDateTime.ofInstant(Instant.ofEpochSecond(scheduled), ZoneId.systemDefault())
     }
 


### PR DESCRIPTION
- fix #5861 
#5859 

- [x] add default schedule time (1 hr from now truncate minutes, seconds - aligned with web).
- [x] Don't clear message until message is scheduled.

### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)