### PR TITLE
Add Push Notification with Play Service on generic flavor (full FLOSS)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -339,6 +339,7 @@ dependencies {
     "gplayImplementation"("com.google.firebase:firebase-messaging:25.1.0")
 
     implementation("org.unifiedpush.android:connector:3.3.3")
+    "genericImplementation"("org.unifiedpush.android:embedded-fcm-distributor:3.1.0")
 
     // compose
     implementation(platform("androidx.compose:compose-bom:2026.05.01"))

--- a/app/src/main/java/com/nextcloud/talk/account/AccountVerificationActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/account/AccountVerificationActivity.kt
@@ -60,7 +60,6 @@ import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
-import org.unifiedpush.android.connector.UnifiedPush
 import java.net.CookieManager
 import javax.inject.Inject
 
@@ -408,15 +407,21 @@ class AccountVerificationActivity : BaseActivity() {
         // - By default, use the Play Services if available
         // - If this is a first user, and we have an External UnifiedPush distributor,
         //    and the server supports it: we use it
+        // - Else if there is an embedded distributor (so this is a generic flavor, and the
+        //    Play services are installed) => we use it for all accounts that support web push
         // - Else we skip push registrations
         if (ClosedInterfaceImpl().isGooglePlayServicesAvailable) {
             ClosedInterfaceImpl().setUpPushTokenRegistration()
             eventBus.post(EventStatus(internalAccountId, EventStatus.EventType.PUSH_REGISTRATION, true))
         } else if (userManager.users.blockingGet().size == 1 &&
-            UnifiedPush.getDistributors(context).isNotEmpty() &&
+            UnifiedPushUtils.getExternalDistributors(context).isNotEmpty() &&
             userManager.getUserWithId(internalAccountId).blockingGet().hasWebPushCapability
         ) {
             useUnifiedPushIntroduced()
+        } else if (UnifiedPushUtils.hasEmbeddedDistributor(context) &&
+            userManager.users.blockingGet().any { it.hasWebPushCapability }
+        ) {
+            useEmbeddedUnifiedPush()
         } else {
             Log.w(TAG, "Skipping push registration.")
             eventBus.post(EventStatus(internalAccountId, EventStatus.EventType.PUSH_REGISTRATION, false))
@@ -434,11 +439,31 @@ class AccountVerificationActivity : BaseActivity() {
             dialogForUnifiedPush { res ->
                 if (res) {
                     useUnifiedPush()
+                } else {
+                    fallbackToEmbeddedUnifiedPush()
                 }
             }
         } else {
             useUnifiedPush()
         }
+    }
+
+    /**
+     * Check if there is an embedded distributor, and use it if present,
+     * else, send EventStatus PUSH_REGISTRATION with success=false
+     */
+    private fun fallbackToEmbeddedUnifiedPush() {
+        if (UnifiedPushUtils.hasEmbeddedDistributor(context)) {
+            useEmbeddedUnifiedPush()
+        } else {
+            eventBus.post(EventStatus(internalAccountId, EventStatus.EventType.PUSH_REGISTRATION, false))
+        }
+    }
+
+    private fun useEmbeddedUnifiedPush() {
+        UnifiedPushUtils.useEmbeddedDistributor(context)
+        UnifiedPushUtils.registerWithCurrentDistributor(context)
+        eventBus.post(EventStatus(internalAccountId, EventStatus.EventType.PUSH_REGISTRATION, true))
     }
 
     private fun useUnifiedPush() {
@@ -449,7 +474,7 @@ class AccountVerificationActivity : BaseActivity() {
                 eventBus.post(EventStatus(internalAccountId, EventStatus.EventType.PUSH_REGISTRATION, true))
             } ?: run {
                 Log.d(TAG, "No UnifiedPush distrib selected")
-                eventBus.post(EventStatus(internalAccountId, EventStatus.EventType.PUSH_REGISTRATION, false))
+                fallbackToEmbeddedUnifiedPush()
             }
         }
     }

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -89,6 +89,7 @@ import com.nextcloud.talk.utils.ParticipantPermissions
 import com.nextcloud.talk.utils.ShareUtils
 import com.nextcloud.talk.utils.ShortcutManagerHelper
 import com.nextcloud.talk.utils.SpreedFeatures
+import com.nextcloud.talk.utils.UnifiedPushUtils
 import com.nextcloud.talk.utils.UserIdUtils
 import com.nextcloud.talk.utils.bundle.BundleKeys
 import com.nextcloud.talk.utils.bundle.BundleKeys.ADD_ADDITIONAL_ACCOUNT
@@ -363,7 +364,8 @@ class ConversationsListActivity : BaseActivity() {
             !platformPermissionUtil.isPostNotificationsPermissionGranted() &&
             (
                 ClosedInterfaceImpl().isGooglePlayServicesAvailable ||
-                    appPreferences.useUnifiedPush
+                    appPreferences.useUnifiedPush ||
+                    UnifiedPushUtils.hasEmbeddedDistributor(context)
                 )
         ) {
             requestPermissions(

--- a/app/src/main/java/com/nextcloud/talk/diagnosis/DiagnosisActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/diagnosis/DiagnosisActivity.kt
@@ -50,6 +50,7 @@ import com.nextcloud.talk.utils.DisplayUtils
 import com.nextcloud.talk.utils.NotificationUtils
 import com.nextcloud.talk.utils.PushUtils.Companion.LATEST_PUSH_REGISTRATION_AT_PUSH_PROXY
 import com.nextcloud.talk.utils.PushUtils.Companion.LATEST_PUSH_REGISTRATION_AT_SERVER
+import com.nextcloud.talk.utils.UnifiedPushUtils
 import com.nextcloud.talk.utils.UserIdUtils
 import com.nextcloud.talk.utils.permissions.PlatformPermissionUtil
 import com.nextcloud.talk.utils.power.PowerManagerUtils
@@ -103,7 +104,7 @@ class DiagnosisActivity : BaseActivity() {
 
         val colorScheme = viewThemeUtils.getColorScheme(this)
         isGooglePlayServicesAvailable = ClosedInterfaceImpl().isGooglePlayServicesAvailable
-        nUnifiedPushServices = UnifiedPush.getDistributors(this).size
+        nUnifiedPushServices = UnifiedPushUtils.getExternalDistributors(this).size
         offerUnifiedPush = nUnifiedPushServices > 0 &&
             userManager.users.blockingGet().all { it.hasWebPushCapability }
         useUnifiedPush = appPreferences.useUnifiedPush

--- a/app/src/main/java/com/nextcloud/talk/diagnosis/DiagnosisActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/diagnosis/DiagnosisActivity.kt
@@ -80,6 +80,7 @@ class DiagnosisActivity : BaseActivity() {
     lateinit var platformPermissionUtil: PlatformPermissionUtil
 
     private var isGooglePlayServicesAvailable: Boolean = false
+    private var useEmbeddedDistrib: Boolean = false
 
     private var nUnifiedPushServices = 0
     private var offerUnifiedPush: Boolean = false
@@ -108,6 +109,7 @@ class DiagnosisActivity : BaseActivity() {
         offerUnifiedPush = nUnifiedPushServices > 0 &&
             userManager.users.blockingGet().all { it.hasWebPushCapability }
         useUnifiedPush = appPreferences.useUnifiedPush
+        useEmbeddedDistrib = UnifiedPushUtils.hasEmbeddedDistributor(context) && !useUnifiedPush
         unifiedPushService = UnifiedPush.getAckDistributor(this) ?: "N/A"
 
         setContent {
@@ -161,7 +163,9 @@ class DiagnosisActivity : BaseActivity() {
                                 viewState = viewState,
                                 onTestPushClick = { diagnosisViewModel.fetchTestPushResult() },
                                 onDismissDialog = { diagnosisViewModel.dismissDialog() },
-                                showTestPushButton = isGooglePlayServicesAvailable || useUnifiedPush,
+                                showTestPushButton = isGooglePlayServicesAvailable ||
+                                    useUnifiedPush ||
+                                    useEmbeddedDistrib,
                                 isOnline = isOnline
                             )
                         }
@@ -255,7 +259,7 @@ class DiagnosisActivity : BaseActivity() {
             value = Build.VERSION.SDK_INT.toString()
         )
 
-        if (isGooglePlayServicesAvailable) {
+        if (isGooglePlayServicesAvailable || useEmbeddedDistrib) {
             addDiagnosisEntry(
                 key = context.resources.getString(R.string.nc_diagnosis_gplay_available_title),
                 value = context.resources.getString(R.string.nc_diagnosis_gplay_available_yes)
@@ -306,7 +310,7 @@ class DiagnosisActivity : BaseActivity() {
             value = getStringForBoolean(useUnifiedPush)
         )
 
-        if (useUnifiedPush) {
+        if (useUnifiedPush || useEmbeddedDistrib) {
             setupAppValuesForPush()
             setupAppValuesForUnifiedPush()
         } else if (isGooglePlayServicesAvailable) {

--- a/app/src/main/java/com/nextcloud/talk/diagnosis/DiagnosisActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/diagnosis/DiagnosisActivity.kt
@@ -259,17 +259,27 @@ class DiagnosisActivity : BaseActivity() {
             value = Build.VERSION.SDK_INT.toString()
         )
 
-        if (isGooglePlayServicesAvailable || useEmbeddedDistrib) {
-            addDiagnosisEntry(
-                key = context.resources.getString(R.string.nc_diagnosis_gplay_available_title),
-                value = context.resources.getString(R.string.nc_diagnosis_gplay_available_yes)
-            )
-        } else {
-            addDiagnosisEntry(
-                key = context.resources.getString(R.string.nc_diagnosis_gplay_available_title),
-                value = context.resources.getString(R.string.nc_diagnosis_gplay_available_no_short)
-            )
+        when (true) {
+            isGooglePlayServicesAvailable -> {
+                addDiagnosisEntry(
+                    key = context.resources.getString(R.string.nc_diagnosis_gplay_available_title),
+                    value = context.resources.getString(R.string.nc_diagnosis_gplay_available_yes)
+                )
+            }
+            useEmbeddedDistrib -> {
+                addDiagnosisEntry(
+                    key = context.resources.getString(R.string.nc_diagnosis_gplay_available_title),
+                    value = context.resources.getString(R.string.nc_diagnosis_gplay_available_yes_up)
+                )
+            }
+            else -> {
+                addDiagnosisEntry(
+                    key = context.resources.getString(R.string.nc_diagnosis_gplay_available_title),
+                    value = context.resources.getString(R.string.nc_diagnosis_gplay_available_no_short)
+                )
+            }
         }
+
         addDiagnosisEntry(
             key = getString(R.string.nc_diagnosis_unifiedpush_available_title),
             value = context.resources.getQuantityString(

--- a/app/src/main/java/com/nextcloud/talk/jobs/PushRegistrationWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/PushRegistrationWorker.kt
@@ -102,6 +102,10 @@ class PushRegistrationWorker(context: Context, workerParams: WorkerParameters) :
         } else if (useUnifiedPush) {
             Log.d(TAG, "PushRegistrationWorker called via $origin (unifiedPushWork)")
             unifiedPushWork()
+        } else if (UnifiedPushUtils.hasEmbeddedDistributor(applicationContext)) {
+            Log.d(TAG, "PushRegistrationWorker called via $origin (unifiedPushWork#embeddedDistrib)")
+            UnifiedPushUtils.useEmbeddedDistributor(applicationContext)
+            unifiedPushWork()
         } else {
             Log.d(TAG, "PushRegistrationWorker called via $origin (proxyPushWork)")
             proxyPushWork()

--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -328,7 +328,7 @@ class SettingsActivity :
     }
 
     private fun showUnifiedPushToggle(): Boolean =
-        UnifiedPush.getDistributors(this).isNotEmpty() &&
+        UnifiedPushUtils.getExternalDistributors(this).isNotEmpty() &&
             userManager.users.blockingGet().all { it.hasWebPushCapability }
 
     private fun setupUnifiedPushSettings() {
@@ -342,7 +342,7 @@ class SettingsActivity :
             binding.settingsUnifiedpush.visibility = View.GONE
             binding.settingsUnifiedpushService.visibility = View.GONE
         } else {
-            val nDistrib = UnifiedPush.getDistributors(context).size
+            val nDistrib = UnifiedPushUtils.getExternalDistributors(context).size
             binding.settingsUnifiedpush.visibility = View.VISIBLE
             binding.settingsUnifiedpushSwitch.isChecked = appPreferences.useUnifiedPush
             binding.settingsUnifiedpush.setOnClickListener {

--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -388,7 +388,10 @@ class SettingsActivity :
     @SuppressLint("StringFormatInvalid")
     @Suppress("LongMethod")
     private fun setupNotificationPermissionSettings() {
-        if (ClosedInterfaceImpl().isGooglePlayServicesAvailable || appPreferences.useUnifiedPush) {
+        if (ClosedInterfaceImpl().isGooglePlayServicesAvailable ||
+            appPreferences.useUnifiedPush ||
+            UnifiedPushUtils.hasEmbeddedDistributor(context)
+        ) {
             binding.settingsPushOnlyWrapper.visibility = View.VISIBLE
             binding.settingsGplayNotAvailable.visibility = View.GONE
             binding.settingsPushNotAvailable.visibility = View.GONE

--- a/app/src/main/java/com/nextcloud/talk/utils/UnifiedPushUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/UnifiedPushUtils.kt
@@ -97,6 +97,24 @@ object UnifiedPushUtils {
         enqueuePushWorker(context, false, "disableExternalUnifiedPush")
     }
 
+    /**
+     * Check if we have a FCM embedded distributor, to get push notifications,
+     * using the Play services, using Web Push
+     *
+     * Available on the generic flavor only
+     */
+    @JvmStatic
+    fun hasEmbeddedDistributor(context: Context) = context.packageName in UnifiedPush.getDistributors(context)
+
+    @JvmStatic
+    fun useEmbeddedDistributor(context: Context) = UnifiedPush.saveDistributor(context, context.packageName)
+
+    @JvmStatic
+    fun getExternalDistributors(context: Context) =
+        UnifiedPush.getDistributors(context).filter {
+            it != context.packageName
+        }
+
     private fun enqueuePushWorker(context: Context, useUnifiedPush: Boolean, origin: String) {
         val data = Data.Builder()
             .putString(PushRegistrationWorker.ORIGIN, "UnifiedPushUtils#$origin")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -236,6 +236,7 @@ How to translate with transifex:
     <string name="nc_diagnosis_app_users_amount" translatable="false">Registered users</string>
     <string name="nc_diagnosis_gplay_available_title" translatable="false">Google Play services</string>
     <string name="nc_diagnosis_gplay_available_yes" translatable="false">Google Play services are available</string>
+    <string name="nc_diagnosis_gplay_available_yes_up" translatable="false">Google Play services are available, with the embedded distributor</string>
     <string name="nc_diagnosis_gplay_available_no" translatable="false">Google Play services are not available. Notifications are not supported</string>
     <string name="nc_diagnosis_gplay_available_no_short" translatable="false">Google Play services are not available.</string>
     <string name="nc_diagnosis_unifiedpush_available_title" translatable="false">UnifiedPush services</string>

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -278,6 +278,7 @@
          <trusted-key id="7F0C6700F82B97092092AFF84DA93C0B57A98B11">
             <trusting group="org.unifiedpush.android" name="connector" version="3.3.2"/>
             <trusting group="org.unifiedpush.android" name="connector" version="3.3.3"/>
+            <trusting group="org.unifiedpush.android" name="embedded-fcm-distributor" version="3.1.0"/>
          </trusted-key>
          <trusted-key id="7F36E793AE3252E5D9E9B98FEE9E7DC9D92FC896" group="com.google.errorprone"/>
          <trusted-key id="8461EFA0E74ABAE010DE66994EB27DB2A3B88B8B">


### PR DESCRIPTION
This PR is based on #5883, it is marked as draft until the previous PR is merged

It adds a component, [FCM embedded UnifiedPush distributor](https://unifiedpush.org/kdoc/embedded_fcm_distributor/), that allows to get push notifications with the Play Services, without using firebase-messaging, and the proprietary libs. It is therefore compatible with F-Droid inclusion.

It gives Play Services notifications with web push requests: so the notification proxy, isn't used

<!--
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...
-->

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)