### PR TITLE
Share only the conversation link without extra text

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
@@ -305,7 +305,6 @@ class ConversationInfoActivity : BaseActivity() {
                     this,
                     user.baseUrl,
                     state.conversationToken,
-                    state.conversation?.name,
                     CapabilitiesUtil.canGeneratePrettyURL(user)
                 )
             },

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -1149,7 +1149,6 @@ class ConversationsListActivity : BaseActivity() {
             this,
             currentUser?.baseUrl,
             conversation.token,
-            conversation.name,
             canGeneratePrettyURL
         )
     }

--- a/app/src/main/java/com/nextcloud/talk/utils/ShareUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/ShareUtils.kt
@@ -6,24 +6,31 @@
  */
 package com.nextcloud.talk.utils
 
-import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Intent
+import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import com.nextcloud.talk.R
 
 object ShareUtils {
 
-    @SuppressLint("StringFormatMatches")
-    fun shareConversationLink(
-        context: Activity,
-        baseUrl: String?,
-        roomToken: String?,
-        conversationName: String?,
-        canGeneratePrettyURL: Boolean
-    ) {
-        if (baseUrl.isNullOrBlank() || roomToken.isNullOrBlank() || conversationName.isNullOrBlank()) {
-            return
+    fun shareConversationLink(context: Activity, baseUrl: String?, roomToken: String?, canGeneratePrettyURL: Boolean) {
+        val conversationLink = buildConversationLink(baseUrl, roomToken, canGeneratePrettyURL) ?: return
+
+        val sendIntent: Intent = Intent().apply {
+            action = Intent.ACTION_SEND
+            putExtra(Intent.EXTRA_TEXT, conversationLink)
+            type = "text/plain"
+        }
+
+        val shareIntent = Intent.createChooser(sendIntent, context.getString(R.string.nc_share_link))
+        context.startActivity(shareIntent)
+    }
+
+    @VisibleForTesting
+    fun buildConversationLink(baseUrl: String?, roomToken: String?, canGeneratePrettyURL: Boolean): String? {
+        if (baseUrl.isNullOrBlank() || roomToken.isNullOrBlank()) {
+            return null
         }
 
         val uriBuilder = baseUrl.toUri()
@@ -36,23 +43,6 @@ object ShareUtils {
         uriBuilder.appendPath("call")
         uriBuilder.appendPath(roomToken)
 
-        val uriToShareConversation = uriBuilder.build()
-
-        val shareConversationLink = String.format(
-            context.getString(
-                R.string.share_link_to_conversation,
-                conversationName,
-                uriToShareConversation.toString()
-            )
-        )
-
-        val sendIntent: Intent = Intent().apply {
-            action = Intent.ACTION_SEND
-            putExtra(Intent.EXTRA_TEXT, shareConversationLink)
-            type = "text/plain"
-        }
-
-        val shareIntent = Intent.createChooser(sendIntent, context.getString(R.string.nc_share_link))
-        context.startActivity(shareIntent)
+        return uriBuilder.build().toString()
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -952,7 +952,6 @@ How to translate with transifex:
     <string name="nc_edit_icon">Edit</string>
     <string name="get_invitations_error">Failed to fetch pending invitations</string>
     <string name="message_last_edited_by">Edited by %1$s</string>
-    <string name="share_link_to_conversation">Join conversation %1$s at %2$s</string>
     <string name="nc_conversation_settings">Conversation settings</string>
     <string name="ban_participant">Ban participant</string>
     <string name="show_banned_participants">Show banned participants</string>

--- a/app/src/test/java/com/nextcloud/talk/utils/ShareUtilsTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/utils/ShareUtilsTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.utils
+
+import android.app.Application
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, sdk = [33])
+class ShareUtilsTest {
+
+    @Test
+    fun `builds pretty URL when capability is available`() {
+        val link = ShareUtils.buildConversationLink(BASE_URL, ROOM_TOKEN, canGeneratePrettyURL = true)
+        assertEquals("$BASE_URL/call/$ROOM_TOKEN", link)
+    }
+
+    @Test
+    fun `builds index_php URL when pretty URL capability is missing`() {
+        val link = ShareUtils.buildConversationLink(BASE_URL, ROOM_TOKEN, canGeneratePrettyURL = false)
+        assertEquals("$BASE_URL/index.php/call/$ROOM_TOKEN", link)
+    }
+
+    @Test
+    fun `link is the bare URL with no extra text`() {
+        val link = ShareUtils.buildConversationLink(BASE_URL, ROOM_TOKEN, canGeneratePrettyURL = true)
+        // The shared text must be only the URL — no "Join conversation … at …" wrapper.
+        assertEquals("$BASE_URL/call/$ROOM_TOKEN", link)
+    }
+
+    @Test
+    fun `returns null when baseUrl is blank`() {
+        assertNull(ShareUtils.buildConversationLink("", ROOM_TOKEN, canGeneratePrettyURL = true))
+        assertNull(ShareUtils.buildConversationLink(null, ROOM_TOKEN, canGeneratePrettyURL = true))
+    }
+
+    @Test
+    fun `returns null when roomToken is blank`() {
+        assertNull(ShareUtils.buildConversationLink(BASE_URL, "", canGeneratePrettyURL = true))
+        assertNull(ShareUtils.buildConversationLink(BASE_URL, null, canGeneratePrettyURL = true))
+    }
+
+    companion object {
+        private const val BASE_URL = "https://server.example.com"
+        private const val ROOM_TOKEN = "abc123"
+    }
+}


### PR DESCRIPTION
When sharing the conversation link, it always has some extra text at the beginning:

> Join conversation [conversation name] at [conversation link]

This text is not needed, and only the conversation link should be shared/copied.

Especially since nowadays most places where you paste things (like chat apps and text editors) will show a preview of the link anyway.

Handles both the "Share link" action in the long-press menu of the conversation list as well as "Share conversation link" in the "Conversation settings".

### 🖼️ Screenshots

N/A


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI