### PR TITLE
fix (chat): avoid SQLiteConstraintException

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
@@ -1082,7 +1082,17 @@ class OfflineFirstChatRepository @Inject constructor(
             it.asEntity(currentUser.id!!)
         }
 
-        chatDao.upsertChatMessagesAndDeleteTemp(internalConversationId, chatMessageEntities)
+        try {
+            chatDao.upsertChatMessagesAndDeleteTemp(internalConversationId, chatMessageEntities)
+        } catch (e: android.database.sqlite.SQLiteConstraintException) {
+            // Skipped persisting messages: conversation $internalConversationId not in DB yet.
+            // This avoids "SQLiteConstraintException: FOREIGN KEY constraint failed".
+            // It may happen when a notification for a newly created conversation is opened. The websocket was just
+            // faster than the API request so no conversation for the message exists yet. Just swallow the exception
+            // and let the insurance request handle it.
+            Log.w(TAG, "Skip persisting messages from signaling: conversation not in DB yet. Swallowed exception: $e")
+            return emptyList()
+        }
 
         if (emitOnIncoming) {
             val hasIncomingFromOther = chatMessages.any { msg ->


### PR DESCRIPTION
- fix https://github.com/nextcloud/talk-android/issues/6340

Skipped persisting messages: conversation $internalConversationId not in DB yet.
This avoids "SQLiteConstraintException: FOREIGN KEY constraint failed".

I could not reproduce but that's my theory:
It may happen when a notification for a newly created conversation is opened. The websocket was just faster than the API request so no conversation for the message exists yet. Just swallow the exception and let the insurance request handle it.


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
