### PR TITLE
rename diagnose to diagnosis

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -246,7 +246,7 @@
             android:theme="@style/AppTheme" />
 
         <activity
-            android:name=".diagnose.DiagnoseActivity"
+            android:name=".diagnosis.DiagnosisActivity"
             android:theme="@style/AppTheme" />
 
         <activity

--- a/app/src/main/java/com/nextcloud/talk/dagger/modules/ViewModelModule.kt
+++ b/app/src/main/java/com/nextcloud/talk/dagger/modules/ViewModelModule.kt
@@ -20,7 +20,7 @@ import com.nextcloud.talk.conversationcreation.ConversationCreationViewModel
 import com.nextcloud.talk.conversationinfo.viewmodel.ConversationInfoViewModel
 import com.nextcloud.talk.conversationinfoedit.viewmodel.ConversationInfoEditViewModel
 import com.nextcloud.talk.conversationlist.viewmodels.ConversationsListViewModel
-import com.nextcloud.talk.diagnose.DiagnoseViewModel
+import com.nextcloud.talk.diagnosis.DiagnosisViewModel
 import com.nextcloud.talk.invitation.viewmodels.InvitationsViewModel
 import com.nextcloud.talk.messagesearch.MessageSearchViewModel
 import com.nextcloud.talk.openconversations.viewmodels.OpenConversationsViewModel
@@ -152,8 +152,8 @@ abstract class ViewModelModule {
 
     @Binds
     @IntoMap
-    @ViewModelKey(DiagnoseViewModel::class)
-    abstract fun diagnoseViewModel(viewModel: DiagnoseViewModel): ViewModel
+    @ViewModelKey(DiagnosisViewModel::class)
+    abstract fun diagnosisViewModel(viewModel: DiagnosisViewModel): ViewModel
 
     @Binds
     @IntoMap

--- a/app/src/main/java/com/nextcloud/talk/diagnosis/DiagnosisContentComposable.kt
+++ b/app/src/main/java/com/nextcloud/talk/diagnosis/DiagnosisContentComposable.kt
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-package com.nextcloud.talk.diagnose
+package com.nextcloud.talk.diagnosis
 
 import android.content.ClipData
 import android.content.ClipboardManager
@@ -52,8 +52,8 @@ import com.nextcloud.talk.R
 
 @Suppress("LongParameterList")
 @Composable
-fun DiagnoseContentComposable(
-    data: State<List<DiagnoseActivity.DiagnoseElement>>,
+fun DiagnosisContentComposable(
+    data: State<List<DiagnosisActivity.DiagnosisElement>>,
     isLoading: Boolean,
     showDialog: Boolean,
     viewState: NotificationUiState,
@@ -76,7 +76,7 @@ fun DiagnoseContentComposable(
     ) {
         data.value.forEach { element ->
             when (element) {
-                is DiagnoseActivity.DiagnoseElement.DiagnoseHeadline -> {
+                is DiagnosisActivity.DiagnosisElement.DiagnosisHeadline -> {
                     Text(
                         modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
                         text = element.headline,
@@ -88,7 +88,7 @@ fun DiagnoseContentComposable(
                     )
                 }
 
-                is DiagnoseActivity.DiagnoseElement.DiagnoseEntry -> {
+                is DiagnosisActivity.DiagnosisElement.DiagnosisEntry -> {
                     Text(
                         text = element.key,
                         color = colorResource(R.color.high_emphasis_text),
@@ -244,16 +244,16 @@ fun getMessage(context: Context, viewState: NotificationUiState): String =
 
 @Preview(showBackground = true)
 @Composable
-fun DiagnoseContentPreview() {
+fun DiagnosisContentPreview() {
     val state = remember {
         mutableStateOf(
             listOf(
-                DiagnoseActivity.DiagnoseElement.DiagnoseHeadline("Headline"),
-                DiagnoseActivity.DiagnoseElement.DiagnoseEntry("Key", "Value")
+                DiagnosisActivity.DiagnosisElement.DiagnosisHeadline("Headline"),
+                DiagnosisActivity.DiagnosisElement.DiagnosisEntry("Key", "Value")
             )
         )
     }
-    DiagnoseContentComposable(
+    DiagnosisContentComposable(
         state,
         false,
         true,

--- a/app/src/main/java/com/nextcloud/talk/diagnosis/DiagnosisViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/diagnosis/DiagnosisViewModel.kt
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-package com.nextcloud.talk.diagnose
+package com.nextcloud.talk.diagnosis
 
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
@@ -20,7 +20,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @Suppress("TooGenericExceptionCaught")
-class DiagnoseViewModel @Inject constructor(
+class DiagnosisViewModel @Inject constructor(
     private val ncApiCoroutines: NcApiCoroutines,
     private val currentUserProvider: CurrentUserProviderOld
 ) : ViewModel() {

--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -61,7 +61,7 @@ import com.nextcloud.talk.conversationlist.ConversationsListActivity.Companion.N
 import com.nextcloud.talk.data.network.NetworkMonitor
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.databinding.ActivitySettingsBinding
-import com.nextcloud.talk.diagnose.DiagnoseActivity
+import com.nextcloud.talk.diagnosis.DiagnosisActivity
 import com.nextcloud.talk.jobs.AccountRemovalWorker
 import com.nextcloud.talk.jobs.CapabilitiesWorker
 import com.nextcloud.talk.jobs.ContactAddressBookWorker
@@ -171,7 +171,7 @@ class SettingsActivity :
             resources!!.getString(R.string.nc_app_product_name)
         )
 
-        setupDiagnose()
+        setupDiagnosis()
 
         setupPrivacyUrl(isOnline.value)
         setupSourceCodeUrl(isOnline.value)
@@ -372,9 +372,9 @@ class SettingsActivity :
             // handle notification permission on API level >= 33
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 if (platformPermissionUtil.isPostNotificationsPermissionGranted()) {
-                    binding.ncDiagnoseNotificationPermissionSubtitle.text =
+                    binding.ncDiagnosisNotificationPermissionSubtitle.text =
                         resources.getString(R.string.nc_settings_notifications_granted)
-                    binding.ncDiagnoseNotificationPermissionSubtitle.setTextColor(
+                    binding.ncDiagnosisNotificationPermissionSubtitle.setTextColor(
                         resources.getColor(R.color.high_emphasis_text, null)
                     )
                     binding.settingsCallSound.isEnabled = true
@@ -382,9 +382,9 @@ class SettingsActivity :
                     binding.settingsMessageSound.isEnabled = true
                     binding.settingsMessageSound.alpha = ENABLED_ALPHA
                 } else {
-                    binding.ncDiagnoseNotificationPermissionSubtitle.text =
+                    binding.ncDiagnosisNotificationPermissionSubtitle.text =
                         resources.getString(R.string.nc_settings_notifications_declined)
-                    binding.ncDiagnoseNotificationPermissionSubtitle.setTextColor(
+                    binding.ncDiagnosisNotificationPermissionSubtitle.setTextColor(
                         resources.getColor(R.color.nc_darkRed, null)
                     )
 
@@ -471,7 +471,7 @@ class SettingsActivity :
             val dialogBuilder = MaterialAlertDialogBuilder(this)
                 .setTitle(R.string.nc_notifications_troubleshooting_dialog_title)
                 .setMessage(R.string.nc_notifications_troubleshooting_dialog_text)
-                .setNegativeButton(R.string.nc_diagnose_dialog_open_checklist) { _, _ ->
+                .setNegativeButton(R.string.nc_diagnosis_dialog_open_checklist) { _, _ ->
                     startActivity(
                         Intent(
                             Intent.ACTION_VIEW,
@@ -479,7 +479,7 @@ class SettingsActivity :
                         )
                     )
                 }
-                .setPositiveButton(R.string.nc_diagnose_dialog_open_dontkillmyapp_website) { _, _ ->
+                .setPositiveButton(R.string.nc_diagnosis_dialog_open_dontkillmyapp_website) { _, _ ->
                     startActivity(
                         Intent(
                             Intent.ACTION_VIEW,
@@ -487,8 +487,8 @@ class SettingsActivity :
                         )
                     )
                 }
-                .setNeutralButton(R.string.nc_diagnose_dialog_open_diagnose) { _, _ ->
-                    val intent = Intent(context, DiagnoseActivity::class.java)
+                .setNeutralButton(R.string.nc_diagnosis_dialog_open_diagnosis) { _, _ ->
+                    val intent = Intent(context, DiagnosisActivity::class.java)
                     startActivity(intent)
                 }
             viewThemeUtils.dialog.colorMaterialAlertDialogBackground(this, dialogBuilder)
@@ -548,9 +548,9 @@ class SettingsActivity :
         }
     }
 
-    private fun setupDiagnose() {
-        binding.diagnoseWrapper.setOnClickListener {
-            val intent = Intent(context, DiagnoseActivity::class.java)
+    private fun setupDiagnosis() {
+        binding.diagnosisWrapper.setOnClickListener {
+            val intent = Intent(context, DiagnosisActivity::class.java)
             startActivity(intent)
         }
     }

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -284,7 +284,7 @@
                             android:textSize="@dimen/headline_text_size" />
 
                         <com.google.android.material.textview.MaterialTextView
-                            android:id="@+id/nc_diagnose_notification_permission_subtitle"
+                            android:id="@+id/nc_diagnosis_notification_permission_subtitle"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content" />
                     </LinearLayout>
@@ -680,7 +680,7 @@
                     android:textStyle="bold" />
 
                 <LinearLayout
-                    android:id="@+id/diagnose_wrapper"
+                    android:id="@+id/diagnosis_wrapper"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:background="?android:attr/selectableItemBackground"
@@ -688,17 +688,17 @@
                     android:padding="@dimen/standard_padding">
 
                     <com.google.android.material.textview.MaterialTextView
-                        android:id="@+id/diagnose_title"
+                        android:id="@+id/diagnosis_title"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="@string/nc_settings_diagnose_title"
+                        android:text="@string/nc_settings_diagnosis_title"
                         android:textSize="@dimen/headline_text_size" />
 
                     <com.google.android.material.textview.MaterialTextView
-                        android:id="@+id/diagnose_subtitle"
+                        android:id="@+id/diagnosis_subtitle"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="@string/nc_settings_diagnose_subtitle" />
+                        android:text="@string/nc_settings_diagnosis_subtitle" />
                 </LinearLayout>
 
                 <LinearLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -183,19 +183,19 @@ How to translate with transifex:
 
     <string name="nc_profile_personal_info_title">Personal Info</string>
 
-    <string name="nc_settings_diagnose_title">Diagnosis</string>
-    <string name="nc_settings_diagnose_subtitle">Open diagnosis screen to check settings or create bug report</string>
-
     <string name="nc_settings_notifications_granted">Notifications are granted</string>
     <string name="nc_settings_notifications_declined">Notifications are declined</string>
     <string name="gplay_available_no">Google Play services are not available.Notifications are not supported</string>
 
-    <!-- Diagnose -->
+    <string name="nc_settings_diagnosis_title">Diagnosis</string>
+    <string name="nc_settings_diagnosis_subtitle">Open diagnosis screen to check settings or create bug report</string>
+
+    <!-- Diagnosis -->
+    <string name="nc_diagnosis_dialog_open_checklist">Open troubleshooting checklist</string>
+    <string name="nc_diagnosis_dialog_open_dontkillmyapp_website">Open dontkillmyapp.com</string>
     <string name="nc_notifications_troubleshooting_dialog_title">Notification troubleshooting</string>
     <string name="nc_notifications_troubleshooting_dialog_text">Notification permission and battery settings are correctly set up to receive notifications. If you have problems to receive notifications anyway, please check if the notification channels for calls and messages are enabled. Further help can be found at DontKillMyApp.com or at the troubleshooting checklist. If this does not help, please go to diagnosis screen and send a bug report.</string>
-    <string name="nc_diagnose_dialog_open_checklist">Open troubleshooting checklist</string>
-    <string name="nc_diagnose_dialog_open_dontkillmyapp_website">Open dontkillmyapp.com</string>
-    <string name="nc_diagnose_dialog_open_diagnose">Open diagnosis screen</string>
+    <string name="nc_diagnosis_dialog_open_diagnosis">Open diagnosis screen</string>
 
     <string name="nc_ignore_battery_optimization_dialog_title">Ignore battery optimization</string>
     <string name="nc_ignore_battery_optimization_dialog_text">Battery optimization is not ignored. This should be changed to make sure that notifications work in the background! Please click OK and select \"All apps\" -> %1$s and then \"Do not optimize\" or \"Allow background usage -> Unrestricted\".</string>
@@ -204,55 +204,56 @@ How to translate with transifex:
     <string name="nc_notification_warning">Notifications are not set up correctly</string>
     <string name="nc_not_now">Not now</string>
 
-    <string name="nc_diagnose_meta_category_title" translatable="false" >Meta information</string>
-    <string name="nc_diagnose_meta_system_report_date" translatable="false">Generation of system report</string>
-    <string name="nc_diagnose_phone_category_title" translatable="false">Phone</string>
-    <string name="nc_diagnose_device_name_title" translatable="false">Device</string>
-    <string name="nc_diagnose_android_version_title" translatable="false">Android version</string>
-    <string name="nc_diagnose_app_category_title" translatable="false">App</string>
-    <string name="nc_diagnose_app_name_title" translatable="false">App name</string>
-    <string name="nc_diagnose_app_version_title" translatable="false">App version</string>
-    <string name="nc_diagnose_app_users_amount" translatable="false">Registered users</string>
-    <string name="nc_diagnose_gplay_available_title" translatable="false">Google Play services</string>
-    <string name="nc_diagnose_gplay_available_yes" translatable="false">Google Play services are available</string>
-    <string name="nc_diagnose_gplay_available_no" translatable="false">Google Play services are not available. Notifications are not supported</string>
-    <string name="nc_diagnose_battery_optimization_title" translatable="false">Battery settings</string>
-    <string name="nc_diagnose_battery_optimization_not_ignored" translatable="false">Battery optimization is enabled which might cause issues. You should disable battery optimization!</string>
-    <string name="nc_diagnose_battery_optimization_ignored" translatable="false">Battery optimization is ignored, all fine</string>
-    <string name="nc_diagnose_notification_permission" translatable="false">Notification permissions</string>
-    <string name="nc_diagnose_notification_calls_channel_permission" translatable="false">Calls notification channel enabled?</string>
-    <string name="nc_diagnose_notification_messages_channel_permission" translatable="false">Messages notification channel enabled?</string>
-    <string name="nc_diagnose_firebase_push_token_title" translatable="false">Firebase push token</string>
-    <string name="nc_diagnose_firebase_push_token_latest_generated" translatable="false">Latest firebase push token generation</string>
-    <string name="nc_diagnose_firebase_push_token_latest_fetch" translatable="false">Latest firebase push token fetch</string>
-    <string name="nc_diagnose_firebase_push_token_missing" translatable="false">No firebase push token set. Please create a bug report.</string>
-    <string name="nc_diagnose_account_category_title" translatable="false">Current account</string>
-    <string name="nc_diagnose_account_server" translatable="false">Server</string>
-    <string name="nc_diagnose_account_user_name" translatable="false">User</string>
-    <string name="nc_diagnose_account_server_notification_app" translatable="false">Server notification app installed?</string>
-    <string name="nc_diagnose_account_user_status_enabled" translatable="false">User status enabled?</string>
-    <string name="nc_diagnose_latest_push_registration_at_server" translatable="false">Latest push registration at server</string>
-    <string name="nc_diagnose_latest_push_registration_at_server_fail" translatable="false">Not yet registered at server</string>
-    <string name="nc_diagnose_latest_push_registration_at_push_proxy" translatable="false">Latest push registration at push proxy</string>
-    <string name="nc_diagnose_latest_push_registration_at_push_proxy_fail" translatable="false">Not yet registered at push proxy</string>
-    <string name="nc_diagnose_server_version" translatable="false">Server version</string>
-    <string name="nc_diagnose_server_talk_version" translatable="false">Server Talk version</string>
-    <string name="nc_diagnose_signaling_mode_title" translatable="false">Signaling Mode</string>
-    <string name="nc_diagnose_signaling_mode_intern" translatable="false">Internal</string>
-    <string name="nc_diagnose_signaling_mode_extern" translatable="false">External</string>
     <string name="send_email">Send email</string>
     <string name="create_issue">Create issue</string>
-    <string name="nc_diagnose_flavor" translatable="false">Build flavor</string>
     <string name="nc_test_push_button">Test push notifications</string>
     <string name="nc_test_results">Test results</string>
     <string name="message_copied">Message copied</string>
     <string name="nc_push_notification_message">Push notification is sent successfully. You should now receive a notification on this device with the title \'Testing push notifications\'</string>
-    <string name="nc_diagnose_notifications_granted" translatable="false">Notifications are granted</string>
-    <string name="nc_diagnose_notifications_declined" translatable="false">Notifications are declined</string>
-    <string name="nc_diagnose_unknown" translatable="false">"Unknown"</string>
-    <string name="nc_diagnose_yes" translatable="false">"Yes"</string>
-    <string name="nc_diagnose_no" translatable="false">"No"</string>
 
+    <string name="nc_diagnosis_meta_category_title" translatable="false" >Meta information</string>
+    <string name="nc_diagnosis_meta_system_report_date" translatable="false">Generation of system report</string>
+    <string name="nc_diagnosis_phone_category_title" translatable="false">Phone</string>
+    <string name="nc_diagnosis_device_name_title" translatable="false">Device</string>
+    <string name="nc_diagnosis_android_version_title" translatable="false">Android version</string>
+    <string name="nc_diagnosis_app_category_title" translatable="false">App</string>
+    <string name="nc_diagnosis_app_name_title" translatable="false">App name</string>
+    <string name="nc_diagnosis_app_version_title" translatable="false">App version</string>
+    <string name="nc_diagnosis_app_users_amount" translatable="false">Registered users</string>
+    <string name="nc_diagnosis_gplay_available_title" translatable="false">Google Play services</string>
+    <string name="nc_diagnosis_gplay_available_yes" translatable="false">Google Play services are available</string>
+    <string name="nc_diagnosis_gplay_available_no" translatable="false">Google Play services are not available. Notifications are not supported</string>
+    <string name="nc_diagnosis_battery_optimization_title" translatable="false">Battery settings</string>
+    <string name="nc_diagnosis_battery_optimization_not_ignored" translatable="false">Battery optimization is enabled which might cause issues. You should disable battery optimization!</string>
+    <string name="nc_diagnosis_battery_optimization_ignored" translatable="false">Battery optimization is ignored, all fine</string>
+    <string name="nc_diagnosis_notification_permission" translatable="false">Notification permissions</string>
+    <string name="nc_diagnosis_notification_calls_channel_permission" translatable="false">Calls notification channel enabled?</string>
+    <string name="nc_diagnosis_notification_messages_channel_permission" translatable="false">Messages notification channel enabled?</string>
+    <string name="nc_diagnosis_firebase_push_token_title" translatable="false">Firebase push token</string>
+    <string name="nc_diagnosis_firebase_push_token_latest_generated" translatable="false">Latest firebase push token generation</string>
+    <string name="nc_diagnosis_firebase_push_token_latest_fetch" translatable="false">Latest firebase push token fetch</string>
+    <string name="nc_diagnosis_firebase_push_token_missing" translatable="false">No firebase push token set. Please create a bug report.</string>
+    <string name="nc_diagnosis_account_category_title" translatable="false">Current account</string>
+    <string name="nc_diagnosis_account_server" translatable="false">Server</string>
+    <string name="nc_diagnosis_account_user_name" translatable="false">User</string>
+    <string name="nc_diagnosis_account_server_notification_app" translatable="false">Server notification app installed?</string>
+    <string name="nc_diagnosis_account_user_status_enabled" translatable="false">User status enabled?</string>
+    <string name="nc_diagnosis_latest_push_registration_at_server" translatable="false">Latest push registration at server</string>
+    <string name="nc_diagnosis_latest_push_registration_at_server_fail" translatable="false">Not yet registered at server</string>
+    <string name="nc_diagnosis_latest_push_registration_at_push_proxy" translatable="false">Latest push registration at push proxy</string>
+    <string name="nc_diagnosis_latest_push_registration_at_push_proxy_fail" translatable="false">Not yet registered at push proxy</string>
+    <string name="nc_diagnosis_server_version" translatable="false">Server version</string>
+    <string name="nc_diagnosis_server_talk_version" translatable="false">Server Talk version</string>
+    <string name="nc_diagnosis_signaling_mode_title" translatable="false">Signaling Mode</string>
+    <string name="nc_diagnosis_signaling_mode_intern" translatable="false">Internal</string>
+    <string name="nc_diagnosis_signaling_mode_extern" translatable="false">External</string>
+
+    <string name="nc_diagnosis_notifications_granted" translatable="false">Notifications are granted</string>
+    <string name="nc_diagnosis_notifications_declined" translatable="false">Notifications are declined</string>
+    <string name="nc_diagnosis_unknown" translatable="false">"Unknown"</string>
+    <string name="nc_diagnosis_yes" translatable="false">"Yes"</string>
+    <string name="nc_diagnosis_no" translatable="false">"No"</string>
+    <string name="nc_diagnosis_flavor" translatable="false">Build flavor</string>
 
     <!-- Conversation menu -->
     <string name="nc_leave">Leave conversation</string>


### PR DESCRIPTION
This will rename all occurences of `diagnose` to `diagnosis`.

Strings for the diagnosis screen itself have been created with new keys in order to fix transifex sync.

A few strings will have to be translated again.


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)