### PR TITLE
Improve mark as read logic

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/chat/ChatView.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/chat/ChatView.kt
@@ -302,15 +302,13 @@ fun ChatView(
         }
     }
 
-    LaunchedEffect(isAtNewest) {
+    LaunchedEffect(isAtNewest, state.chatItems) {
         if (!isAtNewest) return@LaunchedEffect
 
-        latestChatItems
-            .getOrNull(listState.firstVisibleItemIndex)
-            ?.let { item ->
-                if (item is ChatViewModel.ChatItem.MessageItem) {
-                    callbacks.advanceLocalLastReadMessageIfNeeded?.invoke(item.uiMessage.id)
-                }
+        state.chatItems
+            .firstNotNullOfOrNull { (it as? ChatViewModel.ChatItem.MessageItem)?.uiMessage?.id }
+            ?.let { newestId ->
+                callbacks.advanceLocalLastReadMessageIfNeeded?.invoke(newestId)
             }
     }
 


### PR DESCRIPTION
Resolves: #6059

According to our friend Claude:

The mark-as-read effect had two independent bugs:
  
- If the chat opened with the scroll position already at the bottom (e.g. only one unread message), or a new message arrived while the user was already at the bottom, the effect never re-ran since it only triggered on a  change of the "at newest" state — leaving messages unmarked as read.
- If the first item in the list was a non-message entry (such as a date separator), the index-based lookup silently bailed out without advancing the read position at all.
  
The fix makes the effect re-evaluate whenever the message list changes, and replaces the index-based item lookup with a search that skips non-message entries and reliably resolves the newest actual message.


### 🚧 TODO

- [x] test & review for a while

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)