### PR TITLE
  Fix Activity back-stack leak in back navigation and message forwarding

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -405,6 +405,7 @@ class ChatActivity :
                 onBackPressedDispatcher.onBackPressed()
             } else {
                 val intent = Intent(this@ChatActivity, ConversationsListActivity::class.java)
+                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
                 startActivity(intent)
                 finish()
             }
@@ -3396,7 +3397,9 @@ class ChatActivity :
 
         val intent = Intent(this, ConversationsListActivity::class.java)
         intent.putExtras(bundle)
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
         startActivity(intent)
+        finish()
     }
 
     fun remindMeLater(message: ChatMessage?) {

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -226,6 +226,9 @@ class ConversationsListActivity : BaseActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
+        setIntent(intent)
+        forwardMessageState.value = intent.getBooleanExtra(KEY_FORWARD_MSG_FLAG, false)
+        conversationsListViewModel.setHideRoomToken(intent.getStringExtra(KEY_FORWARD_HIDE_SOURCE_ROOM))
         handleEcoSystemIntent(intent)
     }
 


### PR DESCRIPTION
  Both code paths that navigate from ChatActivity to
  ConversationsListActivity were calling startActivity without
  FLAG_ACTIVITY_CLEAR_TOP, creating a new ConversationsListActivity
  instance each time instead of reusing the existing one. After several
  back-and-forth navigations the back stack accumulated dozens of stopped
  Activity instances — each keeping its ChatViewModel and
  observeMessages flow alive — causing redundant concurrent
  buildChatItems calls and heavy GC pressure.

  Fix back navigation by adding FLAG_ACTIVITY_CLEAR_TOP | FLAG_ACTIVITY_SINGLE_TOP: when ConversationsListActivity is already
  in the stack Android pops everything above it (including the current
  ChatActivity) and delivers the intent to the existing instance.

  Fix forwardMessage the same way and add finish() for the case where
  ConversationsListActivity is not yet in the stack. Update
  ConversationsListActivity.onNewIntent to apply the forward extras
  (KEY_FORWARD_MSG_FLAG, KEY_FORWARD_HIDE_SOURCE_ROOM) and call
  setIntent so the forwarded message text is available when the user
  picks a destination, enabling the CLEAR_TOP path to work correctly.

AI-assistant: Claude Code v2.1.142 (Claude Sonnet 4.6)


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)