### PR TITLE
fix(l10n): Replace hard-coded strings for translate-ability

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/chat/ChatView.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/chat/ChatView.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -416,7 +417,7 @@ fun UnreadMessagesPopup(unreadCount: Int, onClick: () -> Unit, modifier: Modifie
         modifier = modifier
     ) {
         Text(
-            text = "$unreadCount new message${if (unreadCount > 1) "s" else ""}",
+            text = pluralStringResource(R.plurals.nc_new_messages_count, unreadCount, unreadCount),
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
             color = colorScheme.onSecondaryContainer
         )
@@ -471,7 +472,7 @@ fun UnreadMessagesMarker() {
         )
 
         Text(
-            text = "Unread messages",
+            text = stringResource(R.string.nc_new_messages),
             modifier = Modifier.padding(horizontal = 12.dp),
             fontSize = 12.sp,
             color = colorScheme.onSurfaceVariant

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -451,6 +451,10 @@ How to translate with transifex:
     <string name="nc_conversation_menu_conversation_go_to_file">Go to file</string>
     <string name="nc_conversation_menu_conversation_info">Conversation info</string>
     <string name="nc_new_messages">Unread messages</string>
+    <plurals name="nc_new_messages_count">
+        <item quantity="one">%d new message</item>
+        <item quantity="other">%d new messages</item>
+    </plurals>
     <string name="nc_sent_a_gif" formatted="true">%1$s sent a GIF.</string>
     <string name="nc_sent_an_audio" formatted="true">%1$s sent an audio.</string>
     <string name="nc_sent_a_video" formatted="true">%1$s sent a video.</string>


### PR DESCRIPTION
### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)