### PR TITLE
fix(call): ignore stale roomJoined events that fire before joinRoomndCall

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -302,6 +302,7 @@ class CallActivity : CallBaseActivity() {
     private var externalSignalingServer: ExternalSignalingServer? = null
     private var webSocketClient: WebSocketInstance? = null
     private var webSocketConnectionHelper: WebSocketConnectionHelper? = null
+    private var joinRoomInitiated = false
     private var hasMCU = false
     private var hasExternalSignalingServer = false
     private var conversationPassword: String? = null
@@ -1521,6 +1522,7 @@ class CallActivity : CallBaseActivity() {
             .toSet()
 
     private fun joinRoomAndCall() {
+        joinRoomInitiated = true
         callSession = ApplicationWideCurrentRoomHolder.getInstance().session
         val apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(ApiUtils.API_V4, 1))
         Log.d(TAG, "joinRoomAndCall")
@@ -1874,7 +1876,11 @@ class CallActivity : CallBaseActivity() {
                 }
 
                 "roomJoined" -> {
-                    Log.d(TAG, "onMessageEvent 'roomJoined'")
+                    Log.d(TAG, "onMessageEvent 'roomJoined' joinRoomInitiated=$joinRoomInitiated")
+                    if (!joinRoomInitiated) {
+                        Log.d(TAG, "Ignoring stale roomJoined event (joinRoomAndCall not yet called)")
+                        return
+                    }
                     startSendingNick()
                     if (webSocketCommunicationEvent.getHashMap()!!["roomToken"] == roomToken) {
                         performCall()
@@ -1943,6 +1949,7 @@ class CallActivity : CallBaseActivity() {
 
     private fun hangup(shutDownView: Boolean, endCallForAll: Boolean) {
         Log.d(TAG, "hangup! shutDownView=$shutDownView")
+        joinRoomInitiated = false
         if (shutDownView) {
             setCallState(CallStatus.LEAVING)
         }


### PR DESCRIPTION
When the app launches and immediately joins an existing call, the WebSocket may already be connected from a previous session. The server sends a stale roomJoined event before joinRoomAndCall() is called, causing performCall() to fire prematurely. Later when joinRoomAndCall runs, the WebSocket does a local join and the server never re-sends the participant list. The call stays stuck in JOINED and never transitions to IN_CONVERSATION.

Add joinRoomInitiated flag to guard the roomJoined handler against stale events. Only process roomJoined after joinRoomAndCall has been called.

This fixes Issue #6044 . I used OpenCode and GLM-5.1 to debug and fix this bug.

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)