### PR TITLE
fix(chat): fix missing notifications because of the delete=true bug.

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
@@ -1228,9 +1228,13 @@ class OfflineFirstChatRepository @Inject constructor(
         sendWithoutNotification: Boolean,
         referenceId: String
     ): ChatMessageEntity {
-        val currentTimeMillies = System.currentTimeMillis()
+        val currentTimeMillis = System.currentTimeMillis()
 
-        val currentTimeWithoutYear = SendMessageUtils().removeYearFromTimestamp(currentTimeMillies)
+        // only use the time of a day so it can fit into an integer
+        val timeOfDayMillis = SendMessageUtils().timeOfDayMillis(currentTimeMillis)
+
+        // make it negative -> sending the lastReadMessage to server checks "-1 < messageId" to avoid temporary messages
+        val negativeTimeOfDayMillis = timeOfDayMillis * MINUS_ONE
 
         val parentMessageId = if (replyTo != 0) {
             replyTo.toLong()
@@ -1239,9 +1243,9 @@ class OfflineFirstChatRepository @Inject constructor(
         }
 
         val entity = ChatMessageEntity(
-            internalId = "$internalConversationId@_temp_$currentTimeMillies",
+            internalId = "$internalConversationId@_temp_$currentTimeMillis",
             internalConversationId = internalConversationId,
-            id = currentTimeWithoutYear.toLong(),
+            id = negativeTimeOfDayMillis,
             threadId = threadId,
             message = message,
             deleted = false,
@@ -1254,7 +1258,7 @@ class OfflineFirstChatRepository @Inject constructor(
             parentMessageId = parentMessageId,
             systemMessageType = ChatMessage.SystemMessageType.DUMMY,
             replyable = false,
-            timestamp = currentTimeMillies / MILLIES,
+            timestamp = currentTimeMillis / MILLIES,
             expirationTimestamp = 0,
             actorDisplayName = currentUser.displayName!!,
             referenceId = referenceId,
@@ -1278,5 +1282,7 @@ class OfflineFirstChatRepository @Inject constructor(
         private const val RETRY_LIMIT_FALLBACK_ATTEMPT = 5
         private const val MILLIES = 1000L
         private const val INSURANCE_REQUEST_DELAY = 2 * 60 * MILLIES
+
+        private const val MINUS_ONE = -1L
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
@@ -1707,7 +1707,10 @@ class ChatViewModel @AssistedInject constructor(
     }
 
     fun advanceLocalLastReadMessageIfNeeded(messageId: Int) {
-        if (localLastReadMessage < messageId) {
+        Log.d(TAG, "advanceLocalLastReadMessageIfNeeded, messageId: $messageId")
+        Log.d(TAG, "advanceLocalLastReadMessageIfNeeded, localLastReadMessage: $localLastReadMessage")
+        if (localLastReadMessage < messageId && -1 < messageId) {
+            Log.d(TAG, "advanceLocalLastReadMessageIfNeeded, setting localLastReadMessage to $messageId")
             localLastReadMessage = messageId
         }
     }
@@ -1716,7 +1719,16 @@ class ChatViewModel @AssistedInject constructor(
      * Please use with caution to not spam the server
      */
     fun updateRemoteLastReadMessageIfNeeded(credentials: String, url: String) {
+        Log.d(TAG, "updateRemoteLastReadMessageIfNeeded, localLastReadMessage: $localLastReadMessage")
+        Log.d(
+            TAG,
+            "updateRemoteLastReadMessageIfNeeded, _uiState.value.conversation!!.lastReadMessage: " +
+                _uiState.value.conversation!!.lastReadMessage
+        )
+
         if (localLastReadMessage > _uiState.value.conversation!!.lastReadMessage) {
+            Log.d(TAG, "updateRemoteLastReadMessageIfNeeded, setChatReadMessage...")
+
             setChatReadMessage(credentials, url, localLastReadMessage)
         }
     }

--- a/app/src/main/java/com/nextcloud/talk/utils/message/SendMessageUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/message/SendMessageUtils.kt
@@ -19,14 +19,13 @@ class SendMessageUtils {
     }
 
     @Suppress("MagicNumber")
-    fun removeYearFromTimestamp(timestampMillis: Long): Int {
+    fun timeOfDayMillis(timestampMillis: Long): Int {
         val calendar = Calendar.getInstance().apply { timeInMillis = timestampMillis }
 
-        val month = calendar.get(Calendar.MONTH)
-        val day = calendar.get(Calendar.DAY_OF_MONTH)
         val hour = calendar.get(Calendar.HOUR_OF_DAY)
         val minute = calendar.get(Calendar.MINUTE)
         val second = calendar.get(Calendar.SECOND)
-        return (month * 1000000) + (day * 10000) + (hour * 100) + (minute * 10) + second
+        val millis = calendar.get(Calendar.MILLISECOND)
+        return (hour * 3_600_000) + (minute * 60_000) + (second * 1_000) + millis
     }
 }


### PR DESCRIPTION
fix #5979
fix #6020
fix #6212 (most probably)

The temporary message IDs were higher than the realistic message IDs from server and it could happen that they were transmitted as the lastReadMessageId. That happened rarely because in most cases the server response already returned to overwrite the temporary ids before the lastReadMessageId was transmitted. But it happened sometimes. And this caused the annoying behavior that after leaving the chat, when a notification was received, immediately afterwards another notification was received with delete=true which deleted the prior notification (So there must be logic on serverside that delete=true is sent when the lastReadMessageId is higher). This happened so fast that the user never saw a notification at all, only a "Failed to get NC notification" toast if debug mode was enabled.

To avoid this behavior, the message id of temporary messages is now a negative value and the localLastReadMessage is only set for positive message IDs, so temporary messages are not taken into account.

Furthermore removeYearFromTimestamp was replaced with timeOfDayMillis to make the ids better understandable for humans. Keeping the int datatype and using the timeOfDayMillis helper should be the right decision as changing it to long would result in a chain of refactoring.


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
