### PR TITLE
Fixing single line message formatting on long word edge cases

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/chat/ChatMessageScaffold.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/chat/ChatMessageScaffold.kt
@@ -22,11 +22,12 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -36,19 +37,16 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.remember
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.style.TextOverflow
-import com.nextcloud.talk.chat.ui.model.MessageTypeContent
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.RoundRect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.colorResource
@@ -57,6 +55,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -66,6 +65,7 @@ import com.nextcloud.talk.R
 import com.nextcloud.talk.chat.ui.model.ChatMessageUi
 import com.nextcloud.talk.chat.ui.model.MessageReactionUi
 import com.nextcloud.talk.chat.ui.model.MessageStatusIcon
+import com.nextcloud.talk.chat.ui.model.MessageTypeContent
 import com.nextcloud.talk.contacts.loadImage
 import com.nextcloud.talk.ui.theme.LocalViewThemeUtils
 import com.nextcloud.talk.utils.DateUtils
@@ -431,7 +431,11 @@ private fun ColumnScope.MessageBodyWithMetadata(
                     modifier = Modifier.align(Alignment.End),
                     verticalAlignment = Alignment.Bottom
                 ) {
-                    Box(modifier = Modifier.padding(bottom = 5.dp)) {
+                    Box(
+                        modifier = Modifier
+                            .padding(bottom = 5.dp)
+                            .weight(1f, fill = false)
+                    ) {
                         content()
                     }
                     MessageMetadata(uiMessage)
@@ -853,7 +857,9 @@ fun TimeDisplay(message: ChatMessageUi, color: Color = colorScheme.onSurfaceVari
         timeString,
         fontSize = timeTextSize,
         textAlign = TextAlign.Center,
-        color = color
+        color = color,
+        maxLines = 1,
+        softWrap = false
     )
 }
 


### PR DESCRIPTION
- fixes #6319 

There was an edge case for `MetadataLayoutMode.INLINE ` messages in `ChatMessageScaffold`, where long messages would break the formatting of the time display.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="345" height="711" alt="Screenshot 2026-06-11 at 10 54 55 AM" src="https://github.com/user-attachments/assets/2a2fe98b-45b2-4bdf-a2dd-a59187aa7569" /> | <img width="345" height="711" alt="Screenshot 2026-06-11 at 11 02 09 AM" src="https://github.com/user-attachments/assets/5512b6d0-a177-4dd3-87a6-5e93427389f3" />


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
