### PR TITLE
  Fix three sources of excessive buildChatItems invocations when opening a conversation

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -406,6 +406,7 @@ class ChatActivity :
             } else {
                 val intent = Intent(this@ChatActivity, ConversationsListActivity::class.java)
                 startActivity(intent)
+                finish()
             }
         }
     }

--- a/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
@@ -529,7 +529,7 @@ class ChatViewModel @AssistedInject constructor(
                 messages.let(::handleSystemMessages)
                     .let(::handleThreadMessages)
             }
-    // .distinctUntilChangedBy { it.map { msg -> msg.jsonMessageId } }
+            .distinctUntilChanged()
 
     private val trackedParentIds = MutableStateFlow<Set<Long>>(emptySet())
 
@@ -1025,6 +1025,7 @@ class ChatViewModel @AssistedInject constructor(
         ) { messages, lastCommonRead, parentMap, conversationLastRead, expandedParents ->
             CombinedInput(messages, lastCommonRead, parentMap, conversationLastRead, expandedParents)
         }
+            .debounce(MESSAGES_REBUILD_DEBOUNCE_MS)
             .map { (messages, lastCommonRead, parentMap, conversationLastRead, expandedParents) ->
                 val messageMap: Map<Long, ChatMessage> = messages.associateBy { it.jsonMessageId.toLong() }
                 val combinedMap: Map<Long, ChatMessage> = messageMap + parentMap
@@ -2294,6 +2295,7 @@ class ChatViewModel @AssistedInject constructor(
         private const val WEBSOCKET_CONNECT_TIMEOUT_MS = 3000L
         private const val WEBSOCKET_POLL_INTERVAL_MS = 50L
         private const val ROOM_REFRESH_DEBOUNCE_MS = 500L
+        private const val MESSAGES_REBUILD_DEBOUNCE_MS = 200L
         private const val LOBBY_POLLING_INTERVAL_MS = 5_000L
         private const val GROUPING_TIME_WINDOW_SECONDS = 300L
         private const val TIMESTAMP_TO_MILLIS = 1000L


### PR DESCRIPTION
  Fix three sources of excessive buildChatItems invocations when opening
  a conversation:

  - Finish ChatActivity when navigating back to the conversation list so
  the ChatViewModel is destroyed immediately. Without this, each
  back-navigation left a live ViewModel behind, and re-opening any chat
  accumulated N concurrent observeMessages flows — each independently
  calling buildChatItems on every DB update.
  - Add debounce(200 ms) to the combined messages/conversation/parents
  flow. Room emits on every DB transaction during the initial sync,
  firing buildChatItems 50–100+ times per second. The debounce
  coalesces bursts that arrive within 200 ms into a single rebuild.
  - Add distinctUntilChanged() to messagesFlow to suppress Room
  re-emissions where the actual message list content has not changed
  (e.g. unrelated table writes that touch the same Room-observed tables).

AI-assistant: Claude Code v2.1.142 (Claude Sonnet 4.6)
Signed-off-by: Marcel Hibbe <dev@mhibbe.de>


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)