### PR TITLE
Fix to avoid nickChanged messages after call hangup

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -237,6 +237,7 @@ class CallActivity : CallBaseActivity() {
     private var videoCapturer: VideoCapturer? = null
     private var rootEglBase: EglBase? = null
     private var signalingDisposable: Disposable? = null
+    private var nickSendingDisposable: Disposable? = null
     private var iceServers: MutableList<PeerConnection.IceServer>? = null
     private var cameraEnumerator: CameraEnumerator? = null
     private var roomToken: String? = null
@@ -1962,6 +1963,8 @@ class CallActivity : CallBaseActivity() {
         stopCallingSound()
         callTimeHandler.removeCallbacksAndMessages(null)
         dispose(null)
+        dispose(nickSendingDisposable)
+        nickSendingDisposable = null
 
         if (shutDownView) {
             terminateAudioVideo()
@@ -2560,6 +2563,8 @@ class CallActivity : CallBaseActivity() {
         currentCallStatus === CallStatus.CONNECTING || isConnectionEstablished
 
     private fun startSendingNick() {
+        dispose(nickSendingDisposable)
+        nickSendingDisposable = null
         val dataChannelMessage = DataChannelMessage()
         dataChannelMessage.type = "nickChanged"
         val nickChangedPayload: MutableMap<String, String> = HashMap()
@@ -2570,11 +2575,11 @@ class CallActivity : CallBaseActivity() {
             if (peerConnectionWrapper.isMCUPublisher) {
                 Observable
                     .interval(1, TimeUnit.SECONDS)
-                    .repeatUntil { !isConnectionEstablished || isDestroyed }
+                    .takeWhile { isConnectionEstablished && !isDestroyed }
                     .observeOn(Schedulers.io())
                     .subscribe(object : Observer<Long> {
                         override fun onSubscribe(d: Disposable) {
-                            // unused atm
+                            nickSendingDisposable = d
                         }
 
                         override fun onNext(aLong: Long) {


### PR DESCRIPTION
Observable.interval never completes so repeatUntil was a no-op, and the Disposable was never stored, making the subscription impossible to cancel. Multiple calls to startSendingNick() accumulated permanent subscriptions. Replaced repeatUntil with takeWhile, stored the Disposable, and dispose it both at the start of startSendingNick() and in hangup().

Without this fix, the console is spammed with entries like this even after the call hung up:

```
2026-05-29 10:39:13.006  7667-8972  com.nextcl...ionWrapper com.nextcloud.talk2                  D  Queuing data channel message (DataChannelMessage(type=nickChanged, payload=null, payloadMap={name=marcel2, userid=marcel2})) Dj3o548NhNFnfEIhUJxD114EC2mZtn6Y3L-ZQ_-j4EaSsO27TDyQXhaCubMyijqz9478g7OW
2026-05-29 10:39:14.005  7667-8972  com.nextcl...ionWrapper com.nextcloud.talk2                  D  Queuing data channel message (DataChannelMessage(type=nickChanged, payload=null, payloadMap={name=marcel2, userid=marcel2})) Dj3o548NhNFnfEIhUJxD114EC2mZtn6Y3L-ZQ_-j4EaSsO27TDyQXhaCubMyijqz9478g7OW
2026-05-29 10:39:15.005  7667-8972  com.nextcl...ionWrapper com.nextcloud.talk2                  D  Queuing data channel message (DataChannelMessage(type=nickChanged, payload=null, payloadMap={name=marcel2, userid=marcel2})) Dj3o548NhNFnfEIhUJxD114EC2mZtn6Y3L-ZQ_-j4EaSsO27TDyQXhaCubMyijqz9478g7OW
2026-05-29 10:39:16.006  7667-8972  com.nextcl...ionWrapper com.nextcloud.talk2                  D  Queuing data channel message (DataChannelMessage(type=nickChanged, payload=null, payloadMap={name=marcel2, userid=marcel2})) Dj3o548NhNFnfEIhUJxD114EC2mZtn6Y3L-ZQ_-j4EaSsO27TDyQXhaCubMyijqz9478g7OW
2026-05-29 10:39:17.005  7667-8972  com.nextcl...ionWrapper com.nextcloud.talk2                  D  Queuing data channel message (DataChannelMessage(type=nickChanged, payload=null, payloadMap={name=marcel2, userid=marcel2})) Dj3o548NhNFnfEIhUJxD114EC2mZtn6Y3L-ZQ_-j4EaSsO27TDyQXhaCubMyijqz9478g7OW
```

AI-assistant: Claude Code v2.1.142 (Claude Sonnet 4.6)


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)