### PR TITLE
fix (chat): ensure all markdown tables are rendered + improve design

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/chat/MarkdownText.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/chat/MarkdownText.kt
@@ -27,9 +27,11 @@ import android.view.MotionEvent
 import android.view.View
 import android.widget.TextView
 import androidx.appcompat.widget.AppCompatTextView
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -65,6 +67,9 @@ private const val CHIP_CORNER_RADIUS_DP = 16f
 private const val MESSAGE_LINKIFY_MASK = Linkify.PHONE_NUMBERS or
     Linkify.EMAIL_ADDRESSES
 
+// GFM table separator row: starts with | followed by optional spaces/colons and at least 3 dashes
+private val TABLE_SEPARATOR_REGEX = Regex("""^\|[ :]*-{3,}""", RegexOption.MULTILINE)
+
 val validLinkRegex = Regex(
     """(?<!\w)https?://(?:www\.)?[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+(?:/[^\s)]*)?""",
     RegexOption.IGNORE_CASE
@@ -98,6 +103,9 @@ fun MarkdownText(
     val messageId = message.id
     val onMessageLongClick = LocalMessageLongClickHandler.current
     val onLongClickState = rememberUpdatedState(onMessageLongClick)
+    val hasTable = remember(message.plainMessage) {
+        message.plainMessage.contains(TABLE_SEPARATOR_REGEX)
+    }
 
     if (LocalInspectionMode.current) {
         Text(
@@ -109,7 +117,7 @@ fun MarkdownText(
         )
     } else {
         AndroidView(
-            modifier = modifier,
+            modifier = if (hasTable) modifier.fillMaxWidth() else modifier,
             factory = { ctx ->
                 val gestureDetector = GestureDetector(
                     ctx,
@@ -183,7 +191,7 @@ fun MarkdownText(
 
                 resolveFileParams(ssb, message)
                 applySearchHighlight(ssb, highlightSearchTerm, searchHighlightColorArgb)
-                textView.text = ssb
+                markwon.setParsedMarkdown(textView, ssb)
                 textView.setLinkTextColor(linkColorArgb)
                 val needsMovementMethod = (hasClickableChips || hasLinks) && maxLines == Int.MAX_VALUE
                 if (needsMovementMethod) {

--- a/app/src/main/java/com/nextcloud/talk/utils/message/MessageUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/message/MessageUtils.kt
@@ -58,6 +58,13 @@ class MessageUtils(val context: Context) {
     companion object {
         private const val TAG = "MessageUtils"
 
+        private const val TABLE_CELL_PADDING_DP = 8f
+        private const val TABLE_BORDER_WIDTH_DP = 1f
+        private const val TABLE_BORDER_ALPHA = 0x4D // ~30 %
+        private const val TABLE_HEADER_BG_ALPHA = 0x1A // ~10 %
+        private const val COLOR_ALPHA_SHIFT = 24
+        private const val COLOR_RGB_MASK = 0x00FFFFFF
+
         private var cachedMarkwon: Markwon? = null
         private var cachedContextRef: WeakReference<Context>? = null
         private var cachedTextColor: Int = 0
@@ -86,7 +93,21 @@ class MessageUtils(val context: Context) {
                     }
                 })
                 .usePlugin(TaskListPlugin.create(drawable))
-                .usePlugin(TablePlugin.create { _ -> })
+                .usePlugin(
+                    TablePlugin.create { tableTheme ->
+                        val density = context.resources.displayMetrics.density
+                        val cellPaddingPx = (TABLE_CELL_PADDING_DP * density).toInt()
+                        val borderWidthPx = maxOf(1, (TABLE_BORDER_WIDTH_DP * density).toInt())
+                        // Derive border/header colors from textColor so they adapt to
+                        // both light (dark text) and dark (light text) message bubbles.
+                        val rgb = textColor and COLOR_RGB_MASK
+                        tableTheme
+                            .tableCellPadding(cellPaddingPx)
+                            .tableBorderWidth(borderWidthPx)
+                            .tableBorderColor((TABLE_BORDER_ALPHA shl COLOR_ALPHA_SHIFT) or rgb)
+                            .tableHeaderRowBackgroundColor((TABLE_HEADER_BG_ALPHA shl COLOR_ALPHA_SHIFT) or rgb)
+                    }
+                )
                 .usePlugin(StrikethroughPlugin.create())
                 .build()
             cachedMarkwon = markwon


### PR DESCRIPTION
- fix https://github.com/nextcloud/talk-android/issues/6332

MessageUtils.kt — Configure TablePlugin with a proper theme (cell padding, border width/color, header background derived from textColor). Without this, tables render with no visual structure.

  MarkdownText.kt — Two changes:

  1. markwon.setParsedMarkdown(textView, ssb) instead of textView.text = ssb — ensures Markwon's afterSetText() hook fires, which calls TableRowsScheduler.schedule() and sets the Invalidator on each TableRowSpan.
  2. modifier = if (hasTable) modifier.fillMaxWidth() else modifier — the root cause fix. TableRowSpan.getSize() returns width=0 on its first call (layouts are empty), causing Compose to measure the TextView at 0px wide. With a 0px canvas, draw() checks recreateLayouts(0) → 0 != 0 = false → no layouts created, no invalidate() call → table is permanently invisible. fillMaxWidth() gives the TextView the full bubble width (≤280dp), so draw() gets a real canvas width, creates the cell layouts, fires invalidate(), and the re-layout renders the table at the correct height.

  The hasTable check uses a fast regex (^\|[ :]*-{3,}) so only table messages get the full-width treatment — regular messages continue to wrap-content as before.

AI-assistant: Claude Code v2.1.142 (Claude Sonnet 4.6)

### 🖼️ Screenshots

Improved design

🏚️ Before | 🏡 After
---|---
<img width="637" height="1367" alt="grafik" src="https://github.com/user-attachments/assets/e81faff5-e3f0-4a0c-9402-ba18322fffc3" /> | <img width="642" height="1365" alt="grafik" src="https://github.com/user-attachments/assets/1b24b4de-b6dd-41c7-9212-f413ae387412" />

Fix to render all markdown tables

🏚️ Before | 🏡 After
---|---
<img width="639" height="366" alt="grafik" src="https://github.com/user-attachments/assets/7da11ef1-3dfe-4f20-800b-7d40941842c1" /> | <img width="639" height="471" alt="grafik" src="https://github.com/user-attachments/assets/041be63a-37f7-4463-bb65-786dddb78de8" />


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
