### PR TITLE
Hide filenames for media in chat.

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/chat/MediaMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/chat/MediaMessage.kt
@@ -46,7 +46,13 @@ fun MediaMessage(
     conversationThreadId: Long? = null,
     onImageClick: (Int) -> Unit
 ) {
-    val captionText = message.message.takeUnless { it == FILE_PLACEHOLDER_MESSAGE }
+    val hasExplicitCaption = message.plainMessage != FILE_PLACEHOLDER_MESSAGE
+    val hasPreview = !typeContent.previewUrl.isNullOrEmpty()
+    val captionText = when {
+        hasExplicitCaption -> message.message
+        !hasPreview -> message.message
+        else -> null
+    }
     val hasCaption = captionText != null
     val mediaInset = 4.dp
     val mediaShape = remember(message.incoming) {


### PR DESCRIPTION
Implements #6056 

Added setting to always show filenames.

### 🖼️ Screenshots

🏚️ Before | 🏡 After | ⚙️ Setting
---|---|---
<img width="1080" height="2400" alt="Screenshot_20260415_142108" src="https://github.com/user-attachments/assets/6c33d073-4e88-4070-9b61-12742eaadd55" /> | <img width="1080" height="2400" alt="Screenshot_20260415_142035" src="https://github.com/user-attachments/assets/9fa51ecb-4d7a-4f87-90ce-588a5641c4dc" /> | <img width="1080" height="2400" alt="Screenshot_20260415_143559" src="https://github.com/user-attachments/assets/54b62a46-a7d4-4a87-b219-d272bb41bf5d" />


### 🚧 TODO

- [ ] Translate setting text, @string/nc_settings_show_media_filenames_title & @string/nc_settings_show_media_filenames_desc

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)