### PR TITLE
🖼️ Show images in message notifications

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.kt
@@ -484,7 +484,7 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
             pushMessage.subject = ncNotification.subject.orEmpty()
         }
 
-        checkAndExtractImagePreviewData (ncNotification)
+        checkAndExtractImagePreviewData(ncNotification)
     }
 
     private fun checkAndExtractImagePreviewData(
@@ -686,11 +686,13 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
     private fun styleImageNotification(notificationBuilder: NotificationCompat.Builder) {
         val bitmap = loadImageBitmapSync(imagePreviewUrl!!)
         if (bitmap != null) {
-            notificationBuilder.setStyle(
-                NotificationCompat.BigPictureStyle()
-                    .bigPicture(bitmap)
-                    .bigLargeIcon(null as Bitmap?)
-            )
+            notificationBuilder
+                .setLargeIcon(bitmap)
+                .setStyle(
+                    NotificationCompat.BigPictureStyle()
+                        .bigPicture(bitmap)
+                        .bigLargeIcon(null as Bitmap?)
+                )
         }
     }
 


### PR DESCRIPTION
* Resolves #2300
* Currently a simple check if the message ships an image info and if so, display it.

### 🖼️ Screenshots

Home | Collapsed | Expanded
---|---|---
<img width="1080" height="2376" alt="home" src="https://github.com/user-attachments/assets/182a691f-0677-49ae-8750-0187062aeaad" />|<img width="1080" height="2376" alt="collapsed" src="https://github.com/user-attachments/assets/2e477f3d-5384-46a9-a0e7-4901818de568" />|<img width="1080" height="2376" alt="expanded" src="https://github.com/user-attachments/assets/dab3bd64-99f6-420a-be72-7d8961b337f4" />

### 🚧 TODO

- [x] discuss hardening

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)