### PR TITLE
Allow uploading of WebP images by converting to supported format.

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/jobs/UploadAndShareFilesWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/UploadAndShareFilesWorker.kt
@@ -38,6 +38,7 @@ import com.nextcloud.talk.upload.normal.FileUploader
 import com.nextcloud.talk.users.UserManager
 import com.nextcloud.talk.utils.CapabilitiesUtil
 import com.nextcloud.talk.utils.FileUtils
+import com.nextcloud.talk.utils.Mimetype
 import com.nextcloud.talk.utils.NotificationUtils
 import com.nextcloud.talk.utils.RemoteFileUtils
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_INTERNAL_USER_ID
@@ -102,9 +103,24 @@ class UploadAndShareFilesWorker(val context: Context, workerParameters: WorkerPa
             require(sourceFile.isNotEmpty())
             checkNotNull(roomToken)
 
-            val sourceFileUri = sourceFile.toUri()
+            var sourceFileUri = sourceFile.toUri()
             fileName = FileUtils.getFileName(sourceFileUri, context)
             file = FileUtils.getFileFromUri(context, sourceFileUri)
+
+            val mimeType = context.contentResolver.getType(sourceFileUri)
+            if (mimeType == Mimetype.IMAGE_WEBP && file != null) {
+                val convertedFile = FileUtils.convertWebp(context, file!!)
+                if (convertedFile == null) {
+                    Log.e(TAG, "WebP conversion failed for $fileName")
+                    initNotificationSetup()
+                    showFailedToUploadNotification()
+                    return Result.failure()
+                }
+                file = convertedFile
+                fileName = convertedFile.name
+                sourceFileUri = Uri.fromFile(convertedFile)
+            }
+
             val remotePath = getRemotePath(currentUser)
 
             initNotificationSetup()

--- a/app/src/main/java/com/nextcloud/talk/utils/FileUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/FileUtils.kt
@@ -12,6 +12,8 @@ package com.nextcloud.talk.utils
 import android.content.ContentResolver
 import android.content.Context
 import android.database.Cursor
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.net.Uri
 import android.provider.OpenableColumns
 import android.util.Log
@@ -27,6 +29,7 @@ object FileUtils {
     private val TAG = FileUtils::class.java.simpleName
     private const val RADIX: Int = 16
     private const val MD5_LENGTH: Int = 32
+    private const val JPEG_QUALITY = 80
 
     /**
      * Creates a new [File]
@@ -149,6 +152,41 @@ object FileUtils {
         }
 
         return filename
+    }
+
+    /**
+     * Returns PNG [File] for transparent WebP, and JPG [File] for opaque WebP image.
+     * Returns null if conversion fails.
+     */
+    fun convertWebp(context: Context, sourceFile: File): File? {
+        val bitmap = BitmapFactory.decodeFile(sourceFile.absolutePath)
+        if (bitmap == null) {
+            Log.e(TAG, "Failed to decode WebP file: ${sourceFile.absolutePath}")
+            return null
+        }
+        val (format, extension) = if (bitmap.hasAlpha()) {
+            Bitmap.CompressFormat.PNG to "png"
+        } else {
+            Bitmap.CompressFormat.JPEG to "jpg"
+        }
+        val outputFileName = sourceFile.nameWithoutExtension + ".$extension"
+        File(context.applicationContext.filesDir, outputFileName).let { if (it.exists()) it.delete() }
+        return try {
+            val outputFile = getTempCacheFile(context, outputFileName)
+            val quality = if (format == Bitmap.CompressFormat.JPEG) JPEG_QUALITY else 0
+            val compressed = FileOutputStream(outputFile).use { out -> bitmap.compress(format, quality, out) }
+            bitmap.recycle()
+            if (compressed) {
+                outputFile
+            } else {
+                Log.e(TAG, "Failed to compress WebP bitmap to $format")
+                outputFile.delete()
+                null
+            }
+        } catch (e: IOException) {
+            Log.e(TAG, "IOException during WebP conversion", e)
+            null
+        }
     }
 
     @JvmStatic

--- a/app/src/main/java/com/nextcloud/talk/utils/Mimetype.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/Mimetype.kt
@@ -23,6 +23,7 @@ object Mimetype {
     const val IMAGE_JPG = "image/jpg"
     const val IMAGE_GIF = "image/gif"
     const val IMAGE_HEIC = "image/heic"
+    const val IMAGE_WEBP = "image/webp"
 
     const val VIDEO_MP4 = "video/mp4"
     const val VIDEO_QUICKTIME = "video/quicktime"


### PR DESCRIPTION
Addresses #6011

Detects WebP images on upload and converts them before upload. Transparent images are converted to PNG files, and opaque images are converted to JPG.

### 🖼️ Screenshots
x | x | x
---|---|---
![Screenshot_20260331_152801_Talk](https://github.com/user-attachments/assets/7f13db6a-10a4-45bb-b712-de09cf2d7fd5) | ![Screenshot_20260331_153349_Talk](https://github.com/user-attachments/assets/60340463-ee91-42c3-8123-2af591dc9c8a) | ![Screenshot_20260331_153410_Talk](https://github.com/user-attachments/assets/0732b0e2-766a-42df-93f2-26ee4b46c90e)


### 🚧 TODO

Optional: Display specific notification to user if the conversion fails. Currently it displays the same upload failed notification as before. 

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)