### PR TITLE
set inputEditText maxHeight to a third of the screen height

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/ui/MessageInput.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/MessageInput.kt
@@ -61,7 +61,7 @@ class MessageInput : FrameLayout {
         inputEditText = findViewById(R.id.messageInput)
         val displayMetrics = resources.displayMetrics
         val screenHeight = displayMetrics.heightPixels
-        inputEditText.maxHeight = screenHeight / 2
+        inputEditText.maxHeight = screenHeight / 3
 
         attachmentButton = findViewById(R.id.attachmentButton)
         messageSendButton = findViewById(R.id.messageSendButton)


### PR DESCRIPTION
fix https://github.com/nextcloud/talk-android/issues/6331



### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
