### PR TITLE
🔁  Add swipe actions to conversation list items

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -472,6 +472,21 @@ class ConversationsListActivity : BaseActivity() {
                 }
             }
         }
+
+        lifecycleScope.launch {
+            conversationsListViewModel.favoriteState.collect { state ->
+                when (state) {
+                    is ConversationsListViewModel.FavoriteUiState.Success -> {
+                        conversationsListViewModel.resetFavoriteState()
+                    }
+                    is ConversationsListViewModel.FavoriteUiState.Error -> {
+                        showSnackbar(resources.getString(R.string.nc_common_error_sorry))
+                        conversationsListViewModel.resetFavoriteState()
+                    }
+                    ConversationsListViewModel.FavoriteUiState.None -> { /* no-op */ }
+                }
+            }
+        }
     }
 
     private fun handleNoteToSelfShortcut(noteToSelfAvailable: Boolean, noteToSelfToken: String) {
@@ -1093,38 +1108,12 @@ class ConversationsListActivity : BaseActivity() {
         }
     }
 
-    @Suppress("Detekt.TooGenericExceptionCaught", "TooGenericExceptionCaught")
     private fun addConversationToFavorites(conversation: ConversationModel) {
-        val apiVersion = ApiUtils.getConversationApiVersion(currentUser!!, intArrayOf(ApiUtils.API_V4, ApiUtils.API_V1))
-        val url = ApiUtils.getUrlForRoomFavorite(apiVersion, currentUser?.baseUrl!!, conversation.token)
-        lifecycleScope.launch {
-            try {
-                withContext(Dispatchers.IO) { ncApiCoroutines.addConversationToFavorites(credentials!!, url) }
-                fetchRooms()
-                showSnackbar(
-                    String.format(resources.getString(R.string.added_to_favorites), conversation.displayName)
-                )
-            } catch (e: Exception) {
-                showSnackbar(resources.getString(R.string.nc_common_error_sorry))
-            }
-        }
+        conversationsListViewModel.addConversationToFavorites(conversation)
     }
 
-    @Suppress("Detekt.TooGenericExceptionCaught", "TooGenericExceptionCaught")
     private fun removeConversationFromFavorites(conversation: ConversationModel) {
-        val apiVersion = ApiUtils.getConversationApiVersion(currentUser!!, intArrayOf(ApiUtils.API_V4, ApiUtils.API_V1))
-        val url = ApiUtils.getUrlForRoomFavorite(apiVersion, currentUser?.baseUrl!!, conversation.token)
-        lifecycleScope.launch {
-            try {
-                withContext(Dispatchers.IO) { ncApiCoroutines.removeConversationFromFavorites(credentials!!, url) }
-                fetchRooms()
-                showSnackbar(
-                    String.format(resources.getString(R.string.removed_from_favorites), conversation.displayName)
-                )
-            } catch (e: Exception) {
-                showSnackbar(resources.getString(R.string.nc_common_error_sorry))
-            }
-        }
+        conversationsListViewModel.removeConversationFromFavorites(conversation)
     }
 
     private fun markConversationAsUnread(conversation: ConversationModel) {

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -462,9 +462,6 @@ class ConversationsListActivity : BaseActivity() {
             conversationsListViewModel.readUnreadState.collect { state ->
                 when (state) {
                     is ConversationsListViewModel.ConversationReadUnreadUiState.Success -> {
-                        fetchRooms()
-                        val resId = if (state.isMarkedRead) R.string.marked_as_read else R.string.marked_as_unread
-                        showSnackbar(String.format(resources.getString(resId), state.conversationDisplayName))
                         conversationsListViewModel.resetReadUnreadState()
                     }
                     is ConversationsListViewModel.ConversationReadUnreadUiState.Error -> {

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/data/OfflineConversationsRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/data/OfflineConversationsRepository.kt
@@ -44,6 +44,8 @@ interface OfflineConversationsRepository {
 
     suspend fun updateConversation(conversationModel: ConversationModel)
 
+    suspend fun updateConversationLocallyAndEmit(user: User, conversation: ConversationModel)
+
     @Deprecated("use observeConversation")
     suspend fun getLocallyStoredConversation(user: User, roomToken: String): ConversationModel?
 

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/data/network/OfflineFirstConversationsRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/data/network/OfflineFirstConversationsRepository.kt
@@ -127,6 +127,12 @@ class OfflineFirstConversationsRepository @Inject constructor(
         dao.updateConversation(entity)
     }
 
+    override suspend fun updateConversationLocallyAndEmit(user: User, conversation: ConversationModel) {
+        dao.updateConversation(conversation.asEntity())
+        val updatedList = getListOfConversations(user.id!!)
+        _roomListFlow.emit(updatedList)
+    }
+
     override suspend fun getLocallyStoredConversation(user: User, roomToken: String): ConversationModel? {
         val id = user.id!!
         return getConversation(id, roomToken)

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ui/ConversationList.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ui/ConversationList.kt
@@ -7,6 +7,7 @@
 package com.nextcloud.talk.conversationlist.ui
 
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -31,7 +32,6 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -225,18 +225,9 @@ fun ConversationList(
 /** Possible swipe states for conversation row actions. */
 private enum class SwipeValue { Settled, StartToEnd, EndToStart }
 
-/**
- * Wraps [content] with horizontal swipe actions:
- *  - Swipe right (StartToEnd): mark read / unread — easy trigger (~15 % of width).
- *    The StartToEnd anchor sits at 30 % of the component width; with a 50 % positional
- *    threshold the gesture fires after ~15 % of total width.
- *  - Swipe left (EndToStart): leave room — destructive, requires ≥ 50 % of width.
- *    The EndToStart anchor sits at full component width; with a 50 % positional threshold
- *    the gesture fires after exactly 50 % of total width.
- *
- * Haptic feedback matching swipe-to-reply fires the moment the threshold is crossed.
- * The item always springs back to [SwipeValue.Settled] after release.
- */
+private const val POP_SCALE_PEAK = 1.35f
+
+@Suppress("LongMethod")
 @Composable
 private fun SwipeableConversationItem(
     model: ConversationModel,
@@ -249,6 +240,10 @@ private fun SwipeableConversationItem(
     val coroutineScope = rememberCoroutineScope()
 
     val offsetX = remember { Animatable(0f) }
+    val popScale = remember { Animatable(1f) }
+    val popAnimationSpec = remember {
+        spring<Float>(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium)
+    }
     var itemWidth by remember { mutableIntStateOf(0) }
     var hapticFiredRight by remember { mutableStateOf(false) }
     var hapticFiredLeft by remember { mutableStateOf(false) }
@@ -260,6 +255,18 @@ private fun SwipeableConversationItem(
                 offsetX.value < -1f -> SwipeValue.EndToStart
                 else -> SwipeValue.Settled
             }
+        }
+    }
+    val startToEndProgress by remember {
+        derivedStateOf {
+            val threshold = itemWidth * 0.20f
+            if (threshold > 0f) (offsetX.value / threshold).coerceIn(0f, 1f) else 0f
+        }
+    }
+    val endToStartProgress by remember {
+        derivedStateOf {
+            val threshold = itemWidth * 0.40f
+            if (threshold > 0f) (-offsetX.value / threshold).coerceIn(0f, 1f) else 0f
         }
     }
 
@@ -287,6 +294,7 @@ private fun SwipeableConversationItem(
                     if (dragStart != null && horizontalStarted) {
                         hapticFiredRight = false
                         hapticFiredLeft = false
+                        coroutineScope.launch { popScale.snapTo(1f) }
                         horizontalDrag(dragStart.id) { change ->
                             val delta = change.position.x - change.previousPosition.x
                             val newOffset = (offsetX.value + delta).coerceIn(endToStartLimit, startToEndLimit)
@@ -294,10 +302,18 @@ private fun SwipeableConversationItem(
                             if (!hapticFiredRight && startToEndThreshold > 0 && newOffset >= startToEndThreshold) {
                                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                                 hapticFiredRight = true
+                                coroutineScope.launch {
+                                    popScale.snapTo(POP_SCALE_PEAK)
+                                    popScale.animateTo(1f, popAnimationSpec)
+                                }
                             }
                             if (!hapticFiredLeft && endToStartThreshold < 0 && newOffset <= endToStartThreshold) {
                                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                                 hapticFiredLeft = true
+                                coroutineScope.launch {
+                                    popScale.snapTo(POP_SCALE_PEAK)
+                                    popScale.animateTo(1f, popAnimationSpec)
+                                }
                             }
                             change.consume()
                         }
@@ -317,7 +333,13 @@ private fun SwipeableConversationItem(
                 }
             }
     ) {
-        SwipeBackground(modifier = Modifier.matchParentSize(), swipeDirection = swipeDirection, model = currentModel)
+        SwipeBackground(
+            modifier = Modifier.matchParentSize(),
+            swipeDirection = swipeDirection,
+            model = currentModel,
+            progress = if (swipeDirection == SwipeValue.StartToEnd) startToEndProgress else endToStartProgress,
+            popScale = popScale.value
+        )
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -330,31 +352,37 @@ private fun SwipeableConversationItem(
 }
 
 @Composable
-private fun SwipeBackground(modifier: Modifier = Modifier, swipeDirection: SwipeValue, model: ConversationModel) {
-    val markAsReadLabel = stringResource(R.string.nc_mark_as_read)
-    val markAsUnreadLabel = stringResource(R.string.nc_mark_as_unread)
-    val leaveLabel = stringResource(R.string.nc_leave)
-
+private fun SwipeBackground(
+    modifier: Modifier = Modifier,
+    swipeDirection: SwipeValue,
+    model: ConversationModel,
+    progress: Float,
+    popScale: Float
+) {
     when (swipeDirection) {
         SwipeValue.StartToEnd -> {
-            val iconRes = if (model.unreadMessages > 0) {
-                R.drawable.ic_mark_chat_read_24px
-            } else {
-                R.drawable.ic_mark_chat_unread_24px
-            }
-            val label = if (model.unreadMessages > 0) markAsReadLabel else markAsUnreadLabel
+            val iconColor = MaterialTheme.colorScheme.onPrimaryContainer
             Box(
                 modifier = modifier
                     .background(MaterialTheme.colorScheme.primaryContainer)
                     .padding(horizontal = 24.dp),
                 contentAlignment = Alignment.CenterStart
             ) {
-                Icon(
-                    painter = painterResource(iconRes),
-                    contentDescription = label,
-                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                    modifier = Modifier.size(24.dp)
-                )
+                if (model.unreadMessages > 0) {
+                    ReadIcon(
+                        progress = progress,
+                        popScale = popScale,
+                        color = iconColor,
+                        modifier = Modifier.size(24.dp)
+                    )
+                } else {
+                    UnreadIcon(
+                        progress = progress,
+                        popScale = popScale,
+                        color = iconColor,
+                        modifier = Modifier.size(24.dp)
+                    )
+                }
             }
         }
         SwipeValue.EndToStart -> {
@@ -364,10 +392,10 @@ private fun SwipeBackground(modifier: Modifier = Modifier, swipeDirection: Swipe
                     .padding(horizontal = 24.dp),
                 contentAlignment = Alignment.CenterEnd
             ) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_exit_to_app_black_24dp),
-                    contentDescription = leaveLabel,
-                    tint = MaterialTheme.colorScheme.onError,
+                LeaveIcon(
+                    progress = progress,
+                    popScale = popScale,
+                    color = MaterialTheme.colorScheme.onError,
                     modifier = Modifier.size(24.dp)
                 )
             }

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ui/ConversationList.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ui/ConversationList.kt
@@ -7,6 +7,7 @@
 package com.nextcloud.talk.conversationlist.ui
 
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
@@ -40,19 +41,23 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.AwaitPointerEventScope
+import androidx.compose.ui.input.pointer.PointerId
+import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
@@ -109,7 +114,8 @@ fun ConversationList(
     listState: LazyListState = rememberLazyListState(),
     /** Extra bottom padding added as LazyColumn contentPadding so the last item is reachable above the nav bar. */
     contentBottomPadding: Dp = 0.dp,
-    onSwipeConversation: (ConversationOpsAction, ConversationModel) -> Unit = { _, _ -> }
+    onSwipeConversation: (ConversationOpsAction, ConversationModel) -> Unit = { _, _ -> },
+    isOnline: Boolean = true
 ) {
     var prevIndex by remember { mutableIntStateOf(listState.firstVisibleItemIndex) }
     var prevOffset by remember { mutableIntStateOf(listState.firstVisibleItemScrollOffset) }
@@ -165,14 +171,18 @@ fun ConversationList(
                     when (entry) {
                         is ConversationListEntry.Header ->
                             "header_${entry.title}"
+
                         is ConversationListEntry.ConversationEntry ->
                             "conv_${entry.model.token}"
+
                         is ConversationListEntry.MessageResultEntry ->
                             "msg_${entry.result.conversationToken}_" +
                                 "${entry.result.messageId ?: entry.result.messageExcerpt.take(MSG_KEY_EXCERPT_LENGTH)}"
+
                         is ConversationListEntry.ContactEntry ->
                             // Contacts can legitimately appear multiple times in search results.
                             "contact_${entry.participant.actorId}_${entry.participant.actorType}_$index"
+
                         ConversationListEntry.LoadMore ->
                             "load_more"
                     }
@@ -185,7 +195,8 @@ fun ConversationList(
                     is ConversationListEntry.ConversationEntry ->
                         SwipeableConversationItem(
                             model = entry.model,
-                            onSwipe = { action -> onSwipeConversation(action, entry.model) }
+                            onSwipe = { action -> onSwipeConversation(action, entry.model) },
+                            enabled = isOnline
                         ) {
                             ConversationListItem(
                                 model = entry.model,
@@ -233,26 +244,41 @@ private const val NON_DESTRUCTIVE_SWIPE_THRESHOLD = 0.20f
 
 private const val NON_DESTRUCTIVE_SWIPE_END_LIMIT = 0.3f
 
-@Suppress("LongMethod")
+private val swipePopAnimationSpec = spring<Float>(
+    dampingRatio = Spring.DampingRatioMediumBouncy,
+    stiffness = Spring.StiffnessMedium
+)
+
+private class SwipeParams(
+    val coroutineScope: CoroutineScope,
+    val haptic: HapticFeedback,
+    val offsetX: Animatable<Float, AnimationVector1D>,
+    val popScale: Animatable<Float, AnimationVector1D>,
+    val getModel: () -> ConversationModel,
+    val onSwipe: (ConversationOpsAction) -> Unit
+)
+
+private data class SwipeThresholds(
+    val startToEndThreshold: Float,
+    val startToEndLimit: Float,
+    val endToStartThreshold: Float,
+    val endToStartLimit: Float
+)
+
 @Composable
 private fun SwipeableConversationItem(
     model: ConversationModel,
     onSwipe: (ConversationOpsAction) -> Unit,
+    enabled: Boolean = true,
     content: @Composable () -> Unit
 ) {
     val currentModel by rememberUpdatedState(model)
     val currentOnSwipe by rememberUpdatedState(onSwipe)
     val haptic = LocalHapticFeedback.current
     val coroutineScope = rememberCoroutineScope()
-
     val offsetX = remember { Animatable(0f) }
     val popScale = remember { Animatable(1f) }
-    val popAnimationSpec = remember {
-        spring<Float>(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium)
-    }
     var itemWidth by remember { mutableIntStateOf(0) }
-    var hapticFiredRight by remember { mutableStateOf(false) }
-    var hapticFiredLeft by remember { mutableStateOf(false) }
 
     val swipeDirection by remember {
         derivedStateOf {
@@ -276,67 +302,14 @@ private fun SwipeableConversationItem(
         }
     }
 
+    val swipeParams = SwipeParams(coroutineScope, haptic, offsetX, popScale, { currentModel }, { currentOnSwipe(it) })
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .onSizeChanged { size -> itemWidth = size.width }
-            .pointerInput(Unit) {
-                awaitEachGesture {
-                    val startToEndThreshold = itemWidth * NON_DESTRUCTIVE_SWIPE_THRESHOLD
-                    val startToEndLimit = itemWidth * NON_DESTRUCTIVE_SWIPE_END_LIMIT
-                    val endToStartThreshold = -itemWidth * DESTRUCTIVE_SWIPE_THRESHOLD
-                    val endToStartLimit = -itemWidth.toFloat()
-
-                    val down = awaitFirstDown(requireUnconsumed = false)
-                    var horizontalStarted = false
-                    val dragStart = awaitHorizontalTouchSlopOrCancellation(down.id) { change, _ ->
-                        val dx = abs(change.position.x - change.previousPosition.x)
-                        val dy = abs(change.position.y - change.previousPosition.y)
-                        if (dx > dy) {
-                            change.consume()
-                            horizontalStarted = true
-                        }
-                    }
-                    if (dragStart != null && horizontalStarted) {
-                        hapticFiredRight = false
-                        hapticFiredLeft = false
-                        coroutineScope.launch { popScale.snapTo(1f) }
-                        horizontalDrag(dragStart.id) { change ->
-                            val delta = change.position.x - change.previousPosition.x
-                            val newOffset = (offsetX.value + delta).coerceIn(endToStartLimit, startToEndLimit)
-                            coroutineScope.launch { offsetX.snapTo(newOffset) }
-                            if (!hapticFiredRight && startToEndThreshold > 0 && newOffset >= startToEndThreshold) {
-                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                hapticFiredRight = true
-                                coroutineScope.launch {
-                                    popScale.snapTo(POP_SCALE_PEAK)
-                                    popScale.animateTo(1f, popAnimationSpec)
-                                }
-                            }
-                            if (!hapticFiredLeft && endToStartThreshold < 0 && newOffset <= endToStartThreshold) {
-                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                hapticFiredLeft = true
-                                coroutineScope.launch {
-                                    popScale.snapTo(POP_SCALE_PEAK)
-                                    popScale.animateTo(1f, popAnimationSpec)
-                                }
-                            }
-                            change.consume()
-                        }
-                        val finalOffset = offsetX.value
-                        if (hapticFiredRight && finalOffset >= startToEndThreshold) {
-                            val action = if (currentModel.unreadMessages > 0) {
-                                ConversationOpsAction.MarkAsRead
-                            } else {
-                                ConversationOpsAction.MarkAsUnread
-                            }
-                            currentOnSwipe(action)
-                        } else if (hapticFiredLeft && finalOffset <= endToStartThreshold) {
-                            currentOnSwipe(ConversationOpsAction.Leave)
-                        }
-                        coroutineScope.launch { offsetX.animateTo(0f, spring()) }
-                    }
-                }
+            .pointerInput(enabled) {
+                if (!enabled) return@pointerInput
+                awaitSwipeGesture({ itemWidth }, swipeParams)
             }
     ) {
         SwipeBackground(
@@ -356,6 +329,73 @@ private fun SwipeableConversationItem(
         }
     }
 }
+
+private suspend fun PointerInputScope.awaitSwipeGesture(getItemWidth: () -> Int, params: SwipeParams) {
+    awaitEachGesture {
+        val width = getItemWidth()
+        val thresholds = SwipeThresholds(
+            startToEndThreshold = width * NON_DESTRUCTIVE_SWIPE_THRESHOLD,
+            startToEndLimit = width * NON_DESTRUCTIVE_SWIPE_END_LIMIT,
+            endToStartThreshold = -width * DESTRUCTIVE_SWIPE_THRESHOLD,
+            endToStartLimit = -width.toFloat()
+        )
+        val down = awaitFirstDown(requireUnconsumed = false)
+        var horizontalStarted = false
+        val dragStart = awaitHorizontalTouchSlopOrCancellation(down.id) { change, _ ->
+            val dx = abs(change.position.x - change.previousPosition.x)
+            val dy = abs(change.position.y - change.previousPosition.y)
+            if (dx > dy) {
+                change.consume()
+                horizontalStarted = true
+            }
+        }
+        if (dragStart == null || !horizontalStarted) return@awaitEachGesture
+        handleConfirmedSwipeDrag(dragStart.id, params, thresholds)
+    }
+}
+
+private suspend fun AwaitPointerEventScope.handleConfirmedSwipeDrag(
+    dragId: PointerId,
+    params: SwipeParams,
+    thresholds: SwipeThresholds
+) {
+    var hapticFiredRight = false
+    var hapticFiredLeft = false
+    params.coroutineScope.launch { params.popScale.snapTo(1f) }
+    horizontalDrag(dragId) { change ->
+        val delta = change.position.x - change.previousPosition.x
+        val newOffset = (params.offsetX.value + delta).coerceIn(thresholds.endToStartLimit, thresholds.startToEndLimit)
+        params.coroutineScope.launch { params.offsetX.snapTo(newOffset) }
+        if (!hapticFiredRight && thresholds.startToEndThreshold > 0 && newOffset >= thresholds.startToEndThreshold) {
+            params.haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+            hapticFiredRight = true
+            params.coroutineScope.launch {
+                params.popScale.snapTo(POP_SCALE_PEAK)
+                params.popScale.animateTo(1f, swipePopAnimationSpec)
+            }
+        }
+        if (!hapticFiredLeft && thresholds.endToStartThreshold < 0 && newOffset <= thresholds.endToStartThreshold) {
+            params.haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+            hapticFiredLeft = true
+            params.coroutineScope.launch {
+                params.popScale.snapTo(POP_SCALE_PEAK)
+                params.popScale.animateTo(1f, swipePopAnimationSpec)
+            }
+        }
+        change.consume()
+    }
+    val finalOffset = params.offsetX.value
+    when {
+        hapticFiredRight && finalOffset >= thresholds.startToEndThreshold ->
+            params.onSwipe(resolveReadUnreadAction(params.getModel()))
+        hapticFiredLeft && finalOffset <= thresholds.endToStartThreshold ->
+            params.onSwipe(ConversationOpsAction.Leave)
+    }
+    params.coroutineScope.launch { params.offsetX.animateTo(0f, spring()) }
+}
+
+private fun resolveReadUnreadAction(model: ConversationModel): ConversationOpsAction =
+    if (model.unreadMessages > 0) ConversationOpsAction.MarkAsRead else ConversationOpsAction.MarkAsUnread
 
 @Composable
 private fun SwipeBackground(
@@ -391,6 +431,7 @@ private fun SwipeBackground(
                 }
             }
         }
+
         SwipeValue.EndToStart -> {
             Box(
                 modifier = modifier
@@ -406,6 +447,7 @@ private fun SwipeBackground(
                 )
             }
         }
+
         SwipeValue.Settled -> {}
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ui/ConversationList.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ui/ConversationList.kt
@@ -227,6 +227,12 @@ private enum class SwipeValue { Settled, StartToEnd, EndToStart }
 
 private const val POP_SCALE_PEAK = 1.35f
 
+private const val DESTRUCTIVE_SWIPE_THRESHOLD = 0.40f
+
+private const val NON_DESTRUCTIVE_SWIPE_THRESHOLD = 0.20f
+
+private const val NON_DESTRUCTIVE_SWIPE_END_LIMIT = 0.3f
+
 @Suppress("LongMethod")
 @Composable
 private fun SwipeableConversationItem(
@@ -259,13 +265,13 @@ private fun SwipeableConversationItem(
     }
     val startToEndProgress by remember {
         derivedStateOf {
-            val threshold = itemWidth * 0.20f
+            val threshold = itemWidth * NON_DESTRUCTIVE_SWIPE_THRESHOLD
             if (threshold > 0f) (offsetX.value / threshold).coerceIn(0f, 1f) else 0f
         }
     }
     val endToStartProgress by remember {
         derivedStateOf {
-            val threshold = itemWidth * 0.40f
+            val threshold = itemWidth * DESTRUCTIVE_SWIPE_THRESHOLD
             if (threshold > 0f) (-offsetX.value / threshold).coerceIn(0f, 1f) else 0f
         }
     }
@@ -276,9 +282,9 @@ private fun SwipeableConversationItem(
             .onSizeChanged { size -> itemWidth = size.width }
             .pointerInput(Unit) {
                 awaitEachGesture {
-                    val startToEndThreshold = itemWidth * 0.20f
-                    val startToEndLimit = itemWidth * 0.3f
-                    val endToStartThreshold = -itemWidth * 0.40f
+                    val startToEndThreshold = itemWidth * NON_DESTRUCTIVE_SWIPE_THRESHOLD
+                    val startToEndLimit = itemWidth * NON_DESTRUCTIVE_SWIPE_END_LIMIT
+                    val endToStartThreshold = -itemWidth * DESTRUCTIVE_SWIPE_THRESHOLD
                     val endToStartLimit = -itemWidth.toFloat()
 
                     val down = awaitFirstDown(requireUnconsumed = false)

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ui/ConversationList.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ui/ConversationList.kt
@@ -6,7 +6,14 @@
  */
 package com.nextcloud.talk.conversationlist.ui
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitHorizontalTouchSlopOrCancellation
+import androidx.compose.foundation.gestures.horizontalDrag
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -14,6 +21,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -23,22 +31,32 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -49,6 +67,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
@@ -59,6 +78,8 @@ import com.nextcloud.talk.models.domain.ConversationModel
 import com.nextcloud.talk.models.domain.SearchMessageEntry
 import com.nextcloud.talk.models.json.participants.Participant
 import com.nextcloud.talk.utils.ApiUtils
+import kotlin.math.abs
+import kotlin.math.roundToInt
 
 private const val MSG_KEY_EXCERPT_LENGTH = 20
 
@@ -87,7 +108,8 @@ fun ConversationList(
     onScrollStopped: (lastVisibleIndex: Int) -> Unit = {},
     listState: LazyListState = rememberLazyListState(),
     /** Extra bottom padding added as LazyColumn contentPadding so the last item is reachable above the nav bar. */
-    contentBottomPadding: Dp = 0.dp
+    contentBottomPadding: Dp = 0.dp,
+    onSwipeConversation: (ConversationOpsAction, ConversationModel) -> Unit = { _, _ -> }
 ) {
     var prevIndex by remember { mutableIntStateOf(listState.firstVisibleItemIndex) }
     var prevOffset by remember { mutableIntStateOf(listState.firstVisibleItemScrollOffset) }
@@ -161,15 +183,20 @@ fun ConversationList(
                         ConversationSectionHeader(title = entry.title)
 
                     is ConversationListEntry.ConversationEntry ->
-                        ConversationListItem(
+                        SwipeableConversationItem(
                             model = entry.model,
-                            currentUser = currentUser,
-                            callbacks = ConversationListItemCallbacks(
-                                onClick = { onConversationClick(entry.model) },
-                                onLongClick = { onConversationLongClick(entry.model) }
-                            ),
-                            searchQuery = searchQuery
-                        )
+                            onSwipe = { action -> onSwipeConversation(action, entry.model) }
+                        ) {
+                            ConversationListItem(
+                                model = entry.model,
+                                currentUser = currentUser,
+                                callbacks = ConversationListItemCallbacks(
+                                    onClick = { onConversationClick(entry.model) },
+                                    onLongClick = { onConversationLongClick(entry.model) }
+                                ),
+                                searchQuery = searchQuery
+                            )
+                        }
 
                     is ConversationListEntry.MessageResultEntry ->
                         MessageResultListItem(
@@ -192,6 +219,160 @@ fun ConversationList(
                 }
             }
         }
+    }
+}
+
+/** Possible swipe states for conversation row actions. */
+private enum class SwipeValue { Settled, StartToEnd, EndToStart }
+
+/**
+ * Wraps [content] with horizontal swipe actions:
+ *  - Swipe right (StartToEnd): mark read / unread — easy trigger (~15 % of width).
+ *    The StartToEnd anchor sits at 30 % of the component width; with a 50 % positional
+ *    threshold the gesture fires after ~15 % of total width.
+ *  - Swipe left (EndToStart): leave room — destructive, requires ≥ 50 % of width.
+ *    The EndToStart anchor sits at full component width; with a 50 % positional threshold
+ *    the gesture fires after exactly 50 % of total width.
+ *
+ * Haptic feedback matching swipe-to-reply fires the moment the threshold is crossed.
+ * The item always springs back to [SwipeValue.Settled] after release.
+ */
+@Composable
+private fun SwipeableConversationItem(
+    model: ConversationModel,
+    onSwipe: (ConversationOpsAction) -> Unit,
+    content: @Composable () -> Unit
+) {
+    val currentModel by rememberUpdatedState(model)
+    val currentOnSwipe by rememberUpdatedState(onSwipe)
+    val haptic = LocalHapticFeedback.current
+    val coroutineScope = rememberCoroutineScope()
+
+    val offsetX = remember { Animatable(0f) }
+    var itemWidth by remember { mutableIntStateOf(0) }
+    var hapticFiredRight by remember { mutableStateOf(false) }
+    var hapticFiredLeft by remember { mutableStateOf(false) }
+
+    val swipeDirection by remember {
+        derivedStateOf {
+            when {
+                offsetX.value > 1f -> SwipeValue.StartToEnd
+                offsetX.value < -1f -> SwipeValue.EndToStart
+                else -> SwipeValue.Settled
+            }
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .onSizeChanged { size -> itemWidth = size.width }
+            .pointerInput(Unit) {
+                awaitEachGesture {
+                    val startToEndThreshold = itemWidth * 0.20f
+                    val startToEndLimit = itemWidth * 0.3f
+                    val endToStartThreshold = -itemWidth * 0.40f
+                    val endToStartLimit = -itemWidth.toFloat()
+
+                    val down = awaitFirstDown(requireUnconsumed = false)
+                    var horizontalStarted = false
+                    val dragStart = awaitHorizontalTouchSlopOrCancellation(down.id) { change, _ ->
+                        val dx = abs(change.position.x - change.previousPosition.x)
+                        val dy = abs(change.position.y - change.previousPosition.y)
+                        if (dx > dy) {
+                            change.consume()
+                            horizontalStarted = true
+                        }
+                    }
+                    if (dragStart != null && horizontalStarted) {
+                        hapticFiredRight = false
+                        hapticFiredLeft = false
+                        horizontalDrag(dragStart.id) { change ->
+                            val delta = change.position.x - change.previousPosition.x
+                            val newOffset = (offsetX.value + delta).coerceIn(endToStartLimit, startToEndLimit)
+                            coroutineScope.launch { offsetX.snapTo(newOffset) }
+                            if (!hapticFiredRight && startToEndThreshold > 0 && newOffset >= startToEndThreshold) {
+                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                hapticFiredRight = true
+                            }
+                            if (!hapticFiredLeft && endToStartThreshold < 0 && newOffset <= endToStartThreshold) {
+                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                hapticFiredLeft = true
+                            }
+                            change.consume()
+                        }
+                        val finalOffset = offsetX.value
+                        if (hapticFiredRight && finalOffset >= startToEndThreshold) {
+                            val action = if (currentModel.unreadMessages > 0) {
+                                ConversationOpsAction.MarkAsRead
+                            } else {
+                                ConversationOpsAction.MarkAsUnread
+                            }
+                            currentOnSwipe(action)
+                        } else if (hapticFiredLeft && finalOffset <= endToStartThreshold) {
+                            currentOnSwipe(ConversationOpsAction.Leave)
+                        }
+                        coroutineScope.launch { offsetX.animateTo(0f, spring()) }
+                    }
+                }
+            }
+    ) {
+        SwipeBackground(modifier = Modifier.matchParentSize(), swipeDirection = swipeDirection, model = currentModel)
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .offset { IntOffset(offsetX.value.roundToInt(), 0) }
+                .background(MaterialTheme.colorScheme.surface)
+        ) {
+            content()
+        }
+    }
+}
+
+@Composable
+private fun SwipeBackground(modifier: Modifier = Modifier, swipeDirection: SwipeValue, model: ConversationModel) {
+    val markAsReadLabel = stringResource(R.string.nc_mark_as_read)
+    val markAsUnreadLabel = stringResource(R.string.nc_mark_as_unread)
+    val leaveLabel = stringResource(R.string.nc_leave)
+
+    when (swipeDirection) {
+        SwipeValue.StartToEnd -> {
+            val iconRes = if (model.unreadMessages > 0) {
+                R.drawable.ic_mark_chat_read_24px
+            } else {
+                R.drawable.ic_mark_chat_unread_24px
+            }
+            val label = if (model.unreadMessages > 0) markAsReadLabel else markAsUnreadLabel
+            Box(
+                modifier = modifier
+                    .background(MaterialTheme.colorScheme.primaryContainer)
+                    .padding(horizontal = 24.dp),
+                contentAlignment = Alignment.CenterStart
+            ) {
+                Icon(
+                    painter = painterResource(iconRes),
+                    contentDescription = label,
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                    modifier = Modifier.size(24.dp)
+                )
+            }
+        }
+        SwipeValue.EndToStart -> {
+            Box(
+                modifier = modifier
+                    .background(MaterialTheme.colorScheme.error)
+                    .padding(horizontal = 24.dp),
+                contentAlignment = Alignment.CenterEnd
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_exit_to_app_black_24dp),
+                    contentDescription = leaveLabel,
+                    tint = MaterialTheme.colorScheme.onError,
+                    modifier = Modifier.size(24.dp)
+                )
+            }
+        }
+        SwipeValue.Settled -> {}
     }
 }
 

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ui/ConversationsListScreen.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ui/ConversationsListScreen.kt
@@ -309,7 +309,8 @@ fun ConversationsListScreen(
                                     onScrollChanged = callbacks.onScrollChanged,
                                     onScrollStopped = callbacks.onScrollStopped,
                                     listState = lazyListState,
-                                    contentBottomPadding = paddingValues.calculateBottomPadding()
+                                    contentBottomPadding = paddingValues.calculateBottomPadding(),
+                                    onSwipeConversation = callbacks.onConversationOpsAction
                                 )
                         }
                         // Empty-state overlay (centered; handles its own visibility)

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ui/ConversationsListScreen.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ui/ConversationsListScreen.kt
@@ -310,7 +310,8 @@ fun ConversationsListScreen(
                                     onScrollStopped = callbacks.onScrollStopped,
                                     listState = lazyListState,
                                     contentBottomPadding = paddingValues.calculateBottomPadding(),
-                                    onSwipeConversation = callbacks.onConversationOpsAction
+                                    onSwipeConversation = callbacks.onConversationOpsAction,
+                                    isOnline = isOnline
                                 )
                         }
                         // Empty-state overlay (centered; handles its own visibility)

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ui/LeaveIcon.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ui/LeaveIcon.kt
@@ -1,0 +1,46 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.nextcloud.talk.conversationlist.ui
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.withTransform
+import androidx.compose.ui.graphics.vector.PathParser
+import androidx.compose.ui.util.lerp
+
+private const val LEAVE_VIEWPORT = 24f
+private const val LEAVE_ARROW_MAX_DX = 2f
+
+@Composable
+internal fun LeaveIcon(progress: Float, popScale: Float, color: Color, modifier: Modifier = Modifier) {
+    val doorPath = remember {
+        PathParser().parsePathString(
+            "M19,3H5c-1.11,0 -2,0.9 -2,2v4h2V5h14v14H5v-4H3v4c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2V5c0,-1.1 -0.9,-2 -2,-2z"
+        ).toPath()
+    }
+    val arrowPath = remember {
+        PathParser().parsePathString(
+            "M10.09,15.59L11.5,17l5,-5 -5,-5 -1.41,1.41L12.67,11H3v2h9.67l-2.58,2.59z"
+        ).toPath()
+    }
+    Canvas(modifier = modifier) {
+        val s = size.width / LEAVE_VIEWPORT
+        withTransform({ scale(s, s, Offset.Zero) }) {
+            withTransform({ scale(popScale, popScale, Offset(LEAVE_VIEWPORT / 2f, LEAVE_VIEWPORT / 2f)) }) {
+                drawPath(doorPath, color)
+                withTransform({ translate(left = lerp(0f, LEAVE_ARROW_MAX_DX, progress)) }) {
+                    drawPath(arrowPath, color)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ui/LeaveIcon.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ui/LeaveIcon.kt
@@ -24,7 +24,8 @@ private const val LEAVE_ARROW_MAX_DX = 2f
 internal fun LeaveIcon(progress: Float, popScale: Float, color: Color, modifier: Modifier = Modifier) {
     val doorPath = remember {
         PathParser().parsePathString(
-            "M19,3H5c-1.11,0 -2,0.9 -2,2v4h2V5h14v14H5v-4H3v4c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2V5c0,-1.1 -0.9,-2 -2,-2z"
+            "M19,3H5c-1.11,0 -2,0.9 -2,2v4h2V5h14v14H5v-4H3v4c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2V5c0," +
+                "-1.1 -0.9,-2 -2,-2z"
         ).toPath()
     }
     val arrowPath = remember {

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ui/ReadIcon.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ui/ReadIcon.kt
@@ -1,0 +1,55 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.nextcloud.talk.conversationlist.ui
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.graphics.drawscope.withTransform
+import androidx.compose.ui.graphics.vector.PathParser
+import androidx.compose.ui.util.lerp
+
+private const val ICON_VIEWPORT = 960f
+private const val CHECKMARK_X_MIN = 553f
+private const val CHECKMARK_X_MAX = 920f
+private const val CHECKMARK_CENTROID_X = 722f
+private const val CHECKMARK_CENTROID_Y = 640f
+
+@Composable
+internal fun ReadIcon(progress: Float, popScale: Float, color: Color, modifier: Modifier = Modifier) {
+    val bubblePath = remember {
+        PathParser().parsePathString(
+            "M80,880L80,160Q80,127 103.5,103.5Q127,80 160,80L800,80Q833,80 856.5,103.5Q880,127 880,160" +
+                "L880,440L800,440L800,160Q800,160 800,160Q800,160 800,160" +
+                "L160,160Q160,160 160,160Q160,160 160,160L160,685L206,640L480,640L480,720L240,720L80,880Z"
+        ).toPath()
+    }
+    val checkmarkPath = remember {
+        PathParser().parsePathString("M694,800L553,658L609,602L694,687L864,517L920,574L694,800Z").toPath()
+    }
+    Canvas(modifier = modifier) {
+        val s = size.width / ICON_VIEWPORT
+        withTransform({ scale(s, s, Offset.Zero) }) {
+            drawPath(bubblePath, color)
+            if (progress < 1f) {
+                val clipRight = lerp(CHECKMARK_X_MIN, CHECKMARK_X_MAX, progress)
+                clipRect(0f, 0f, clipRight, ICON_VIEWPORT) {
+                    drawPath(checkmarkPath, color)
+                }
+            } else {
+                withTransform({ scale(popScale, popScale, Offset(CHECKMARK_CENTROID_X, CHECKMARK_CENTROID_Y)) }) {
+                    drawPath(checkmarkPath, color)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ui/UnreadIcon.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ui/UnreadIcon.kt
@@ -1,0 +1,47 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.nextcloud.talk.conversationlist.ui
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.withTransform
+import androidx.compose.ui.graphics.vector.PathParser
+
+private const val ICON_VIEWPORT = 960f
+private const val DOT_CENTER_X = 760f
+private const val DOT_CENTER_Y = 120f
+
+@Composable
+internal fun UnreadIcon(progress: Float, popScale: Float, color: Color, modifier: Modifier = Modifier) {
+    val bubblePath = remember {
+        PathParser().parsePathString(
+            "M80,880L80,160Q80,127 103.5,103.5Q127,80 160,80L564,80Q560,100 560,120Q560,140 564,160" +
+                "L160,160Q160,160 160,160Q160,160 160,160L160,685L206,640L800,640Q800,640 800,640Q800,640 800,640" +
+                "L800,316Q823,311 843,302.5Q863,294 880,280L880,640Q880,673 856.5,696.5Q833,720 800,720L240,720L80,880Z"
+        ).toPath()
+    }
+    val dotPath = remember {
+        PathParser().parsePathString(
+            "M760,240Q710,240 675,205Q640,170 640,120Q640,70 675,35Q710,0 760,0" +
+                "Q810,0 845,35Q880,70 880,120Q880,170 845,205Q810,240 760,240Z"
+        ).toPath()
+    }
+    Canvas(modifier = modifier) {
+        val s = size.width / ICON_VIEWPORT
+        withTransform({ scale(s, s, Offset.Zero) }) {
+            drawPath(bubblePath, color)
+            withTransform({ scale(progress * popScale, progress * popScale, Offset(DOT_CENTER_X, DOT_CENTER_Y)) }) {
+                drawPath(dotPath, color)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/viewmodels/ConversationsListViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/viewmodels/ConversationsListViewModel.kt
@@ -108,8 +108,7 @@ class ConversationsListViewModel @Inject constructor(
 
     sealed class ConversationReadUnreadUiState {
         data object None : ConversationReadUnreadUiState()
-        data class Success(val conversationDisplayName: String, val isMarkedRead: Boolean) :
-            ConversationReadUnreadUiState()
+        data object Success : ConversationReadUnreadUiState()
         data object Error : ConversationReadUnreadUiState()
     }
 
@@ -582,6 +581,8 @@ class ConversationsListViewModel @Inject constructor(
 
     @Suppress("Detekt.TooGenericExceptionCaught")
     fun markConversationAsRead(conversation: ConversationModel) {
+        val original = conversation.copy()
+        val optimistic = conversation.copy(unreadMessages = 0, unreadMention = false, unreadMentionDirect = false)
         val messageId = if (conversation.remoteServer.isNullOrEmpty()) conversation.lastMessage?.id?.toInt() else null
         val apiVersion = ApiUtils.getChatApiVersion(
             currentUser.capabilities?.spreedCapability!!,
@@ -589,12 +590,18 @@ class ConversationsListViewModel @Inject constructor(
         )
         val url = ApiUtils.getUrlForChatReadMarker(apiVersion, currentUser.baseUrl, conversation.token)
         viewModelScope.launch {
+            withContext(Dispatchers.IO) {
+                repository.updateConversationLocallyAndEmit(currentUser, optimistic)
+            }
             try {
                 withContext(Dispatchers.IO) {
                     withRetry(1) { conversationsRepository.markConversationAsRead(credentials, url, messageId) }
                 }
-                _readUnreadState.value = ConversationReadUnreadUiState.Success(conversation.displayName, true)
+                _readUnreadState.value = ConversationReadUnreadUiState.Success
             } catch (e: Exception) {
+                withContext(Dispatchers.IO) {
+                    repository.updateConversationLocallyAndEmit(currentUser, original)
+                }
                 _readUnreadState.value = ConversationReadUnreadUiState.Error
             }
         }
@@ -602,18 +609,26 @@ class ConversationsListViewModel @Inject constructor(
 
     @Suppress("Detekt.TooGenericExceptionCaught")
     fun markConversationAsUnread(conversation: ConversationModel) {
+        val original = conversation.copy()
+        val optimistic = conversation.copy(unreadMessages = 1)
         val apiVersion = ApiUtils.getChatApiVersion(
             currentUser.capabilities?.spreedCapability!!,
             intArrayOf(ApiUtils.API_V1)
         )
         val url = ApiUtils.getUrlForChatReadMarker(apiVersion, currentUser.baseUrl, conversation.token)
         viewModelScope.launch {
+            withContext(Dispatchers.IO) {
+                repository.updateConversationLocallyAndEmit(currentUser, optimistic)
+            }
             try {
                 withContext(Dispatchers.IO) {
                     withRetry(1) { conversationsRepository.markConversationAsUnread(credentials, url) }
                 }
-                _readUnreadState.value = ConversationReadUnreadUiState.Success(conversation.displayName, false)
+                _readUnreadState.value = ConversationReadUnreadUiState.Success
             } catch (e: Exception) {
+                withContext(Dispatchers.IO) {
+                    repository.updateConversationLocallyAndEmit(currentUser, original)
+                }
                 _readUnreadState.value = ConversationReadUnreadUiState.Error
             }
         }

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/viewmodels/ConversationsListViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/viewmodels/ConversationsListViewModel.kt
@@ -115,6 +115,15 @@ class ConversationsListViewModel @Inject constructor(
     private val _readUnreadState = MutableStateFlow<ConversationReadUnreadUiState>(ConversationReadUnreadUiState.None)
     val readUnreadState: StateFlow<ConversationReadUnreadUiState> = _readUnreadState.asStateFlow()
 
+    sealed class FavoriteUiState {
+        data object None : FavoriteUiState()
+        data object Success : FavoriteUiState()
+        data object Error : FavoriteUiState()
+    }
+
+    private val _favoriteState = MutableStateFlow<FavoriteUiState>(FavoriteUiState.None)
+    val favoriteState: StateFlow<FavoriteUiState> = _favoriteState.asStateFlow()
+
     object GetRoomsStartState : ViewState
     class GetRoomsErrorState(val throwable: Throwable) : ViewState
     open class GetRoomsSuccessState(val listIsNotEmpty: Boolean) : ViewState
@@ -630,6 +639,58 @@ class ConversationsListViewModel @Inject constructor(
                     repository.updateConversationLocallyAndEmit(currentUser, original)
                 }
                 _readUnreadState.value = ConversationReadUnreadUiState.Error
+            }
+        }
+    }
+
+    fun resetFavoriteState() {
+        _favoriteState.value = FavoriteUiState.None
+    }
+
+    @Suppress("Detekt.TooGenericExceptionCaught")
+    fun addConversationToFavorites(conversation: ConversationModel) {
+        val original = conversation.copy()
+        val optimistic = conversation.copy(favorite = true)
+        val apiVersion = ApiUtils.getConversationApiVersion(currentUser, intArrayOf(ApiUtils.API_V4, ApiUtils.API_V1))
+        val url = ApiUtils.getUrlForRoomFavorite(apiVersion, currentUser.baseUrl, conversation.token)
+        viewModelScope.launch {
+            withContext(Dispatchers.IO) {
+                repository.updateConversationLocallyAndEmit(currentUser, optimistic)
+            }
+            try {
+                withContext(Dispatchers.IO) {
+                    withRetry(1) { conversationsRepository.addConversationToFavorites(credentials, url) }
+                }
+                _favoriteState.value = FavoriteUiState.Success
+            } catch (e: Exception) {
+                withContext(Dispatchers.IO) {
+                    repository.updateConversationLocallyAndEmit(currentUser, original)
+                }
+                _favoriteState.value = FavoriteUiState.Error
+            }
+        }
+    }
+
+    @Suppress("Detekt.TooGenericExceptionCaught")
+    fun removeConversationFromFavorites(conversation: ConversationModel) {
+        val original = conversation.copy()
+        val optimistic = conversation.copy(favorite = false)
+        val apiVersion = ApiUtils.getConversationApiVersion(currentUser, intArrayOf(ApiUtils.API_V4, ApiUtils.API_V1))
+        val url = ApiUtils.getUrlForRoomFavorite(apiVersion, currentUser.baseUrl, conversation.token)
+        viewModelScope.launch {
+            withContext(Dispatchers.IO) {
+                repository.updateConversationLocallyAndEmit(currentUser, optimistic)
+            }
+            try {
+                withContext(Dispatchers.IO) {
+                    withRetry(1) { conversationsRepository.removeConversationFromFavorites(credentials, url) }
+                }
+                _favoriteState.value = FavoriteUiState.Success
+            } catch (e: Exception) {
+                withContext(Dispatchers.IO) {
+                    repository.updateConversationLocallyAndEmit(currentUser, original)
+                }
+                _favoriteState.value = FavoriteUiState.Error
             }
         }
     }

--- a/app/src/main/java/com/nextcloud/talk/repositories/conversations/ConversationsRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/repositories/conversations/ConversationsRepository.kt
@@ -58,4 +58,8 @@ interface ConversationsRepository {
     suspend fun markConversationAsRead(credentials: String, url: String, messageId: Int?): GenericOverall
 
     suspend fun markConversationAsUnread(credentials: String, url: String): GenericOverall
+
+    suspend fun addConversationToFavorites(credentials: String, url: String): GenericOverall
+
+    suspend fun removeConversationFromFavorites(credentials: String, url: String): GenericOverall
 }

--- a/app/src/main/java/com/nextcloud/talk/repositories/conversations/ConversationsRepositoryImpl.kt
+++ b/app/src/main/java/com/nextcloud/talk/repositories/conversations/ConversationsRepositoryImpl.kt
@@ -153,6 +153,12 @@ class ConversationsRepositoryImpl(private val api: NcApi, private val coroutineA
     override suspend fun markConversationAsUnread(credentials: String, url: String): GenericOverall =
         coroutineApi.markRoomAsUnread(credentials, url)
 
+    override suspend fun addConversationToFavorites(credentials: String, url: String): GenericOverall =
+        coroutineApi.addConversationToFavorites(credentials, url)
+
+    override suspend fun removeConversationFromFavorites(credentials: String, url: String): GenericOverall =
+        coroutineApi.removeConversationFromFavorites(credentials, url)
+
     companion object {
         const val STATUS_CODE_OK = 200
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -306,8 +306,6 @@ How to translate with transifex:
     <string name="nc_open_to_guest_app_users">Also open to guest app users</string>
     <string name="nc_new_conversation_visibility">Visibility</string>
 
-    <string name="added_to_favorites">Added conversation %1$s to favorites</string>
-    <string name="removed_from_favorites">Removed conversation %1$s from favorites</string>
     <string name="deleted_conversation">Deleted conversation %1$s</string>
     <string name="left_conversation">You left the conversation %1$s</string>
     <string name="renamed_conversation">Conversation %1$s was renamed</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -308,8 +308,6 @@ How to translate with transifex:
 
     <string name="added_to_favorites">Added conversation %1$s to favorites</string>
     <string name="removed_from_favorites">Removed conversation %1$s from favorites</string>
-    <string name="marked_as_unread">Marked conversation %1$s as unread</string>
-    <string name="marked_as_read">Marked conversation %1$s as read</string>
     <string name="deleted_conversation">Deleted conversation %1$s</string>
     <string name="left_conversation">You left the conversation %1$s</string>
     <string name="renamed_conversation">Conversation %1$s was renamed</string>

--- a/detekt.yml
+++ b/detekt.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2017-2026 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: GPL-3.0-or-later
 build:
-  maxIssues: 95
+  maxIssues: 96
   weights:
     # complexity: 2
     # LongParameterList: 1


### PR DESCRIPTION
Resolves: https://github.com/nextcloud/talk-android/issues/6181

A follow up would be to improve the leave-action which fails in certain scenarions, but does so via bottom sheet and convo-info activity as well. However the error snackbar texts are precise on the info screen but generic on the convo list. this is not an issue introduced by this PR, hence left out, to not grow its complexity.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)