### PR TITLE
Bugfix/noid/use extra shortcut id only when supported

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -329,7 +329,7 @@ class ConversationsListActivity : BaseActivity() {
 
         // Share sheet shortcut tap: Android delivers ACTION_SEND with EXTRA_SHORTCUT_ID.
         // Extract the room token from the shortcut ID so we can pre-select the conversation.
-        if (hasActivityActionSendIntent()) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && hasActivityActionSendIntent()) {
             val shortcutId = intent.getStringExtra(Intent.EXTRA_SHORTCUT_ID)
             if (shortcutId != null) {
                 pendingDirectShareToken = DirectShareHelper.extractTokenFromShortcutId(shortcutId)

--- a/app/src/main/java/com/nextcloud/talk/ui/chat/ChatMessageScaffold.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/chat/ChatMessageScaffold.kt
@@ -144,7 +144,7 @@ private fun ChatMessageUi.hasMentionChips(): Boolean =
         message.contains("{$key}") && parameter["type"] in mentionChipTypes
     }
 
-@Suppress("Detekt.LongMethod")
+@Suppress("Detekt.LongMethod", "LongParameterList")
 @Composable
 fun MessageScaffold(
     uiMessage: ChatMessageUi,
@@ -313,6 +313,7 @@ private fun MessageBubbleWithReactions(
     }
 }
 
+@Suppress("LongParameterList")
 @Composable
 private fun MessageBubbleContent(
     uiMessage: ChatMessageUi,


### PR DESCRIPTION
followup to https://github.com/nextcloud/talk-android/pull/6024

+ resolve detect warnings

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)