### PR TITLE
fix(i18n): Remove leading space from push notification error message

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,7 +69,7 @@ How to translate with transifex:
     <string name="nc_display_name_not_fetched">Display name couldn\'t be fetched, aborting</string>
     <string name="nc_nextcloud_talk_app_not_installed">%1$s not available (not installed or restricted by admin)</string>
     <string name="nc_display_name_not_stored">Could not store display name, aborting</string>
-    <string name="nc_push_notification_error"> Sorry something went wrong, error is %1$s</string>
+    <string name="nc_push_notification_error">Sorry something went wrong, error is %1$s</string>
     <string name="nc_push_notification_fetch_error">Sorry something went wrong, cannot fetch test push message</string>
 
     <string name="nc_search">Search</string>


### PR DESCRIPTION
See https://docs.nextcloud.com/server/latest/developer_manual/basics/translations.html#dos-and-don-ts

Reported at Transifex.
