### PR TITLE
add fullscreen permission setting

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -8,6 +8,7 @@ package com.nextcloud.talk.conversationlist
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.app.NotificationManager
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -925,6 +926,8 @@ class ConversationsListActivity : BaseActivity() {
         val notificationPermissionNotGranted = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
             !platformPermissionUtil.isPostNotificationsPermissionGranted()
         val batteryOptimizationNotIgnored = !PowerManagerUtils().isIgnoringBatteryOptimizations()
+        val fullScreenIntentNotGranted = Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE &&
+            !getSystemService(NotificationManager::class.java).canUseFullScreenIntent()
 
         val messagesChannelNotEnabled = !NotificationUtils.isMessagesNotificationChannelEnabled(this)
         val callsChannelNotEnabled = !NotificationUtils.isCallsNotificationChannelEnabled(this)
@@ -934,6 +937,7 @@ class ConversationsListActivity : BaseActivity() {
 
         val settingsOfUserAreWrong = notificationPermissionNotGranted ||
             batteryOptimizationNotIgnored ||
+            fullScreenIntentNotGranted ||
             messagesChannelNotEnabled ||
             callsChannelNotEnabled ||
             !serverNotificationAppInstalled

--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -15,6 +15,7 @@ import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.annotation.SuppressLint
 import android.app.KeyguardManager
+import android.app.NotificationManager
 import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
@@ -432,6 +433,36 @@ class SettingsActivity :
                 }
             }
 
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                val notificationManager = getSystemService(NotificationManager::class.java)
+                if (notificationManager.canUseFullScreenIntent()) {
+                    binding.fullScreenIntentPermissionSubtitle.text =
+                        resources.getString(R.string.full_screen_intent_permission_granted)
+                    binding.fullScreenIntentPermissionSubtitle.setTextColor(
+                        resources.getColor(R.color.high_emphasis_text, null)
+                    )
+                } else {
+                    binding.fullScreenIntentPermissionSubtitle.text =
+                        resources.getString(R.string.full_screen_intent_permission_not_granted)
+                    binding.fullScreenIntentPermissionSubtitle.setTextColor(
+                        resources.getColor(R.color.nc_darkRed, null)
+                    )
+
+                    if (openedByNotificationWarning) {
+                        DrawableUtils.blinkDrawable(binding.settingsFullScreenIntentWrapper.background)
+                    }
+
+                    binding.settingsFullScreenIntentWrapper.setOnClickListener {
+                        val intent = Intent(Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT).apply {
+                            data = "package:$packageName".toUri()
+                        }
+                        startActivity(intent)
+                    }
+                }
+            } else {
+                binding.settingsFullScreenIntentWrapper.visibility = View.GONE
+            }
+
             // handle notification permission on API level >= 33
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 if (platformPermissionUtil.isPostNotificationsPermissionGranted()) {
@@ -572,15 +603,24 @@ class SettingsActivity :
             )
         }
 
+        val canUseFullScreenIntent = Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE ||
+            getSystemService(NotificationManager::class.java).canUseFullScreenIntent()
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             if (platformPermissionUtil.isPostNotificationsPermissionGranted() &&
                 PowerManagerUtils().isIgnoringBatteryOptimizations()
             ) {
                 binding.settingsNotificationsPermissionWrapper.setOnClickListener { click() }
                 binding.settingsBatteryOptimizationWrapper.setOnClickListener { click() }
+                if (canUseFullScreenIntent) {
+                    binding.settingsFullScreenIntentWrapper.setOnClickListener { click() }
+                }
             }
         } else if (PowerManagerUtils().isIgnoringBatteryOptimizations()) {
             binding.settingsBatteryOptimizationWrapper.setOnClickListener { click() }
+            if (canUseFullScreenIntent) {
+                binding.settingsFullScreenIntentWrapper.setOnClickListener { click() }
+            }
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -323,6 +323,7 @@ class SettingsActivity :
         setupUnifiedPushSettings()
         setupNotificationSoundsSettings()
         setupNotificationPermissionSettings()
+        setupFullScreenIntentPermissionSetting()
         setupServerNotificationAppCheck()
     }
 
@@ -433,36 +434,6 @@ class SettingsActivity :
                 }
             }
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                val notificationManager = getSystemService(NotificationManager::class.java)
-                if (notificationManager.canUseFullScreenIntent()) {
-                    binding.fullScreenIntentPermissionSubtitle.text =
-                        resources.getString(R.string.full_screen_intent_permission_granted)
-                    binding.fullScreenIntentPermissionSubtitle.setTextColor(
-                        resources.getColor(R.color.high_emphasis_text, null)
-                    )
-                } else {
-                    binding.fullScreenIntentPermissionSubtitle.text =
-                        resources.getString(R.string.full_screen_intent_permission_not_granted)
-                    binding.fullScreenIntentPermissionSubtitle.setTextColor(
-                        resources.getColor(R.color.nc_darkRed, null)
-                    )
-
-                    if (openedByNotificationWarning) {
-                        DrawableUtils.blinkDrawable(binding.settingsFullScreenIntentWrapper.background)
-                    }
-
-                    binding.settingsFullScreenIntentWrapper.setOnClickListener {
-                        val intent = Intent(Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT).apply {
-                            data = "package:$packageName".toUri()
-                        }
-                        startActivity(intent)
-                    }
-                }
-            } else {
-                binding.settingsFullScreenIntentWrapper.visibility = View.GONE
-            }
-
             // handle notification permission on API level >= 33
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 if (platformPermissionUtil.isPostNotificationsPermissionGranted()) {
@@ -513,6 +484,37 @@ class SettingsActivity :
                 binding.settingsGplayNotAvailable.visibility = View.VISIBLE
                 binding.settingsPushNotAvailable.visibility = View.GONE
             }
+        }
+    }
+
+    private fun setupFullScreenIntentPermissionSetting() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            val notificationManager = getSystemService(NotificationManager::class.java)
+            if (notificationManager.canUseFullScreenIntent()) {
+                binding.fullScreenIntentPermissionSubtitle.text =
+                    resources.getString(R.string.full_screen_intent_permission_granted)
+                binding.fullScreenIntentPermissionSubtitle.setTextColor(
+                    resources.getColor(R.color.high_emphasis_text, null)
+                )
+            } else {
+                binding.fullScreenIntentPermissionSubtitle.text =
+                    resources.getString(R.string.full_screen_intent_permission_not_granted)
+                binding.fullScreenIntentPermissionSubtitle.setTextColor(
+                    resources.getColor(R.color.nc_darkRed, null)
+                )
+
+                if (openedByNotificationWarning) {
+                    DrawableUtils.blinkDrawable(binding.settingsFullScreenIntentWrapper.background)
+                }
+            }
+            binding.settingsFullScreenIntentWrapper.setOnClickListener {
+                val intent = Intent(Settings.ACTION_MANAGE_APP_USE_FULL_SCREEN_INTENT).apply {
+                    data = "package:$packageName".toUri()
+                }
+                startActivity(intent)
+            }
+        } else {
+            binding.settingsFullScreenIntentWrapper.visibility = View.GONE
         }
     }
 
@@ -603,24 +605,15 @@ class SettingsActivity :
             )
         }
 
-        val canUseFullScreenIntent = Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE ||
-            getSystemService(NotificationManager::class.java).canUseFullScreenIntent()
-
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             if (platformPermissionUtil.isPostNotificationsPermissionGranted() &&
                 PowerManagerUtils().isIgnoringBatteryOptimizations()
             ) {
                 binding.settingsNotificationsPermissionWrapper.setOnClickListener { click() }
                 binding.settingsBatteryOptimizationWrapper.setOnClickListener { click() }
-                if (canUseFullScreenIntent) {
-                    binding.settingsFullScreenIntentWrapper.setOnClickListener { click() }
-                }
             }
         } else if (PowerManagerUtils().isIgnoringBatteryOptimizations()) {
             binding.settingsBatteryOptimizationWrapper.setOnClickListener { click() }
-            if (canUseFullScreenIntent) {
-                binding.settingsFullScreenIntentWrapper.setOnClickListener { click() }
-            }
         }
     }
 

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -373,6 +373,27 @@
                             tools:text="@string/battery_optimization_ignored"/>
                     </LinearLayout>
 
+                    <LinearLayout
+                        android:id="@+id/settings_full_screen_intent_wrapper"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="?android:attr/selectableItemBackground"
+                        android:orientation="vertical"
+                        android:padding="@dimen/standard_padding">
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/full_screen_intent_permission_title"
+                            android:textSize="@dimen/headline_text_size" />
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/full_screen_intent_permission_subtitle"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            tools:text="@string/full_screen_intent_permission_granted" />
+                    </LinearLayout>
+
                 </LinearLayout>
 
                 <LinearLayout

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -373,27 +373,6 @@
                             tools:text="@string/battery_optimization_ignored"/>
                     </LinearLayout>
 
-                    <LinearLayout
-                        android:id="@+id/settings_full_screen_intent_wrapper"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:background="?android:attr/selectableItemBackground"
-                        android:orientation="vertical"
-                        android:padding="@dimen/standard_padding">
-
-                        <com.google.android.material.textview.MaterialTextView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:text="@string/full_screen_intent_permission_title"
-                            android:textSize="@dimen/headline_text_size" />
-
-                        <com.google.android.material.textview.MaterialTextView
-                            android:id="@+id/full_screen_intent_permission_subtitle"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            tools:text="@string/full_screen_intent_permission_granted" />
-                    </LinearLayout>
-
                 </LinearLayout>
 
                 <LinearLayout
@@ -424,6 +403,27 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/nc_diagnosis_push_available_no"/>
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/settings_full_screen_intent_wrapper"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?android:attr/selectableItemBackground"
+                    android:orientation="vertical"
+                    android:padding="@dimen/standard_padding">
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/full_screen_intent_permission_title"
+                        android:textSize="@dimen/headline_text_size" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/full_screen_intent_permission_subtitle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        tools:text="@string/full_screen_intent_permission_granted" />
                 </LinearLayout>
 
                 <LinearLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,6 +123,9 @@ How to translate with transifex:
     <string name="battery_optimization_not_ignored">Battery optimization is enabled which might cause issues. You should disable battery optimization!</string>
     <string name="battery_optimization_ignored">Battery optimization is ignored, all fine</string>
     <string name="notification_permission">Notification permissions</string>
+    <string name="full_screen_intent_permission_title">Show incoming call screen</string>
+    <string name="full_screen_intent_permission_granted">Incoming call screen over lock screen is granted, all fine</string>
+    <string name="full_screen_intent_permission_not_granted">Incoming call screen over lock screen is not granted. Please grant this so incoming calls appear on the lock screen!</string>
 
 
     <string name="nc_settings_appearance">Appearance</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,7 +123,7 @@ How to translate with transifex:
     <string name="battery_optimization_not_ignored">Battery optimization is enabled which might cause issues. You should disable battery optimization!</string>
     <string name="battery_optimization_ignored">Battery optimization is ignored, all fine</string>
     <string name="notification_permission">Notification permissions</string>
-    <string name="full_screen_intent_permission_title">Show incoming call screen</string>
+    <string name="full_screen_intent_permission_title">Show incoming call over lock screen</string>
     <string name="full_screen_intent_permission_granted">Incoming call screen over lock screen is granted, all fine</string>
     <string name="full_screen_intent_permission_not_granted">Incoming call screen over lock screen is not granted. Please grant this so incoming calls appear on the lock screen!</string>
 


### PR DESCRIPTION
Add option for fullscreen permission in settings.

---

Necessary that the call notification screen is shown without to unlock the phone.

I encountered the following behavior:

- USE_FULL_SCREEN_INTENT is granted when running via debug in Android Studio.

- It is not granted when building the app and running the apk. So the unlock screen is shown instead when a call comes in.

- However google play console has a setting to allow USE_FULL_SCREEN_INTENT by default for this app, as it is a call app. Hopefully this will work in v23.0.1 and USE_FULL_SCREEN_INTENT is granted when installed via Google Play.


The setting is especially useful for users who don't install via gplay.



### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)