### PR TITLE
Change single emoji text size to 2.5x

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/chat/ChatMessageScaffold.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/chat/ChatMessageScaffold.kt
@@ -71,12 +71,14 @@ import com.nextcloud.talk.contacts.loadImage
 import com.nextcloud.talk.ui.theme.LocalViewThemeUtils
 import com.nextcloud.talk.utils.DateUtils
 import com.nextcloud.talk.utils.DisplayUtils
+import com.nextcloud.talk.utils.TextMatchers
 import java.time.LocalDate
 
 private val regularTextSize = 16.sp
 private val timeTextSize = 12.sp
 private val authorTextSize = 12.sp
 private const val LINE_SPACING = 1.2f
+private const val SINGLE_EMOJI_SIZE_MULTIPLIER = 2.5f
 private const val HALF_OPACITY = 127
 private const val MESSAGE_LENGTH_THRESHOLD = 25
 private const val ANIMATED_BLINK = 500
@@ -785,21 +787,26 @@ internal fun resolveMarkdownSource(message: ChatMessageUi): String {
 
 @Composable
 fun EnrichedText(message: ChatMessageUi, modifier: Modifier, maxLines: Int = Int.MAX_VALUE) {
+    val isSingleEmoji = message.messageParameters.isEmpty() &&
+        TextMatchers.isMessageWithSingleEmoticonOnly(message.plainMessage)
+    val fontSize = if (isSingleEmoji) regularTextSize * SINGLE_EMOJI_SIZE_MULTIPLIER else regularTextSize
+
     if (message.renderMarkdown) {
         MarkdownText(
             message = message,
             textColor = colorScheme.onSurface,
             modifier = modifier,
-            maxLines = maxLines
+            maxLines = maxLines,
+            textSizeSp = fontSize.value
         )
     } else {
         MentionEnrichedText(
             message = message,
             modifier = modifier,
             textStyle = TextStyle(
-                fontSize = regularTextSize,
+                fontSize = fontSize,
                 color = colorScheme.onSurface,
-                lineHeight = regularTextSize * LINE_SPACING
+                lineHeight = fontSize * LINE_SPACING
             ),
             maxLines = maxLines
         )

--- a/app/src/main/java/com/nextcloud/talk/ui/chat/MarkdownText.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/chat/MarkdownText.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
 import coil.imageLoader
@@ -67,7 +68,8 @@ fun MarkdownText(
     message: ChatMessageUi,
     textColor: Color,
     modifier: Modifier = Modifier,
-    maxLines: Int = Int.MAX_VALUE
+    maxLines: Int = Int.MAX_VALUE,
+    textSizeSp: Float = TEXT_SIZE_SP
 ) {
     val context = LocalContext.current
     val textColorArgb = textColor.toArgb()
@@ -89,7 +91,13 @@ fun MarkdownText(
     val onLongClickState = rememberUpdatedState(onMessageLongClick)
 
     if (LocalInspectionMode.current) {
-        Text(text = message.plainMessage, color = textColor, modifier = modifier, maxLines = maxLines)
+        Text(
+            text = message.plainMessage,
+            color = textColor,
+            modifier = modifier,
+            maxLines = maxLines,
+            fontSize = textSizeSp.sp
+        )
     } else {
         AndroidView(
             modifier = modifier,
@@ -117,7 +125,7 @@ fun MarkdownText(
             },
             update = { textView ->
                 textView.setTextColor(textColorArgb)
-                textView.setTextSize(TypedValue.COMPLEX_UNIT_SP, TEXT_SIZE_SP)
+                textView.setTextSize(TypedValue.COMPLEX_UNIT_SP, textSizeSp)
                 textView.maxLines = maxLines
                 textView.setLineSpacing(0f, textView.textSize * LINE_HEIGHT_MULTIPLIER / textView.paint.fontSpacing)
                 val markwon = MessageUtils.buildMarkwon(context, textColorArgb)


### PR DESCRIPTION
2.5x text size multiplier for single emoji message, builds on top of #6108

### 🚧 TODO

- [x] merge #6108

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)