### PR TITLE
fix(conversationlist): use actual network state as initial value for isOnline

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/data/network/NetworkMonitorImpl.kt
+++ b/app/src/main/java/com/nextcloud/talk/data/network/NetworkMonitorImpl.kt
@@ -74,8 +74,14 @@ class NetworkMonitorImpl @Inject constructor(private val context: Context) : Net
     }.stateIn(
         CoroutineScope(Dispatchers.IO),
         SharingStarted.WhileSubscribed(COROUTINE_TIMEOUT),
-        false
+        isCurrentlyConnected()
     )
+
+    private fun isCurrentlyConnected(): Boolean {
+        val network = connectivityManager.activeNetwork ?: return false
+        val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+    }
 
     companion object {
         private val TAG = NetworkMonitorImpl::class.java.simpleName


### PR DESCRIPTION
Sometimes it happened to me that the conversation list failed to load after an initial install. I was not able to reproduce it reliable, but it could have happened because the initial value of isOnline was false (see usage in OfflineFirstConversationsRepository.getRooms()). On first app launch, no subscriber has triggered the callback yet, so .value is still false, the server fetch is skipped, and the empty local DB is shown.

Now the actual online state is returned also for an initial check when the flow is not subscribed yet.


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)