### PR TITLE
fix display of time for edited messages

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/chat/ChatMessageScaffold.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/chat/ChatMessageScaffold.kt
@@ -127,13 +127,14 @@ private fun shouldShowTimeNextToContent(
     showQuote: Boolean
 ): Boolean {
     val containsLinebreak = message.message.contains("\n") || message.message.contains("\r")
-    val shouldHideTime = forceTimeBelow ||
+    val shouldShowTimeBelowContent = forceTimeBelow ||
         forceTimeOverlay ||
         message.hasMentionChips() ||
         showQuote ||
-        containsLinebreak
+        containsLinebreak ||
+        message.isEdited
 
-    return !shouldHideTime && (message.message.length < MESSAGE_LENGTH_THRESHOLD)
+    return !shouldShowTimeBelowContent && (message.message.length < MESSAGE_LENGTH_THRESHOLD)
 }
 
 private val mentionChipTypes = setOf("user", "guest", "call", "user-group", "email", "circle")


### PR DESCRIPTION
fix https://github.com/nextcloud/talk-android/issues/6231

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)