### PR TITLE
use application name as user agent

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/account/data/network/NetworkLoginDataSource.kt
+++ b/app/src/main/java/com/nextcloud/talk/account/data/network/NetworkLoginDataSource.kt
@@ -12,6 +12,7 @@ import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import com.nextcloud.talk.account.data.model.LoginCompletion
 import com.nextcloud.talk.account.data.model.LoginResponse
+import com.nextcloud.talk.utils.ApiUtils
 import okhttp3.FormBody
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -101,6 +102,7 @@ class NetworkLoginDataSource(val okHttpClient: OkHttpClient) {
             .url(url)
             .post(FormBody.Builder().build())
             .addHeader("Clear-Site-Data", "cookies")
+            .header("User-Agent", ApiUtils.loginUserAgent)
             .build()
 
         okHttpClient.newCall(request).execute().use { response ->

--- a/app/src/main/java/com/nextcloud/talk/dagger/modules/RestModule.java
+++ b/app/src/main/java/com/nextcloud/talk/dagger/modules/RestModule.java
@@ -232,9 +232,12 @@ public class RestModule {
         public Response intercept(@NonNull Chain chain) throws IOException {
             Request original = chain.request();
             Request.Builder requestBuilder = original.newBuilder()
-                .header("User-Agent", ApiUtils.getUserAgent())
                 .header("ngrok-skip-browser-warning", "true")
                 .method(original.method(), original.body());
+
+            if (TextUtils.isEmpty(original.header("User-Agent"))) {
+                requestBuilder.header("User-Agent", ApiUtils.getUserAgent());
+            }
 
             if (isOcsEndpoint(original)) {
                 requestBuilder

--- a/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.kt
@@ -39,6 +39,14 @@ object ApiUtils {
     val userAgent = "Mozilla/5.0 (Android) Nextcloud-Talk v"
         get() = field + BuildConfig.VERSION_NAME
 
+    // shown to the user in the browser during the login flow, so it uses the human-readable product name
+    @JvmStatic
+    val loginUserAgent: String
+        get() {
+            val productName = sharedApplication!!.resources.getString(R.string.nc_app_product_name)
+            return "Mozilla/5.0 (Android) $productName v${BuildConfig.VERSION_NAME}"
+        }
+
     @Deprecated(
         "This is only supported on API v1-3, in API v4+ please use " +
             "{@link ApiUtils#getUrlForAttendees(int, String, String)} instead."

--- a/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/ApiUtils.kt
@@ -39,11 +39,14 @@ object ApiUtils {
     val userAgent = "Mozilla/5.0 (Android) Nextcloud-Talk v"
         get() = field + BuildConfig.VERSION_NAME
 
+    private const val DEFAULT_LOGIN_PRODUCT_NAME = "Nextcloud Talk"
+
     // shown to the user in the browser during the login flow, so it uses the human-readable product name
     @JvmStatic
     val loginUserAgent: String
         get() {
-            val productName = sharedApplication!!.resources.getString(R.string.nc_app_product_name)
+            val productName = sharedApplication?.resources?.getString(R.string.nc_app_product_name)
+                ?: DEFAULT_LOGIN_PRODUCT_NAME
             return "Mozilla/5.0 (Android) $productName v${BuildConfig.VERSION_NAME}"
         }
 


### PR DESCRIPTION


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)


### How to test

see http requests in logcat.
For all requests there should be
`User-Agent: Mozilla/5.0 (Android) Nextcloud-Talk v24.1.0 Alpha 15`
Only for the login request there should be
`User-Agent: Mozilla/5.0 (Android) Nextcloud Talk v24.1.0 Alpha 15` (can also be seen at the login website)

so it's "Nextcloud-Talk" vs "Nextcloud Talk".

Seems meaningless when it's the native Nextcloud Talk client, but it's important for branded clients.


## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
