### PR TITLE
feat: Show draft message in case the conversation has one attached to it

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.kt
+++ b/app/src/main/java/com/nextcloud/talk/adapters/items/ConversationItem.kt
@@ -246,6 +246,16 @@ class ConversationItem(
         }
 
     private fun setLastMessage(holder: ConversationItemViewHolder, appContext: Context) {
+        val draftText = model.messageDraft?.messageText?.takeIf { it.isNotBlank() }
+        if (draftText != null) {
+            showDraft(holder, appContext, draftText)
+            return
+        }
+
+        holder.binding.dialogLastMessage.setTextColor(
+            ContextCompat.getColor(context, R.color.textColorMaxContrast)
+        )
+
         if (chatMessage != null) {
             holder.binding.dialogDate.visibility = View.VISIBLE
             holder.binding.dialogDate.text = DateUtils.getRelativeTimeSpanString(
@@ -275,6 +285,19 @@ class ConversationItem(
             holder.binding.dialogDate.visibility = View.GONE
             holder.binding.dialogLastMessage.text = ""
         }
+    }
+
+    private fun showDraft(holder: ConversationItemViewHolder, appContext: Context, draftText: String) {
+        holder.binding.dialogDate.visibility = View.VISIBLE
+        holder.binding.dialogDate.text = DateUtils.getRelativeTimeSpanString(
+            model.lastActivity * MILLIES,
+            System.currentTimeMillis(),
+            0,
+            DateUtils.FORMAT_ABBREV_RELATIVE
+        )
+
+        val label = String.format(appContext.getString(R.string.nc_draft_prefix), draftText)
+        viewThemeUtils.talk.themeDraftSubline(holder.binding.dialogLastMessage, label, draftText)
     }
 
     private fun calculateRegularLastMessageText(appContext: Context): CharSequence =

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/data/network/OfflineFirstConversationsRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/data/network/OfflineFirstConversationsRepository.kt
@@ -58,7 +58,7 @@ class OfflineFirstConversationsRepository @Inject constructor(
             if (networkMonitor.isOnline.value) {
                 val conversationEntitiesFromSync = getRoomsFromServer(user)
                 if (!conversationEntitiesFromSync.isNullOrEmpty()) {
-                    val conversationModelsFromSync = conversationEntitiesFromSync.map(ConversationEntity::asModel)
+                    val conversationModelsFromSync = getListOfConversations(user.id!!)
                     _roomListFlow.emit(conversationModelsFromSync)
                 }
             }

--- a/app/src/main/java/com/nextcloud/talk/ui/theme/TalkSpecificViewThemeUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/theme/TalkSpecificViewThemeUtils.kt
@@ -325,6 +325,28 @@ class TalkSpecificViewThemeUtils @Inject constructor(
         }
     }
 
+    fun themeDraftSubline(textView: TextView, fullText: String, draftText: String) {
+        withScheme(textView) { scheme ->
+            val prefixEnd = fullText.length - draftText.length
+            val spannable = android.text.SpannableStringBuilder(fullText)
+            spannable.setSpan(
+                StyleSpan(Typeface.BOLD),
+                0,
+                prefixEnd,
+                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+            spannable.setSpan(
+                ForegroundColorSpan(dynamicColor.primary().getArgb(scheme)),
+                0,
+                prefixEnd,
+                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+            textView.setTypeface(null, Typeface.NORMAL)
+            textView.setTextColor(ContextCompat.getColor(textView.context, R.color.textColorMaxContrast))
+            textView.setText(spannable, TextView.BufferType.SPANNABLE)
+        }
+    }
+
     fun themeForegroundColorSpan(context: Context): ForegroundColorSpan {
         return withScheme(context) { scheme ->
             return@withScheme ForegroundColorSpan(dynamicColor.primary().getArgb(scheme))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -465,6 +465,7 @@ How to translate with transifex:
     <string name="nc_message_quote_cancel_reply">Cancel reply</string>
     <!-- When translating to German, please use non-formal variant -->
     <string name="nc_formatted_message_you">You: %1$s</string>
+    <string name="nc_draft_prefix">Draft: %1$s</string>
     <string name="nc_message_read">Message read</string>
     <string name="nc_message_sent">Message sent</string>
     <string name="nc_message_added_to_notes">Message added to notes</string>


### PR DESCRIPTION
- Ref: https://github.com/nextcloud/spreed/issues/15542

also fixing the issue that before when fetching the conversations from the server, the server-state has been exposed to the UI, not the upserted state from DB including the client-side only data.

### 🖼️ Screenshots

<img width="1080" height="2376" alt="yellow" src="https://github.com/user-attachments/assets/8a6e8064-4fab-49fd-834c-76be8f05aa87" />

### 🚧 TODO

- [ ] review & merge

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)