### PR TITLE
Fix call state timing regression causing delayed audio routing

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -1016,6 +1016,12 @@ class CallActivity : CallBaseActivity() {
         checkRecordingConsentAndInitiateCall()
 
         if (permissionUtil!!.isMicrophonePermissionGranted()) {
+            // Fix regression introduced with ForegroundService flow:
+            // ensure any incoming ringtone/calling sound is stopped
+            // BEFORE promoting call to foreground service.
+            // Prevents ringtone continuing after answering call.
+            stopCallingSound()
+
             CallForegroundService.start(applicationContext, conversationName, intent.extras)
             if (!microphoneOn) {
                 onMicrophoneClick()


### PR DESCRIPTION
## Summary

This patch restores the original call initialization timing from 22.0.3.

In 22.1.x `prepareCall()` was moved later behind permission checks and foreground service startup.  
As a result `currentCallStatus = IN_CONVERSATION` may be set later than before.

On some devices this can delay audio routing, speakerphone activation, or other call startup behavior.

## Root cause

Regression introduced during call startup refactoring in 22.1.x.

## Fix

Move `prepareCall()` earlier to match the previous 22.0.3 behavior.

## Testing

Built locally and verified startup sequence changes.

Full push-notification based incoming-call testing could not be completed in the local build environment because Google push services were unavailable.

Regression comparison performed between:
- v22.0.3
- v22.1.0rc1

