### PR TITLE
docs(dev): Add info for agents to respect the general design principles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,13 @@ Layout/menu files follow the component they belong to:
 | AdapterView item | —                      | `item_person.xml`               |
 | Partial layout   | —                      | `partial_stats_bar.xml`         |
 
+## Design
+
+- Follow Material Design 3 guidelines
+- In addition to any Material Design wording guidelines, follow the Nextcloud wording guidelines at https://docs.nextcloud.com/server/latest/developer_manual/design/foundations.html#wording
+- Ensure the app works in both light and dark theme
+- Ensure the app works with different server primary colors by using the colorTheme of viewThemeUtils
+
 ## After Making Changes
 
 After finishing code changes, run `./gradlew detekt ktlintCheck` and fix any new errors or warnings before considering the task done.


### PR DESCRIPTION
Follow-up for https://github.com/nextcloud/talk-android/pull/5990, as discussed with @AndyScherzinger 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)