### PR TITLE
👇👇 Add message double tap action

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingDeckCardViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingDeckCardViewHolder.kt
@@ -11,6 +11,8 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.util.Log
+import android.view.GestureDetector
+import android.view.MotionEvent
 import android.view.View
 import android.widget.ImageView
 import androidx.core.content.ContextCompat
@@ -74,7 +76,7 @@ class IncomingDeckCardViewHolder(incomingView: View, payload: Any) :
     var boardName: String? = null
     var cardLink: String? = null
 
-    @SuppressLint("SetTextI18n")
+    @SuppressLint("SetTextI18n", "ClickableViewAccessibility")
     override fun onBind(message: ChatMessage) {
         super.onBind(message)
         this.message = message
@@ -95,9 +97,22 @@ class IncomingDeckCardViewHolder(incomingView: View, payload: Any) :
         // parent message handling
         setParentMessageDataOnMessageItem(message)
 
-        binding.cardView.setOnLongClickListener { l: View? ->
-            commonMessageInterface.onOpenMessageActionsDialog(message)
-            true
+        binding.cardView.isLongClickable = true
+        val cardViewGestureDetector = GestureDetector(
+            context,
+            object : GestureDetector.SimpleOnGestureListener() {
+                override fun onLongPress(e: MotionEvent) {
+                    commonMessageInterface.onOpenMessageActionsDialog(message)
+                }
+                override fun onDoubleTap(e: MotionEvent): Boolean {
+                    commonMessageInterface.onOpenMessageActionsDialog(message)
+                    return true
+                }
+            }
+        )
+        binding.cardView.setOnTouchListener { _, event ->
+            cardViewGestureDetector.onTouchEvent(event)
+            false
         }
 
         binding.cardView.setOnClickListener {

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingTextMessageViewHolder.kt
@@ -9,9 +9,12 @@
  */
 package com.nextcloud.talk.adapters.messages
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.util.Log
 import android.util.TypedValue
+import android.view.GestureDetector
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.CheckBox
@@ -98,6 +101,7 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) :
         processMessage(message, hasCheckboxes)
     }
 
+    @SuppressLint("ClickableViewAccessibility")
     @Suppress("LongMethod")
     private fun processMessage(message: ChatMessage, hasCheckboxes: Boolean) {
         var textSize = context.resources!!.getDimension(R.dimen.chat_text_size)
@@ -181,9 +185,22 @@ class IncomingTextMessageViewHolder(itemView: View, payload: Any) :
                 View.GONE
             }
 
-        binding.messageQuote.quotedChatMessageView.setOnLongClickListener { l: View? ->
-            commonMessageInterface.onOpenMessageActionsDialog(message)
-            true
+        binding.messageQuote.quotedChatMessageView.isLongClickable = true
+        val quotedChatMessageViewGestureDetector = GestureDetector(
+            context,
+            object : GestureDetector.SimpleOnGestureListener() {
+                override fun onLongPress(e: MotionEvent) {
+                    commonMessageInterface.onOpenMessageActionsDialog(message)
+                }
+                override fun onDoubleTap(e: MotionEvent): Boolean {
+                    commonMessageInterface.onOpenMessageActionsDialog(message)
+                    return true
+                }
+            }
+        )
+        binding.messageQuote.quotedChatMessageView.setOnTouchListener { _, event ->
+            quotedChatMessageViewGestureDetector.onTouchEvent(event)
+            false
         }
 
         itemView.setTag(R.string.replyable_message_view_tag, message.replyable)

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingVoiceMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/IncomingVoiceMessageViewHolder.kt
@@ -95,7 +95,6 @@ class IncomingVoiceMessageViewHolder(incomingView: View, payload: Any) :
         binding.messageTime.text = dateUtils.getLocalTimeStringFromTimestamp(message.timestamp)
 
         setAvatarAndAuthorOnMessageItem(message)
-
         colorizeMessageBubble(message)
 
         itemView.isSelected = false

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingLinkPreviewMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingLinkPreviewMessageViewHolder.kt
@@ -11,6 +11,8 @@ package com.nextcloud.talk.adapters.messages
 import android.annotation.SuppressLint
 import android.content.Context
 import android.util.Log
+import android.view.GestureDetector
+import android.view.MotionEvent
 import android.view.View
 import androidx.appcompat.content.res.AppCompatResources
 import autodagger.AutoInjector
@@ -67,7 +69,7 @@ class OutcomingLinkPreviewMessageViewHolder(outcomingView: View, payload: Any) :
 
     lateinit var commonMessageInterface: CommonMessageInterface
 
-    @SuppressLint("SetTextI18n")
+    @SuppressLint("SetTextI18n", "ClickableViewAccessibility")
     override fun onBind(message: ChatMessage) {
         super.onBind(message)
         this.message = message
@@ -87,7 +89,6 @@ class OutcomingLinkPreviewMessageViewHolder(outcomingView: View, payload: Any) :
         )
 
         binding.messageText.text = processedMessageText
-
         itemView.isSelected = false
 
         // parent message handling
@@ -114,15 +115,23 @@ class OutcomingLinkPreviewMessageViewHolder(outcomingView: View, payload: Any) :
 
         binding.checkMark.contentDescription = readStatusContentDescriptionString
 
-        LinkPreview().showLink(
-            message,
-            ncApi,
-            binding.referenceInclude,
-            itemView.context
+        LinkPreview().showLink(message, ncApi, binding.referenceInclude, itemView.context)
+        binding.referenceInclude.referenceWrapper.isLongClickable = true
+        val referenceWrapperGestureDetector = GestureDetector(
+            context,
+            object : GestureDetector.SimpleOnGestureListener() {
+                override fun onLongPress(e: MotionEvent) {
+                    commonMessageInterface.onOpenMessageActionsDialog(message)
+                }
+                override fun onDoubleTap(e: MotionEvent): Boolean {
+                    commonMessageInterface.onOpenMessageActionsDialog(message)
+                    return true
+                }
+            }
         )
-        binding.referenceInclude.referenceWrapper.setOnLongClickListener { l: View? ->
-            commonMessageInterface.onOpenMessageActionsDialog(message)
-            true
+        binding.referenceInclude.referenceWrapper.setOnTouchListener { _, event ->
+            referenceWrapperGestureDetector.onTouchEvent(event)
+            false
         }
 
         itemView.setTag(R.string.replyable_message_view_tag, message.replyable)

--- a/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/messages/OutcomingTextMessageViewHolder.kt
@@ -9,9 +9,12 @@
  */
 package com.nextcloud.talk.adapters.messages
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.util.Log
 import android.util.TypedValue
+import android.view.GestureDetector
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.CheckBox
@@ -102,6 +105,7 @@ class OutcomingTextMessageViewHolder(itemView: View) :
         processMessage(message, hasCheckboxes)
     }
 
+    @SuppressLint("ClickableViewAccessibility")
     @Suppress("Detekt.LongMethod")
     private fun processMessage(message: ChatMessage, hasCheckboxes: Boolean) {
         var isBubbled = true
@@ -196,9 +200,22 @@ class OutcomingTextMessageViewHolder(itemView: View) :
                 View.GONE
             }
 
-        binding.messageQuote.quotedChatMessageView.setOnLongClickListener { l: View? ->
-            commonMessageInterface.onOpenMessageActionsDialog(message)
-            true
+        binding.messageQuote.quotedChatMessageView.isLongClickable = true
+        val quotedChatMessageViewGestureDetector = GestureDetector(
+            context,
+            object : GestureDetector.SimpleOnGestureListener() {
+                override fun onLongPress(e: MotionEvent) {
+                    commonMessageInterface.onOpenMessageActionsDialog(message)
+                }
+                override fun onDoubleTap(e: MotionEvent): Boolean {
+                    commonMessageInterface.onOpenMessageActionsDialog(message)
+                    return true
+                }
+            }
+        )
+        binding.messageQuote.quotedChatMessageView.setOnTouchListener { _, event ->
+            quotedChatMessageViewGestureDetector.onTouchEvent(event)
+            false
         }
 
         binding.checkMark.visibility = View.INVISIBLE

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -1649,7 +1649,7 @@ class ChatActivity :
         adapter?.setLoadMoreListener(this)
         adapter?.setDateHeadersFormatter { format(it) }
         adapter?.setOnMessageViewLongClickListener { view, message -> onMessageViewLongClick(view, message) }
-        adapter?.setOnMessageClickListener{ message -> onMessageClick(message) }
+        adapter?.setOnMessageClickListener { message -> onMessageClick(message) }
 
         adapter?.registerViewClickListener(
             R.id.playPauseBtn


### PR DESCRIPTION
Resolves #5240

... by adding a double tab calculating logic to chatkits listerner mechanism _and_ for the long-press listener implementation on certain messages also replaces it with a gesture implementation handling long-press + doubleTap - in the later the double tab will not work _if_ there is also a single tap logic i.e. when navigation via click on a reply section of a message.

Also had to extract/short some bind methods to resolve the newly caused detekt warnings to make the check turn green again

### 🚧 TODO

- [ ] review/test/merge

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)