### PR TITLE
fix(upload): fix attachment sharing failure due to chunked upload filecache bug

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/jobs/ShareOperationWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/ShareOperationWorker.kt
@@ -26,6 +26,7 @@ import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_INTERNAL_USER_ID
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_META_DATA
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_ROOM_TOKEN
 import io.reactivex.schedulers.Schedulers
+import retrofit2.HttpException
 import javax.inject.Inject
 
 @AutoInjector(NextcloudTalkApplication::class)
@@ -46,6 +47,16 @@ class ShareOperationWorker(context: Context, workerParams: WorkerParameters) : W
 
     override fun doWork(): Result {
         for (filePath in filesArray) {
+            tryCreateShare(filePath)
+        }
+        return Result.success()
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun tryCreateShare(filePath: String?) {
+        for (attempt in 1..SHARE_MAX_ATTEMPTS) {
+            var succeeded = false
+            var shouldRetry = false
             ncApi.createRemoteShare(
                 credentials,
                 ApiUtils.getSharingUrl(baseUrl!!),
@@ -56,11 +67,18 @@ class ShareOperationWorker(context: Context, workerParams: WorkerParameters) : W
             )
                 .subscribeOn(Schedulers.io())
                 .blockingSubscribe(
-                    {},
-                    { e -> Log.w(TAG, "error while creating RemoteShare", e) }
+                    { succeeded = true },
+                    { e ->
+                        if (e is HttpException && e.code() == HTTP_NOT_FOUND && attempt < SHARE_MAX_ATTEMPTS) {
+                            shouldRetry = true
+                        } else {
+                            Log.w(TAG, "error while creating RemoteShare", e)
+                        }
+                    }
                 )
+            if (succeeded || !shouldRetry) return
+            Thread.sleep(SHARE_RETRY_DELAY_MS)
         }
-        return Result.success()
     }
 
     init {
@@ -78,6 +96,9 @@ class ShareOperationWorker(context: Context, workerParams: WorkerParameters) : W
 
     companion object {
         private val TAG = ShareOperationWorker::class.simpleName
+        private const val HTTP_NOT_FOUND = 404
+        private const val SHARE_MAX_ATTEMPTS = 4
+        private const val SHARE_RETRY_DELAY_MS = 2000L
 
         fun shareFile(roomToken: String?, currentUser: User, remotePath: String, metaData: String?) {
             val paths: MutableList<String> = ArrayList()

--- a/app/src/main/java/com/nextcloud/talk/jobs/UploadAndShareFilesWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/UploadAndShareFilesWorker.kt
@@ -308,7 +308,7 @@ class UploadAndShareFilesWorker(val context: Context, workerParameters: WorkerPa
         private const val ROOM_TOKEN = "ROOM_TOKEN"
         private const val CONVERSATION_NAME = "CONVERSATION_NAME"
         private const val META_DATA = "META_DATA"
-        private const val CHUNK_UPLOAD_THRESHOLD_SIZE: Long = 1024000
+        private const val CHUNK_UPLOAD_THRESHOLD_SIZE: Long = 20 * 1024 * 1024
         private const val NOTIFICATION_FILE_NAME_MAX_LENGTH = 20
         private const val THREE_DOTS = "…"
         private const val HUNDRED_PERCENT = 100

--- a/app/src/main/java/com/nextcloud/talk/upload/chunked/ChunkedFileUploader.kt
+++ b/app/src/main/java/com/nextcloud/talk/upload/chunked/ChunkedFileUploader.kt
@@ -122,7 +122,7 @@ class ChunkedFileUploader(
         }
     }
 
-    @Suppress("Detekt.ComplexMethod")
+    @Suppress("Detekt.ComplexMethod", "Detekt.ReturnCount")
     private fun getUploadedChunks(davResource: DavResource, uploadFolderUri: String): MutableList<Chunk> {
         val davResponse = DavResponse()
         val memberElements: MutableList<at.bitfire.dav4jvm.Response> = ArrayList()
@@ -142,9 +142,14 @@ class ChunkedFileUploader(
                 Unit
             }
         } catch (e: IOException) {
-            throw IOException("Error reading remote path", e)
+            // PROPFIND on Nextcloud chunked-upload folders can return unexpected responses
+            // (e.g. 200 instead of 207). Treat any failure as "no chunks uploaded yet" so
+            // we fall back to a full upload rather than aborting entirely.
+            Log.w(TAG, "PROPFIND failed — assuming no chunks on server, will upload from scratch: ${e.message}")
+            return ArrayList()
         } catch (e: DavException) {
-            throw IOException("Error reading remote path", e)
+            Log.w(TAG, "PROPFIND failed — assuming no chunks on server, will upload from scratch: ${e.message}")
+            return ArrayList()
         }
         for (memberElement in memberElements) {
             remoteFiles.add(
@@ -271,21 +276,23 @@ class ChunkedFileUploader(
     }
 
     private fun initHttpClient(okHttpClient: OkHttpClient, currentUser: User) {
-        val okHttpClientBuilder: OkHttpClient.Builder = okHttpClient.newBuilder()
-        okHttpClientBuilder.followRedirects(false)
-        okHttpClientBuilder.followSslRedirects(false)
-        // okHttpClientBuilder.readTimeout(Duration.ofMinutes(30)) // TODO set timeout
-        okHttpClientBuilder.protocols(listOf(Protocol.HTTP_1_1))
-        okHttpClientBuilder.authenticator(
-            RestModule.HttpAuthenticator(
-                ApiUtils.getCredentials(
-                    currentUser.username,
-                    currentUser.token
-                )!!,
-                "Authorization"
+        val builder = OkHttpClient.Builder()
+            .followRedirects(false)
+            .followSslRedirects(false)
+            .protocols(listOf(Protocol.HTTP_1_1))
+            .sslSocketFactory(okHttpClient.sslSocketFactory, okHttpClient.x509TrustManager!!)
+            .hostnameVerifier(okHttpClient.hostnameVerifier)
+            .authenticator(
+                RestModule.HttpAuthenticator(
+                    ApiUtils.getCredentials(
+                        currentUser.username,
+                        currentUser.token
+                    )!!,
+                    "Authorization"
+                )
             )
-        )
-        this.okHttpClientNoRedirects = okHttpClientBuilder.build()
+        okHttpClient.proxy?.let { builder.proxy(it) }
+        this.okHttpClientNoRedirects = builder.build()
     }
 
     private fun assembleChunks(uploadFolderUri: String, targetPath: String) {
@@ -294,6 +301,7 @@ class ChunkedFileUploader(
             currentUser.userId!!,
             targetPath
         )
+        createRemoteFolder(targetPath)
         val originUri = "$uploadFolderUri/.file"
 
         DavResource(
@@ -304,15 +312,27 @@ class ChunkedFileUploader(
             true
         ) { response: Response ->
             if (response.isSuccessful) {
-                ShareOperationWorker.shareFile(
-                    roomToken,
-                    currentUser,
-                    targetPath,
-                    metaData
-                )
+                ShareOperationWorker.shareFile(roomToken, currentUser, targetPath, metaData)
             } else {
                 throw IOException("Failed to assemble chunks. response code: " + response.code)
             }
+        }
+    }
+
+    private fun createRemoteFolder(targetPath: String) {
+        val folderPath = targetPath.substringBeforeLast('/')
+        if (folderPath.isEmpty() || folderPath == "/") return
+        val folderUri = ApiUtils.getUrlForFileUpload(currentUser.baseUrl!!, currentUser.userId!!, folderPath)
+        try {
+            DavResource(okHttpClientNoRedirects!!, folderUri.toHttpUrlOrNull()!!).mkCol(
+                xmlBody = null
+            ) { _ -> }
+        } catch (e: HttpException) {
+            if (e.code != METHOD_NOT_ALLOWED_CODE) {
+                Log.w(TAG, "Unexpected error creating remote folder $folderPath: ${e.code}")
+            }
+        } catch (e: IOException) {
+            Log.w(TAG, "Failed to create remote folder $folderPath", e)
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/upload/normal/FileUploader.kt
+++ b/app/src/main/java/com/nextcloud/talk/upload/normal/FileUploader.kt
@@ -29,7 +29,6 @@ import okhttp3.RequestBody
 import okhttp3.Response
 import java.io.File
 import java.io.IOException
-import java.io.InputStream
 
 class FileUploader(
     okHttpClient: OkHttpClient,
@@ -116,37 +115,33 @@ class FileUploader(
             .flatMap { upload(sourceFileUri, fileName, remotePath, metaData) }
 
     @Suppress("Detekt.TooGenericExceptionCaught")
-    private fun createRequestBody(sourceFileUri: Uri): RequestBody? {
-        var requestBody: RequestBody? = null
+    private fun createRequestBody(sourceFileUri: Uri): RequestBody? =
         try {
-            val input: InputStream = context.contentResolver.openInputStream(sourceFileUri)!!
-            input.use {
-                val buf = ByteArray(input.available())
-                while (it.read(buf) != -1) {
-                    requestBody = RequestBody.create("application/octet-stream".toMediaTypeOrNull(), buf)
-                }
-            }
+            val bytes = context.contentResolver.openInputStream(sourceFileUri)!!.use { it.readBytes() }
+            RequestBody.create("application/octet-stream".toMediaTypeOrNull(), bytes)
         } catch (e: Exception) {
             Log.e(TAG, "failed to create RequestBody for $sourceFileUri", e)
+            null
         }
-        return requestBody
-    }
 
     private fun initHttpClient(okHttpClient: OkHttpClient, currentUser: User) {
-        val okHttpClientBuilder: OkHttpClient.Builder = okHttpClient.newBuilder()
-        okHttpClientBuilder.followRedirects(false)
-        okHttpClientBuilder.followSslRedirects(false)
-        okHttpClientBuilder.protocols(listOf(Protocol.HTTP_1_1))
-        okHttpClientBuilder.authenticator(
-            RestModule.HttpAuthenticator(
-                ApiUtils.getCredentials(
-                    currentUser.username,
-                    currentUser.token
-                )!!,
-                "Authorization"
+        val builder = OkHttpClient.Builder()
+            .followRedirects(false)
+            .followSslRedirects(false)
+            .protocols(listOf(Protocol.HTTP_1_1))
+            .sslSocketFactory(okHttpClient.sslSocketFactory, okHttpClient.x509TrustManager!!)
+            .hostnameVerifier(okHttpClient.hostnameVerifier)
+            .authenticator(
+                RestModule.HttpAuthenticator(
+                    ApiUtils.getCredentials(
+                        currentUser.username,
+                        currentUser.token
+                    )!!,
+                    "Authorization"
+                )
             )
-        )
-        this.okHttpClientNoRedirects = okHttpClientBuilder.build()
+        okHttpClient.proxy?.let { builder.proxy(it) }
+        this.okHttpClientNoRedirects = builder.build()
     }
 
     @Suppress("Detekt.ThrowsCount")


### PR DESCRIPTION
## Summary

Sending images/files in Talk chat silently fails — the upload completes but the file never appears in the conversation for either the sender or recipient. This affects all self-hosted Nextcloud servers and has been reported across multiple server versions.

## Steps to Reproduce

1. Open any Talk conversation
2. Tap the attachment button and select a photo (> 1 MB) from the gallery
3. Observe: no image appears in chat; no error is shown to the user

## Expected Behavior

The image is uploaded to Nextcloud files and shared into the conversation as a message attachment.

## Actual Behavior

The upload silently succeeds internally but the file never appears in chat for sender or recipient.

## Root Cause

Nextcloud's chunked upload assembly is broken on affected server versions. The final WebDAV `MOVE` (from `/remote.php/dav/uploads/<user>/<uuid>/.file` to `/remote.php/dav/files/<user>/Talk/<filename>`) returns HTTP **201 Created**, but the server silently fails to register the file in its `oc_filecache` database. A `HEAD` request immediately after the "successful" MOVE returns **404** — the file doesn't exist as far as Nextcloud's APIs are concerned.

When the app then calls the OCS sharing API to share the file into the Talk room, it gets:
```
HTTP 404 — "Wrong path, file/folder does not exist"
```

The bug only manifests via chunked upload. Direct `PUT` upload correctly updates the filecache.

Network trace confirming the issue:
```
MKCOL .../uploads/<user>/<uuid>                              → 201
PUT   .../uploads/<user>/<uuid>/0*                           → 201 (all chunks)
MOVE  .../uploads/.../.file → .../files/<user>/Talk/photo.jpg → 201 ← claims success
HEAD  .../files/<user>/Talk/photo.jpg                        → 404 ← not in filecache
POST  /ocs/v2.php/.../shares  path=/Talk/photo.jpg           → 404 "Wrong path"
```

## Fix

Raise `CHUNK_UPLOAD_THRESHOLD_SIZE` from 1 MB to 20 MB in `UploadAndShareFilesWorker`. Files under 20 MB (virtually all phone photos) now go through direct `PUT` upload, which correctly updates the filecache. Chunked upload is preserved for files over 20 MB.

Additional hardening:

- **`ChunkedFileUploader`**: Build a fresh `OkHttpClient` that does not inherit `OCS-APIRequest: true` / `Accept: application/json` from the app's singleton client. Those headers were causing sabre/dav to return JSON `200` instead of XML `207 Multi-Status` for `PROPFIND`, breaking dav4jvm. `PROPFIND` failures now fall back gracefully to re-uploading all chunks.
- **`FileUploader`**: Fix `createRequestBody()` to use `readBytes()` instead of `available()`, which returns 0 for `content://` URIs and caused the PUT body to be empty.
- **`ShareOperationWorker`**: Retry share creation up to 4 times with a 2 s delay on 404, as a safety net for large files still going through chunked upload.

## Affected Versions

Reproducible on self-hosted Nextcloud regardless of server version (confirmed on multiple servers). iOS and web Talk clients are not affected because they do not use chunked upload for typical-sized attachments.

### 🖼️ Screenshots

Not applicable — the fix is upload/share logic with no UI changes.

### 🏁 Checklist

- [x] ⛑️ Tests — not needed (bug is server-version-specific; requires a live Nextcloud server to reproduce)
- [x] 🔖 Capability — not needed (no capability gating required)
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful
