### PR TITLE
fix: handle undeliverable RxJava network exceptions globally

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/application/NextcloudTalkApplication.kt
+++ b/app/src/main/java/com/nextcloud/talk/application/NextcloudTalkApplication.kt
@@ -60,9 +60,13 @@ import com.vanniktech.emoji.EmojiManager
 import com.vanniktech.emoji.google.GoogleEmojiProvider
 import de.cotech.hw.SecurityKeyManager
 import de.cotech.hw.SecurityKeyManagerConfig
+import io.reactivex.exceptions.UndeliverableException
+import io.reactivex.plugins.RxJavaPlugins
 import okhttp3.OkHttpClient
 import org.conscrypt.Conscrypt
 import org.webrtc.PeerConnectionFactory
+import java.io.IOException
+import java.net.SocketException
 import java.security.Security
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -121,6 +125,16 @@ class NextcloudTalkApplication :
     override fun onCreate() {
         Log.d(TAG, "onCreate")
         sharedApplication = this
+
+        RxJavaPlugins.setErrorHandler { e ->
+            var throwable: Throwable = if (e is UndeliverableException) e.cause ?: e else e
+            if (throwable is IOException || throwable is SocketException) {
+                Log.w(TAG, "Undeliverable network exception ignored", throwable)
+                return@setErrorHandler
+            }
+            Thread.currentThread().uncaughtExceptionHandler
+                ?.uncaughtException(Thread.currentThread(), throwable)
+        }
 
         val securityKeyManager = SecurityKeyManager.getInstance()
         val securityKeyConfigBuilder = SecurityKeyManagerConfig.Builder()


### PR DESCRIPTION
  Add a global RxJavaPlugins error handler in NextcloudTalkApplication to
  prevent crashes caused by ConnectException (ECONNREFUSED) arriving after
  a subscriber has already been disposed (e.g. user navigated away while a
  network call was in-flight).

  IOException and SocketException are logged and ignored since they
  represent expected network conditions. All other undeliverable exceptions
  are still forwarded to the uncaught exception handler so real bugs
  continue to surface as crashes.

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)