### PR TITLE
fix: prevent chips from overlapping in multi-row system messages

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/chat/SystemMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/chat/SystemMessage.kt
@@ -68,10 +68,16 @@ fun SystemMessage(message: ChatMessageUi) {
         val highlightedAnnotated = remember(annotated, highlightSearchTerm) {
             annotated.withSearchHighlight(highlightSearchTerm)
         }
+        val resolvedTextStyle =
+            if (inlineContent.isEmpty()) {
+                textStyle
+            } else {
+                textStyle.copy(lineHeight = androidx.compose.ui.unit.TextUnit.Unspecified)
+            }
         Box(modifier = Modifier.fillMaxWidth()) {
             Text(
                 highlightedAnnotated,
-                style = systemMessageTextStyle,
+                style = resolvedTextStyle,
                 color = colorScheme.onSurface,
                 inlineContent = inlineContent,
                 textAlign = TextAlign.Center,
@@ -168,8 +174,7 @@ private fun buildSystemMessageContent(
             if (mention != null) {
                 val inlineId = "sysmsg-${message.id}-$mentionCounter"
                 mentionCounter++
-                appendMentionChip(inlineId, mention, inlineContent, textStyle, isMultilineLayout = false)
-                if (addLineBreaks) append("\n")
+                appendMentionChip(inlineId, mention, inlineContent, textStyle, isMultilineLayout = addLineBreaks)
             } else {
                 val name = message.messageParameters[key]?.get("name") ?: match.value
                 val start = length


### PR DESCRIPTION
  bodyMedium's lineHeight (20sp) is smaller than the chip height (24dp),
  causing chips on wrapped lines to bleed into adjacent rows. Clearing
  lineHeight when inline content is present lets the chip height drive
  row spacing naturally. Also passes isMultilineLayout correctly so chip
  placeholder alignment switches to Bottom when wrapping is detected,
  which is what actually forces the line height to expand.

AI-assistant: Claude Code v2.1.142 (Claude Sonnet 4.6)

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)