### PR TITLE
prevent scroll jump to newest message while loading older history

### DIFF
--- a/app/src/androidTest/java/com/nextcloud/talk/data/database/dao/ChatBlocksDaoTest.kt
+++ b/app/src/androidTest/java/com/nextcloud/talk/data/database/dao/ChatBlocksDaoTest.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -323,6 +324,96 @@ class ChatBlocksDaoTest {
             )
 
             assertEquals(2, resultsForThreadId123.first().size)
+        }
+
+    @Test
+    fun testReplaceConnectedChatBlocks() =
+        runTest {
+            val user = createUserEntity("account1", "Account 1")
+            usersDao.saveUser(user)
+            val account1 = usersDao.getUserWithUserId("account1").blockingGet()
+
+            conversationsDao.upsertConversations(
+                account1.id,
+                listOf(
+                    createConversationEntity(
+                        accountId = account1.id,
+                        token = "abc",
+                        roomName = "Conversation One"
+                    )
+                )
+            )
+
+            val conversation = conversationsDao.getConversationsForUser(account1.id).first()[0]
+
+            val blockA = ChatBlockEntity(
+                internalConversationId = conversation.internalId,
+                accountId = conversation.accountId,
+                token = conversation.token,
+                threadId = null,
+                oldestMessageId = 10,
+                newestMessageId = 20,
+                hasHistory = true
+            )
+            val blockB = ChatBlockEntity(
+                internalConversationId = conversation.internalId,
+                accountId = conversation.accountId,
+                token = conversation.token,
+                threadId = null,
+                oldestMessageId = 18,
+                newestMessageId = 30,
+                hasHistory = true
+            )
+            val blockC = ChatBlockEntity(
+                internalConversationId = conversation.internalId,
+                accountId = conversation.accountId,
+                token = conversation.token,
+                threadId = null,
+                oldestMessageId = 29,
+                newestMessageId = 35,
+                hasHistory = false
+            )
+
+            chatBlocksDao.upsertChatBlock(blockA)
+            chatBlocksDao.upsertChatBlock(blockB)
+            chatBlocksDao.upsertChatBlock(blockC)
+
+            val connectedBlocks =
+                chatBlocksDao.getConnectedChatBlocks(
+                    internalConversationId = conversation.internalId,
+                    threadId = null,
+                    oldestMessageId = 10,
+                    newestMessageId = 35
+                ).first()
+            assertEquals(3, connectedBlocks.size)
+
+            val mergedBlock = ChatBlockEntity(
+                internalConversationId = conversation.internalId,
+                accountId = conversation.accountId,
+                token = conversation.token,
+                threadId = null,
+                oldestMessageId = 10,
+                newestMessageId = 40,
+                hasHistory = false
+            )
+
+            chatBlocksDao.replaceConnectedChatBlocks(connectedBlocks, mergedBlock)
+
+            val persistedLatest = chatBlocksDao.getLatestChatBlock(conversation.internalId, null).first()
+            assertNotNull(persistedLatest)
+            assertEquals(mergedBlock.oldestMessageId, persistedLatest!!.oldestMessageId)
+            assertEquals(mergedBlock.newestMessageId, persistedLatest.newestMessageId)
+            assertEquals(mergedBlock.hasHistory, persistedLatest.hasHistory)
+
+            assertEquals(
+                1,
+                chatBlocksDao.getConnectedChatBlocks(
+                    internalConversationId = conversation.internalId,
+                    threadId = null,
+                    oldestMessageId = 10,
+                    newestMessageId = 40
+                ).first().size
+            )
         }
 
     private fun createUserEntity(userId: String, userName: String) =

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -2686,6 +2686,7 @@ class ChatActivity :
         }
     }
 
+    // this is triggered too often when scrolling. Must be made sure it's triggered only once.
     private fun loadMoreMessagesCompose() {
         chatViewModel.loadMoreMessagesCompose()
     }

--- a/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
@@ -534,7 +534,6 @@ class OfflineFirstChatRepository @Inject constructor(
             newestMessageId = newestMessageIdForNewChatBlock,
             hasHistory = hasHistory
         )
-        chatBlocksDao.upsertChatBlock(newChatBlock)
         updateBlocks(newChatBlock)
     }
 
@@ -667,6 +666,8 @@ class OfflineFirstChatRepository @Inject constructor(
     }
 
     private suspend fun updateBlocks(chatBlock: ChatBlockEntity) {
+        chatBlocksDao.upsertChatBlock(chatBlock)
+
         val connectedChatBlocks =
             chatBlocksDao.getConnectedChatBlocks(
                 internalConversationId = internalConversationId,

--- a/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
@@ -691,9 +691,6 @@ class OfflineFirstChatRepository @Inject constructor(
             val hasHistory = !hasNoHistory
             Log.d(TAG, "hasHistory = $hasHistory")
 
-            chatBlocksDao.deleteChatBlocks(connectedChatBlocks)
-            Log.d(TAG, "These chat blocks were deleted")
-
             val newChatBlock = ChatBlockEntity(
                 internalConversationId = internalConversationId,
                 accountId = conversationModel.accountId,
@@ -703,7 +700,7 @@ class OfflineFirstChatRepository @Inject constructor(
                 newestMessageId = newestIdFromDbChatBlocks,
                 hasHistory = hasHistory
             )
-            chatBlocksDao.upsertChatBlock(newChatBlock)
+            chatBlocksDao.replaceConnectedChatBlocks(connectedChatBlocks, newChatBlock)
             Log.d(TAG, "A new chat block was created that covers all the range of the found chatblocks")
             Log.d(TAG, "new chatBlock - oldest MessageId: $oldestIdFromDbChatBlocks")
             Log.d(TAG, "new chatBlock - newest MessageId: $newestIdFromDbChatBlocks")

--- a/app/src/main/java/com/nextcloud/talk/data/database/dao/ChatBlocksDao.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/database/dao/ChatBlocksDao.kt
@@ -12,6 +12,7 @@ import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import com.nextcloud.talk.data.database.model.ChatBlockEntity
 import kotlinx.coroutines.flow.Flow
 
@@ -72,6 +73,12 @@ interface ChatBlocksDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertChatBlock(chatBlock: ChatBlockEntity)
+
+    @Transaction
+    suspend fun replaceConnectedChatBlocks(connectedBlocks: List<ChatBlockEntity>, mergedBlock: ChatBlockEntity) {
+        deleteChatBlocks(connectedBlocks)
+        upsertChatBlock(mergedBlock)
+    }
 
     @Query(
         """

--- a/app/src/main/java/com/nextcloud/talk/data/database/dao/ChatBlocksDao.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/database/dao/ChatBlocksDao.kt
@@ -76,8 +76,29 @@ interface ChatBlocksDao {
 
     @Transaction
     suspend fun replaceConnectedChatBlocks(connectedBlocks: List<ChatBlockEntity>, mergedBlock: ChatBlockEntity) {
-        deleteChatBlocks(connectedBlocks)
-        upsertChatBlock(mergedBlock)
+        val newestConnectedBlock = connectedBlocks.maxByOrNull { it.newestMessageId }
+
+        if (newestConnectedBlock == null) {
+            upsertChatBlock(mergedBlock)
+            return
+        }
+
+        val updatedBlock = newestConnectedBlock.copy(
+            internalConversationId = mergedBlock.internalConversationId,
+            accountId = mergedBlock.accountId,
+            token = mergedBlock.token,
+            threadId = mergedBlock.threadId,
+            oldestMessageId = mergedBlock.oldestMessageId,
+            newestMessageId = mergedBlock.newestMessageId,
+            hasHistory = mergedBlock.hasHistory
+        )
+
+        upsertChatBlock(updatedBlock)
+
+        val blocksToDelete = connectedBlocks.filter { it.id != updatedBlock.id }
+        if (blocksToDelete.isNotEmpty()) {
+            deleteChatBlocks(blocksToDelete)
+        }
     }
 
     @Query(


### PR DESCRIPTION
fix #6022

When older messages were loaded, connected chat blocks were merged by deleting old blocks and inserting a new one in separate DAO operations. This created a state with no latest chat block, so the message observer emitted an empty list (only for a very short time) and the UI jumped to the newest message because it lost the anchor.

To fix this chat blocks are now replaced atomically in a single transaction. This removes the transient empty state and keeps the current scroll position stable.


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)