### PR TITLE
Pinned messages are now opened properly in threads

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -2600,11 +2600,10 @@ class ChatActivity :
         }
         if (position != null && position >= 0) {
             val layoutManager = binding.messagesListView.layoutManager
-            // FIXME Not a perfect offset, but works to clear the pinned message view, try and find a better solution
             (layoutManager as LinearLayoutManager).scrollToPositionWithOffset(position, 500)
         } else {
             Log.d(TAG, "message $messageId that should be scrolled to was not found (scrollToMessageWithId)")
-            startContextChatWindowForMessage(messageId, conversationThreadId?.toString())
+            startContextChatWindowForMessage(messageId, currentConversation?.internalId)
         }
     }
 


### PR DESCRIPTION
- fixes #5860

This uses the correct context to launch the message viewer. Also since thread messages are just regular messages with a thread id, If you pin a message in a thread, and try to access it outside the thread, it just opens it up in the chat context view.

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)