### PR TITLE
stop calling sound when preparing call

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -1041,6 +1041,7 @@ class CallActivity : CallBaseActivity() {
     }
 
     private fun prepareCall() {
+        stopCallingSound()
         basicInitialization()
         initViews()
         // updateSelfVideoViewPosition(true)


### PR DESCRIPTION
Some users complain about ringtone continuing to ring when a call is joined. It could not be reproduced but code wise it makes sense to call stopCallingSound here.

This is adapted from the PR
https://github.com/nextcloud/talk-android/pull/6092


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)