### PR TITLE
Revamp (floating) date header

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/chat/ChatView.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/chat/ChatView.kt
@@ -35,6 +35,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -352,21 +353,13 @@ fun ChatView(
         }
 
         // Sticky date header
-        Surface(
+        DateHeaderLabel(
+            text = stickyDateHeaderText,
             modifier = Modifier
                 .align(Alignment.TopCenter)
-                .padding(top = 12.dp)
-                .alpha(stickyDateHeaderAlpha),
-            shape = RoundedCornerShape(16.dp),
-            color = colorScheme.secondaryContainer,
-            tonalElevation = 2.dp
-        ) {
-            Text(
-                stickyDateHeaderText,
-                modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
-                color = colorScheme.onSecondaryContainer
-            )
-        }
+                .padding(top = 2.dp)
+                .alpha(stickyDateHeaderAlpha)
+        )
 
         // Unread messages popup
         if (showUnreadPopup.value) {
@@ -435,32 +428,26 @@ fun UnreadMessagesPopup(unreadCount: Int, onClick: () -> Unit, modifier: Modifie
 }
 
 @Composable
-fun DateHeader(date: LocalDate) {
-    val viewThemeUtils = LocalViewThemeUtils.current
-    val colorScheme = viewThemeUtils.getColorScheme(LocalContext.current)
+fun DateHeaderLabel(text: String, modifier: Modifier = Modifier) {
+    Text(
+        text = text,
+        modifier = modifier
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh, RoundedCornerShape(12.dp))
+            .padding(horizontal = 12.dp, vertical = 4.dp),
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurface
+    )
+}
 
+@Composable
+fun DateHeader(date: LocalDate) {
     val text = when (date) {
         LocalDate.now() -> stringResource(R.string.nc_date_header_today)
         LocalDate.now().minusDays(1) -> stringResource(R.string.nc_date_header_yesterday)
         else -> date.format(DateTimeFormatter.ofPattern("MMM dd, yyyy"))
     }
-
-    Box(
-        modifier = Modifier
-            .fillMaxWidth(),
-        contentAlignment = Alignment.Center
-    ) {
-        Text(
-            text = text,
-            modifier = Modifier
-                .background(
-                    colorScheme.secondaryContainer,
-                    RoundedCornerShape(12.dp)
-                )
-                .padding(horizontal = 12.dp, vertical = 6.dp),
-            fontSize = 12.sp,
-            color = colorScheme.onSecondaryContainer
-        )
+    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+        DateHeaderLabel(text = text)
     }
 }
 


### PR DESCRIPTION
- more like floating card but with less elevation
- bodyMedium styled text
- closer to the top bar

Overall closer to other messengers 

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)