### PR TITLE
Add "Copy message link" to message actions to be on par with server

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -183,6 +183,7 @@ import com.nextcloud.talk.utils.Mimetype
 import com.nextcloud.talk.utils.NotificationUtils
 import com.nextcloud.talk.utils.ParticipantPermissions
 import com.nextcloud.talk.utils.SpreedFeatures
+import com.nextcloud.talk.utils.UriUtils
 import com.nextcloud.talk.utils.VibrationUtils
 import com.nextcloud.talk.utils.bundle.BundleKeys
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_CALL_VOICE_ONLY
@@ -947,6 +948,7 @@ class ChatActivity :
                                 onForward = { forwardMessage(msg) },
                                 onEdit = { messageInputViewModel.edit(msg) },
                                 onCopy = { copyMessage(msg) },
+                                onCopyMessageLink = { copyMessageLink(msg) },
                                 onMarkAsUnread = { markAsUnread(msg) },
                                 onRemind = { remindMeLater(msg) },
                                 onPin = { pinMessage(msg) },
@@ -3493,6 +3495,26 @@ class ChatActivity :
             message?.getRichText()
         )
         clipboardManager.setPrimaryClip(clipData)
+    }
+
+    fun copyMessageLink(message: ChatMessage) {
+        val baseUrl = conversationUser?.baseUrl
+        if (baseUrl.isNullOrEmpty()) {
+            Snackbar.make(binding.root, R.string.nc_common_error_sorry, Snackbar.LENGTH_LONG).show()
+            return
+        }
+
+        val messageLink = UriUtils.getMessageLink(baseUrl, roomToken, message.jsonMessageId.toLong())
+
+        val clipboardManager =
+            getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
+        val clipData = ClipData.newPlainText(
+            resources?.getString(R.string.nc_app_product_name),
+            messageLink
+        )
+        clipboardManager.setPrimaryClip(clipData)
+
+        Snackbar.make(binding.root, R.string.nc_common_copy_success, Snackbar.LENGTH_SHORT).show()
     }
 
     fun translateMessage(message: ChatMessage?) {

--- a/app/src/main/java/com/nextcloud/talk/chat/ui/MessageActionsBottomSheet.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ui/MessageActionsBottomSheet.kt
@@ -129,6 +129,7 @@ data class MessageActionsState(
     val showForward: Boolean,
     val showEdit: Boolean,
     val showCopy: Boolean,
+    val showCopyMessageLink: Boolean,
     val showMarkAsUnread: Boolean,
     val showRemind: Boolean,
     val showPin: Boolean,
@@ -242,6 +243,8 @@ internal fun buildMessageActionsState(
             isOnline,
         showEdit = isMessageEditable,
         showCopy = !message.isDeleted,
+        showCopyMessageLink = !message.isDeleted &&
+            ChatMessage.MessageType.SYSTEM_MESSAGE != messageType,
         showMarkAsUnread = hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.CHAT_READ_MARKER) &&
             ChatMessage.MessageType.SYSTEM_MESSAGE != messageType &&
             isOnline,
@@ -279,6 +282,7 @@ fun MessageActionsBottomSheet(
     onForward: () -> Unit,
     onEdit: () -> Unit,
     onCopy: () -> Unit,
+    onCopyMessageLink: () -> Unit,
     onMarkAsUnread: () -> Unit,
     onRemind: () -> Unit,
     onPin: () -> Unit,
@@ -306,6 +310,7 @@ fun MessageActionsBottomSheet(
             onForward = onForward,
             onEdit = onEdit,
             onCopy = onCopy,
+            onCopyMessageLink = onCopyMessageLink,
             onMarkAsUnread = onMarkAsUnread,
             onRemind = onRemind,
             onPin = onPin,
@@ -332,6 +337,7 @@ internal fun MessageActionsSheetContent(
     onForward: () -> Unit,
     onEdit: () -> Unit,
     onCopy: () -> Unit,
+    onCopyMessageLink: () -> Unit,
     onMarkAsUnread: () -> Unit,
     onRemind: () -> Unit,
     onPin: () -> Unit,
@@ -432,6 +438,16 @@ internal fun MessageActionsSheetContent(
                         text = stringResource(R.string.nc_copy_message),
                         onClick = {
                             onCopy()
+                            onDismiss()
+                        }
+                    )
+                }
+                if (actionsState.showCopyMessageLink) {
+                    MessageActionItem(
+                        iconRes = R.drawable.ic_open_in_new,
+                        text = stringResource(R.string.nc_copy_message_link),
+                        onClick = {
+                            onCopyMessageLink()
                             onDismiss()
                         }
                     )
@@ -808,6 +824,7 @@ private fun PreviewMessageActionsSheetContent() {
         showForward = true,
         showEdit = true,
         showCopy = true,
+        showCopyMessageLink = true,
         showMarkAsUnread = true,
         showRemind = true,
         showPin = true,
@@ -830,6 +847,7 @@ private fun PreviewMessageActionsSheetContent() {
                 onForward = {},
                 onEdit = {},
                 onCopy = {},
+                onCopyMessageLink = {},
                 onMarkAsUnread = {},
                 onRemind = {},
                 onPin = {},
@@ -864,6 +882,7 @@ private fun PreviewMessageActionsSheetPinned() {
                     showForward = false,
                     showEdit = false,
                     showCopy = true,
+                    showCopyMessageLink = true,
                     showMarkAsUnread = false,
                     showRemind = false,
                     showPin = true,
@@ -882,6 +901,7 @@ private fun PreviewMessageActionsSheetPinned() {
                 onForward = {},
                 onEdit = {},
                 onCopy = {},
+                onCopyMessageLink = {},
                 onMarkAsUnread = {},
                 onRemind = {},
                 onPin = {},

--- a/app/src/main/java/com/nextcloud/talk/utils/UriUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/UriUtils.kt
@@ -41,6 +41,13 @@ class UriUtils {
             return url.toUri().lastPathSegment ?: ""
         }
 
+        /**
+         * Builds a shareable web link to a specific chat message, matching the web client format:
+         * {baseUrl}/call/{token}#message_{messageId}
+         */
+        fun getMessageLink(baseUrl: String, roomToken: String, messageId: Long): String =
+            "${baseUrl.trimEnd('/')}/call/$roomToken#message_$messageId"
+
         fun isInstanceInternalFileUrl(baseUrl: String, url: String): Boolean {
             // https://cloud.nextcloud.com/apps/files/?dir=/Engineering&fileid=41
             return (

--- a/app/src/main/res/drawable/ic_open_in_new.xml
+++ b/app/src/main/res/drawable/ic_open_in_new.xml
@@ -1,0 +1,16 @@
+<!--
+  ~ Nextcloud Talk - Android Client
+  ~
+  ~ SPDX-FileCopyrightText: 2018-2025 Google LLC
+  ~ SPDX-License-Identifier: Apache-2.0
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#FF000000"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M200,840Q167,840 143.5,816.5Q120,793 120,760L120,200Q120,167 143.5,143.5Q167,120 200,120L480,120L480,200L200,200L200,760L760,760L760,480L840,480L840,760Q840,793 816.5,816.5Q793,840 760,840L200,840ZM376,640L320,584L704,200L560,200L560,120L840,120L840,400L760,400L760,256L376,640Z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -599,6 +599,7 @@ How to translate with transifex:
 
     <!-- Chat -->
     <string name="nc_copy_message">Copy</string>
+    <string name="nc_copy_message_link">Copy message link</string>
     <string name="nc_forward_message">Forward</string>
     <string name="nc_reply">Reply</string>
     <string name="nc_reply_privately">Reply privately</string>

--- a/app/src/test/java/com/nextcloud/talk/chat/ui/MessageActionsStateTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/chat/ui/MessageActionsStateTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.chat.ui
+
+import com.nextcloud.talk.chat.data.model.ChatMessage
+import com.nextcloud.talk.data.user.model.User
+import com.nextcloud.talk.models.json.capabilities.SpreedCapability
+import com.nextcloud.talk.utils.DateUtils
+import org.junit.Assert
+import org.junit.Test
+import org.mockito.Mockito
+
+class MessageActionsStateTest {
+
+    private val dateUtils = Mockito.mock(DateUtils::class.java)
+
+    private fun buildStateFor(message: ChatMessage) =
+        buildMessageActionsState(
+            message = message,
+            user = User().apply { userId = "alice" },
+            conversation = null,
+            hasChatPermission = true,
+            hasReactPermission = true,
+            spreedCapabilities = SpreedCapability(),
+            isOnline = true,
+            dateUtils = dateUtils,
+            conversationThreadId = null
+        )
+
+    @Test
+    fun showCopyMessageLink_trueForRegularMessage() {
+        val msg = ChatMessage().apply {
+            jsonMessageId = 4
+            message = "Hello world"
+        }
+        Assert.assertTrue(buildStateFor(msg).showCopyMessageLink)
+    }
+
+    @Test
+    fun showCopyMessageLink_falseForDeletedMessage() {
+        val msg = ChatMessage().apply {
+            jsonMessageId = 4
+            message = "Hello world"
+            isDeleted = true
+        }
+        Assert.assertFalse(buildStateFor(msg).showCopyMessageLink)
+    }
+
+    @Test
+    fun showCopyMessageLink_falseForSystemMessage() {
+        // isSystemMessage is computed at construction time, so the type must be set via the constructor
+        val msg = ChatMessage(
+            jsonMessageId = 4,
+            systemMessageType = ChatMessage.SystemMessageType.CONVERSATION_CREATED
+        )
+        Assert.assertFalse(buildStateFor(msg).showCopyMessageLink)
+    }
+}

--- a/app/src/test/java/com/nextcloud/talk/utils/UriUtilsTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/utils/UriUtilsTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.utils
+
+import org.junit.Assert
+import org.junit.Test
+
+class UriUtilsTest {
+
+    @Test
+    fun getMessageLink_buildsWebClientFormat() {
+        val link = UriUtils.getMessageLink("https://cloud.example.com", "mwcskgpz", 4)
+        Assert.assertEquals("https://cloud.example.com/call/mwcskgpz#message_4", link)
+    }
+
+    @Test
+    fun getMessageLink_trimsTrailingSlashOnBaseUrl() {
+        val link = UriUtils.getMessageLink("https://cloud.example.com/", "abc123", 42)
+        Assert.assertEquals("https://cloud.example.com/call/abc123#message_42", link)
+    }
+
+    @Test
+    fun getMessageLink_keepsSubpathBaseUrl() {
+        val link = UriUtils.getMessageLink("https://example.com/nextcloud", "token1", 7)
+        Assert.assertEquals("https://example.com/nextcloud/call/token1#message_7", link)
+    }
+}


### PR DESCRIPTION
Add a "Copy message link" option to the long-press message actions bottom sheet. It copies a link in the same format the web client uses ({baseUrl}/call/{token}#message_{messageId}) to the clipboard, so the link can be shared (e.g. by email) and opened in the browser, landing on the referenced message.

Resolves: https://github.com/nextcloud/talk-android/issues/2361

Tested via emulator.

Assisted-by: ClaudeCode:claude-opus-4-8

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="596" height="777" alt="image" src="https://github.com/user-attachments/assets/146ca10c-7a3b-402f-84eb-4c7b643a9864" /> | <img width="596" height="777" alt="image" src="https://github.com/user-attachments/assets/ec2ee95f-bbb1-4f13-a467-f630d80a9ea6" />


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)