### PR TITLE
use subfolders for attachments

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/api/NcApiCoroutines.kt
+++ b/app/src/main/java/com/nextcloud/talk/api/NcApiCoroutines.kt
@@ -13,7 +13,7 @@ import com.nextcloud.talk.models.json.autocomplete.AutocompleteOverall
 import com.nextcloud.talk.models.json.chat.ChatOverall
 import com.nextcloud.talk.models.json.chat.ChatOverallSingleMessage
 import com.nextcloud.talk.models.json.chatpostattachment.ChatPostAttachmentOverall
-import com.nextcloud.talk.models.json.chatpostattachment.PostConversationAttachmentResponse
+import com.nextcloud.talk.models.json.chatpostattachment.PostConversationAttachmentRequest
 import com.nextcloud.talk.models.json.chatprobeattachmentfolder.ChatProbeAttachmentFolderOverall
 import com.nextcloud.talk.models.json.chatprobeattachmentfolder.ProbeConversationAttachmentRequest
 import com.nextcloud.talk.models.json.conversations.RoomOverall
@@ -491,7 +491,7 @@ interface NcApiCoroutines {
     suspend fun postConversationAttachment(
         @Header("Authorization") authorization: String,
         @Url url: String,
-        @Body body: PostConversationAttachmentResponse
+        @Body body: PostConversationAttachmentRequest
     ): ChatPostAttachmentOverall
 
     @PUT

--- a/app/src/main/java/com/nextcloud/talk/api/NcApiCoroutines.kt
+++ b/app/src/main/java/com/nextcloud/talk/api/NcApiCoroutines.kt
@@ -12,6 +12,10 @@ import com.nextcloud.talk.conversationinfo.CreateRoomRequest
 import com.nextcloud.talk.models.json.autocomplete.AutocompleteOverall
 import com.nextcloud.talk.models.json.chat.ChatOverall
 import com.nextcloud.talk.models.json.chat.ChatOverallSingleMessage
+import com.nextcloud.talk.models.json.chatpostattachment.ChatPostAttachmentOverall
+import com.nextcloud.talk.models.json.chatpostattachment.PostConversationAttachmentResponse
+import com.nextcloud.talk.models.json.chatprobeattachmentfolder.ChatProbeAttachmentFolderOverall
+import com.nextcloud.talk.models.json.chatprobeattachmentfolder.ProbeConversationAttachmentRequest
 import com.nextcloud.talk.models.json.conversations.RoomOverall
 import com.nextcloud.talk.models.json.conversations.RoomsOverall
 import com.nextcloud.talk.models.json.generic.GenericOverall
@@ -475,4 +479,25 @@ interface NcApiCoroutines {
     // Url is: /api/{apiVersion}/chat/{token}/read
     @DELETE
     suspend fun markRoomAsUnread(@Header("Authorization") authorization: String, @Url url: String): GenericOverall
+
+    @POST
+    suspend fun probeConversationAttachmentFolder(
+        @Header("Authorization") authorization: String,
+        @Url url: String,
+        @Body request: ProbeConversationAttachmentRequest
+    ): ChatProbeAttachmentFolderOverall
+
+    @POST
+    suspend fun postConversationAttachment(
+        @Header("Authorization") authorization: String,
+        @Url url: String,
+        @Body body: PostConversationAttachmentResponse
+    ): ChatPostAttachmentOverall
+
+    @PUT
+    suspend fun uploadFile(
+        @Header("Authorization") authorization: String,
+        @Url url: String,
+        @Body body: RequestBody
+    ): Response<GenericOverall>
 }

--- a/app/src/main/java/com/nextcloud/talk/jobs/UploadAndShareFilesWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/UploadAndShareFilesWorker.kt
@@ -26,16 +26,14 @@ import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
-import at.bitfire.dav4jvm.DavResource
 import autodagger.AutoInjector
 import com.nextcloud.talk.R
 import com.nextcloud.talk.activities.MainActivity
 import com.nextcloud.talk.api.NcApi
 import com.nextcloud.talk.api.NcApiCoroutines
 import com.nextcloud.talk.application.NextcloudTalkApplication
-import com.nextcloud.talk.dagger.modules.RestModule
 import com.nextcloud.talk.data.user.model.User
-import com.nextcloud.talk.models.json.chatpostattachment.PostConversationAttachmentResponse
+import com.nextcloud.talk.models.json.chatpostattachment.PostConversationAttachmentRequest
 import com.nextcloud.talk.models.json.chatprobeattachmentfolder.ChatProbeAttachmentData
 import com.nextcloud.talk.models.json.chatprobeattachmentfolder.ProbeConversationAttachmentRequest
 import com.nextcloud.talk.upload.chunked.ChunkedFileUploader
@@ -53,14 +51,9 @@ import com.nextcloud.talk.utils.database.user.CurrentUserProviderOld
 import com.nextcloud.talk.utils.permissions.PlatformPermissionUtil
 import com.nextcloud.talk.utils.preferences.AppPreferences
 import kotlinx.coroutines.runBlocking
-import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
-import okhttp3.Protocol
-import okhttp3.RequestBody
-import okhttp3.Response
 import java.io.File
-import java.io.IOException
 import java.util.UUID
 import javax.inject.Inject
 
@@ -235,7 +228,7 @@ class UploadAndShareFilesWorker(val context: Context, workerParameters: WorkerPa
                 return@runBlocking false
             }
 
-            val params = PostConversationAttachmentResponse().apply {
+            val params = PostConversationAttachmentRequest().apply {
                 filePath = tempRemotePath
                 referenceId = uploadId
                 talkMetaData = metaData
@@ -255,46 +248,6 @@ class UploadAndShareFilesWorker(val context: Context, workerParameters: WorkerPa
 
     private fun resolveFinalFileName(originalName: String, probeData: ChatProbeAttachmentData): String =
         probeData.renames?.get(originalName) ?: originalName
-
-    private fun uploadFileToDraftPathUsingWebDav(sourceFileUri: Uri, remotePath: String): Boolean =
-        runCatching {
-            val mimeType = context.contentResolver.getType(sourceFileUri)?.toMediaTypeOrNull()
-            val requestBody = RequestBody.create(mimeType, file!!)
-            val uploadUrl = ApiUtils.getUrlForFileUpload(
-                currentUser.baseUrl!!,
-                currentUser.userId!!,
-                remotePath
-            )
-            val davResource = DavResource(
-                createWebDavClientWithAuth(),
-                uploadUrl.toHttpUrlOrNull()!!
-            )
-            davResource.put(requestBody) { response: Response ->
-                if (!response.isSuccessful) {
-                    throw IOException("Failed to upload file to draft folder. response code: ${response.code}")
-                }
-            }
-            FileUtils.copyFileToCache(context, sourceFileUri, fileName)
-            true
-        }
-            .onFailure { Log.e(TAG, "Failed to upload draft attachment via WebDAV", it) }
-            .getOrDefault(false)
-
-    private fun createWebDavClientWithAuth(): OkHttpClient =
-        okHttpClient.newBuilder()
-            .followRedirects(false)
-            .followSslRedirects(false)
-            .protocols(listOf(Protocol.HTTP_1_1))
-            .authenticator(
-                RestModule.HttpAuthenticator(
-                    ApiUtils.getCredentials(
-                        currentUser.username,
-                        currentUser.token
-                    )!!,
-                    "Authorization"
-                )
-            )
-            .build()
 
     private fun getRemotePath(currentUser: User): String {
         val remotePath = CapabilitiesUtil.getAttachmentFolder(

--- a/app/src/main/java/com/nextcloud/talk/jobs/UploadAndShareFilesWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/UploadAndShareFilesWorker.kt
@@ -26,16 +26,23 @@ import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
+import at.bitfire.dav4jvm.DavResource
 import autodagger.AutoInjector
 import com.nextcloud.talk.R
 import com.nextcloud.talk.activities.MainActivity
 import com.nextcloud.talk.api.NcApi
+import com.nextcloud.talk.api.NcApiCoroutines
 import com.nextcloud.talk.application.NextcloudTalkApplication
+import com.nextcloud.talk.dagger.modules.RestModule
 import com.nextcloud.talk.data.user.model.User
+import com.nextcloud.talk.models.json.chatpostattachment.PostConversationAttachmentResponse
+import com.nextcloud.talk.models.json.chatprobeattachmentfolder.ChatProbeAttachmentData
+import com.nextcloud.talk.models.json.chatprobeattachmentfolder.ProbeConversationAttachmentRequest
 import com.nextcloud.talk.upload.chunked.ChunkedFileUploader
 import com.nextcloud.talk.upload.chunked.OnDataTransferProgressListener
 import com.nextcloud.talk.upload.normal.FileUploader
 import com.nextcloud.talk.users.UserManager
+import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.CapabilitiesUtil
 import com.nextcloud.talk.utils.FileUtils
 import com.nextcloud.talk.utils.NotificationUtils
@@ -45,9 +52,16 @@ import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_ROOM_TOKEN
 import com.nextcloud.talk.utils.database.user.CurrentUserProviderOld
 import com.nextcloud.talk.utils.permissions.PlatformPermissionUtil
 import com.nextcloud.talk.utils.preferences.AppPreferences
+import kotlinx.coroutines.runBlocking
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.RequestBody
+import okhttp3.Response
 import java.io.File
+import java.io.IOException
+import java.util.UUID
 import javax.inject.Inject
 
 @AutoInjector(NextcloudTalkApplication::class)
@@ -60,6 +74,9 @@ class UploadAndShareFilesWorker(val context: Context, workerParameters: WorkerPa
 
     @Inject
     lateinit var userManager: UserManager
+
+    @Inject
+    lateinit var ncApiCoroutines: NcApiCoroutines
 
     @Inject
     lateinit var currentUserProvider: CurrentUserProviderOld
@@ -107,9 +124,12 @@ class UploadAndShareFilesWorker(val context: Context, workerParameters: WorkerPa
             file = FileUtils.getFileFromUri(context, sourceFileUri)
             val remotePath = getRemotePath(currentUser)
 
+            val useConversationSubfolders = CapabilitiesUtil.hasConversationSubfoldersForAttachments(
+                currentUser.capabilities!!.spreedCapability!!
+            )
             initNotificationSetup()
             file?.let { isChunkedUploading = it.length() > CHUNK_UPLOAD_THRESHOLD_SIZE }
-            val uploadSuccess: Boolean = uploadFile(sourceFileUri, metaData, remotePath)
+            val uploadSuccess: Boolean = uploadFile(sourceFileUri, metaData, remotePath, useConversationSubfolders)
 
             if (uploadSuccess) {
                 cancelNotification()
@@ -129,24 +149,153 @@ class UploadAndShareFilesWorker(val context: Context, workerParameters: WorkerPa
         }
     }
 
-    private fun uploadFile(sourceFileUri: Uri, metaData: String?, remotePath: String): Boolean =
+    private fun uploadFile(
+        sourceFileUri: Uri,
+        metaData: String?,
+        remotePath: String,
+        useConversationSubfolders: Boolean
+    ): Boolean =
         if (file == null) {
             false
+        } else if (useConversationSubfolders) {
+            uploadUsingConversationSubfolders(sourceFileUri, metaData)
         } else if (isChunkedUploading) {
             Log.d(TAG, "starting chunked upload because size is " + file!!.length())
-
             initNotificationWithPercentage()
             val mimeType = context.contentResolver.getType(sourceFileUri)?.toMediaTypeOrNull()
-
-            chunkedFileUploader = ChunkedFileUploader(okHttpClient, currentUser, roomToken, metaData, this)
+            chunkedFileUploader = ChunkedFileUploader(
+                okHttpClient,
+                currentUser,
+                roomToken,
+                metaData,
+                this,
+                ncApiCoroutines,
+                useConversationSubfolders
+            )
             chunkedFileUploader!!.upload(file!!, mimeType, remotePath)
         } else {
             Log.d(TAG, "starting normal upload (not chunked) of $fileName")
-
-            FileUploader(okHttpClient, context, currentUser, roomToken, ncApi, file!!)
+            FileUploader(
+                okHttpClient,
+                context,
+                currentUser,
+                roomToken,
+                ncApi,
+                file!!,
+                ncApiCoroutines,
+                useConversationSubfolders
+            )
                 .upload(sourceFileUri, fileName, remotePath, metaData)
                 .blockingFirst()
         }
+
+    private fun uploadUsingConversationSubfolders(sourceFileUri: Uri, metaData: String?): Boolean =
+        runBlocking {
+            val credentials = ApiUtils.getCredentials(
+                currentUser.username,
+                currentUser.token
+            ) ?: return@runBlocking false
+            val uploadId = UUID.randomUUID().toString()
+            val fileNames = ProbeConversationAttachmentRequest().apply {
+                fileNames = listOf(fileName)
+            }
+
+            val probeResponse = ncApiCoroutines.probeConversationAttachmentFolder(
+                credentials,
+                ApiUtils.getUrlForChatAttachmentFolder(ApiUtils.API_V1, currentUser.baseUrl, roomToken),
+                fileNames
+            )
+
+            val draftFolderPath = probeResponse.ocs?.data?.folder
+            if (draftFolderPath.isNullOrEmpty()) {
+                Log.e(TAG, "Draft folder path missing in probe response")
+                return@runBlocking false
+            }
+            val predictedName = resolveFinalFileName(fileName, probeResponse.ocs?.data!!)
+            val tempRemotePath = "/$draftFolderPath/$uploadId-$fileName"
+
+            val uploadSuccess = if (isChunkedUploading) {
+                initNotificationWithPercentage()
+                val mimeType = context.contentResolver.getType(sourceFileUri)?.toMediaTypeOrNull()
+                chunkedFileUploader = ChunkedFileUploader(
+                    okHttpClient,
+                    currentUser,
+                    roomToken,
+                    metaData,
+                    this@UploadAndShareFilesWorker,
+                    ncApiCoroutines,
+                    true
+                )
+                chunkedFileUploader!!.upload(file!!, mimeType, tempRemotePath)
+            } else {
+                FileUploader(okHttpClient, context, currentUser, roomToken, ncApi, file!!, ncApiCoroutines, true)
+                    .uploadToConversationSubfolder(sourceFileUri, tempRemotePath)
+            }
+
+            if (!uploadSuccess) {
+                return@runBlocking false
+            }
+
+            val params = PostConversationAttachmentResponse().apply {
+                filePath = tempRemotePath
+                referenceId = uploadId
+                talkMetaData = metaData
+                fileName = predictedName
+            }
+
+            runCatching {
+                ncApiCoroutines.postConversationAttachment(
+                    credentials,
+                    ApiUtils.getUrlForChatAttachment(ApiUtils.API_V1, currentUser.baseUrl, roomToken),
+                    params
+                )
+            }
+                .onFailure { Log.e(TAG, "Failed to finalize uploaded attachment", it) }
+                .isSuccess
+        }
+
+    private fun resolveFinalFileName(originalName: String, probeData: ChatProbeAttachmentData): String =
+        probeData.renames?.get(originalName) ?: originalName
+
+    private fun uploadFileToDraftPathUsingWebDav(sourceFileUri: Uri, remotePath: String): Boolean =
+        runCatching {
+            val mimeType = context.contentResolver.getType(sourceFileUri)?.toMediaTypeOrNull()
+            val requestBody = RequestBody.create(mimeType, file!!)
+            val uploadUrl = ApiUtils.getUrlForFileUpload(
+                currentUser.baseUrl!!,
+                currentUser.userId!!,
+                remotePath
+            )
+            val davResource = DavResource(
+                createWebDavClientWithAuth(),
+                uploadUrl.toHttpUrlOrNull()!!
+            )
+            davResource.put(requestBody) { response: Response ->
+                if (!response.isSuccessful) {
+                    throw IOException("Failed to upload file to draft folder. response code: ${response.code}")
+                }
+            }
+            FileUtils.copyFileToCache(context, sourceFileUri, fileName)
+            true
+        }
+            .onFailure { Log.e(TAG, "Failed to upload draft attachment via WebDAV", it) }
+            .getOrDefault(false)
+
+    private fun createWebDavClientWithAuth(): OkHttpClient =
+        okHttpClient.newBuilder()
+            .followRedirects(false)
+            .followSslRedirects(false)
+            .protocols(listOf(Protocol.HTTP_1_1))
+            .authenticator(
+                RestModule.HttpAuthenticator(
+                    ApiUtils.getCredentials(
+                        currentUser.username,
+                        currentUser.token
+                    )!!,
+                    "Authorization"
+                )
+            )
+            .build()
 
     private fun getRemotePath(currentUser: User): String {
         val remotePath = CapabilitiesUtil.getAttachmentFolder(

--- a/app/src/main/java/com/nextcloud/talk/jobs/UploadAndShareFilesWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/UploadAndShareFilesWorker.kt
@@ -182,8 +182,7 @@ class UploadAndShareFilesWorker(val context: Context, workerParameters: WorkerPa
                 roomToken,
                 ncApi,
                 file!!,
-                ncApiCoroutines,
-                useConversationSubfolders
+                ncApiCoroutines
             )
                 .upload(sourceFileUri, fileName, remotePath, metaData)
                 .blockingFirst()
@@ -228,7 +227,7 @@ class UploadAndShareFilesWorker(val context: Context, workerParameters: WorkerPa
                 )
                 chunkedFileUploader!!.upload(file!!, mimeType, tempRemotePath)
             } else {
-                FileUploader(okHttpClient, context, currentUser, roomToken, ncApi, file!!, ncApiCoroutines, true)
+                FileUploader(okHttpClient, context, currentUser, roomToken, ncApi, file!!, ncApiCoroutines)
                     .uploadToConversationSubfolder(sourceFileUri, tempRemotePath)
             }
 

--- a/app/src/main/java/com/nextcloud/talk/models/json/chatpostattachment/ChatPostAttachmentData.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/chatpostattachment/ChatPostAttachmentData.kt
@@ -1,0 +1,23 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.nextcloud.talk.models.json.chatpostattachment
+
+import android.os.Parcelable
+import com.bluelinelabs.logansquare.annotation.JsonField
+import com.bluelinelabs.logansquare.annotation.JsonObject
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+@JsonObject
+data class ChatPostAttachmentData(
+    @JsonField(name = ["renames"])
+    var renames: LinkedHashMap<String, String>? = null
+) : Parcelable {
+    // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
+    constructor() : this(null)
+}

--- a/app/src/main/java/com/nextcloud/talk/models/json/chatpostattachment/ChatPostAttachmentOCS.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/chatpostattachment/ChatPostAttachmentOCS.kt
@@ -1,0 +1,23 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.nextcloud.talk.models.json.chatpostattachment
+
+import android.os.Parcelable
+import com.bluelinelabs.logansquare.annotation.JsonField
+import com.bluelinelabs.logansquare.annotation.JsonObject
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+@JsonObject
+data class ChatPostAttachmentOCS(
+    @JsonField(name = ["data"])
+    var data: ChatPostAttachmentData? = null
+) : Parcelable {
+    // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
+    constructor() : this(null)
+}

--- a/app/src/main/java/com/nextcloud/talk/models/json/chatpostattachment/ChatPostAttachmentOverall.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/chatpostattachment/ChatPostAttachmentOverall.kt
@@ -1,0 +1,23 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.nextcloud.talk.models.json.chatpostattachment
+
+import android.os.Parcelable
+import com.bluelinelabs.logansquare.annotation.JsonField
+import com.bluelinelabs.logansquare.annotation.JsonObject
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+@JsonObject
+data class ChatPostAttachmentOverall(
+    @JsonField(name = ["ocs"])
+    var ocs: ChatPostAttachmentOCS? = null
+) : Parcelable {
+    // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
+    constructor() : this(null)
+}

--- a/app/src/main/java/com/nextcloud/talk/models/json/chatpostattachment/PostConversationAttachmentRequest.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/chatpostattachment/PostConversationAttachmentRequest.kt
@@ -11,7 +11,7 @@ import com.bluelinelabs.logansquare.annotation.JsonField
 import com.bluelinelabs.logansquare.annotation.JsonObject
 
 @JsonObject
-class PostConversationAttachmentResponse {
+class PostConversationAttachmentRequest {
 
     @JsonField(name = ["filePath"])
     var filePath: String? = null

--- a/app/src/main/java/com/nextcloud/talk/models/json/chatpostattachment/PostConversationAttachmentResponse.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/chatpostattachment/PostConversationAttachmentResponse.kt
@@ -1,0 +1,27 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.nextcloud.talk.models.json.chatpostattachment
+
+import com.bluelinelabs.logansquare.annotation.JsonField
+import com.bluelinelabs.logansquare.annotation.JsonObject
+
+@JsonObject
+class PostConversationAttachmentResponse {
+
+    @JsonField(name = ["filePath"])
+    var filePath: String? = null
+
+    @JsonField(name = ["referenceId"])
+    var referenceId: String? = null
+
+    @JsonField(name = ["talkMetaData"])
+    var talkMetaData: String? = null
+
+    @JsonField(name = ["fileName"])
+    var fileName: String? = null
+}

--- a/app/src/main/java/com/nextcloud/talk/models/json/chatprobeattachmentfolder/ChatProbeAttachmentData.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/chatprobeattachmentfolder/ChatProbeAttachmentData.kt
@@ -1,0 +1,25 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.nextcloud.talk.models.json.chatprobeattachmentfolder
+
+import android.os.Parcelable
+import com.bluelinelabs.logansquare.annotation.JsonField
+import com.bluelinelabs.logansquare.annotation.JsonObject
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+@JsonObject
+data class ChatProbeAttachmentData(
+    @JsonField(name = ["folder"])
+    var folder: String? = null,
+    @JsonField(name = ["renames"])
+    var renames: LinkedHashMap<String, String>? = null
+) : Parcelable {
+    // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
+    constructor() : this(null, null)
+}

--- a/app/src/main/java/com/nextcloud/talk/models/json/chatprobeattachmentfolder/ChatProbeAttachmentFolderOCS.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/chatprobeattachmentfolder/ChatProbeAttachmentFolderOCS.kt
@@ -1,0 +1,26 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.nextcloud.talk.models.json.chatprobeattachmentfolder
+
+import android.os.Parcelable
+import com.bluelinelabs.logansquare.annotation.JsonField
+import com.bluelinelabs.logansquare.annotation.JsonObject
+import com.nextcloud.talk.models.json.generic.GenericMeta
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+@JsonObject
+data class ChatProbeAttachmentFolderOCS(
+    @JsonField(name = ["meta"])
+    var meta: GenericMeta?,
+    @JsonField(name = ["data"])
+    var data: ChatProbeAttachmentData? = null
+) : Parcelable {
+    // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
+    constructor() : this(null)
+}

--- a/app/src/main/java/com/nextcloud/talk/models/json/chatprobeattachmentfolder/ChatProbeAttachmentFolderOverall.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/chatprobeattachmentfolder/ChatProbeAttachmentFolderOverall.kt
@@ -1,0 +1,23 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.nextcloud.talk.models.json.chatprobeattachmentfolder
+
+import android.os.Parcelable
+import com.bluelinelabs.logansquare.annotation.JsonField
+import com.bluelinelabs.logansquare.annotation.JsonObject
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+@JsonObject
+data class ChatProbeAttachmentFolderOverall(
+    @JsonField(name = ["ocs"])
+    var ocs: ChatProbeAttachmentFolderOCS?
+) : Parcelable {
+    // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
+    constructor() : this(null)
+}

--- a/app/src/main/java/com/nextcloud/talk/models/json/chatprobeattachmentfolder/ProbeConversationAttachmentRequest.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/chatprobeattachmentfolder/ProbeConversationAttachmentRequest.kt
@@ -1,0 +1,18 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.nextcloud.talk.models.json.chatprobeattachmentfolder
+
+import com.bluelinelabs.logansquare.annotation.JsonField
+import com.bluelinelabs.logansquare.annotation.JsonObject
+
+@JsonObject
+class ProbeConversationAttachmentRequest {
+
+    @JsonField(name = ["fileNames"])
+    var fileNames: List<String>? = null
+}

--- a/app/src/main/java/com/nextcloud/talk/upload/chunked/ChunkedFileUploader.kt
+++ b/app/src/main/java/com/nextcloud/talk/upload/chunked/ChunkedFileUploader.kt
@@ -20,7 +20,10 @@ import at.bitfire.dav4jvm.property.GetContentType
 import at.bitfire.dav4jvm.property.GetLastModified
 import at.bitfire.dav4jvm.property.ResourceType
 import autodagger.AutoInjector
+import com.nextcloud.talk.api.NcApiCoroutines
 import com.nextcloud.talk.application.NextcloudTalkApplication
+import com.nextcloud.talk.dagger.modules.RestModule
+import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.filebrowser.models.DavResponse
 import com.nextcloud.talk.filebrowser.models.properties.NCEncrypted
 import com.nextcloud.talk.filebrowser.models.properties.NCPermission
@@ -28,8 +31,6 @@ import com.nextcloud.talk.filebrowser.models.properties.NCPreview
 import com.nextcloud.talk.filebrowser.models.properties.OCFavorite
 import com.nextcloud.talk.filebrowser.models.properties.OCId
 import com.nextcloud.talk.filebrowser.models.properties.OCSize
-import com.nextcloud.talk.dagger.modules.RestModule
-import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.jobs.ShareOperationWorker
 import com.nextcloud.talk.remotefilebrowser.model.RemoteFileBrowserItem
 import com.nextcloud.talk.utils.ApiUtils
@@ -52,7 +53,9 @@ class ChunkedFileUploader(
     val currentUser: User,
     val roomToken: String,
     val metaData: String?,
-    val listener: OnDataTransferProgressListener
+    val listener: OnDataTransferProgressListener,
+    val ncApiCoroutines: NcApiCoroutines,
+    val supportsConversationFolders: Boolean
 ) {
 
     private var okHttpClientNoRedirects: OkHttpClient? = null
@@ -92,7 +95,7 @@ class ChunkedFileUploader(
             }
 
             if (isUploadSuccessful) {
-                assembleChunks(uploadFolderUri, targetPath)
+                assembleChunks(uploadFolderUri, targetPath, supportsConversationFolders)
             }
             return isUploadSuccessful
         } catch (e: Exception) {
@@ -288,12 +291,13 @@ class ChunkedFileUploader(
         this.okHttpClientNoRedirects = okHttpClientBuilder.build()
     }
 
-    private fun assembleChunks(uploadFolderUri: String, targetPath: String) {
-        val destinationUri: String = ApiUtils.getUrlForFileUpload(
+    private fun assembleChunks(uploadFolderUri: String, targetPath: String, useConversationSubfolders: Boolean) {
+        val destinationUri = ApiUtils.getUrlForFileUpload(
             currentUser.baseUrl!!,
             currentUser.userId!!,
             targetPath
         )
+
         val originUri = "$uploadFolderUri/.file"
 
         DavResource(
@@ -304,12 +308,14 @@ class ChunkedFileUploader(
             true
         ) { response: Response ->
             if (response.isSuccessful) {
-                ShareOperationWorker.shareFile(
-                    roomToken,
-                    currentUser,
-                    targetPath,
-                    metaData
-                )
+                if (!useConversationSubfolders) {
+                    ShareOperationWorker.shareFile(
+                        roomToken,
+                        currentUser,
+                        targetPath,
+                        metaData
+                    )
+                }
             } else {
                 throw IOException("Failed to assemble chunks. response code: " + response.code)
             }

--- a/app/src/main/java/com/nextcloud/talk/upload/normal/FileUploader.kt
+++ b/app/src/main/java/com/nextcloud/talk/upload/normal/FileUploader.kt
@@ -13,6 +13,7 @@ import android.util.Log
 import at.bitfire.dav4jvm.DavResource
 import at.bitfire.dav4jvm.exception.HttpException
 import com.nextcloud.talk.api.NcApi
+import com.nextcloud.talk.api.NcApiCoroutines
 import com.nextcloud.talk.dagger.modules.RestModule
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.jobs.ShareOperationWorker
@@ -37,7 +38,9 @@ class FileUploader(
     val currentUser: User,
     val roomToken: String,
     val ncApi: NcApi,
-    val file: File
+    val file: File,
+    val ncApiCoroutines: NcApiCoroutines,
+    val conversationSubfolders: Boolean
 ) {
 
     private var okHttpClientNoRedirects: OkHttpClient? = null
@@ -45,6 +48,19 @@ class FileUploader(
 
     init {
         initHttpClient(okHttpClient, currentUser)
+    }
+
+    suspend fun uploadToConversationSubfolder(sourceFileUri: Uri, target: String): Boolean {
+        val response = requireNotNull(ncApiCoroutines) { "NcApiCoroutines is required" }.uploadFile(
+            currentUser.getCredentials(),
+            ApiUtils.getUrlForFileUpload(
+                currentUser.baseUrl!!,
+                currentUser.userId!!,
+                target
+            ),
+            createRequestBody(sourceFileUri) ?: return false
+        )
+        return response.isSuccessful
     }
 
     fun upload(sourceFileUri: Uri, fileName: String, remotePath: String, metaData: String?): Observable<Boolean> =

--- a/app/src/main/java/com/nextcloud/talk/upload/normal/FileUploader.kt
+++ b/app/src/main/java/com/nextcloud/talk/upload/normal/FileUploader.kt
@@ -39,8 +39,7 @@ class FileUploader(
     val roomToken: String,
     val ncApi: NcApi,
     val file: File,
-    val ncApiCoroutines: NcApiCoroutines,
-    val conversationSubfolders: Boolean
+    val ncApiCoroutines: NcApiCoroutines
 ) {
 
     private var okHttpClientNoRedirects: OkHttpClient? = null
@@ -51,7 +50,7 @@ class FileUploader(
     }
 
     suspend fun uploadToConversationSubfolder(sourceFileUri: Uri, target: String): Boolean {
-        val response = requireNotNull(ncApiCoroutines) { "NcApiCoroutines is required" }.uploadFile(
+        val response = ncApiCoroutines.uploadFile(
             currentUser.getCredentials(),
             ApiUtils.getUrlForFileUpload(
                 currentUser.baseUrl!!,

--- a/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.kt
@@ -565,4 +565,10 @@ object ApiUtils {
 
     fun getUrlForScheduledMessage(baseUrl: String?, token: String, messageId: String?): String =
         getUrlForScheduledMessages(baseUrl, token) + "/$messageId"
+
+    fun getUrlForChatAttachment(version: Int, baseUrl: String?, token: String): String =
+        getUrlForChat(version, baseUrl, token) + "/attachment"
+
+    fun getUrlForChatAttachmentFolder(version: Int, baseUrl: String?, token: String): String =
+        getUrlForChatAttachment(version, baseUrl, token) + "/folder"
 }

--- a/app/src/main/java/com/nextcloud/talk/utils/CapabilitiesUtil.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/CapabilitiesUtil.kt
@@ -112,7 +112,6 @@ object CapabilitiesUtil {
         return spreedCapabilities.features?.contains(spreedFeatures.value) == true
     }
 
-    @JvmStatic
     fun hasConversationSubfoldersForAttachments(spreedCapabilities: SpreedCapability): Boolean {
         if (spreedCapabilities.config?.containsKey("attachments") == true) {
             val map = spreedCapabilities.config!!["attachments"]

--- a/app/src/main/java/com/nextcloud/talk/utils/CapabilitiesUtil.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/CapabilitiesUtil.kt
@@ -112,6 +112,17 @@ object CapabilitiesUtil {
         return spreedCapabilities.features?.contains(spreedFeatures.value) == true
     }
 
+    @JvmStatic
+    fun hasConversationSubfoldersForAttachments(spreedCapabilities: SpreedCapability): Boolean {
+        if (spreedCapabilities.config?.containsKey("attachments") == true) {
+            val map = spreedCapabilities.config!!["attachments"]
+            if (map?.containsKey("conversation-subfolders") == true) {
+                return map["conversation-subfolders"].toString().toBoolean()
+            }
+        }
+        return false
+    }
+
     fun isSharedItemsAvailable(spreedCapabilities: SpreedCapability): Boolean =
         hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.RICH_OBJECT_LIST_MEDIA)
 


### PR DESCRIPTION
Resolve #6034 

For NC34, we use subfolders for attachments per conversation. 

1. We need to get the draft folder from the endpoint, predicted filenames in case of conflict from the endpoint ....../attachment/folder endpoint
2. Upload attachments to the draft folder using the predicted filenames.
3. Call ....../attachment endpoint to finalise the upload and to post a chat message.


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)