### PR TITLE
docs: Add reasoning for the allowance of http as well as user certs

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -6,9 +6,11 @@
   ~ SPDX-License-Identifier: GPL-3.0-or-later
 -->
 <network-security-config>
+    <!-- Allowing cleartextTrafficPermitted - we don't control the server yet strongly suggesting TLS/SSL -->
     <base-config cleartextTrafficPermitted="true">
         <trust-anchors>
             <certificates src="system"/>
+            <!-- We allow user-certificates so managed device can make use of self-signed/client certificates -->
             <certificates src="user"/>
         </trust-anchors>
     </base-config>


### PR DESCRIPTION
### 🚧 TODO

- [x] merge

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)