### PR TITLE
Implementing Media Controls for Voice Messages

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -195,6 +195,7 @@ configurations.configureEach {
 }
 
 dependencies {
+    implementation("androidx.media3:media3-session:1.10.1")
     kapt("org.jetbrains.kotlin:kotlin-metadata-jvm:$kotlinVersion")
     implementation("androidx.room:room-testing-android:$roomVersion")
     implementation("androidx.compose.foundation:foundation-layout:1.11.2")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -194,6 +194,7 @@ configurations.configureEach {
 }
 
 dependencies {
+    implementation("androidx.media3:media3-session:1.10.1")
     kapt("org.jetbrains.kotlin:kotlin-metadata-jvm:$kotlinVersion")
     implementation("androidx.room:room-testing-android:$roomVersion")
     implementation("androidx.compose.foundation:foundation-layout:1.12.0")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,6 +47,7 @@
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.WRITE_CONTACTS" />
     <uses-permission android:name="android.permission.READ_PROFILE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
 
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />
     <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
@@ -337,6 +338,15 @@
             <meta-data
                 android:name="android.provider.CONTACTS_STRUCTURE"
                 android:resource="@xml/contacts" />
+        </service>
+
+        <service
+            android:name=".chat.data.io.VoiceMessageMediaService"
+            android:foregroundServiceType="mediaPlayback"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="androidx.media3.session.MediaSessionService" />
+            </intent-filter>
         </service>
 
         <service

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,6 +47,7 @@
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.WRITE_CONTACTS" />
     <uses-permission android:name="android.permission.READ_PROFILE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
 
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />
     <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
@@ -332,6 +333,15 @@
             <meta-data
                 android:name="android.provider.CONTACTS_STRUCTURE"
                 android:resource="@xml/contacts" />
+        </service>
+
+        <service
+            android:name=".chat.data.io.VoiceMessageMediaService"
+            android:foregroundServiceType="mediaPlayback"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="androidx.media3.session.MediaSessionService" />
+            </intent-filter>
         </service>
 
         <service

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -417,8 +417,8 @@ class ChatActivity :
             val currentPosition = controller.currentPosition
             val duration = controller.duration.takeIf { it > 0 } ?: 1
 
-            val progress = (currentPosition.toFloat() / duration) * 100f
-            val secondsPlayed = (currentPosition / 1000)
+            val progress = (currentPosition.toFloat() / duration) * FLOAT_100
+            val secondsPlayed = (currentPosition / MILLIS_1000)
 
             val msg = chatViewModel.currentVoiceMessage?.apply {
                 voiceMessageSeekbarProgress = kotlin.math.ceil(progress).toInt()
@@ -438,7 +438,7 @@ class ChatActivity :
             while (isActive) {
                 updateSeekbarUi()
                 // Poll every 150ms for smooth seekbar updates
-                delay(150L)
+                delay(MILLIS_150)
             }
         }
     }
@@ -1061,6 +1061,7 @@ class ChatActivity :
         }
     }
 
+    @Suppress("ReturnCount", "CyclomaticComplexMethod")
     private fun onVoiceClick(messageId: Int) {
         fun getAudioDuration(audioFilePath: String): Long {
             val retriever = MediaMetadataRetriever()
@@ -1070,8 +1071,8 @@ class ChatActivity :
                 val durationString = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
                 val durationLong = durationString?.toLong() ?: 0L
 
-                durationLong / 1000
-            } catch (e: Exception) {
+                durationLong / ONE_SECOND_IN_MILLIS
+            } catch (e: IllegalArgumentException) {
                 e.printStackTrace()
                 0L
             } finally {
@@ -1366,14 +1367,9 @@ class ChatActivity :
 
             mediaController?.addListener(playerListener)
 
-            // If the controller connects and is already playing (e.g. background playback),
-            // start polling immediately
             if (mediaController?.isPlaying == true) {
                 startProgressPolling()
             }
-
-            // (Optional) Add a Player.Listener here if you want the Activity
-            // to reactively listen to playback state changes (e.g., when a track ends).
         }, ContextCompat.getMainExecutor(this))
     }
 
@@ -2926,7 +2922,7 @@ class ChatActivity :
         )
     }
 
-    public override fun onDestroy() {
+    override fun onDestroy() {
         super.onDestroy()
         logConversationInfos("onDestroy")
 
@@ -4113,6 +4109,9 @@ class ChatActivity :
         private const val GET_ROOM_INFO_DELAY_NORMAL: Long = 30000
         private const val GET_ROOM_INFO_DELAY_LOBBY: Long = 5000
         private const val MILLIS_250 = 250L
+        private const val MILLIS_150 = 150L
+        private const val MILLIS_1000 = 1000L
+        private const val FLOAT_100 = 100f
         private const val AGE_THRESHOLD_FOR_DELETE_MESSAGE: Int = 21600000 // (6 hours in millis = 6 * 3600 * 1000)
         private const val REQUEST_SHARE_FILE_PERMISSION: Int = 221
         private const val REQUEST_RECORD_AUDIO_PERMISSION = 222

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -18,12 +18,14 @@ import android.Manifest
 import android.annotation.SuppressLint
 import android.content.ClipData
 import android.content.ClipboardManager
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.res.AssetFileDescriptor
 import android.database.Cursor
 import android.location.LocationManager
+import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -68,6 +70,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalDensity
+import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.core.content.PermissionChecker
 import androidx.core.content.PermissionChecker.PERMISSION_GRANTED
@@ -81,6 +84,11 @@ import androidx.fragment.app.commit
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.Player
+import androidx.media3.session.MediaController
+import androidx.media3.session.SessionToken
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
@@ -89,6 +97,7 @@ import androidx.work.WorkManager
 import autodagger.AutoInjector
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
+import com.google.common.util.concurrent.ListenableFuture
 import com.nextcloud.android.common.ui.color.ColorUtil
 import com.nextcloud.talk.BuildConfig
 import com.nextcloud.talk.R
@@ -99,6 +108,7 @@ import com.nextcloud.talk.adapters.messages.CallStartedMessageInterface
 import com.nextcloud.talk.api.NcApi
 import com.nextcloud.talk.api.NcApiCoroutines
 import com.nextcloud.talk.application.NextcloudTalkApplication
+import com.nextcloud.talk.chat.data.io.VoiceMessageMediaService
 import com.nextcloud.talk.chat.data.model.ChatMessage
 import com.nextcloud.talk.chat.data.model.FileParameters
 import com.nextcloud.talk.chat.ui.ChatEmptyState
@@ -222,6 +232,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.Subscribe
@@ -293,6 +304,9 @@ class ChatActivity :
     private val upcomingEventUiState =
         mutableStateOf<ChatViewModel.UpcomingEventUIState>(ChatViewModel.UpcomingEventUIState.None)
     private val overflowContainerHeightPx = mutableIntStateOf(0)
+
+    private var mediaControllerFuture: ListenableFuture<MediaController>? = null
+    private var mediaController: MediaController? = null
 
     private val startSelectContactForResult = registerForActivityResult(
         ActivityResultContracts
@@ -395,6 +409,73 @@ class ChatActivity :
     private var pendingTargetSearchQuery: String? = null
 
     private lateinit var pickMultipleMedia: ActivityResultLauncher<PickVisualMediaRequest>
+
+    private var progressJob: Job? = null
+
+    private fun updateSeekbarUi() {
+        mediaController?.let { controller ->
+            val currentPosition = controller.currentPosition
+            val duration = controller.duration.takeIf { it > 0 } ?: 1
+
+            val progress = (currentPosition.toFloat() / duration) * 100f
+            val secondsPlayed = (currentPosition / 1000)
+
+            val msg = chatViewModel.currentVoiceMessage?.apply {
+                voiceMessageSeekbarProgress = kotlin.math.ceil(progress).toInt()
+                voiceMessagePlayedSeconds = secondsPlayed.toInt()
+            }
+
+            val currentMediaId = controller.currentMediaItem?.mediaId
+            if (currentMediaId != null && msg != null) {
+                chatViewModel.syncVoiceMessageUiState(msg)
+            }
+        }
+    }
+
+    private fun startProgressPolling() {
+        progressJob?.cancel()
+        progressJob = lifecycleScope.launch {
+            while (isActive) {
+                updateSeekbarUi()
+                // Poll every 150ms for smooth seekbar updates
+                delay(150L)
+            }
+        }
+    }
+
+    private fun stopProgressPolling() {
+        progressJob?.cancel()
+        progressJob = null
+    }
+
+    private val playerListener = object : Player.Listener {
+        override fun onIsPlayingChanged(isPlaying: Boolean) {
+            if (isPlaying) {
+                startProgressPolling()
+            } else {
+                stopProgressPolling()
+                updateSeekbarUi()
+            }
+
+            chatViewModel.currentVoiceMessage?.apply {
+                isPlayingVoiceMessage = isPlaying
+            }?.let { chatViewModel.syncVoiceMessageUiState(it) }
+        }
+
+        // Catches instant changes (e.g., manual seeks, skipping to the next track)
+        override fun onPositionDiscontinuity(
+            oldPosition: Player.PositionInfo,
+            newPosition: Player.PositionInfo,
+            reason: Int
+        ) {
+            updateSeekbarUi()
+        }
+
+        override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+            // Ensures the UI resets immediately when transitioning to the next voice message
+            updateSeekbarUi()
+        }
+    }
 
     private val onBackPressedCallback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
@@ -795,7 +876,7 @@ class ChatActivity :
                 ) {
                     val currentlyPlayingId by chatViewModel.currentlyPlayedMessageId.collectAsState(null)
 
-                    val isOneToOneConversation = uiState.isOneToOneConversation
+                    val isOneToOneConversation by remember { mutableStateOf(uiState.isOneToOneConversation) }
                     Log.d(TAG, "isOneToOneConversation=" + isOneToOneConversation)
 
                     // list of the file ids of messages being downloaded
@@ -817,7 +898,6 @@ class ChatActivity :
                         state = ChatViewState(
                             chatItems = uiState.items,
                             isOneToOneConversation = isOneToOneConversation,
-                            currentlyPlayingVoiceMessageId = currentlyPlayingId,
                             conversationThreadId = conversationThreadId,
                             chatMode = chatMode,
                             highlightedMessageId = uiState.highlightedMessageId,
@@ -837,8 +917,15 @@ class ChatActivity :
                                 onSwipeReply = { handleSwipeToReply(it) },
                                 onFileClick = { downloadAndOpenFile(it, openWhenDownloadState, downloadingFileState) },
                                 onPollClick = { pollId, pollName -> openPollDialog(pollId, pollName) },
-                                onVoicePlayPauseClick = { onVoicePlayPauseClickCompose(it) },
-                                onVoiceSeek = { _, progress -> chatViewModel.seekToMediaPlayer(progress) },
+                                onVoicePlayPauseClick = { onVoiceClick(it) },
+                                onVoiceSeek = { id, progress ->
+                                    mediaController?.let { controller ->
+                                        if (id.toString() == controller.currentMediaItem?.mediaId) {
+                                            val pos = controller.duration * progress / 100f
+                                            controller.seekTo(pos.toLong())
+                                        }
+                                    }
+                                },
                                 onVoiceSpeedClick = { onVoiceSpeedClickCompose(it) },
                                 onReactionClick = { messageId, emoji -> handleReactionClick(messageId, emoji) },
                                 onReactionLongClick = { messageId -> openReactionsDialog(messageId) },
@@ -974,6 +1061,121 @@ class ChatActivity :
         }
     }
 
+    private fun onVoiceClick(messageId: Int) {
+        fun getAudioDuration(audioFilePath: String): Long {
+            val retriever = MediaMetadataRetriever()
+
+            return try {
+                retriever.setDataSource(audioFilePath)
+                val durationString = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+                val durationLong = durationString?.toLong() ?: 0L
+
+                durationLong / 1000
+            } catch (e: Exception) {
+                e.printStackTrace()
+                0L
+            } finally {
+                retriever.release()
+            }
+        }
+
+        fun setupAndPlay(controller: MediaController, message: ChatMessage, file: String) {
+            val avatarUrl = chatViewModel.getAvatarUrl(message)
+
+            val metadata = MediaMetadata.Builder()
+                .setTitle(message.actorDisplayName)
+                .setArtist("Voice Message")
+                .setArtworkUri(avatarUrl.toUri())
+                .build()
+
+            val mediaItem = MediaItem.Builder()
+                .setMediaId(message.jsonMessageId.toString())
+                .setMediaMetadata(metadata)
+                .setUri(file)
+                .build()
+
+            controller.setMediaItem(mediaItem)
+
+            controller.prepare()
+            controller.play()
+        }
+
+        fun setUpWaveform(message: ChatMessage, file: File) {
+            if (message.voiceMessageFloatArray != null) return
+
+            val filename = message.fileParameters.name
+            message.isDownloadingVoiceMessage = true
+
+            chatViewModel.syncVoiceMessageUiState(message)
+
+            CoroutineScope(Dispatchers.Default).launch {
+                val waveform = AudioUtils.audioFileToFloatArray(file)
+                appPreferences.saveWaveFormForFile(filename, waveform.toTypedArray())
+                message.voiceMessageFloatArray = waveform
+
+                withContext(Dispatchers.Main) {
+                    message.isDownloadingVoiceMessage = false
+                    chatViewModel.syncVoiceMessageUiState(message)
+                }
+            }
+        }
+
+        fun prepareVoiceMessage(controller: MediaController, message: ChatMessage): Boolean {
+            val currentMessageId = message.jsonMessageId.toString()
+            val filename = message.fileParameters.name
+            if (filename.isEmpty()) {
+                return true
+            }
+
+            val file = FileUtils.resolveSharedAttachmentFile(context.cacheDir, filename) ?: return true
+            val fileURI = file.toUri()
+            val filePath = fileURI.toString()
+
+            chatViewModel.syncVoiceMessageUiState(
+                message.apply {
+                    voiceMessageDuration = getAudioDuration(filePath).toInt()
+                }
+            )
+
+            if (controller.currentMediaItem?.mediaId != currentMessageId) {
+                if (!file.exists()) {
+                    downloadFileToCache(message, true) {
+                        setupAndPlay(controller, message, filePath)
+                        setUpWaveform(message, file)
+                    }
+                } else {
+                    setupAndPlay(controller, message, filePath)
+                    setUpWaveform(message, file)
+                }
+
+                return true
+            }
+            return false
+        }
+
+        lifecycleScope.launch {
+            val message = chatViewModel.getMessageById(messageId.toLong()).first()
+
+            mediaController?.let { controller ->
+                // If a message is still playing, it must be paused first before another can be loaded
+                val currentMessageId = message.jsonMessageId.toString()
+                if (controller.isPlaying && controller.currentMediaItem?.mediaId != currentMessageId) return@launch
+
+                chatViewModel.currentVoiceMessage = message
+
+                // If the controller is playing a new voice message, initialize
+                if (prepareVoiceMessage(controller, message)) return@launch
+
+                // If the controller is playing the same voice message, pause/resume
+                if (controller.isPlaying) {
+                    controller.pause()
+                } else {
+                    controller.play()
+                }
+            }
+        }
+    }
+
     @Composable
     private fun LazyListState.visibleItemsWithThreshold(): List<String> =
         remember(this) {
@@ -1009,57 +1211,6 @@ class ChatActivity :
 
     private fun onLoadQuotedMessage(messageId: Int) {
         chatViewModel.jumpToQuotedMessage(messageId.toLong())
-    }
-
-    private fun onVoicePlayPauseClickCompose(messageId: Int) {
-        lifecycleScope.launch {
-            val isCurrentlyPlaying = chatViewModel.uiState.value.items
-                .mapNotNull { (it as? ChatViewModel.ChatItem.MessageItem)?.uiMessage }
-                .firstOrNull { it.id == messageId }
-                ?.content
-                ?.let { it as? MessageTypeContent.Voice }
-                ?.isPlaying ?: false
-
-            val message = chatViewModel.getMessageById(messageId.toLong()).first()
-            val filename = message.fileParameters.name
-            if (filename.isEmpty()) {
-                return@launch
-            }
-
-            val file = FileUtils.resolveSharedAttachmentFile(context.cacheDir, filename)
-            if (file == null) {
-                return@launch
-            }
-            if (file.exists()) {
-                if (isCurrentlyPlaying) {
-                    chatViewModel.pauseMediaPlayer(true)
-                    chatViewModel.pauseVoiceMessageUiState(messageId)
-                } else {
-                    val uiSpeed = chatViewModel.uiState.value.items
-                        .mapNotNull { (it as? ChatViewModel.ChatItem.MessageItem)?.uiMessage }
-                        .firstOrNull { it.id == messageId }
-                        ?.content
-                        ?.let { it as? MessageTypeContent.Voice }
-                        ?.playbackSpeed ?: PlaybackSpeed.NORMAL
-                    chatViewModel.setPlayBack(uiSpeed)
-
-                    val retrieved = appPreferences.getWaveFormFromFile(filename)
-                    if (retrieved.isEmpty()) {
-                        setUpWaveform(message)
-                    } else {
-                        if (message.voiceMessageFloatArray == null || message.voiceMessageFloatArray!!.isEmpty()) {
-                            message.voiceMessageFloatArray = retrieved.toFloatArray()
-                            chatViewModel.syncVoiceMessageUiState(message)
-                        }
-                        startPlayback(file, message)
-                    }
-                }
-            } else {
-                downloadFileToCache(message, true) {
-                    setUpWaveform(message)
-                }
-            }
-        }
     }
 
     @Suppress("Detekt.TooGenericExceptionCaught")
@@ -1196,8 +1347,8 @@ class ChatActivity :
 
         pendingTargetMessageId = extras?.getString(BundleKeys.KEY_MESSAGE_ID)?.toLongOrNull()?.takeIf { it > 0L }
             ?: extras?.getLong(BundleKeys.KEY_MESSAGE_ID)?.takeIf { it > 0L }
-        pendingTargetThreadId = extras?.getString(BundleKeys.KEY_THREAD_ID)?.toLongOrNull()?.takeIf { it > 0L }
-            ?: extras?.getLong(BundleKeys.KEY_THREAD_ID)?.takeIf { it > 0L }
+        pendingTargetThreadId = extras?.getString(KEY_THREAD_ID)?.toLongOrNull()?.takeIf { it > 0L }
+            ?: extras?.getLong(KEY_THREAD_ID)?.takeIf { it > 0L }
         pendingTargetSearchQuery = extras?.getString(BundleKeys.KEY_SEARCH_QUERY)
     }
 
@@ -1206,6 +1357,24 @@ class ChatActivity :
         active = true
         this.lifecycle.addObserver(AudioUtils)
         this.lifecycle.addObserver(chatViewModel)
+
+        val sessionToken = SessionToken(this, ComponentName(this, VoiceMessageMediaService::class.java))
+        mediaControllerFuture = MediaController.Builder(this, sessionToken).buildAsync()
+
+        mediaControllerFuture?.addListener({
+            mediaController = mediaControllerFuture?.get()
+
+            mediaController?.addListener(playerListener)
+
+            // If the controller connects and is already playing (e.g. background playback),
+            // start polling immediately
+            if (mediaController?.isPlaying == true) {
+                startProgressPolling()
+            }
+
+            // (Optional) Add a Player.Listener here if you want the Activity
+            // to reactively listen to playback state changes (e.g., when a track ends).
+        }, ContextCompat.getMainExecutor(this))
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -1218,6 +1387,12 @@ class ChatActivity :
         active = false
         this.lifecycle.removeObserver(AudioUtils)
         this.lifecycle.removeObserver(chatViewModel)
+
+        mediaController?.removeListener(playerListener)
+        stopProgressPolling()
+
+        mediaControllerFuture?.let { MediaController.releaseFuture(it) }
+        mediaController = null
     }
 
     @OptIn(FlowPreview::class)
@@ -1842,38 +2017,6 @@ class ChatActivity :
                 }
             }
         }
-    }
-
-    private fun setUpWaveform(message: ChatMessage, thenPlay: Boolean = true, backgroundPlayAllowed: Boolean = false) {
-        val filename = message.fileParameters.name
-        val file = FileUtils.resolveSharedAttachmentFile(context.cacheDir, filename)
-        if (file == null) {
-            return
-        }
-        if (file.exists() && message.voiceMessageFloatArray == null) {
-            message.isDownloadingVoiceMessage = true
-            chatViewModel.syncVoiceMessageUiState(message)
-            CoroutineScope(Dispatchers.Default).launch {
-                val r = AudioUtils.audioFileToFloatArray(file)
-                appPreferences.saveWaveFormForFile(filename, r.toTypedArray())
-                message.voiceMessageFloatArray = r
-                withContext(Dispatchers.Main) {
-                    message.isDownloadingVoiceMessage = false
-                    chatViewModel.syncVoiceMessageUiState(message)
-                    startPlayback(file, message)
-                }
-            }
-        } else {
-            startPlayback(file, message)
-        }
-    }
-
-    private fun startPlayback(file: File, message: ChatMessage) {
-        chatViewModel.clearMediaPlayerQueue()
-        chatViewModel.queueInMediaPlayer(file.canonicalPath, message)
-        chatViewModel.startCyclingMediaPlayer()
-        message.isPlayingVoiceMessage = true
-        chatViewModel.syncVoiceMessageUiState(message)
     }
 
     private fun updateTypingIndicator() {

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -18,12 +18,14 @@ import android.Manifest
 import android.annotation.SuppressLint
 import android.content.ClipData
 import android.content.ClipboardManager
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.res.AssetFileDescriptor
 import android.database.Cursor
 import android.location.LocationManager
+import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -68,6 +70,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalDensity
+import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.core.content.PermissionChecker
 import androidx.core.content.PermissionChecker.PERMISSION_GRANTED
@@ -81,6 +84,11 @@ import androidx.fragment.app.commit
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.Player
+import androidx.media3.session.MediaController
+import androidx.media3.session.SessionToken
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
@@ -90,6 +98,7 @@ import androidx.work.WorkManager
 import autodagger.AutoInjector
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
+import com.google.common.util.concurrent.ListenableFuture
 import com.nextcloud.android.common.ui.color.ColorUtil
 import com.nextcloud.talk.BuildConfig
 import com.nextcloud.talk.R
@@ -99,6 +108,7 @@ import com.nextcloud.talk.adapters.messages.CallStartedMessageInterface
 import com.nextcloud.talk.api.NcApi
 import com.nextcloud.talk.api.NcApiCoroutines
 import com.nextcloud.talk.application.NextcloudTalkApplication
+import com.nextcloud.talk.chat.data.io.VoiceMessageMediaService
 import com.nextcloud.talk.attachmentpreview.FileAttachmentPreviewFragment
 import com.nextcloud.talk.chat.data.model.ChatMessage
 import com.nextcloud.talk.chat.data.model.FileParameters
@@ -225,6 +235,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.greenrobot.eventbus.Subscribe
@@ -296,6 +307,9 @@ class ChatActivity :
     private val upcomingEventUiState =
         mutableStateOf<ChatViewModel.UpcomingEventUIState>(ChatViewModel.UpcomingEventUIState.None)
     private val overflowContainerHeightPx = mutableIntStateOf(0)
+
+    private var mediaControllerFuture: ListenableFuture<MediaController>? = null
+    private var mediaController: MediaController? = null
 
     private val startSelectContactForResult = registerForActivityResult(
         ActivityResultContracts
@@ -398,6 +412,73 @@ class ChatActivity :
     private var pendingTargetSearchQuery: String? = null
 
     private lateinit var pickMultipleMedia: ActivityResultLauncher<PickVisualMediaRequest>
+
+    private var progressJob: Job? = null
+
+    private fun updateSeekbarUi() {
+        mediaController?.let { controller ->
+            val currentPosition = controller.currentPosition
+            val duration = controller.duration.takeIf { it > 0 } ?: 1
+
+            val progress = (currentPosition.toFloat() / duration) * FLOAT_100
+            val secondsPlayed = (currentPosition / MILLIS_1000)
+
+            val msg = chatViewModel.currentVoiceMessage?.apply {
+                voiceMessageSeekbarProgress = kotlin.math.ceil(progress).toInt()
+                voiceMessagePlayedSeconds = secondsPlayed.toInt()
+            }
+
+            val currentMediaId = controller.currentMediaItem?.mediaId
+            if (currentMediaId != null && msg != null) {
+                chatViewModel.syncVoiceMessageUiState(msg)
+            }
+        }
+    }
+
+    private fun startProgressPolling() {
+        progressJob?.cancel()
+        progressJob = lifecycleScope.launch {
+            while (isActive) {
+                updateSeekbarUi()
+                // Poll every 150ms for smooth seekbar updates
+                delay(MILLIS_150)
+            }
+        }
+    }
+
+    private fun stopProgressPolling() {
+        progressJob?.cancel()
+        progressJob = null
+    }
+
+    private val playerListener = object : Player.Listener {
+        override fun onIsPlayingChanged(isPlaying: Boolean) {
+            if (isPlaying) {
+                startProgressPolling()
+            } else {
+                stopProgressPolling()
+                updateSeekbarUi()
+            }
+
+            chatViewModel.currentVoiceMessage?.apply {
+                isPlayingVoiceMessage = isPlaying
+            }?.let { chatViewModel.syncVoiceMessageUiState(it) }
+        }
+
+        // Catches instant changes (e.g., manual seeks, skipping to the next track)
+        override fun onPositionDiscontinuity(
+            oldPosition: Player.PositionInfo,
+            newPosition: Player.PositionInfo,
+            reason: Int
+        ) {
+            updateSeekbarUi()
+        }
+
+        override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+            // Ensures the UI resets immediately when transitioning to the next voice message
+            updateSeekbarUi()
+        }
+    }
 
     private val onBackPressedCallback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
@@ -798,7 +879,7 @@ class ChatActivity :
                 ) {
                     val currentlyPlayingId by chatViewModel.currentlyPlayedMessageId.collectAsState(null)
 
-                    val isOneToOneConversation = uiState.isOneToOneConversation
+                    val isOneToOneConversation by remember { mutableStateOf(uiState.isOneToOneConversation) }
                     Log.d(TAG, "isOneToOneConversation=" + isOneToOneConversation)
 
                     // list of the file ids of messages being downloaded
@@ -820,7 +901,6 @@ class ChatActivity :
                         state = ChatViewState(
                             chatItems = uiState.items,
                             isOneToOneConversation = isOneToOneConversation,
-                            currentlyPlayingVoiceMessageId = currentlyPlayingId,
                             conversationThreadId = conversationThreadId,
                             chatMode = chatMode,
                             highlightedMessageId = uiState.highlightedMessageId,
@@ -840,8 +920,15 @@ class ChatActivity :
                                 onSwipeReply = { handleSwipeToReply(it) },
                                 onFileClick = { downloadAndOpenFile(it, openWhenDownloadState, downloadingFileState) },
                                 onPollClick = { pollId, pollName -> openPollDialog(pollId, pollName) },
-                                onVoicePlayPauseClick = { onVoicePlayPauseClickCompose(it) },
-                                onVoiceSeek = { _, progress -> chatViewModel.seekToMediaPlayer(progress) },
+                                onVoicePlayPauseClick = { onVoiceClick(it) },
+                                onVoiceSeek = { id, progress ->
+                                    mediaController?.let { controller ->
+                                        if (id.toString() == controller.currentMediaItem?.mediaId) {
+                                            val pos = controller.duration * progress / 100f
+                                            controller.seekTo(pos.toLong())
+                                        }
+                                    }
+                                },
                                 onVoiceSpeedClick = { onVoiceSpeedClickCompose(it) },
                                 onReactionClick = { messageId, emoji -> handleReactionClick(messageId, emoji) },
                                 onReactionLongClick = { messageId -> openReactionsDialog(messageId) },
@@ -984,6 +1071,122 @@ class ChatActivity :
         }
     }
 
+    @Suppress("ReturnCount", "CyclomaticComplexMethod")
+    private fun onVoiceClick(messageId: Int) {
+        fun getAudioDuration(audioFilePath: String): Long {
+            val retriever = MediaMetadataRetriever()
+
+            return try {
+                retriever.setDataSource(audioFilePath)
+                val durationString = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+                val durationLong = durationString?.toLong() ?: 0L
+
+                durationLong / ONE_SECOND_IN_MILLIS
+            } catch (e: IllegalArgumentException) {
+                e.printStackTrace()
+                0L
+            } finally {
+                retriever.release()
+            }
+        }
+
+        fun setupAndPlay(controller: MediaController, message: ChatMessage, file: String) {
+            val avatarUrl = chatViewModel.getAvatarUrl(message)
+
+            val metadata = MediaMetadata.Builder()
+                .setTitle(message.actorDisplayName)
+                .setArtist("Voice Message")
+                .setArtworkUri(avatarUrl.toUri())
+                .build()
+
+            val mediaItem = MediaItem.Builder()
+                .setMediaId(message.jsonMessageId.toString())
+                .setMediaMetadata(metadata)
+                .setUri(file)
+                .build()
+
+            controller.setMediaItem(mediaItem)
+
+            controller.prepare()
+            controller.play()
+        }
+
+        fun setUpWaveform(message: ChatMessage, file: File) {
+            if (message.voiceMessageFloatArray != null) return
+
+            val filename = message.fileParameters.name
+            message.isDownloadingVoiceMessage = true
+
+            chatViewModel.syncVoiceMessageUiState(message)
+
+            CoroutineScope(Dispatchers.Default).launch {
+                val waveform = AudioUtils.audioFileToFloatArray(file)
+                appPreferences.saveWaveFormForFile(filename, waveform.toTypedArray())
+                message.voiceMessageFloatArray = waveform
+
+                withContext(Dispatchers.Main) {
+                    message.isDownloadingVoiceMessage = false
+                    chatViewModel.syncVoiceMessageUiState(message)
+                }
+            }
+        }
+
+        fun prepareVoiceMessage(controller: MediaController, message: ChatMessage): Boolean {
+            val currentMessageId = message.jsonMessageId.toString()
+            val filename = message.fileParameters.name
+            if (filename.isEmpty()) {
+                return true
+            }
+
+            val file = FileUtils.resolveSharedAttachmentFile(context.cacheDir, filename) ?: return true
+            val fileURI = file.toUri()
+            val filePath = fileURI.toString()
+
+            chatViewModel.syncVoiceMessageUiState(
+                message.apply {
+                    voiceMessageDuration = getAudioDuration(filePath).toInt()
+                }
+            )
+
+            if (controller.currentMediaItem?.mediaId != currentMessageId) {
+                if (!file.exists()) {
+                    downloadFileToCache(message, true) {
+                        setupAndPlay(controller, message, filePath)
+                        setUpWaveform(message, file)
+                    }
+                } else {
+                    setupAndPlay(controller, message, filePath)
+                    setUpWaveform(message, file)
+                }
+
+                return true
+            }
+            return false
+        }
+
+        lifecycleScope.launch {
+            val message = chatViewModel.getMessageById(messageId.toLong()).first()
+
+            mediaController?.let { controller ->
+                // If a message is still playing, it must be paused first before another can be loaded
+                val currentMessageId = message.jsonMessageId.toString()
+                if (controller.isPlaying && controller.currentMediaItem?.mediaId != currentMessageId) return@launch
+
+                chatViewModel.currentVoiceMessage = message
+
+                // If the controller is playing a new voice message, initialize
+                if (prepareVoiceMessage(controller, message)) return@launch
+
+                // If the controller is playing the same voice message, pause/resume
+                if (controller.isPlaying) {
+                    controller.pause()
+                } else {
+                    controller.play()
+                }
+            }
+        }
+    }
+
     @Composable
     private fun LazyListState.visibleItemsWithThreshold(): List<String> =
         remember(this) {
@@ -1014,57 +1217,6 @@ class ChatActivity :
 
     private fun onLoadQuotedMessage(messageId: Int) {
         chatViewModel.jumpToQuotedMessage(messageId.toLong())
-    }
-
-    private fun onVoicePlayPauseClickCompose(messageId: Int) {
-        lifecycleScope.launch {
-            val isCurrentlyPlaying = chatViewModel.uiState.value.items
-                .mapNotNull { (it as? ChatViewModel.ChatItem.MessageItem)?.uiMessage }
-                .firstOrNull { it.id == messageId }
-                ?.content
-                ?.let { it as? MessageTypeContent.Voice }
-                ?.isPlaying ?: false
-
-            val message = chatViewModel.getMessageById(messageId.toLong()).first()
-            val filename = message.fileParameters.name
-            if (filename.isEmpty()) {
-                return@launch
-            }
-
-            val file = FileUtils.resolveSharedAttachmentFile(context.cacheDir, filename)
-            if (file == null) {
-                return@launch
-            }
-            if (file.exists()) {
-                if (isCurrentlyPlaying) {
-                    chatViewModel.pauseMediaPlayer(true)
-                    chatViewModel.pauseVoiceMessageUiState(messageId)
-                } else {
-                    val uiSpeed = chatViewModel.uiState.value.items
-                        .mapNotNull { (it as? ChatViewModel.ChatItem.MessageItem)?.uiMessage }
-                        .firstOrNull { it.id == messageId }
-                        ?.content
-                        ?.let { it as? MessageTypeContent.Voice }
-                        ?.playbackSpeed ?: PlaybackSpeed.NORMAL
-                    chatViewModel.setPlayBack(uiSpeed)
-
-                    val retrieved = appPreferences.getWaveFormFromFile(filename)
-                    if (retrieved.isEmpty()) {
-                        setUpWaveform(message)
-                    } else {
-                        if (message.voiceMessageFloatArray == null || message.voiceMessageFloatArray!!.isEmpty()) {
-                            message.voiceMessageFloatArray = retrieved.toFloatArray()
-                            chatViewModel.syncVoiceMessageUiState(message)
-                        }
-                        startPlayback(file, message)
-                    }
-                }
-            } else {
-                downloadFileToCache(message, true) {
-                    setUpWaveform(message)
-                }
-            }
-        }
     }
 
     @Suppress("Detekt.TooGenericExceptionCaught")
@@ -1212,6 +1364,19 @@ class ChatActivity :
         active = true
         this.lifecycle.addObserver(AudioUtils)
         this.lifecycle.addObserver(chatViewModel)
+
+        val sessionToken = SessionToken(this, ComponentName(this, VoiceMessageMediaService::class.java))
+        mediaControllerFuture = MediaController.Builder(this, sessionToken).buildAsync()
+
+        mediaControllerFuture?.addListener({
+            mediaController = mediaControllerFuture?.get()
+
+            mediaController?.addListener(playerListener)
+
+            if (mediaController?.isPlaying == true) {
+                startProgressPolling()
+            }
+        }, ContextCompat.getMainExecutor(this))
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -1224,6 +1389,12 @@ class ChatActivity :
         active = false
         this.lifecycle.removeObserver(AudioUtils)
         this.lifecycle.removeObserver(chatViewModel)
+
+        mediaController?.removeListener(playerListener)
+        stopProgressPolling()
+
+        mediaControllerFuture?.let { MediaController.releaseFuture(it) }
+        mediaController = null
     }
 
     @OptIn(FlowPreview::class)
@@ -1867,38 +2038,6 @@ class ChatActivity :
                 }
             }
         }
-    }
-
-    private fun setUpWaveform(message: ChatMessage, thenPlay: Boolean = true, backgroundPlayAllowed: Boolean = false) {
-        val filename = message.fileParameters.name
-        val file = FileUtils.resolveSharedAttachmentFile(context.cacheDir, filename)
-        if (file == null) {
-            return
-        }
-        if (file.exists() && message.voiceMessageFloatArray == null) {
-            message.isDownloadingVoiceMessage = true
-            chatViewModel.syncVoiceMessageUiState(message)
-            CoroutineScope(Dispatchers.Default).launch {
-                val r = AudioUtils.audioFileToFloatArray(file)
-                appPreferences.saveWaveFormForFile(filename, r.toTypedArray())
-                message.voiceMessageFloatArray = r
-                withContext(Dispatchers.Main) {
-                    message.isDownloadingVoiceMessage = false
-                    chatViewModel.syncVoiceMessageUiState(message)
-                    startPlayback(file, message)
-                }
-            }
-        } else {
-            startPlayback(file, message)
-        }
-    }
-
-    private fun startPlayback(file: File, message: ChatMessage) {
-        chatViewModel.clearMediaPlayerQueue()
-        chatViewModel.queueInMediaPlayer(file.canonicalPath, message)
-        chatViewModel.startCyclingMediaPlayer()
-        message.isPlayingVoiceMessage = true
-        chatViewModel.syncVoiceMessageUiState(message)
     }
 
     private fun updateTypingIndicator() {
@@ -4030,6 +4169,9 @@ class ChatActivity :
         private const val GET_ROOM_INFO_DELAY_NORMAL: Long = 30000
         private const val GET_ROOM_INFO_DELAY_LOBBY: Long = 5000
         private const val MILLIS_250 = 250L
+        private const val MILLIS_150 = 150L
+        private const val MILLIS_1000 = 1000L
+        private const val FLOAT_100 = 100f
         private const val AGE_THRESHOLD_FOR_DELETE_MESSAGE: Int = 21600000 // (6 hours in millis = 6 * 3600 * 1000)
         private const val REQUEST_SHARE_FILE_PERMISSION: Int = 221
         private const val REQUEST_RECORD_AUDIO_PERMISSION = 222

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -426,6 +426,9 @@ class ChatActivity :
             val msg = chatViewModel.currentVoiceMessage?.apply {
                 voiceMessageSeekbarProgress = kotlin.math.ceil(progress).toInt()
                 voiceMessagePlayedSeconds = secondsPlayed.toInt()
+                if (controller.duration > 0) {
+                    voiceMessageDuration = (controller.duration / MILLIS_1000).toInt()
+                }
             }
 
             val currentMediaId = controller.currentMediaItem?.mediaId
@@ -1142,13 +1145,18 @@ class ChatActivity :
 
             chatViewModel.syncVoiceMessageUiState(
                 message.apply {
-                    voiceMessageDuration = getAudioDuration(filePath).toInt()
+                    voiceMessageDuration = getAudioDuration(file.absolutePath).toInt()
                 }
             )
 
             if (controller.currentMediaItem?.mediaId != currentMessageId) {
                 if (!file.exists()) {
                     downloadFileToCache(message, true) {
+                        chatViewModel.syncVoiceMessageUiState(
+                            message.apply {
+                                voiceMessageDuration = getAudioDuration(file.absolutePath).toInt()
+                            }
+                        )
                         setupAndPlay(controller, message, filePath)
                         setUpWaveform(message, file)
                     }

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -108,8 +108,8 @@ import com.nextcloud.talk.adapters.messages.CallStartedMessageInterface
 import com.nextcloud.talk.api.NcApi
 import com.nextcloud.talk.api.NcApiCoroutines
 import com.nextcloud.talk.application.NextcloudTalkApplication
-import com.nextcloud.talk.chat.data.io.VoiceMessageMediaService
 import com.nextcloud.talk.attachmentpreview.FileAttachmentPreviewFragment
+import com.nextcloud.talk.chat.data.io.VoiceMessageMediaService
 import com.nextcloud.talk.chat.data.model.ChatMessage
 import com.nextcloud.talk.chat.data.model.FileParameters
 import com.nextcloud.talk.chat.ui.ChatEmptyState
@@ -179,9 +179,9 @@ import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.AudioUtils
 import com.nextcloud.talk.utils.CapabilitiesUtil
 import com.nextcloud.talk.utils.CapabilitiesUtil.hasSpreedFeatureCapability
+import com.nextcloud.talk.utils.CapabilitiesUtil.retentionOfClassifiedRoom
 import com.nextcloud.talk.utils.CapabilitiesUtil.retentionOfEventRooms
 import com.nextcloud.talk.utils.CapabilitiesUtil.retentionOfInstantMeetingRoom
-import com.nextcloud.talk.utils.CapabilitiesUtil.retentionOfClassifiedRoom
 import com.nextcloud.talk.utils.CapabilitiesUtil.retentionOfSIPRoom
 import com.nextcloud.talk.utils.ContactUtils
 import com.nextcloud.talk.utils.ConversationUtils
@@ -877,8 +877,6 @@ class ChatActivity :
                     LocalMessageUtils provides messageUtils,
                     LocalOpenGraphFetcher provides { url -> chatViewModel.fetchOpenGraph(url) }
                 ) {
-                    val currentlyPlayingId by chatViewModel.currentlyPlayedMessageId.collectAsState(null)
-
                     val isOneToOneConversation by remember { mutableStateOf(uiState.isOneToOneConversation) }
                     Log.d(TAG, "isOneToOneConversation=" + isOneToOneConversation)
 

--- a/app/src/main/java/com/nextcloud/talk/chat/data/io/MediaPlayerManager.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/io/MediaPlayerManager.kt
@@ -6,9 +6,12 @@
  */
 
 package com.nextcloud.talk.chat.data.io
-
-import android.media.MediaPlayer
 import android.util.Log
+import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackParameters
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
+import com.nextcloud.talk.application.NextcloudTalkApplication
 import com.nextcloud.talk.chat.ChatActivity
 import com.nextcloud.talk.chat.data.model.ChatMessage
 import com.nextcloud.talk.ui.PlaybackSpeed
@@ -28,6 +31,7 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileNotFoundException
 import kotlin.math.ceil
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Abstraction over the [MediaPlayer](https://developer.android.com/reference/android/media/MediaPlayer) class used
@@ -81,7 +85,7 @@ class MediaPlayerManager : LifecycleAwareManager {
         get() = _mediaPlayerSeekBarPosition
     private val _mediaPlayerSeekBarPosition: MutableSharedFlow<Int> = MutableSharedFlow()
 
-    private var mediaPlayer: MediaPlayer? = null
+    private var mediaPlayer: ExoPlayer? = null
     private var loop = false
     private var scope = MainScope()
 
@@ -106,7 +110,7 @@ class MediaPlayerManager : LifecycleAwareManager {
             init(path)
         } else {
             _managerState.value = MediaPlayerManagerState.RESUMED
-            mediaPlayer!!.start()
+            mediaPlayer!!.play()
             loop = true
             scope.launch { seekbarUpdateObserver() }
         }
@@ -121,13 +125,13 @@ class MediaPlayerManager : LifecycleAwareManager {
             stop()
         }
 
-        val shouldReset = playQueue.first().first != currentDataSource
+        val shouldReset = playQueue.isNotEmpty() && playQueue.first().first != currentDataSource
 
         if (mediaPlayer == null || !scope.isActive || shouldReset) {
             initCycling()
         } else {
             _managerState.value = MediaPlayerManagerState.RESUMED
-            mediaPlayer!!.start()
+            mediaPlayer!!.play()
             loop = true
             scope.launch { seekbarUpdateObserver() }
         }
@@ -171,46 +175,48 @@ class MediaPlayerManager : LifecycleAwareManager {
     fun seekTo(progress: Int) {
         if (mediaPlayer != null) {
             val pos = mediaPlayer!!.duration * (progress / DIVIDER)
-            mediaPlayer!!.seekTo(pos.toInt())
+            mediaPlayer!!.seekTo(pos.toLong())
             mediaPlayerPosition = pos.toInt()
         }
     }
 
     private suspend fun seekbarUpdateObserver() {
+        _currentCycledMessage.value?.voiceMessageDuration = mediaPlayerDuration / ONE_SEC
+        _currentCycledMessage.value?.resetVoiceMessage = false
         withContext(Dispatchers.IO) {
-            _currentCycledMessage.value?.voiceMessageDuration = mediaPlayerDuration / ONE_SEC
-            _currentCycledMessage.value?.resetVoiceMessage = false
             while (true) {
                 if (!loop) {
                     // NOTE: ok so this doesn't stop the loop, but rather stop the update. Wasteful, but minimal
-                    delay(SEEKBAR_UPDATE_DELAY)
+                    delay(SEEKBAR_UPDATE_DELAY.milliseconds)
                     continue
                 }
 
-                mediaPlayer?.let { player ->
-                    try {
-                        if (!player.isPlaying) return@let
-                    } catch (e: IllegalStateException) {
-                        Log.e(TAG, "Seekbar updated during an improper state: $e")
-                        return@let
-                    }
+                withContext(Dispatchers.Main) {
+                    mediaPlayer?.let { p ->
+                        try {
+                            if (!p.isPlaying) return@let
+                        } catch (e: IllegalStateException) {
+                            Log.e(TAG, "Seekbar updated during an improper state: $e")
+                            return@let
+                        }
 
-                    val pos = player.currentPosition
-                    mediaPlayerPosition = pos
-                    val progress = (pos.toFloat() / mediaPlayerDuration) * DIVIDER
-                    val progressI = ceil(progress).toInt()
-                    val seconds = (pos / ONE_SEC)
-                    _mediaPlayerSeekBarPosition.emit(progressI)
-                    _currentCycledMessage.value?.let { msg ->
-                        msg.isPlayingVoiceMessage = true
-                        msg.voiceMessageSeekbarProgress = progressI
-                        msg.voiceMessagePlayedSeconds = seconds
-                        if (progressI >= IS_PLAYED_CUTOFF) msg.wasPlayedVoiceMessage = true
-                        _mediaPlayerSeekBarPositionMsg.emit(msg)
+                        val pos = p.currentPosition
+                        mediaPlayerPosition = pos.toInt()
+                        val progress = (pos.toFloat() / mediaPlayerDuration) * DIVIDER
+                        val progressI = ceil(progress).toInt()
+                        val seconds = (pos / ONE_SEC).toInt()
+                        _mediaPlayerSeekBarPosition.emit(progressI)
+                        _currentCycledMessage.value?.let { msg ->
+                            msg.isPlayingVoiceMessage = true
+                            msg.voiceMessageSeekbarProgress = progressI
+                            msg.voiceMessagePlayedSeconds = seconds
+                            if (progressI >= IS_PLAYED_CUTOFF) msg.wasPlayedVoiceMessage = true
+                            _mediaPlayerSeekBarPositionMsg.emit(msg)
+                        }
                     }
                 }
 
-                delay(SEEKBAR_UPDATE_DELAY)
+                delay(SEEKBAR_UPDATE_DELAY.milliseconds)
             }
         }
     }
@@ -243,23 +249,27 @@ class MediaPlayerManager : LifecycleAwareManager {
     fun setPlayBackSpeed(speed: PlaybackSpeed) {
         requestedPlaybackSpeed = speed
         if (mediaPlayer != null && mediaPlayer!!.isPlaying) {
-            mediaPlayer!!.playbackParams.let { params ->
-                params.speed = speed.value
-                mediaPlayer!!.playbackParams = params
-            }
+            mediaPlayer!!.playbackParameters = PlaybackParameters(speed.value)
         }
     }
 
     private fun init(path: String) {
         try {
-            mediaPlayer = MediaPlayer().apply {
+            val context = NextcloudTalkApplication.sharedApplication!!.applicationContext
+            mediaPlayer = ExoPlayer.Builder(context).build().apply {
                 _managerState.value = MediaPlayerManagerState.SETUP
-                setDataSource(path)
+                setMediaItem(MediaItem.fromUri(path))
                 currentDataSource = path
-                prepareAsync()
-                setOnPreparedListener {
-                    onPrepare()
-                }
+                prepare()
+                addListener(object : Player.Listener {
+                    override fun onPlaybackStateChanged(playbackState: Int) {
+                        if (playbackState == Player.STATE_READY &&
+                            _managerState.value == MediaPlayerManagerState.SETUP
+                        ) {
+                            onPrepare()
+                        }
+                    }
+                })
             }
         } catch (e: Exception) {
             Log.e(ChatActivity.TAG, "failed to initialize mediaPlayer", e)
@@ -269,48 +279,53 @@ class MediaPlayerManager : LifecycleAwareManager {
 
     private fun initCycling() {
         try {
-            mediaPlayer = MediaPlayer().apply {
+            val context = NextcloudTalkApplication.sharedApplication!!.applicationContext
+            mediaPlayer = ExoPlayer.Builder(context).build().apply {
                 _managerState.value = MediaPlayerManagerState.SETUP
                 val pair = playQueue.iterator().next()
-                setDataSource(pair.first)
+                setMediaItem(MediaItem.fromUri(pair.first))
                 currentDataSource = pair.first
                 _currentCycledMessage.value = pair.second
                 playQueue.removeAt(0)
-                prepareAsync()
-                setOnPreparedListener {
-                    onPrepare()
-                }
-
-                setOnCompletionListener {
-                    if (playQueue.iterator().hasNext() && playQueue.first().first != currentDataSource) {
-                        _managerState.value = MediaPlayerManagerState.SETUP
-                        val nextPair = playQueue.iterator().next()
-                        playQueue.removeAt(0)
-                        mediaPlayer?.reset()
-                        mediaPlayer?.setDataSource(nextPair.first)
-                        _currentCycledMessage.value = nextPair.second
-                        prepare()
-                    } else {
-                        mediaPlayer?.release()
-                        mediaPlayer = null
-                        _backgroundPlayUIFlow.tryEmit(null)
-                        _currentCycledMessage.value?.let {
-                            it.resetVoiceMessage = true
-                            it.isPlayingVoiceMessage = false
-                            it.voiceMessageSeekbarProgress = 0
-                            it.voiceMessagePlayedSeconds = 0
-                        }
-                        val completedMessage = _currentCycledMessage.value
-                        _currentCycledMessage.value = null
-                        if (completedMessage != null) {
-                            scope.launch {
-                                _mediaPlayerSeekBarPositionMsg.emit(completedMessage)
+                prepare()
+                addListener(object : Player.Listener {
+                    override fun onPlaybackStateChanged(playbackState: Int) {
+                        if (playbackState == Player.STATE_READY &&
+                            _managerState.value == MediaPlayerManagerState.SETUP
+                        ) {
+                            onPrepare()
+                        } else if (playbackState == Player.STATE_ENDED) {
+                            if (playQueue.iterator().hasNext() && playQueue.first().first != currentDataSource) {
+                                _managerState.value = MediaPlayerManagerState.SETUP
+                                val nextPair = playQueue.iterator().next()
+                                playQueue.removeAt(0)
+                                mediaPlayer?.setMediaItem(MediaItem.fromUri(nextPair.first))
+                                currentDataSource = nextPair.first
+                                _currentCycledMessage.value = nextPair.second
+                                prepare()
+                            } else {
+                                mediaPlayer?.release()
+                                mediaPlayer = null
+                                _backgroundPlayUIFlow.tryEmit(null)
+                                _currentCycledMessage.value?.let {
+                                    it.resetVoiceMessage = true
+                                    it.isPlayingVoiceMessage = false
+                                    it.voiceMessageSeekbarProgress = 0
+                                    it.voiceMessagePlayedSeconds = 0
+                                }
+                                val completedMessage = _currentCycledMessage.value
+                                _currentCycledMessage.value = null
+                                if (completedMessage != null) {
+                                    scope.launch {
+                                        _mediaPlayerSeekBarPositionMsg.emit(completedMessage)
+                                    }
+                                }
+                                loop = false
+                                _managerState.value = MediaPlayerManagerState.STOPPED
                             }
                         }
-                        loop = false
-                        _managerState.value = MediaPlayerManagerState.STOPPED
                     }
-                }
+                })
             }
         } catch (e: Exception) {
             Log.e(ChatActivity.TAG, "failed to initialize mediaPlayer", e)
@@ -318,8 +333,8 @@ class MediaPlayerManager : LifecycleAwareManager {
         }
     }
 
-    private fun MediaPlayer.onPrepare() {
-        mediaPlayerDuration = this.duration
+    private fun ExoPlayer.onPrepare() {
+        mediaPlayerDuration = this.duration.toInt()
 
         val playBackSpeed = requestedPlaybackSpeed?.value
             ?: if (_currentCycledMessage.value?.actorId == null) {
@@ -327,9 +342,9 @@ class MediaPlayerManager : LifecycleAwareManager {
             } else {
                 appPreferences.getPreferredPlayback(_currentCycledMessage.value?.actorId).value
             }
-        mediaPlayer!!.playbackParams = mediaPlayer!!.playbackParams.setSpeed(playBackSpeed)
+        playbackParameters = PlaybackParameters(playBackSpeed)
 
-        start()
+        play()
         _managerState.value = MediaPlayerManagerState.STARTED
         _currentCycledMessage.value?.let {
             it.isPlayingVoiceMessage = true

--- a/app/src/main/java/com/nextcloud/talk/chat/data/io/VoiceMessageMediaService.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/io/VoiceMessageMediaService.kt
@@ -1,0 +1,34 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.nextcloud.talk.chat.data.io
+
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.session.MediaSession
+import androidx.media3.session.MediaSessionService
+
+class VoiceMessageMediaService : MediaSessionService() {
+    private var mediaSession: MediaSession? = null
+
+    @OptIn(UnstableApi::class)
+    override fun onCreate() {
+        super.onCreate()
+        val player = ExoPlayer.Builder(this).build()
+        mediaSession = MediaSession.Builder(this, player).build()
+    }
+
+    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? = mediaSession
+
+    override fun onDestroy() {
+        mediaSession?.player?.release()
+        mediaSession?.release()
+        mediaSession = null
+        super.onDestroy()
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
@@ -35,6 +35,7 @@ import com.nextcloud.talk.conversationlist.DirectShareHelper
 import com.nextcloud.talk.conversationlist.data.OfflineConversationsRepository
 import com.nextcloud.talk.conversationlist.data.network.OfflineFirstConversationsRepository
 import com.nextcloud.talk.conversationlist.viewmodels.ConversationsListViewModel.Companion.FOLLOWED_THREADS_EXIST
+import com.nextcloud.talk.dagger.modules.ApplicationScope
 import com.nextcloud.talk.data.database.mappers.toDomainModel
 import com.nextcloud.talk.data.database.model.ChatMessageEntity
 import com.nextcloud.talk.data.user.model.User
@@ -80,7 +81,6 @@ import io.reactivex.Observer
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
-import com.nextcloud.talk.dagger.modules.ApplicationScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -205,8 +205,6 @@ class ChatViewModel @AssistedInject constructor(
     private val mediaPlayerManager: MediaPlayerManager = MediaPlayerManager.sharedInstance(appPreferences)
     lateinit var currentLifeCycleFlag: LifeCycleFlag
     val disposableSet = mutableSetOf<Disposable>()
-    var mediaPlayerDuration = mediaPlayerManager.mediaPlayerDuration
-    val mediaPlayerPosition = mediaPlayerManager.mediaPlayerPosition
 
     var messageDraft: MessageDraft = MessageDraft()
     var hiddenUpcomingEvent: String? = null
@@ -259,24 +257,8 @@ class ChatViewModel @AssistedInject constructor(
         showUnreadMessagesMarker = shouldShow
     }
 
-    val backgroundPlayUIFlow = mediaPlayerManager.backgroundPlayUIFlow
-
     val mediaPlayerSeekbarObserver: Flow<ChatMessage>
         get() = mediaPlayerManager.mediaPlayerSeekBarPositionMsg
-
-    // FIXME - map this to string id or some other kinda of id idk
-    val currentlyPlayedMessageId: Flow<Int?>
-        get() = mediaPlayerManager.currentCycledMessage.map { msg -> msg?.jsonMessageId }
-
-    val managerStateFlow: Flow<MediaPlayerManager.MediaPlayerManagerState>
-        get() = mediaPlayerManager.managerState
-
-    val voiceMessagePlayBackUIFlow: Flow<PlaybackSpeed>
-        get() = _voiceMessagePlayBackUIFlow
-    private val _voiceMessagePlayBackUIFlow: MutableSharedFlow<PlaybackSpeed> = MutableSharedFlow()
-
-    val getAudioFocusChange: LiveData<AudioFocusRequestManager.ManagerState>
-        get() = audioFocusRequestManager.getManagerState
 
     private val _recordTouchObserver: MutableLiveData<Float> = MutableLiveData()
     val recordTouchObserver: LiveData<Float>
@@ -1974,30 +1956,9 @@ class ChatViewModel @AssistedInject constructor(
         _getVoiceRecordingLocked.postValue(boolean)
     }
 
-    // Made this so that the MediaPlayer in ChatActivity can be focused. Eventually the player logic should be moved
-    // to the MediaPlayerManager class, so the audio focus logic can be handled in ChatViewModel, as it's done in
-    // the MessageInputViewModel
-    fun audioRequest(request: Boolean, callback: () -> Unit) {
-        audioFocusRequestManager.audioFocusRequest(request, callback)
-    }
-
     fun handleOrientationChange() {
         _getCapabilitiesViewState.value = GetCapabilitiesStartState
     }
-
-    // fun getMessageById(url: String, conversationModel: ConversationModel, messageId: Long): Flow<ChatMessage> =
-    //     flow {
-    //         val bundle = Bundle()
-    //         bundle.putString(BundleKeys.KEY_CHAT_URL, url)
-    //         bundle.putString(
-    //             BundleKeys.KEY_CREDENTIALS,
-    //             currentUser.getCredentials()
-    //         )
-    //         bundle.putString(BundleKeys.KEY_ROOM_TOKEN, conversationModel.token)
-    //
-    //         val message = chatRepository.getMessage(messageId, bundle)
-    //         emit(message.first())
-    //     }
 
     @Deprecated("use getMessageById(messageId: Long)")
     fun getMessageById(url: String, conversationModel: ConversationModel, messageId: Long): Flow<ChatMessage> {
@@ -2025,61 +1986,6 @@ class ChatViewModel @AssistedInject constructor(
 
         return chatRepository.getMessage(messageId, bundle)
     }
-
-    // fun getIndividualMessageFromServer(
-    //     credentials: String,
-    //     baseUrl: String,
-    //     token: String,
-    //     messageId: String
-    // ): Flow<ChatMessage?> =
-    //     flow {
-    //         val messages = chatNetworkDataSource.getContextForChatMessage(
-    //             credentials = credentials,
-    //             baseUrl = baseUrl,
-    //             token = token,
-    //             messageId = messageId,
-    //             limit = 1,
-    //             threadId = null
-    //         )
-    //
-    //         if (messages.isNotEmpty()) {
-    //             val message = messages[0]
-    //             emit(message.toDomainModel())
-    //         } else {
-    //             emit(null)
-    //         }
-    //     }.flowOn(Dispatchers.IO)
-
-    suspend fun getNumberOfThreadReplies(threadId: Long): Int = chatRepository.getNumberOfThreadReplies(threadId)
-
-    fun setPlayBack(speed: PlaybackSpeed) {
-        mediaPlayerManager.setPlayBackSpeed(speed)
-        viewModelScope.launch {
-            _voiceMessagePlayBackUIFlow.emit(speed)
-        }
-    }
-
-    fun startMediaPlayer(path: String) {
-        audioRequest(true) {
-            mediaPlayerManager.start(path)
-        }
-    }
-
-    fun startCyclingMediaPlayer() = audioRequest(true, mediaPlayerManager::startCycling)
-
-    fun pauseMediaPlayer(notifyUI: Boolean) {
-        audioRequest(false) {
-            mediaPlayerManager.pause(notifyUI)
-        }
-    }
-
-    fun seekToMediaPlayer(progress: Int) = mediaPlayerManager.seekTo(progress)
-
-    fun stopMediaPlayer() = audioRequest(false, mediaPlayerManager::stop)
-
-    fun queueInMediaPlayer(path: String, msg: ChatMessage) = mediaPlayerManager.addToPlayList(path, msg)
-
-    fun clearMediaPlayerQueue() = mediaPlayerManager.clearPlayList()
 
     inner class JoinRoomObserver : Observer<ConversationModel> {
         override fun onSubscribe(d: Disposable) {

--- a/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
@@ -859,7 +859,10 @@ class ChatViewModel @AssistedInject constructor(
         }
     }
 
+    var currentVoiceMessage: ChatMessage? = null
+
     fun syncVoiceMessageUiState(message: ChatMessage) {
+        currentVoiceMessage = message
         _uiState.update { current ->
             val updatedItems = current.items.map { item ->
                 if (item is ChatItem.MessageItem && item.uiMessage.id == message.jsonMessageId) {

--- a/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
@@ -267,6 +267,12 @@ class ChatViewModel @AssistedInject constructor(
     val mediaPlayerSeekbarObserver: Flow<ChatMessage>
         get() = mediaPlayerManager.mediaPlayerSeekBarPositionMsg
 
+    val currentlyPlayedMessageId: Flow<Int?> = mediaPlayerManager.currentCycledMessage.map { it?.jsonMessageId }
+
+    fun setPlayBack(speed: PlaybackSpeed) {
+        mediaPlayerManager.setPlayBackSpeed(speed)
+    }
+
     private val _recordTouchObserver: MutableLiveData<Float> = MutableLiveData()
     val recordTouchObserver: LiveData<Float>
         get() = _recordTouchObserver

--- a/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
@@ -207,8 +207,6 @@ class ChatViewModel @AssistedInject constructor(
     private val mediaPlayerManager: MediaPlayerManager = MediaPlayerManager.sharedInstance(appPreferences)
     lateinit var currentLifeCycleFlag: LifeCycleFlag
     val disposableSet = mutableSetOf<Disposable>()
-    var mediaPlayerDuration = mediaPlayerManager.mediaPlayerDuration
-    val mediaPlayerPosition = mediaPlayerManager.mediaPlayerPosition
 
     var messageDraft: MessageDraft = MessageDraft()
     var hiddenUpcomingEvent: String? = null
@@ -266,24 +264,8 @@ class ChatViewModel @AssistedInject constructor(
         showUnreadMessagesMarker = shouldShow
     }
 
-    val backgroundPlayUIFlow = mediaPlayerManager.backgroundPlayUIFlow
-
     val mediaPlayerSeekbarObserver: Flow<ChatMessage>
         get() = mediaPlayerManager.mediaPlayerSeekBarPositionMsg
-
-    // FIXME - map this to string id or some other kinda of id idk
-    val currentlyPlayedMessageId: Flow<Int?>
-        get() = mediaPlayerManager.currentCycledMessage.map { msg -> msg?.jsonMessageId }
-
-    val managerStateFlow: Flow<MediaPlayerManager.MediaPlayerManagerState>
-        get() = mediaPlayerManager.managerState
-
-    val voiceMessagePlayBackUIFlow: Flow<PlaybackSpeed>
-        get() = _voiceMessagePlayBackUIFlow
-    private val _voiceMessagePlayBackUIFlow: MutableSharedFlow<PlaybackSpeed> = MutableSharedFlow()
-
-    val getAudioFocusChange: LiveData<AudioFocusRequestManager.ManagerState>
-        get() = audioFocusRequestManager.getManagerState
 
     private val _recordTouchObserver: MutableLiveData<Float> = MutableLiveData()
     val recordTouchObserver: LiveData<Float>
@@ -872,7 +854,10 @@ class ChatViewModel @AssistedInject constructor(
         }
     }
 
+    var currentVoiceMessage: ChatMessage? = null
+
     fun syncVoiceMessageUiState(message: ChatMessage) {
+        currentVoiceMessage = message
         _uiState.update { current ->
             val updatedItems = current.items.map { item ->
                 if (item is ChatItem.MessageItem && item.uiMessage.id == message.jsonMessageId) {
@@ -2058,30 +2043,9 @@ class ChatViewModel @AssistedInject constructor(
         _getVoiceRecordingLocked.postValue(boolean)
     }
 
-    // Made this so that the MediaPlayer in ChatActivity can be focused. Eventually the player logic should be moved
-    // to the MediaPlayerManager class, so the audio focus logic can be handled in ChatViewModel, as it's done in
-    // the MessageInputViewModel
-    fun audioRequest(request: Boolean, callback: () -> Unit) {
-        audioFocusRequestManager.audioFocusRequest(request, callback)
-    }
-
     fun handleOrientationChange() {
         _getCapabilitiesViewState.value = GetCapabilitiesStartState
     }
-
-    // fun getMessageById(url: String, conversationModel: ConversationModel, messageId: Long): Flow<ChatMessage> =
-    //     flow {
-    //         val bundle = Bundle()
-    //         bundle.putString(BundleKeys.KEY_CHAT_URL, url)
-    //         bundle.putString(
-    //             BundleKeys.KEY_CREDENTIALS,
-    //             currentUser.getCredentials()
-    //         )
-    //         bundle.putString(BundleKeys.KEY_ROOM_TOKEN, conversationModel.token)
-    //
-    //         val message = chatRepository.getMessage(messageId, bundle)
-    //         emit(message.first())
-    //     }
 
     @Deprecated("use getMessageById(messageId: Long)")
     fun getMessageById(url: String, conversationModel: ConversationModel, messageId: Long): Flow<ChatMessage> {
@@ -2109,61 +2073,6 @@ class ChatViewModel @AssistedInject constructor(
 
         return chatRepository.getMessage(messageId, bundle)
     }
-
-    // fun getIndividualMessageFromServer(
-    //     credentials: String,
-    //     baseUrl: String,
-    //     token: String,
-    //     messageId: String
-    // ): Flow<ChatMessage?> =
-    //     flow {
-    //         val messages = chatNetworkDataSource.getContextForChatMessage(
-    //             credentials = credentials,
-    //             baseUrl = baseUrl,
-    //             token = token,
-    //             messageId = messageId,
-    //             limit = 1,
-    //             threadId = null
-    //         )
-    //
-    //         if (messages.isNotEmpty()) {
-    //             val message = messages[0]
-    //             emit(message.toDomainModel())
-    //         } else {
-    //             emit(null)
-    //         }
-    //     }.flowOn(Dispatchers.IO)
-
-    suspend fun getNumberOfThreadReplies(threadId: Long): Int = chatRepository.getNumberOfThreadReplies(threadId)
-
-    fun setPlayBack(speed: PlaybackSpeed) {
-        mediaPlayerManager.setPlayBackSpeed(speed)
-        viewModelScope.launch {
-            _voiceMessagePlayBackUIFlow.emit(speed)
-        }
-    }
-
-    fun startMediaPlayer(path: String) {
-        audioRequest(true) {
-            mediaPlayerManager.start(path)
-        }
-    }
-
-    fun startCyclingMediaPlayer() = audioRequest(true, mediaPlayerManager::startCycling)
-
-    fun pauseMediaPlayer(notifyUI: Boolean) {
-        audioRequest(false) {
-            mediaPlayerManager.pause(notifyUI)
-        }
-    }
-
-    fun seekToMediaPlayer(progress: Int) = mediaPlayerManager.seekTo(progress)
-
-    fun stopMediaPlayer() = audioRequest(false, mediaPlayerManager::stop)
-
-    fun queueInMediaPlayer(path: String, msg: ChatMessage) = mediaPlayerManager.addToPlayList(path, msg)
-
-    fun clearMediaPlayerQueue() = mediaPlayerManager.clearPlayList()
 
     inner class JoinRoomObserver : Observer<ConversationModel> {
         override fun onSubscribe(d: Disposable) {

--- a/app/src/main/java/com/nextcloud/talk/ui/ComposeWaveformSeekbar.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/ComposeWaveformSeekbar.kt
@@ -31,6 +31,7 @@ const val WAVEFORM_THUMB_SIZE = 20
 const val WAVEFORM_SIZE = 30
 const val MAX_HEIGHT = 100
 const val OVERLAP = 0.025
+const val PROGRESS = 0.97f
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -98,7 +99,7 @@ fun Preview() {
     val waveData = remember { FloatArray(WAVEFORM_SIZE) { (Math.random() % 1).toFloat() } }
 
     ComposeWaveformSeekBar(
-        0.97f,
+        PROGRESS,
         {},
         modifier = Modifier
             .height(MAX_HEIGHT.dp)

--- a/app/src/main/java/com/nextcloud/talk/ui/ComposeWaveformSeekbar.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/ComposeWaveformSeekbar.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -33,7 +34,13 @@ const val OVERLAP = 0.025
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ComposeWaveformSeekBar(value: Float, onValueChange: (Float) -> Unit, modifier: Modifier, waveData: FloatArray) {
+fun ComposeWaveformSeekBar(
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    modifier: Modifier,
+    waveData: FloatArray,
+    enabled: Boolean
+) {
     val barWidth = Stroke.DefaultMiter
     val thumbSize = WAVEFORM_THUMB_SIZE.dp
     val inversePrimary = MaterialTheme.colorScheme.inversePrimary
@@ -41,6 +48,7 @@ fun ComposeWaveformSeekBar(value: Float, onValueChange: (Float) -> Unit, modifie
 
     Slider(
         value = value,
+        enabled = enabled,
         onValueChange = onValueChange,
         track = {
             Box(
@@ -48,14 +56,18 @@ fun ComposeWaveformSeekBar(value: Float, onValueChange: (Float) -> Unit, modifie
                     .drawWithCache {
                         onDrawBehind {
                             val height = this.size.height
-                            val width = this.size.width
+                            val width = this.size.width + 8.dp.value
                             val midpoint = (this.size.height / 2f)
 
                             val barGap = (width - waveData.size * barWidth) / (waveData.size - 1).toFloat() + 1
                             for (i in waveData.indices) {
                                 val x: Float = i * (barWidth + barGap)
-                                val y: Float = waveData[i] * height
-                                val isXBeforeThumb = (x / this.size.width) <= value
+
+                                if (x < 0f || x > size.width) continue
+
+                                val y: Float = (waveData[i] * height).coerceIn(0f, midpoint)
+
+                                val isXBeforeThumb = x <= value * width
 
                                 drawLine(
                                     if (isXBeforeThumb) inversePrimary else onPrimaryContainer,
@@ -86,11 +98,13 @@ fun Preview() {
     val waveData = remember { FloatArray(WAVEFORM_SIZE) { (Math.random() % 1).toFloat() } }
 
     ComposeWaveformSeekBar(
-        0.0f,
+        0.97f,
         {},
         modifier = Modifier
             .height(MAX_HEIGHT.dp)
-            .fillMaxWidth(),
-        waveData
+            .fillMaxWidth()
+            .padding(8.dp),
+        waveData,
+        true
     )
 }

--- a/app/src/main/java/com/nextcloud/talk/ui/ComposeWaveformSeekbar.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/ComposeWaveformSeekbar.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -30,10 +31,17 @@ const val WAVEFORM_THUMB_SIZE = 20
 const val WAVEFORM_SIZE = 30
 const val MAX_HEIGHT = 100
 const val OVERLAP = 0.025
+const val PROGRESS = 0.97f
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ComposeWaveformSeekBar(value: Float, onValueChange: (Float) -> Unit, modifier: Modifier, waveData: FloatArray) {
+fun ComposeWaveformSeekBar(
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    modifier: Modifier,
+    waveData: FloatArray,
+    enabled: Boolean
+) {
     val barWidth = Stroke.DefaultMiter
     val thumbSize = WAVEFORM_THUMB_SIZE.dp
     val inversePrimary = MaterialTheme.colorScheme.inversePrimary
@@ -41,6 +49,7 @@ fun ComposeWaveformSeekBar(value: Float, onValueChange: (Float) -> Unit, modifie
 
     Slider(
         value = value,
+        enabled = enabled,
         onValueChange = onValueChange,
         track = {
             Box(
@@ -48,14 +57,18 @@ fun ComposeWaveformSeekBar(value: Float, onValueChange: (Float) -> Unit, modifie
                     .drawWithCache {
                         onDrawBehind {
                             val height = this.size.height
-                            val width = this.size.width
+                            val width = this.size.width + 8.dp.value
                             val midpoint = (this.size.height / 2f)
 
                             val barGap = (width - waveData.size * barWidth) / (waveData.size - 1).toFloat() + 1
                             for (i in waveData.indices) {
                                 val x: Float = i * (barWidth + barGap)
-                                val y: Float = waveData[i] * height
-                                val isXBeforeThumb = (x / this.size.width) <= value
+
+                                if (x < 0f || x > size.width) continue
+
+                                val y: Float = (waveData[i] * height).coerceIn(0f, midpoint)
+
+                                val isXBeforeThumb = x <= value * width
 
                                 drawLine(
                                     if (isXBeforeThumb) inversePrimary else onPrimaryContainer,
@@ -86,11 +99,13 @@ fun Preview() {
     val waveData = remember { FloatArray(WAVEFORM_SIZE) { (Math.random() % 1).toFloat() } }
 
     ComposeWaveformSeekBar(
-        0.0f,
+        PROGRESS,
         {},
         modifier = Modifier
             .height(MAX_HEIGHT.dp)
-            .fillMaxWidth(),
-        waveData
+            .fillMaxWidth()
+            .padding(8.dp),
+        waveData,
+        true
     )
 }

--- a/app/src/main/java/com/nextcloud/talk/ui/chat/ChatMessageView.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/chat/ChatMessageView.kt
@@ -52,7 +52,6 @@ private const val QUOTE_HIGHLIGHT_HOLD_MILLIS = 700L
 private const val QUOTE_HIGHLIGHT_FADE_OUT_MILLIS = 1500
 
 data class ChatMessageContext(
-    val currentlyPlayingVoiceMessageId: Int? = null,
     val isOneToOneConversation: Boolean = false,
     val conversationThreadId: Long? = null,
     val hasChatPermission: Boolean = true,
@@ -182,7 +181,6 @@ fun ChatMessageView(
                                 message = message,
                                 isOneToOneConversation = context.isOneToOneConversation,
                                 conversationThreadId = context.conversationThreadId,
-                                currentlyPlayingVoiceMessageId = context.currentlyPlayingVoiceMessageId,
                                 onPlayPauseClick = callbacks.onVoicePlayPauseClick,
                                 onSeek = callbacks.onVoiceSeek,
                                 onSpeedClick = callbacks.onVoiceSpeedClick

--- a/app/src/main/java/com/nextcloud/talk/ui/chat/ChatView.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/chat/ChatView.kt
@@ -94,7 +94,6 @@ data class ChatViewState(
     val chatItems: List<ChatViewModel.ChatItem>,
     val isOneToOneConversation: Boolean,
     val conversationThreadId: Long? = null,
-    val currentlyPlayingVoiceMessageId: Int? = null,
     val hasChatPermission: Boolean = true,
     val initialUnreadCount: Int = 0,
     val initialShowUnreadPopup: Boolean = false,
@@ -409,7 +408,6 @@ fun ChatView(
                                 isSelected = state.highlightedMessageId == chatItem.uiMessage.id,
                                 highlightSearchTerm = state.highlightedSearchTerm,
                                 context = ChatMessageContext(
-                                    currentlyPlayingVoiceMessageId = state.currentlyPlayingVoiceMessageId,
                                     isOneToOneConversation = state.isOneToOneConversation,
                                     conversationThreadId = state.conversationThreadId,
                                     hasChatPermission = state.hasChatPermission,

--- a/app/src/main/java/com/nextcloud/talk/ui/chat/VoiceMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/chat/VoiceMessage.kt
@@ -54,7 +54,6 @@ fun VoiceMessage(
     message: ChatMessageUi,
     isOneToOneConversation: Boolean = false,
     conversationThreadId: Long? = null,
-    currentlyPlayingVoiceMessageId: Int? = null,
     onPlayPauseClick: (Int) -> Unit = {},
     onSeek: (messageId: Int, progress: Int) -> Unit = { _, _ -> },
     onSpeedClick: (messageId: Int) -> Unit = {}
@@ -69,7 +68,7 @@ fun VoiceMessage(
             remember(inversePrimaryColor) { inversePrimaryColor.toArgb() }
             val onPrimaryContainerColor = colorScheme.onPrimaryContainer
             remember(onPrimaryContainerColor) { onPrimaryContainerColor.toArgb() }
-            val remainingSeconds = (typeContent.durationSeconds - typeContent.playedSeconds).coerceAtLeast(0)
+            val remainingSeconds = (typeContent.durationSeconds - typeContent.playedSeconds)
             val waveformData = remember(typeContent.waveform) {
                 val floatArr = typeContent.waveform.toFloatArray()
                 if (floatArr.size < WAVEFORM_SIZE) {
@@ -84,11 +83,7 @@ fun VoiceMessage(
                 label = "size"
             )
 
-            val icon = if (message.id != currentlyPlayingVoiceMessageId) {
-                Icons.Filled.PlayArrow
-            } else {
-                if (typeContent.isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow
-            }
+            val icon = if (typeContent.isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow
 
             Column {
                 Row(
@@ -123,7 +118,8 @@ fun VoiceMessage(
                             .height(animValue.dp)
                             .fillMaxWidth()
                             .padding(8.dp), // or weight(1f),
-                        waveformData
+                        waveformData,
+                        enabled = true
                     )
 
                     TextButton(


### PR DESCRIPTION
- fixes #6066 

Harder than I thought, this required refactoring the entire media player io logic to use MediaSessionService as it's source of truth. While this simplifies the architecture a bit, it also means I have to go about and fix some old bugs once again.

Further follow up PR's would be to move more logic into the view model and simplify chat activity and changing how MediaPlayerManager is used.

<img width="387" height="731" alt="Screenshot 2026-07-06 at 11 43 04 AM" src="https://github.com/user-attachments/assets/689f10ed-96b1-4dc9-b0c7-4c97a5531991" />


### 🚧 TODO

- [x] Get it working
- [x] Fix Pause/Play btn state
- [x] Allow seeking in UI
    - [x] Seeking another messages seekbar also seeks the message next to it, when you play a another message before pausing the currently playing message.
- [x] Add Message MetaData to Control Notification
- [x] Allow waveforms
    - [x] SeekBar speed should match Thumb, might need to do some math here
- [x] Make played seconds update -_-
    - [x] Seconds played should count down from duration

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
