### PR TITLE
Bugfix/noid/ensure successful requests after leaving chat

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/api/NcApi.java
+++ b/app/src/main/java/com/nextcloud/talk/api/NcApi.java
@@ -195,9 +195,6 @@ public interface NcApi {
                                      @Url String url,
                                      @Nullable @Field("password") String password);
 
-    @DELETE
-    Observable<GenericOverall> leaveRoom(@Nullable @Header("Authorization") String authorization, @Url String url);
-
     /*
         Server URL is: baseUrl + ocsApiVersion + spreedApiVersion + /call/callToken
     */

--- a/app/src/main/java/com/nextcloud/talk/api/NcApiCoroutines.kt
+++ b/app/src/main/java/com/nextcloud/talk/api/NcApiCoroutines.kt
@@ -312,6 +312,9 @@ interface NcApiCoroutines {
     @DELETE
     suspend fun unbindRoom(@Header("Authorization") authorization: String, @Url url: String): GenericOverall
 
+    @DELETE
+    suspend fun leaveRoom(@Header("Authorization") authorization: String, @Url url: String): GenericOverall
+
     @GET
     suspend fun getThreads(
         @Header("Authorization") authorization: String,

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -1486,13 +1486,6 @@ class ChatActivity :
                         getRoomInfoTimerHandler?.removeCallbacksAndMessages(null)
                     }
 
-                    if (webSocketInstance != null && currentConversation != null) {
-                        webSocketInstance?.joinRoomWithRoomTokenAndSession(
-                            "",
-                            sessionIdAfterRoomJoined
-                        )
-                    }
-
                     sessionIdAfterRoomJoined = "0"
 
                     if (state.funToCallWhenLeaveSuccessful != null) {
@@ -2850,6 +2843,13 @@ class ChatActivity :
 
     fun leaveRoom(funToCallWhenLeaveSuccessful: (() -> Unit)?) {
         logConversationInfos("leaveRoom")
+
+        // Send the HPB "leave room" immediately, before waiting for the backend DELETE to
+        // confirm. This minimises the window in which the HPB could still consider the user
+        // "in" the room and cause the server to delete a freshly-created notification.
+        if (webSocketInstance != null && currentConversation != null) {
+            webSocketInstance?.joinRoomWithRoomTokenAndSession("", sessionIdAfterRoomJoined)
+        }
 
         var apiVersion = 1
         // FIXME Fix API checking with guests?

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -1477,27 +1477,6 @@ class ChatActivity :
             }
         }
 
-        chatViewModel.leaveRoomViewState.observe(this) { state ->
-            when (state) {
-                is ChatViewModel.LeaveRoomSuccessState -> {
-                    logConversationInfos("leaveRoom#onNext")
-
-                    if (getRoomInfoTimerHandler != null) {
-                        getRoomInfoTimerHandler?.removeCallbacksAndMessages(null)
-                    }
-
-                    sessionIdAfterRoomJoined = "0"
-
-                    if (state.funToCallWhenLeaveSuccessful != null) {
-                        Log.d(TAG, "a callback action was set and is now executed because room was left successfully")
-                        state.funToCallWhenLeaveSuccessful.invoke()
-                    }
-                }
-
-                else -> {}
-            }
-        }
-
         messageInputViewModel.sendChatMessageViewState.observe(this) { state ->
             when (state) {
                 is MessageInputViewModel.SendChatMessageSuccessState -> {
@@ -2841,7 +2820,7 @@ class ChatActivity :
         }
     }
 
-    fun leaveRoom(funToCallWhenLeaveSuccessful: (() -> Unit)?) {
+    fun leaveRoom(functionToCallAfterLeave: (() -> Unit)?) {
         logConversationInfos("leaveRoom")
 
         // Send the HPB "leave room" immediately, before waiting for the backend DELETE to
@@ -2850,6 +2829,7 @@ class ChatActivity :
         if (webSocketInstance != null && currentConversation != null) {
             webSocketInstance?.joinRoomWithRoomTokenAndSession("", sessionIdAfterRoomJoined)
         }
+        sessionIdAfterRoomJoined = "0"
 
         var apiVersion = 1
         // FIXME Fix API checking with guests?
@@ -2866,7 +2846,7 @@ class ChatActivity :
                 conversationUser?.baseUrl!!,
                 roomToken
             ),
-            funToCallWhenLeaveSuccessful
+            functionToCallAfterLeave
         )
     }
 

--- a/app/src/main/java/com/nextcloud/talk/chat/data/network/ChatNetworkDataSource.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/network/ChatNetworkDataSource.kt
@@ -53,7 +53,7 @@ interface ChatNetworkDataSource {
         metadata: String
     ): Observable<GenericOverall>
 
-    fun leaveRoom(credentials: String, url: String): Observable<GenericOverall>
+    suspend fun leaveRoom(credentials: String, url: String): GenericOverall
     suspend fun sendChatMessage(
         credentials: String,
         url: String,

--- a/app/src/main/java/com/nextcloud/talk/chat/data/network/RetrofitChatNetwork.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/network/RetrofitChatNetwork.kt
@@ -134,10 +134,8 @@ class RetrofitChatNetwork(private val ncApi: NcApi, private val ncApiCoroutines:
         metadata: String
     ): Observable<GenericOverall> = ncApi.sendLocation(credentials, url, objectType, objectId, metadata).map { it }
 
-    override fun leaveRoom(credentials: String, url: String): Observable<GenericOverall> =
-        ncApi.leaveRoom(credentials, url).map {
-            it
-        }
+    override suspend fun leaveRoom(credentials: String, url: String): GenericOverall =
+        ncApiCoroutines.leaveRoom(credentials, url)
 
     override suspend fun sendChatMessage(
         credentials: String,

--- a/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
@@ -378,7 +378,7 @@ class ChatViewModel @AssistedInject constructor(
         get() = _joinRoomViewState
 
     object LeaveRoomStartState : ViewState
-    class LeaveRoomSuccessState(val funToCallWhenLeaveSuccessful: (() -> Unit)?) : ViewState
+    object LeaveRoomSuccessState : ViewState
 
     private val _leaveRoomViewState: MutableLiveData<ViewState> = MutableLiveData(LeaveRoomStartState)
     val leaveRoomViewState: LiveData<ViewState>
@@ -1542,15 +1542,19 @@ class ChatViewModel @AssistedInject constructor(
             })
     }
 
-    fun leaveRoom(credentials: String, url: String, funToCallWhenLeaveSuccessful: (() -> Unit)?) {
-        val startNanoTime = System.nanoTime()
+    fun leaveRoom(credentials: String, url: String, functionToCallAfterLeave: (() -> Unit)?) {
         appScope.launch {
             try {
-                chatNetworkDataSource.leaveRoom(credentials, url)
-                Log.d(TAG, "leaveRoom - completed: $startNanoTime")
+                val result = chatNetworkDataSource.leaveRoom(credentials, url)
+                if (result.ocs?.meta?.statusCode == HTTP_CODE_OK) {
+                    Log.d(TAG, "leaveRoom completed")
+                } else {
+                    Log.e(TAG, "leaveRoom failed with OCS status: ${result.ocs?.meta?.statusCode}")
+                }
                 withContext(Dispatchers.Main) {
-                    _leaveRoomViewState.value = LeaveRoomSuccessState(funToCallWhenLeaveSuccessful)
+                    _leaveRoomViewState.value = LeaveRoomSuccessState
                     _getCapabilitiesViewState.value = GetCapabilitiesStartState
+                    functionToCallAfterLeave?.invoke()
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "leaveRoom - ERROR", e)

--- a/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
@@ -80,7 +80,9 @@ import io.reactivex.Observer
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
+import com.nextcloud.talk.dagger.modules.ApplicationScope
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -135,6 +137,7 @@ class ChatViewModel @AssistedInject constructor(
     private val mediaRecorderManager: MediaRecorderManager,
     private val audioFocusRequestManager: AudioFocusRequestManager,
     private val currentUserProvider: CurrentUserProvider,
+    @ApplicationScope private val appScope: CoroutineScope,
     @Assisted private val chatRoomToken: String,
     @Assisted private val conversationThreadId: Long?
 ) : ViewModel(),
@@ -1541,27 +1544,18 @@ class ChatViewModel @AssistedInject constructor(
 
     fun leaveRoom(credentials: String, url: String, funToCallWhenLeaveSuccessful: (() -> Unit)?) {
         val startNanoTime = System.nanoTime()
-        chatNetworkDataSource.leaveRoom(credentials, url)
-            .subscribeOn(Schedulers.io())
-            ?.observeOn(AndroidSchedulers.mainThread())
-            ?.subscribe(object : Observer<GenericOverall> {
-                override fun onSubscribe(d: Disposable) {
-                    disposableSet.add(d)
-                }
-
-                override fun onError(e: Throwable) {
-                    Log.e(TAG, "leaveRoom - leaveRoom - ERROR", e)
-                }
-
-                override fun onComplete() {
-                    Log.d(TAG, "leaveRoom - leaveRoom - completed: $startNanoTime")
-                }
-
-                override fun onNext(t: GenericOverall) {
+        appScope.launch {
+            try {
+                chatNetworkDataSource.leaveRoom(credentials, url)
+                Log.d(TAG, "leaveRoom - completed: $startNanoTime")
+                withContext(Dispatchers.Main) {
                     _leaveRoomViewState.value = LeaveRoomSuccessState(funToCallWhenLeaveSuccessful)
                     _getCapabilitiesViewState.value = GetCapabilitiesStartState
                 }
-            })
+            } catch (e: Exception) {
+                Log.e(TAG, "leaveRoom - ERROR", e)
+            }
+        }
     }
 
     fun createRoom(credentials: String, url: String, queryMap: Map<String, String>) {

--- a/app/src/main/java/com/nextcloud/talk/dagger/modules/ApplicationScope.kt
+++ b/app/src/main/java/com/nextcloud/talk/dagger/modules/ApplicationScope.kt
@@ -1,0 +1,13 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2025 Marcel Hibbe <dev@mhibbe.de>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.dagger.modules
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ApplicationScope

--- a/app/src/main/java/com/nextcloud/talk/dagger/modules/UtilsModule.kt
+++ b/app/src/main/java/com/nextcloud/talk/dagger/modules/UtilsModule.kt
@@ -22,6 +22,10 @@ import dagger.Provides
 import dagger.Reusable
 import java.io.File
 import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import javax.inject.Singleton
 
 @Module(includes = [ContextModule::class])
 class UtilsModule {
@@ -65,4 +69,9 @@ class UtilsModule {
         const val LOG_FILE_NAME = "nc_talk_log.txt"
         private const val LOG_FILE_MAX_SIZE = 1_000_000L // 1 MB per file, 4 files max = 4 MB
     }
+
+    @Provides
+    @Singleton
+    @ApplicationScope
+    fun provideApplicationScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 }

--- a/app/src/main/java/com/nextcloud/talk/dagger/modules/UtilsModule.kt
+++ b/app/src/main/java/com/nextcloud/talk/dagger/modules/UtilsModule.kt
@@ -25,7 +25,6 @@ import javax.inject.Singleton
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import javax.inject.Singleton
 
 @Module(includes = [ContextModule::class])
 class UtilsModule {

--- a/app/src/main/java/com/nextcloud/talk/utils/preview/ComposePreviewUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/preview/ComposePreviewUtils.kt
@@ -58,7 +58,10 @@ import com.nextcloud.talk.logger.Logger
 import com.nextcloud.talk.utils.preferences.AppPreferences
 import com.nextcloud.talk.utils.preferences.AppPreferencesImpl
 import io.reactivex.schedulers.Schedulers
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
@@ -204,6 +207,7 @@ class ComposePreviewUtils private constructor(context: Context) {
             mediaRecorderManager = mediaRecorderManager,
             audioFocusRequestManager = audioFocusRequestManager,
             currentUserProvider = currentUserProvider,
+            appScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
             chatRoomToken = "",
             conversationThreadId = null,
             logger = TestLogger


### PR DESCRIPTION
Fix race conditions while leaving a chat room.

This might have been one reason why servers to deleted a freshly-posted notification because it might have considered to be a user still being in a room. See commit messages for further details.

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
