### PR TITLE
1208 support android auto notifications

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -106,6 +106,19 @@ This requires a working Internet connection.
 
 The generated APK file is saved in ```app/build/outputs/apk``` as ```app-generic-debug.apk```.
 
+### Working with Android Auto
+
+To test [notification extension to Android Auto](https://developer.android.com/training/cars/communication/notification-messaging), Developer settings and Unknown sources need to be enabled in 
+the Android Auto settings: 
+
+1. Open the Settings app on your device
+2. Search for Android Auto, or click on Connected Devices > Android Auto
+3. Scroll all the way down to Version, and click it 10 times to enable Developer settings
+4. Click the 3 dots in the top right and select Developer settings
+5. Enable Unknown sources
+
+You can now receive notifications on Android Auto from a Nextcloud Talk development build.
+
 ### App flavours
 
 The app is currently equipped to be built with three flavours:

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -99,7 +99,11 @@
 
         <meta-data
             android:name="android.max_aspect"
-            android:value="10" />
+            android:value="10"/>
+
+        <meta-data
+            android:name="com.google.android.gms.car.application"
+            android:resource="@xml/automotive_app_desc"/>
 
         <activity
             android:name=".activities.MainActivity"
@@ -299,11 +303,21 @@
             </intent-filter>
         </receiver>
 
-        <receiver android:name=".receivers.DirectReplyReceiver" />
-        <receiver android:name=".receivers.MarkAsReadReceiver" />
-        <receiver android:name=".receivers.DeclineCallReceiver" android:exported="false" />
-        <receiver android:name=".receivers.DismissRecordingAvailableReceiver" />
-        <receiver android:name=".receivers.ShareRecordingToChatReceiver" />
+        <receiver
+            android:name=".receivers.DirectReplyReceiver"
+            android:exported="false" />
+        <receiver
+            android:name=".receivers.MarkAsReadReceiver"
+            android:exported="false" />
+        <receiver
+            android:name=".receivers.DismissRecordingAvailableReceiver"
+            android:exported="false" />
+        <receiver
+            android:name=".receivers.ShareRecordingToChatReceiver"
+            android:exported="false" />
+        <receiver
+            android:name=".receivers.DeclineCallReceiver"
+            android:exported="false" />
 
         <service
             android:name=".utils.SyncService"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -100,7 +100,11 @@
 
         <meta-data
             android:name="android.max_aspect"
-            android:value="10" />
+            android:value="10"/>
+
+        <meta-data
+            android:name="com.google.android.gms.car.application"
+            android:resource="@xml/automotive_app_desc"/>
 
         <activity
             android:name=".activities.MainActivity"
@@ -314,11 +318,21 @@
             </intent-filter>
         </receiver>
 
-        <receiver android:name=".receivers.DirectReplyReceiver" />
-        <receiver android:name=".receivers.MarkAsReadReceiver" />
-        <receiver android:name=".receivers.DeclineCallReceiver" android:exported="false" />
-        <receiver android:name=".receivers.DismissRecordingAvailableReceiver" />
-        <receiver android:name=".receivers.ShareRecordingToChatReceiver" />
+        <receiver
+            android:name=".receivers.DirectReplyReceiver"
+            android:exported="false" />
+        <receiver
+            android:name=".receivers.MarkAsReadReceiver"
+            android:exported="false" />
+        <receiver
+            android:name=".receivers.DismissRecordingAvailableReceiver"
+            android:exported="false" />
+        <receiver
+            android:name=".receivers.ShareRecordingToChatReceiver"
+            android:exported="false" />
+        <receiver
+            android:name=".receivers.DeclineCallReceiver"
+            android:exported="false" />
 
         <service
             android:name=".utils.SyncService"

--- a/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.kt
@@ -762,6 +762,10 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
     }
 
     private fun styleImageNotification(notificationBuilder: NotificationCompat.Builder) {
+        val notificationUser = pushMessage.notificationUser
+        val senderName = notificationUser?.name ?: ""
+        val conversationTitle = pushMessage.subject.ifEmpty { senderName }
+
         val bitmap = loadImageBitmapSync(imagePreviewUrl!!)
         if (bitmap != null) {
             notificationBuilder
@@ -770,6 +774,7 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
                     NotificationCompat.BigPictureStyle()
                         .bigPicture(bitmap)
                         .bigLargeIcon(null as Bitmap?)
+                        .setBigContentTitle(conversationTitle)
                 )
         }
     }
@@ -821,10 +826,19 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
             }
             person.setIcon(loadAvatarSync(avatarUrl, context!!))
         }
-        notificationBuilder.setStyle(getStyle(person.build(), style))
+        val deviceUser = Person.Builder()
+            .setKey(signatureVerification.user!!.id.toString() + "@" + signatureVerification.user!!.userId)
+            .setName(signatureVerification.user!!.displayName ?: signatureVerification.user!!.userId ?: "You")
+            .build()
+        notificationBuilder.setStyle(getStyle(deviceUser, person.build(), style))
     }
 
-    private fun buildIntentForAction(cls: Class<*>, systemNotificationId: Int, messageId: Int): PendingIntent {
+    private fun buildIntentForAction(
+        cls: Class<*>,
+        systemNotificationId: Int,
+        messageId: Int,
+        mutable: Boolean = true
+    ): PendingIntent {
         val actualIntent = Intent(context, cls)
 
         // NOTE - systemNotificationId is an internal ID used on the device only.
@@ -835,7 +849,8 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
         actualIntent.putExtra(KEY_MESSAGE_ID, messageId)
 
         val intentFlag: Int = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            val mutabilityFlag = if (mutable) PendingIntent.FLAG_MUTABLE else PendingIntent.FLAG_IMMUTABLE
+            mutabilityFlag or PendingIntent.FLAG_UPDATE_CURRENT
         } else {
             PendingIntent.FLAG_UPDATE_CURRENT
         }
@@ -854,7 +869,8 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
             val pendingIntent = buildIntentForAction(
                 MarkAsReadReceiver::class.java,
                 systemNotificationId,
-                messageId
+                messageId,
+                mutable = false
             )
             val markAsReadAction = NotificationCompat.Action.Builder(
                 R.drawable.ic_mark_chat_read_24px,
@@ -964,9 +980,13 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
         notificationBuilder.addAction(shareRecordingAction)
     }
 
-    private fun getStyle(person: Person, style: NotificationCompat.MessagingStyle?): NotificationCompat.MessagingStyle {
-        val newStyle = NotificationCompat.MessagingStyle(person)
-        newStyle.conversationTitle = pushMessage.subject
+    private fun getStyle(
+        deviceUser: Person,
+        sender: Person,
+        style: NotificationCompat.MessagingStyle?
+    ): NotificationCompat.MessagingStyle {
+        val newStyle = NotificationCompat.MessagingStyle(deviceUser)
+        newStyle.conversationTitle = pushMessage.subject.ifEmpty { sender.name }
         newStyle.isGroupConversation = "one2one" != conversationType
         style?.messages?.forEach(
             Consumer { message: NotificationCompat.MessagingStyle.Message ->
@@ -979,7 +999,7 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
                 )
             }
         )
-        newStyle.addMessage(pushMessage.text, pushMessage.timestamp, person)
+        newStyle.addMessage(pushMessage.text, pushMessage.timestamp, sender)
         return newStyle
     }
 

--- a/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.kt
@@ -30,6 +30,9 @@ import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.Person
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
 import androidx.core.app.RemoteInput
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.toBitmap
@@ -76,7 +79,6 @@ import com.nextcloud.talk.utils.NotificationUtils.cancelAllNotificationsForAccou
 import com.nextcloud.talk.utils.NotificationUtils.cancelNotification
 import com.nextcloud.talk.utils.NotificationUtils.findNotificationForRoom
 import com.nextcloud.talk.utils.NotificationUtils.getCallRingtoneUri
-import com.nextcloud.talk.utils.NotificationUtils.loadAvatarSync
 import com.nextcloud.talk.utils.ParticipantPermissions
 import com.nextcloud.talk.utils.PushUtils
 import com.nextcloud.talk.utils.bundle.BundleKeys
@@ -660,6 +662,7 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
                 }
                 addReplyAction(notificationBuilder, systemNotificationId)
                 addMarkAsReadAction(notificationBuilder, systemNotificationId)
+                pushConversationShortcut(notificationBuilder)
             }
         }
 
@@ -766,17 +769,38 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
         val senderName = notificationUser?.name ?: ""
         val conversationTitle = pushMessage.subject.ifEmpty { senderName }
 
+        val avatarBitmap = loadSenderAvatar(notificationUser)
+        if (avatarBitmap != null) {
+            notificationBuilder.setLargeIcon(avatarBitmap)
+        }
+
         val bitmap = loadImageBitmapSync(imagePreviewUrl!!)
         if (bitmap != null) {
-            notificationBuilder
-                .setLargeIcon(bitmap)
-                .setStyle(
-                    NotificationCompat.BigPictureStyle()
-                        .bigPicture(bitmap)
-                        .bigLargeIcon(null as Bitmap?)
-                        .setBigContentTitle(conversationTitle)
-                )
+            notificationBuilder.setStyle(
+                NotificationCompat.BigPictureStyle()
+                    .bigPicture(bitmap)
+                    .bigLargeIcon(avatarBitmap)
+                    .setBigContentTitle(conversationTitle)
+            )
         }
+    }
+
+    private fun loadSenderAvatar(notificationUser: NotificationUser?): Bitmap? {
+        val userType = notificationUser?.type
+        if (userType != "user" && userType != "guest") return null
+
+        val baseUrl = signatureVerification.user!!.baseUrl
+        val avatarUrl = if ("user" == userType) {
+            ApiUtils.getUrlForAvatar(
+                baseUrl!!,
+                notificationUser.id,
+                false,
+                darkMode = DisplayUtils.isDarkModeOn(context!!)
+            )
+        } else {
+            ApiUtils.getUrlForGuestAvatar(baseUrl!!, notificationUser.name, false)
+        }
+        return NotificationUtils.loadAvatarBitmapSync(avatarUrl, context!!)
     }
 
     private fun loadImageBitmapSync(imageUrl: String): Bitmap? {
@@ -824,13 +848,49 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
             } else {
                 ApiUtils.getUrlForGuestAvatar(baseUrl!!, notificationUser.name, false)
             }
-            person.setIcon(loadAvatarSync(avatarUrl, context!!))
+            val avatarBitmap = NotificationUtils.loadAvatarBitmapSync(avatarUrl, context!!)
+            if (avatarBitmap != null) {
+                person.setIcon(IconCompat.createWithBitmap(avatarBitmap))
+                notificationBuilder.setLargeIcon(avatarBitmap)
+            }
         }
         val deviceUser = Person.Builder()
             .setKey(signatureVerification.user!!.id.toString() + "@" + signatureVerification.user!!.userId)
             .setName(signatureVerification.user!!.displayName ?: signatureVerification.user!!.userId ?: "You")
             .build()
         notificationBuilder.setStyle(getStyle(deviceUser, person.build(), style))
+    }
+
+    private fun pushConversationShortcut(notificationBuilder: NotificationCompat.Builder) {
+        val notificationUser = pushMessage.notificationUser ?: return
+        val roomToken = pushMessage.id ?: return
+
+        val shortcutId = "conversation_${signatureVerification.user!!.id}_$roomToken"
+
+        val personBuilder = Person.Builder()
+            .setKey(signatureVerification.user!!.id.toString() + "@" + notificationUser.id)
+            .setName(EmojiCompat.get().process(notificationUser.name!!))
+
+        val avatarBitmap = loadSenderAvatar(notificationUser)
+        if (avatarBitmap != null) {
+            personBuilder.setIcon(IconCompat.createWithBitmap(avatarBitmap))
+        }
+
+        val intent = Intent(context, MainActivity::class.java).apply {
+            action = Intent.ACTION_VIEW
+            putExtra(KEY_ROOM_TOKEN, roomToken)
+            putExtra(KEY_INTERNAL_USER_ID, signatureVerification.user!!.id)
+        }
+
+        val shortcut = ShortcutInfoCompat.Builder(context!!, shortcutId)
+            .setShortLabel(pushMessage.subject.ifEmpty { notificationUser.name ?: "Chat" })
+            .setLongLived(true)
+            .setIntent(intent)
+            .setPerson(personBuilder.build())
+            .build()
+
+        ShortcutManagerCompat.pushDynamicShortcut(context!!, shortcut)
+        notificationBuilder.setShortcutId(shortcutId)
     }
 
     private fun buildIntentForAction(

--- a/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.kt
@@ -840,7 +840,7 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
             )
         }
         val personBuilder = Person.Builder()
-            .setKey(signatureVerification.user!!.id.toString() + "@" + notificationUser.id)
+            .setKey(user.id.toString() + "@" + notificationUser.id)
             .setName(EmojiCompat.get().process(notificationUser.name!!))
             .setBot("bot" == userType)
 
@@ -850,8 +850,8 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
         }
 
         val deviceUser = Person.Builder()
-            .setKey(signatureVerification.user!!.id.toString() + "@" + signatureVerification.user!!.userId)
-            .setName(signatureVerification.user!!.displayName ?: signatureVerification.user!!.userId ?: "You")
+            .setKey(user.id.toString() + "@" + user.userId)
+            .setName(user.displayName ?: user.userId ?: "You")
             .build()
 
         val sender = personBuilder.build()
@@ -884,7 +884,7 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
         val userType = notificationUser?.type
         if (userType != "user" && userType != "guest") return null
 
-        val baseUrl = signatureVerification.user!!.baseUrl
+        val baseUrl = user.baseUrl
         val avatarUrl = if ("user" == userType) {
             ApiUtils.getUrlForAvatar(
                 baseUrl!!,
@@ -913,14 +913,14 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
         return bitmap
     }
 
-    private fun pushConversationShortcut(notificationBuilder: NotificationCompat.Builder) {
+    private fun pushConversationShortcut(notificationBuilder: NotificationCompat.Builder, avatarBitmap: Bitmap?) {
         val notificationUser = pushMessage.notificationUser ?: return
         val roomToken = pushMessage.id ?: return
 
-        val shortcutId = "conversation_${signatureVerification.user!!.id}_$roomToken"
+        val shortcutId = "conversation_${user.id}_$roomToken"
 
         val personBuilder = Person.Builder()
-            .setKey(signatureVerification.user!!.id.toString() + "@" + notificationUser.id)
+            .setKey(user.id.toString() + "@" + notificationUser.id)
             .setName(EmojiCompat.get().process(notificationUser.name!!))
 
         if (avatarBitmap != null) {
@@ -930,7 +930,7 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
         val intent = Intent(context, MainActivity::class.java).apply {
             action = Intent.ACTION_VIEW
             putExtra(KEY_ROOM_TOKEN, roomToken)
-            putExtra(KEY_INTERNAL_USER_ID, signatureVerification.user!!.id)
+            putExtra(KEY_INTERNAL_USER_ID, user.id)
         }
 
         val shortcut = ShortcutInfoCompat.Builder(context!!, shortcutId)

--- a/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.kt
@@ -16,6 +16,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
@@ -32,6 +33,9 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.Person
 import androidx.core.app.RemoteInput
 import androidx.core.content.ContextCompat
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
 import androidx.core.graphics.drawable.toBitmap
 import androidx.core.net.toUri
 import androidx.emoji2.text.EmojiCompat
@@ -71,8 +75,8 @@ import com.nextcloud.talk.receivers.MarkAsReadReceiver
 import com.nextcloud.talk.receivers.ShareRecordingToChatReceiver
 import com.nextcloud.talk.users.UserManager
 import com.nextcloud.talk.utils.ApiUtils
-import com.nextcloud.talk.utils.DisplayUtils
 import com.nextcloud.talk.utils.ConversationUtils
+import com.nextcloud.talk.utils.DisplayUtils
 import com.nextcloud.talk.utils.NotificationUtils
 import com.nextcloud.talk.utils.NotificationUtils.cancelAllNotificationsForAccount
 import com.nextcloud.talk.utils.NotificationUtils.cancelNotification
@@ -110,13 +114,13 @@ import java.security.InvalidKeyException
 import java.security.NoSuchAlgorithmException
 import java.security.PrivateKey
 import java.util.concurrent.TimeUnit
-import java.util.function.Consumer
 import java.util.zip.CRC32
 import javax.crypto.BadPaddingException
 import javax.crypto.Cipher
 import javax.crypto.NoSuchPaddingException
 import javax.inject.Inject
 
+@Suppress("TooManyFunctions", "LargeClass", "CyclomaticComplexMethod")
 @AutoInjector(NextcloudTalkApplication::class)
 class NotificationWorker(context: Context, workerParams: WorkerParameters) : Worker(context, workerParams) {
 
@@ -700,17 +704,26 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
         val systemNotificationId: Int =
             activeStatusBarNotification?.id ?: calculateCRC32(System.currentTimeMillis().toString()).toInt()
 
-        if (TYPE_CHAT == pushMessage.type || TYPE_REMINDER == pushMessage.type) {
+        if ((TYPE_CHAT == pushMessage.type || TYPE_REMINDER == pushMessage.type) && pushMessage.notificationUser != null) {
             notificationBuilder.setOnlyAlertOnce(false)
-            if (pushMessage.notificationUser != null) {
-                if (imagePreviewUrl != null) {
-                    styleImageNotification(notificationBuilder)
-                } else {
-                    styleChatNotification(notificationBuilder, activeStatusBarNotification)
-                }
-                addReplyAction(notificationBuilder, systemNotificationId)
-                addMarkAsReadAction(notificationBuilder, systemNotificationId)
+            val senderAvatar = loadSenderAvatar(pushMessage.notificationUser)
+            val imageUri = imagePreviewUrl?.let { loadImageBitmapSync(it) }?.let {
+                NotificationUtils.saveBitmapToCache(
+                    context!!,
+                    it,
+                    "notification_preview_${pushMessage.id}.png"
+                )
             }
+
+            styleConversationNotification(
+                notificationBuilder,
+                activeStatusBarNotification,
+                senderAvatar,
+                imageUri
+            )
+            addReplyAction(notificationBuilder, systemNotificationId)
+            addMarkAsReadAction(notificationBuilder, systemNotificationId)
+            pushConversationShortcut(notificationBuilder, senderAvatar)
         }
 
         if (TYPE_RECORDING == pushMessage.type && ncNotification != null) {
@@ -811,17 +824,78 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
         return crc32.value
     }
 
-    private fun styleImageNotification(notificationBuilder: NotificationCompat.Builder) {
-        val bitmap = loadImageBitmapSync(imagePreviewUrl!!)
-        if (bitmap != null) {
-            notificationBuilder
-                .setLargeIcon(bitmap)
-                .setStyle(
-                    NotificationCompat.BigPictureStyle()
-                        .bigPicture(bitmap)
-                        .bigLargeIcon(null as Bitmap?)
-                )
+    private fun styleConversationNotification(
+        notificationBuilder: NotificationCompat.Builder,
+        activeStatusBarNotification: StatusBarNotification?,
+        senderAvatar: Bitmap?,
+        imageUri: Uri?
+    ) {
+        val notificationUser = pushMessage.notificationUser ?: return
+
+        val userType = notificationUser.type
+        var style: NotificationCompat.MessagingStyle? = null
+        if (activeStatusBarNotification != null) {
+            style = NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification(
+                activeStatusBarNotification.notification
+            )
         }
+        val personBuilder = Person.Builder()
+            .setKey(signatureVerification.user!!.id.toString() + "@" + notificationUser.id)
+            .setName(EmojiCompat.get().process(notificationUser.name!!))
+            .setBot("bot" == userType)
+
+        if (senderAvatar != null) {
+            personBuilder.setIcon(IconCompat.createWithBitmap(senderAvatar))
+            notificationBuilder.setLargeIcon(senderAvatar)
+        }
+
+        val deviceUser = Person.Builder()
+            .setKey(signatureVerification.user!!.id.toString() + "@" + signatureVerification.user!!.userId)
+            .setName(signatureVerification.user!!.displayName ?: signatureVerification.user!!.userId ?: "You")
+            .build()
+
+        val sender = personBuilder.build()
+        val newStyle = NotificationCompat.MessagingStyle(deviceUser)
+        newStyle.conversationTitle = pushMessage.subject.ifEmpty { sender.name }
+        newStyle.isGroupConversation = "one2one" != conversationType
+        style?.messages?.forEach { message ->
+            newStyle.addMessage(
+                NotificationCompat.MessagingStyle.Message(
+                    message.text,
+                    message.timestamp,
+                    message.person
+                )
+            )
+        }
+
+        val message = NotificationCompat.MessagingStyle.Message(
+            pushMessage.text,
+            pushMessage.timestamp,
+            sender
+        )
+        if (imageUri != null) {
+            message.setData(imageMimeType ?: "image/*", imageUri)
+        }
+        newStyle.addMessage(message)
+        notificationBuilder.setStyle(newStyle)
+    }
+
+    private fun loadSenderAvatar(notificationUser: NotificationUser?): Bitmap? {
+        val userType = notificationUser?.type
+        if (userType != "user" && userType != "guest") return null
+
+        val baseUrl = signatureVerification.user!!.baseUrl
+        val avatarUrl = if ("user" == userType) {
+            ApiUtils.getUrlForAvatar(
+                baseUrl!!,
+                notificationUser.id,
+                false,
+                darkMode = DisplayUtils.isDarkModeOn(context!!)
+            )
+        } else {
+            ApiUtils.getUrlForGuestAvatar(baseUrl!!, notificationUser.name, false)
+        }
+        return NotificationUtils.loadAvatarBitmapSync(avatarUrl, context!!)
     }
 
     private fun loadImageBitmapSync(imageUrl: String): Bitmap? {
@@ -839,42 +913,43 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
         return bitmap
     }
 
-    private fun styleChatNotification(
-        notificationBuilder: NotificationCompat.Builder,
-        activeStatusBarNotification: StatusBarNotification?
-    ) {
+    private fun pushConversationShortcut(notificationBuilder: NotificationCompat.Builder) {
         val notificationUser = pushMessage.notificationUser ?: return
+        val roomToken = pushMessage.id ?: return
 
-        val userType = notificationUser.type
-        var style: NotificationCompat.MessagingStyle? = null
-        if (activeStatusBarNotification != null) {
-            style = NotificationCompat.MessagingStyle.extractMessagingStyleFromNotification(
-                activeStatusBarNotification.notification
-            )
-        }
-        val person = Person.Builder()
-            .setKey(user.id.toString() + "@" + notificationUser.id)
+        val shortcutId = "conversation_${signatureVerification.user!!.id}_$roomToken"
+
+        val personBuilder = Person.Builder()
+            .setKey(signatureVerification.user!!.id.toString() + "@" + notificationUser.id)
             .setName(EmojiCompat.get().process(notificationUser.name!!))
-            .setBot("bot" == userType)
 
-        if ("user" == userType || "guest" == userType) {
-            val baseUrl = user.baseUrl
-            val avatarUrl = if ("user" == userType) {
-                ApiUtils.getUrlForAvatar(
-                    baseUrl!!,
-                    notificationUser.id,
-                    false,
-                    darkMode = DisplayUtils.isDarkModeOn(context!!)
-                )
-            } else {
-                ApiUtils.getUrlForGuestAvatar(baseUrl!!, notificationUser.name, false)
-            }
-            person.setIcon(loadAvatarSync(avatarUrl, context!!))
+        if (avatarBitmap != null) {
+            personBuilder.setIcon(IconCompat.createWithBitmap(avatarBitmap))
         }
-        notificationBuilder.setStyle(getStyle(person.build(), style))
+
+        val intent = Intent(context, MainActivity::class.java).apply {
+            action = Intent.ACTION_VIEW
+            putExtra(KEY_ROOM_TOKEN, roomToken)
+            putExtra(KEY_INTERNAL_USER_ID, signatureVerification.user!!.id)
+        }
+
+        val shortcut = ShortcutInfoCompat.Builder(context!!, shortcutId)
+            .setShortLabel(pushMessage.subject.ifEmpty { notificationUser.name ?: "Chat" })
+            .setLongLived(true)
+            .setIntent(intent)
+            .setPerson(personBuilder.build())
+            .build()
+
+        ShortcutManagerCompat.pushDynamicShortcut(context!!, shortcut)
+        notificationBuilder.setShortcutId(shortcutId)
     }
 
-    private fun buildIntentForAction(cls: Class<*>, systemNotificationId: Int, messageId: Int): PendingIntent {
+    private fun buildIntentForAction(
+        cls: Class<*>,
+        systemNotificationId: Int,
+        messageId: Int,
+        mutable: Boolean = false
+    ): PendingIntent {
         val actualIntent = Intent(context, cls)
 
         // NOTE - systemNotificationId is an internal ID used on the device only.
@@ -885,7 +960,8 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
         actualIntent.putExtra(KEY_MESSAGE_ID, messageId)
 
         val intentFlag: Int = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            val mutabilityFlag = if (mutable) PendingIntent.FLAG_MUTABLE else PendingIntent.FLAG_IMMUTABLE
+            mutabilityFlag or PendingIntent.FLAG_UPDATE_CURRENT
         } else {
             PendingIntent.FLAG_UPDATE_CURRENT
         }
@@ -904,7 +980,8 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
             val pendingIntent = buildIntentForAction(
                 MarkAsReadReceiver::class.java,
                 systemNotificationId,
-                messageId
+                messageId,
+                mutable = false
             )
             val markAsReadAction = NotificationCompat.Action.Builder(
                 R.drawable.ic_mark_chat_read_24px,
@@ -927,7 +1004,8 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
         val replyPendingIntent = buildIntentForAction(
             DirectReplyReceiver::class.java,
             systemNotificationId,
-            0
+            0,
+            mutable = true
         )
         val replyAction = NotificationCompat.Action.Builder(R.drawable.ic_reply, replyLabel, replyPendingIntent)
             .setSemanticAction(NotificationCompat.Action.SEMANTIC_ACTION_REPLY)
@@ -958,7 +1036,7 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
         dismissIntent.putExtra(KEY_DISMISS_RECORDING_URL, dismissRecordingUrl)
 
         val intentFlag: Int = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         } else {
             PendingIntent.FLAG_UPDATE_CURRENT
         }
@@ -992,7 +1070,7 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
         shareRecordingIntent.putExtra(KEY_ROOM_TOKEN, pushMessage.id)
 
         val intentFlag: Int = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         } else {
             PendingIntent.FLAG_UPDATE_CURRENT
         }
@@ -1012,25 +1090,6 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
             .setAllowGeneratedReplies(true)
             .build()
         notificationBuilder.addAction(shareRecordingAction)
-    }
-
-    private fun getStyle(person: Person, style: NotificationCompat.MessagingStyle?): NotificationCompat.MessagingStyle {
-        val newStyle = NotificationCompat.MessagingStyle(person)
-        newStyle.conversationTitle = pushMessage.subject
-        newStyle.isGroupConversation = "one2one" != conversationType
-        style?.messages?.forEach(
-            Consumer { message: NotificationCompat.MessagingStyle.Message ->
-                newStyle.addMessage(
-                    NotificationCompat.MessagingStyle.Message(
-                        message.text,
-                        message.timestamp,
-                        message.person
-                    )
-                )
-            }
-        )
-        newStyle.addMessage(pushMessage.text, pushMessage.timestamp, person)
-        return newStyle
     }
 
     @Throws(NumberFormatException::class)
@@ -1210,7 +1269,7 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
         // See https://github.com/nextcloud/talk-android/issues/2111
         val requestCode = System.currentTimeMillis().toInt()
         val intentFlag: Int = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
         } else {
             PendingIntent.FLAG_UPDATE_CURRENT
         }

--- a/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
@@ -11,6 +11,7 @@ import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
+import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
 import android.media.AudioAttributes
 import android.net.Uri
@@ -316,7 +317,12 @@ object NotificationUtils {
         )
 
     fun loadAvatarSync(avatarUrl: String, context: Context): IconCompat? {
-        var avatarIcon: IconCompat? = null
+        val bitmap = loadAvatarBitmapSync(avatarUrl, context)
+        return bitmap?.let { IconCompat.createWithBitmap(it) }
+    }
+
+    fun loadAvatarBitmapSync(avatarUrl: String, context: Context): Bitmap? {
+        var avatarBitmap: Bitmap? = null
 
         val request = ImageRequest.Builder(context)
             .data(avatarUrl)
@@ -324,13 +330,11 @@ object NotificationUtils {
             .placeholder(R.drawable.account_circle_96dp)
             .target(
                 onSuccess = { result ->
-                    val bitmap = (result as BitmapDrawable).bitmap
-                    avatarIcon = IconCompat.createWithBitmap(bitmap)
+                    avatarBitmap = (result as BitmapDrawable).bitmap
                 },
                 onError = { error ->
                     error?.let {
-                        val bitmap = (error as BitmapDrawable).bitmap
-                        avatarIcon = IconCompat.createWithBitmap(bitmap)
+                        avatarBitmap = (error as BitmapDrawable).bitmap
                     }
                     Log.w(TAG, "Can't load avatar for URL: $avatarUrl")
                 }
@@ -339,7 +343,7 @@ object NotificationUtils {
 
         context.imageLoader.executeBlocking(request)
 
-        return avatarIcon
+        return avatarBitmap
     }
 
     private data class Channel(val id: String, val name: String, val description: String, val isImportant: Boolean)

--- a/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
@@ -11,12 +11,14 @@ import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
+import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
 import android.media.AudioAttributes
 import android.net.Uri
 import android.service.notification.StatusBarNotification
 import android.text.TextUtils
 import android.util.Log
+import androidx.core.content.FileProvider
 import androidx.core.graphics.drawable.IconCompat
 import androidx.core.net.toUri
 import coil.executeBlocking
@@ -30,6 +32,8 @@ import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.models.RingtoneSettings
 import com.nextcloud.talk.utils.bundle.BundleKeys
 import com.nextcloud.talk.utils.preferences.AppPreferences
+import java.io.File
+import java.io.FileOutputStream
 import java.io.IOException
 
 @Suppress("TooManyFunctions")
@@ -54,6 +58,8 @@ object NotificationUtils {
     // notification group keys
     const val KEY_UPLOAD_GROUP = "com.nextcloud.talk.utils.KEY_UPLOAD_GROUP"
     const val GROUP_SUMMARY_NOTIFICATION_ID = -1
+
+    private const val BITMAP_COMPRESSION_QUALITY = 100
 
     private fun createNotificationChannel(
         context: Context,
@@ -316,7 +322,12 @@ object NotificationUtils {
         )
 
     fun loadAvatarSync(avatarUrl: String, context: Context): IconCompat? {
-        var avatarIcon: IconCompat? = null
+        val bitmap = loadAvatarBitmapSync(avatarUrl, context)
+        return bitmap?.let { IconCompat.createWithBitmap(it) }
+    }
+
+    fun loadAvatarBitmapSync(avatarUrl: String, context: Context): Bitmap? {
+        var avatarBitmap: Bitmap? = null
 
         val request = ImageRequest.Builder(context)
             .data(avatarUrl)
@@ -324,13 +335,11 @@ object NotificationUtils {
             .placeholder(R.drawable.account_circle_96dp)
             .target(
                 onSuccess = { result ->
-                    val bitmap = (result as BitmapDrawable).bitmap
-                    avatarIcon = IconCompat.createWithBitmap(bitmap)
+                    avatarBitmap = (result as BitmapDrawable).bitmap
                 },
                 onError = { error ->
                     error?.let {
-                        val bitmap = (error as BitmapDrawable).bitmap
-                        avatarIcon = IconCompat.createWithBitmap(bitmap)
+                        avatarBitmap = (error as BitmapDrawable).bitmap
                     }
                     Log.w(TAG, "Can't load avatar for URL: $avatarUrl")
                 }
@@ -339,7 +348,20 @@ object NotificationUtils {
 
         context.imageLoader.executeBlocking(request)
 
-        return avatarIcon
+        return avatarBitmap
+    }
+
+    fun saveBitmapToCache(context: Context, bitmap: Bitmap, fileName: String): Uri? {
+        val cacheFile = File(context.cacheDir, fileName)
+        return try {
+            FileOutputStream(cacheFile).use { out ->
+                bitmap.compress(Bitmap.CompressFormat.PNG, BITMAP_COMPRESSION_QUALITY, out)
+            }
+            FileProvider.getUriForFile(context, BuildConfig.APPLICATION_ID, cacheFile)
+        } catch (e: IOException) {
+            Log.e(TAG, "Failed to save bitmap to cache", e)
+            null
+        }
     }
 
     private data class Channel(val id: String, val name: String, val description: String, val isImportant: Boolean)

--- a/app/src/main/res/xml/automotive_app_desc.xml
+++ b/app/src/main/res/xml/automotive_app_desc.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Nextcloud Talk - Android Client
+  ~
+  ~ SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  ~ SPDX-License-Identifier: GPL-3.0-or-later
+  ~ SPDX-FileCopyrightText: 2026 Jens Zalzala <jens@shakingearth.digital>
+  -->
+
+<automotiveApp>
+    <uses name="notification" />
+</automotiveApp>


### PR DESCRIPTION
This addresses issue #1208 and also implements sender profile picture display in notifications.

I left the profile picture code as a separate commit, if for some reason we didn't want to merge that now. The notifications look pretty bad without it on Android Auto though.

### 🖼️ Screenshots

![20260331_125808](https://github.com/user-attachments/assets/96256d0a-8b57-4192-a19b-a818304fa447)
The first notification is from Nextcloud Talk. The second is from Google Messages for comparison.

Full video demo here: https://youtu.be/VWINe70FJkE

🏚️ Before | 🏡 After
---|---
Notification without avatar | Notification with avatar
![Screenshot_20260331_122241_One UI Home](https://github.com/user-attachments/assets/a39d81fe-be73-41f7-b18c-f94e82aef7f7) | ![Screenshot_20260331_123229_One UI Home](https://github.com/user-attachments/assets/c47346a3-ddc5-47fc-aa60-b95015856c58)

### TESTING

Please check the SETUP.md file for instructions on how to test with Android Auto. It took me waaaaay too long to figure out why notifications weren't showing up with my implementation 😅

### 🚧 TODO

Optional: Image notifications currently do not get stacked with text only messages. They also do not use the same Avatar style in notifications. This is because image notifications use `NotificationCompat.BigPictureStyle` instead of `NotificationCompat.MessagingStyle`. We could update it to use MessagingStyle, but the images could display smaller. E.g.

BigPictureStyle | MessagingStyle
---|---
![Screenshot_20260331_113346_One UI Home](https://github.com/user-attachments/assets/af58b67f-bf38-433e-852a-fbed2b1cead9) | ![Screenshot_20260331_112812_One UI Home](https://github.com/user-attachments/assets/106343ad-a3b7-4f8f-ab5d-d106d43c40af)

Note that these screenshots do not have any of the avatar work applied.

It looks like picture preview in notifications is a recent thing, so I didn't want to mess with it too much, but let me know if you'd prefer to have that changed/implemented  as part of this PR. 

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)