### PR TITLE
Add: mark message as read

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -3451,21 +3451,27 @@ class ChatActivity :
         )
     }
 
-    fun markAsUnread(chatMessage: ChatMessage?) {
-        if (chatMessage!!.previousMessageId > NO_PREVIOUS_MESSAGE_ID) {
-            // previousMessageId is taken to mark chat as unread even when "chat-unread" capability is not available
-            // It should be checked if "chat-unread" capability is available and then use
-            // https://nextcloud-talk.readthedocs.io/en/latest/chat/#mark-chat-as-unread
-            chatViewModel.setChatReadMessage(
-                credentials!!,
-                ApiUtils.getUrlForChatReadMarker(
-                    ApiUtils.getChatApiVersion(spreedCapabilities, intArrayOf(ApiUtils.API_V1)),
-                    conversationUser?.baseUrl!!,
-                    roomToken
-                ),
-                chatMessage.previousMessageId
-            )
+    fun markAsUnread(chatMessage: ChatMessage) {
+        val items = chatViewModel.uiState.value.items
+        val selectedIndex = items.indexOfFirst {
+            (it as? ChatViewModel.ChatItem.MessageItem)?.uiMessage?.id == chatMessage.jsonMessageId
         }
+        val lastReadMessage = if (selectedIndex in 0 until items.size - 1) {
+            (selectedIndex + 1 until items.size)
+                .firstNotNullOfOrNull { (items[it] as? ChatViewModel.ChatItem.MessageItem)?.uiMessage?.id }
+                ?: 0
+        } else {
+            0
+        }
+        chatViewModel.setChatReadMessage(
+            credentials!!,
+            ApiUtils.getUrlForChatReadMarker(
+                ApiUtils.getChatApiVersion(spreedCapabilities, intArrayOf(ApiUtils.API_V1)),
+                conversationUser.baseUrl!!,
+                roomToken
+            ),
+            lastReadMessage
+        )
     }
 
     fun copyMessage(message: ChatMessage?) {
@@ -3712,10 +3718,7 @@ class ChatActivity :
             // delete
             ChatMessage.MessageType.REGULAR_TEXT_MESSAGE == message.getCalculateMessageType() ||
             // forward
-            message.previousMessageId > NO_PREVIOUS_MESSAGE_ID &&
-            // mark as unread
-            ChatMessage.MessageType.SYSTEM_MESSAGE != message.getCalculateMessageType() &&
-            BuildConfig.DEBUG
+            ChatMessage.MessageType.SYSTEM_MESSAGE != message.getCalculateMessageType()
 
     private fun isShowMessageDeletionButton(message: ChatMessage): Boolean {
         val isUserAllowedByPrivileges = userAllowedByPrivilages(message)
@@ -3975,7 +3978,6 @@ class ChatActivity :
         private const val FULLY_OPAQUE_INT: Int = 255
         private const val SEMI_TRANSPARENT_INT: Int = 99
         private const val VOICE_MESSAGE_SEEKBAR_BASE = 1000
-        private const val NO_PREVIOUS_MESSAGE_ID: Int = -1
         private const val TOOLBAR_AVATAR_RATIO = 1.5
         private const val STATUS_SIZE_IN_DP = 9f
         private const val HTTP_BAD_REQUEST = 400

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/viewmodels/ConversationsListViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/viewmodels/ConversationsListViewModel.kt
@@ -13,7 +13,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.nextcloud.talk.R
-import com.nextcloud.talk.api.NcApiCoroutines
 import com.nextcloud.talk.arbitrarystorage.ArbitraryStorageManager
 import com.nextcloud.talk.contacts.ContactsRepository
 import com.nextcloud.talk.conversationlist.data.OfflineConversationsRepository
@@ -29,6 +28,7 @@ import com.nextcloud.talk.models.json.conversations.ConversationEnums
 import com.nextcloud.talk.models.json.converters.EnumActorTypeConverter
 import com.nextcloud.talk.models.json.participants.Participant
 import com.nextcloud.talk.openconversations.data.OpenConversationsRepository
+import com.nextcloud.talk.repositories.conversations.ConversationsRepository
 import com.nextcloud.talk.repositories.unifiedsearch.UnifiedSearchRepository
 import com.nextcloud.talk.threadsoverview.data.ThreadsRepository
 import com.nextcloud.talk.ui.dialog.FilterConversationFragment.Companion.ARCHIVE
@@ -76,7 +76,7 @@ class ConversationsListViewModel @Inject constructor(
     private val invitationsRepository: InvitationsRepository,
     private val arbitraryStorageManager: ArbitraryStorageManager,
     var userManager: UserManager,
-    private val ncApiCoroutines: NcApiCoroutines
+    private val conversationsRepository: ConversationsRepository
 ) : ViewModel() {
 
     private val _currentUser = currentUserProvider.currentUser.blockingGet()
@@ -584,7 +584,7 @@ class ConversationsListViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 withContext(Dispatchers.IO) {
-                    withRetry(1) { ncApiCoroutines.setChatReadMarker(credentials, url, messageId) }
+                    withRetry(1) { conversationsRepository.markConversationAsRead(credentials, url, messageId) }
                 }
                 _readUnreadState.value = ConversationReadUnreadUiState.Success(conversation.displayName, true)
             } catch (e: Exception) {
@@ -603,7 +603,7 @@ class ConversationsListViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 withContext(Dispatchers.IO) {
-                    withRetry(1) { ncApiCoroutines.markRoomAsUnread(credentials, url) }
+                    withRetry(1) { conversationsRepository.markConversationAsUnread(credentials, url) }
                 }
                 _readUnreadState.value = ConversationReadUnreadUiState.Success(conversation.displayName, false)
             } catch (e: Exception) {

--- a/app/src/main/java/com/nextcloud/talk/repositories/conversations/ConversationsRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/repositories/conversations/ConversationsRepository.kt
@@ -54,4 +54,8 @@ interface ConversationsRepository {
     suspend fun markConversationAsImportant(credentials: String, baseUrl: String, roomToken: String): GenericOverall
 
     suspend fun markConversationAsUnImportant(credentials: String, baseUrl: String, roomToken: String): GenericOverall
+
+    suspend fun markConversationAsRead(credentials: String, url: String, messageId: Int?): GenericOverall
+
+    suspend fun markConversationAsUnread(credentials: String, url: String): GenericOverall
 }

--- a/app/src/main/java/com/nextcloud/talk/repositories/conversations/ConversationsRepositoryImpl.kt
+++ b/app/src/main/java/com/nextcloud/talk/repositories/conversations/ConversationsRepositoryImpl.kt
@@ -147,6 +147,12 @@ class ConversationsRepositoryImpl(private val api: NcApi, private val coroutineA
     override suspend fun unbanActor(credentials: String, url: String): GenericOverall =
         coroutineApi.unbanActor(credentials, url)
 
+    override suspend fun markConversationAsRead(credentials: String, url: String, messageId: Int?): GenericOverall =
+        coroutineApi.setChatReadMarker(credentials, url, messageId)
+
+    override suspend fun markConversationAsUnread(credentials: String, url: String): GenericOverall =
+        coroutineApi.markRoomAsUnread(credentials, url)
+
     companion object {
         const val STATUS_CODE_OK = 200
     }

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/MessageActionsDialog.kt
@@ -175,7 +175,7 @@ class MessageActionsDialog(
                     canPin
             )
             initMenuMarkAsUnread(
-                message.previousMessageId > NO_PREVIOUS_MESSAGE_ID &&
+                hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.CHAT_READ_MARKER) &&
                     ChatMessage.MessageType.SYSTEM_MESSAGE != message.getCalculateMessageType() &&
                     isOnline
             )
@@ -638,7 +638,6 @@ class MessageActionsDialog(
     companion object {
         private val TAG = MessageActionsDialog::class.java.simpleName
         private const val ACTOR_LENGTH = 6
-        private const val NO_PREVIOUS_MESSAGE_ID: Int = -1
         private const val DELAY: Long = 200
         private const val AGE_THRESHOLD_FOR_EDIT_MESSAGE: Long = 86400000
         private const val ACTOR_BOTS = "bots"


### PR DESCRIPTION
Resolves #6058

### 🚧 TODO

- [ ] review 
- [ ] decide if approach is feasible @mahibi - see https://github.com/nextcloud/talk-android/compare/feat/6058/markMessageAsRead?expand=1#diff-a3567d71e5bb91cd3a5b0f732565ce89ebb3edcaa51f45dfe36922cb1b4e7259R3455

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)