### PR TITLE
Hide filenames for media in chat.

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/chat/MediaMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/chat/MediaMessage.kt
@@ -69,7 +69,13 @@ fun MediaMessage(
     val fileParameters =
         remember { FileParameters(message.messageParameters as HashMap<String?, HashMap<String?, String?>>?) }
 
-    val captionText = message.message.takeUnless { it == FILE_PLACEHOLDER_MESSAGE }
+    val hasExplicitCaption = message.plainMessage != FILE_PLACEHOLDER_MESSAGE
+    val hasPreview = !typeContent.previewUrl.isNullOrEmpty()
+    val captionText = when {
+        hasExplicitCaption -> message.message
+        !hasPreview -> message.message
+        else -> null
+    }
     val hasCaption = captionText != null
     val mediaInset = 4.dp
     val mediaShape = remember(message.incoming) {

--- a/app/src/main/java/com/nextcloud/talk/ui/chat/MediaMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/chat/MediaMessage.kt
@@ -8,7 +8,7 @@
 package com.nextcloud.talk.ui.chat
 
 import android.util.Log
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
@@ -150,6 +150,7 @@ fun MediaMessage(
                 val fallbackPainter = painterResource(typeContent.drawableResourceId)
 
                 Box(modifier = Modifier.fillMaxWidth()) {
+                    val messageLongClickHandler = LocalMessageLongClickHandler.current
                     AsyncImage(
                         model = loadedImage,
                         contentDescription = stringResource(R.string.media_message_content_description),
@@ -161,7 +162,10 @@ fun MediaMessage(
                             .then(if (aspectRatio != null) Modifier.aspectRatio(aspectRatio) else Modifier)
                             .padding(mediaInset)
                             .clip(mediaShape)
-                            .clickable { onImageClick(message.id) },
+                            .combinedClickable(
+                                onClick = { onImageClick(message.id) },
+                                onLongClick = { messageLongClickHandler(message.id) }
+                            ),
                         contentScale = ContentScale.FillWidth,
                         onError = { state ->
                             val cause = state.result.throwable


### PR DESCRIPTION
- replace https://github.com/nextcloud/talk-android/pull/6082
- Implements https://github.com/nextcloud/talk-android/issues/6056

also fix longclick for media messages

thanks for the initial commit to @anakin78z :+1: 


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)