### PR TITLE
Remember microphone mute state when rejoining a call

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -1060,7 +1060,7 @@ class CallActivity : CallBaseActivity() {
 
         if (permissionUtil!!.isMicrophonePermissionGranted()) {
             CallForegroundService.start(applicationContext, conversationName, intent.extras)
-            if (!microphoneOn) {
+            if (!microphoneOn && !appPreferences.callMicrophoneMuted) {
                 onMicrophoneClick()
             }
         }
@@ -1265,6 +1265,7 @@ class CallActivity : CallBaseActivity() {
                     )
                 }
                 toggleMedia(microphoneOn, false)
+                appPreferences.callMicrophoneMuted = !microphoneOn
             } else {
                 binding!!.microphoneButton.setImageResource(R.drawable.ic_mic_white_24px)
                 pulseAnimation!!.start()

--- a/app/src/main/java/com/nextcloud/talk/utils/preferences/AppPreferences.java
+++ b/app/src/main/java/com/nextcloud/talk/utils/preferences/AppPreferences.java
@@ -118,6 +118,10 @@ public interface AppPreferences {
 
     void removeScreenLock();
 
+    boolean getCallMicrophoneMuted();
+
+    void setCallMicrophoneMuted(boolean value);
+
     boolean getIsKeyboardIncognito();
 
     void setIncognitoKeyboard(boolean value);

--- a/app/src/main/java/com/nextcloud/talk/utils/preferences/AppPreferencesImpl.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/preferences/AppPreferencesImpl.kt
@@ -309,6 +309,18 @@ class AppPreferencesImpl(val context: Context) : AppPreferences {
         setScreenLock(false)
     }
 
+    override fun getCallMicrophoneMuted(): Boolean =
+        runBlocking {
+            async { readBoolean(CALL_MICROPHONE_MUTED).first() }
+        }.getCompleted()
+
+    override fun setCallMicrophoneMuted(value: Boolean) =
+        runBlocking<Unit> {
+            async {
+                writeBoolean(CALL_MICROPHONE_MUTED, value)
+            }
+        }
+
     override fun getIsKeyboardIncognito(): Boolean {
         val read = runBlocking { async { readBoolean(INCOGNITO_KEYBOARD).first() } }.getCompleted()
         return read
@@ -672,6 +684,7 @@ class AppPreferencesImpl(val context: Context) : AppPreferences {
         const val NOTIFY_UPGRADE_V3 = "notification_channels_upgrade_to_v3"
         const val SCREEN_SECURITY = "screen_security"
         const val SCREEN_LOCK = "screen_lock"
+        const val CALL_MICROPHONE_MUTED = "call_microphone_muted"
         const val INCOGNITO_KEYBOARD = "incognito_keyboard"
         const val SHOW_ECOSYSTEM = "SHOW_ECOSYSTEM"
         const val PHONE_BOOK_INTEGRATION = "phone_book_integration"


### PR DESCRIPTION
Fix #4938

Currently joining a call will always enable your microphone again, even if you muted it beforehand.
On mobile it’s quite likely that you are in a noisy environment you want to mute yourself in. So now that state is globally remembered, also similar to other apps (except WhatsApp & Signal which are more "phone call" like rather than conference calls).

This also works fine for 1on1 calls, cause there you are likely not muted. Last setting is remembered, which means you will not be muted on reconnect either.


### 🖼️ Screenshots

N/A


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
