### PR TITLE
fix(chat): scroll to newest after sending a message

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -405,6 +405,7 @@ class ChatActivity :
     private var pendingHighlightRetryJob: Job? = null
     private var centerSelectedMessageJob: Job? = null
     private var chatListComposeScope: CoroutineScope? = null
+    private var pendingScrollToNewestMessage: Boolean = false
 
     var webSocketInstance: WebSocketInstance? = null
     var signalingMessageSender: SignalingMessageSender? = null
@@ -658,6 +659,21 @@ class ChatActivity :
 
     private var chatListState: LazyListState? = null
 
+    fun requestScrollToNewestMessage() {
+        val listState = chatListState
+        val composeScope = chatListComposeScope
+
+        if (listState != null && composeScope != null) {
+            pendingScrollToNewestMessage = false
+            chatViewModel.switchToDefaultMode()
+            composeScope.launch {
+                listState.scrollToItem(0)
+            }
+        } else {
+            pendingScrollToNewestMessage = true
+        }
+    }
+
     private fun scrollToMessageById(messageId: Long, logMiss: Boolean = true): Boolean {
         val items = chatViewModel.uiState.value.items
         val targetIndex = items.indexOfFirst { item ->
@@ -773,6 +789,9 @@ class ChatActivity :
                 SideEffect {
                     chatListState = listState
                     chatListComposeScope = composeScope
+                    if (pendingScrollToNewestMessage) {
+                        requestScrollToNewestMessage()
+                    }
                 }
 
                 SideEffect { chatListState = listState }

--- a/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
@@ -1043,6 +1043,7 @@ class MessageInputFragment : Fragment() {
             )
             cancelReply()
             cancelCreateThread()
+            chatActivity.requestScrollToNewestMessage()
         }
     }
 


### PR DESCRIPTION
Always jump to the newest message after sending. 
This is the expected behavior as other messengers do the same.
While it an edge case to send a normal message while looking at older messages, it's common when replying.

Without this fix the "New message" popup was shown while the chat stayed at the old position. This was quite confusing.


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)