### PR TITLE
Update WebSocket data handling for files and system messages

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/data/model/ChatMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/model/ChatMessage.kt
@@ -315,6 +315,7 @@ data class ChatMessage(
         FEDERATED_USER_REMOVED,
         PHONE_ADDED,
         THREAD_CREATED,
+        THREAD_RENAMED,
         MESSAGE_PINNED,
         MESSAGE_UNPINNED
     }
@@ -322,6 +323,16 @@ data class ChatMessage(
     companion object {
         private const val TAG = "ChatMessage"
         private const val MILLIES: Long = 1000L
+
+        val SYSTEM_MESSAGE_TYPE_UNTRANSLATED: Set<SystemMessageType> = setOf(
+            SystemMessageType.REACTION,
+            SystemMessageType.REACTION_DELETED,
+            SystemMessageType.REACTION_REVOKED,
+            SystemMessageType.MESSAGE_DELETED,
+            SystemMessageType.MESSAGE_EDITED,
+            SystemMessageType.THREAD_CREATED,
+            SystemMessageType.THREAD_RENAMED,
+        )
 
         private const val REGEX_STRING_DEFAULT =
             """(\s|\n|^)(https?:\/\/)((?:[-A-Z0-9+_]+\.)+[-A-Z]+(?:\/[-A-Z0-9+&@#%?=~_|!:,.;()]*)*)(\s|\n|$)"""

--- a/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
@@ -270,18 +270,25 @@ class OfflineFirstChatRepository @Inject constructor(
             delay(INSURANCE_REQUEST_DELAY)
             Log.d(TAG, "execute insurance request with latestKnownMessageIdFromSync: $latestKnownMessageIdFromSync")
 
-            var fieldMap = getFieldMap(
-                lookIntoFuture = true,
-                timeout = 0,
-                includeLastKnown = false,
-                lastKnown = latestKnownMessageIdFromSync.toInt(),
-                limit = 200
-            )
-            val networkParams = Bundle()
-            networkParams.putSerializable(BundleKeys.KEY_FIELD_MAP, fieldMap)
-
-            getAndPersistMessages(networkParams)
+            fetchNewMessages()
         }
+    }
+
+    /**
+     * Fetches messages newer than latest known message
+     */
+    private suspend fun fetchNewMessages() {
+        var fieldMap = getFieldMap(
+            lookIntoFuture = true,
+            timeout = 0,
+            includeLastKnown = false,
+            lastKnown = latestKnownMessageIdFromSync.toInt(),
+            limit = 200
+        )
+        val networkParams = Bundle()
+        networkParams.putSerializable(BundleKeys.KEY_FIELD_MAP, fieldMap)
+
+        getAndPersistMessages(networkParams)
     }
 
     override suspend fun loadMoreMessages(
@@ -593,6 +600,16 @@ class OfflineFirstChatRepository @Inject constructor(
         )
         updateBlocks(newChatBlock)
     }
+
+    /**
+     * Returns true if all system messages do not require translation.
+     * Ignores other message types.
+     */
+    private fun isUntranslatedSystemMessage(messagesJson: List<ChatMessageJson>): Boolean =
+        messagesJson.all {
+            it.systemMessageType == ChatMessage.SystemMessageType.DUMMY ||
+                it.systemMessageType in ChatMessage.SYSTEM_MESSAGE_TYPE_UNTRANSLATED
+        }
 
     private suspend fun handleSystemMessagesThatAffectDatabase(messagesJson: List<ChatMessageJson>) {
         var hasPinnedMessageChange = false
@@ -1010,10 +1027,18 @@ class OfflineFirstChatRepository @Inject constructor(
         }
 
     override suspend fun onSignalingChatMessageReceived(chatMessages: List<ChatMessageJson>) {
+        // check if we need to get user specific data from the backend
+        if (!isUntranslatedSystemMessage(chatMessages) ||
+            chatMessages.any { it.messageParameters?.containsKey("file") == true }) {
+            Log.d(TAG, "onSignalingChatMessageReceived force data refresh")
+            fetchNewMessages()
+            return
+        }
+
         persistChatMessagesAndHandleSystemMessages(chatMessages, emitOnIncoming = true)
 
         // we assume that the signaling messages are on top of the latest chatblock and include them inside it.
-        // If for whatever reason the assume was not correct and there would be messages in between, the
+        // If for whatever reason the assumption was not correct and there would be messages in between, the
         // insurance request should fix this by adding the missing messages and updating the chatblocks.
         val latestChatBlock = chatBlocksDao.getLatestChatBlock(internalConversationId, threadId)
         latestChatBlock.first()?.apply {

--- a/app/src/main/java/com/nextcloud/talk/models/json/converters/EnumSystemMessageTypeConverter.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/converters/EnumSystemMessageTypeConverter.kt
@@ -73,6 +73,7 @@ import com.nextcloud.talk.chat.data.model.ChatMessage.SystemMessageType.RECORDIN
 import com.nextcloud.talk.chat.data.model.ChatMessage.SystemMessageType.RECORDING_STARTED
 import com.nextcloud.talk.chat.data.model.ChatMessage.SystemMessageType.RECORDING_STOPPED
 import com.nextcloud.talk.chat.data.model.ChatMessage.SystemMessageType.THREAD_CREATED
+import com.nextcloud.talk.chat.data.model.ChatMessage.SystemMessageType.THREAD_RENAMED
 import com.nextcloud.talk.chat.data.model.ChatMessage.SystemMessageType.USER_ADDED
 import com.nextcloud.talk.chat.data.model.ChatMessage.SystemMessageType.USER_REMOVED
 
@@ -147,6 +148,7 @@ class EnumSystemMessageTypeConverter : StringBasedTypeConverter<ChatMessage.Syst
             "federated_user_removed" -> FEDERATED_USER_REMOVED
             "phone_added" -> PHONE_ADDED
             "thread_created" -> THREAD_CREATED
+            "thread_renamed" -> THREAD_RENAMED
             "message_pinned" -> MESSAGE_PINNED
             "message_unpinned" -> MESSAGE_UNPINNED
             else -> DUMMY


### PR DESCRIPTION
See #6081 

When receiving a WebSocket chat comment with a file attachment, fetch messages via REST call to get user specific file paths. 
This allows the user to display media without needing to wait on the insurance call to trigger. 

Also checks for system messages that need to be localized for the user. This follows the logic of the web app. However, since it doesn't look like we do localization in the Android app, it's set to fetch new data for any system message that is not on the list of untranslated system messages. Partially implements #6064

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)