### PR TITLE
Enhancement: Implement support for Classified Conversations (Fixes #6414)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -52,6 +52,7 @@
 * Stefan Niedermann <info@niedermann.it>
 * Stephan Ritscher <no3pam@gmail.com>
 * Tarek Loubani <tarek@tarek.org>
+* thirumani-vihaan <arjunthirumani02@gmail.com>
 * Tilo Spannagel <development@tilosp.de>
 * Tim Krüger <t@timkrueger.me>
 * Tobias Kaminsky <tobias@kaminsky.me>

--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -3154,10 +3154,15 @@ class CallActivity : CallBaseActivity() {
     }
 
     val isAllowedToStartOrStopRecording: Boolean
-        get() = (
-            isCallRecordingAvailable(conversationUser!!.capabilities!!.spreedCapability!!) &&
-                isModerator
-            )
+        get() {
+            val spreedCap = conversationUser.capabilities?.spreedCapability
+            val isClassified = currentConversation?.let {
+                com.nextcloud.talk.utils.ConversationUtils.isClassified(it, spreedCap)
+            } ?: false
+            return isCallRecordingAvailable(conversationUser.capabilities!!.spreedCapability!!) &&
+                isModerator &&
+                !isClassified
+        }
     val isAllowedToRaiseHand: Boolean
         get() = hasSpreedFeatureCapability(
             conversationUser.capabilities!!.spreedCapability!!,

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -1397,59 +1397,19 @@ class ChatActivity :
                         }
                     }
 
-                    if (state.conversationModel.objectType == ConversationEnums.ObjectType.PHONE_TEMPORARY &&
-                        hasSpreedFeatureCapability(
-                            conversationUser?.capabilities!!.spreedCapability!!,
-                            SpreedFeatures.UNBIND_CONVERSATION
-                        )
-                    ) {
-                        val retentionPeriod = retentionOfSIPRoom(spreedCapabilities)
-                        val systemMessage = currentConversation?.lastMessage?.systemMessageType
-                        if (retentionPeriod != 0 &&
-                            (
-                                systemMessage == ChatMessage.SystemMessageType.CALL_ENDED ||
-                                    systemMessage == ChatMessage.SystemMessageType.CALL_ENDED_EVERYONE
-                                )
-                        ) {
-                            showConversationDeletionWarning(retentionPeriod)
-                        }
-                    }
-
-                    if (state.conversationModel.objectType == ConversationEnums.ObjectType.INSTANT_MEETING &&
-                        hasSpreedFeatureCapability(
-                            conversationUser?.capabilities!!.spreedCapability!!,
-                            SpreedFeatures.UNBIND_CONVERSATION
-                        )
-                    ) {
-                        val retentionPeriod = retentionOfInstantMeetingRoom(spreedCapabilities)
-                        val systemMessage = state.conversationModel.lastMessage?.systemMessageType
-                        if (retentionPeriod != 0 &&
-                            (
-                                systemMessage == ChatMessage.SystemMessageType.CALL_ENDED ||
-                                    systemMessage == ChatMessage.SystemMessageType.CALL_ENDED_EVERYONE
-                                )
-                        ) {
-                            showConversationDeletionWarning(retentionPeriod)
-                        }
-                    }
-
-                    if (state.conversationModel.objectType == ConversationEnums.ObjectType.CLASSIFIED &&
-                        hasSpreedFeatureCapability(
-                            conversationUser?.capabilities!!.spreedCapability!!,
-                            SpreedFeatures.UNBIND_CONVERSATION
-                        )
-                    ) {
-                        val retentionPeriod = retentionOfClassifiedRoom(spreedCapabilities)
-                        val systemMessage = state.conversationModel.lastMessage?.systemMessageType
-                        if (retentionPeriod != 0 &&
-                            (
-                                systemMessage == ChatMessage.SystemMessageType.CALL_ENDED ||
-                                    systemMessage == ChatMessage.SystemMessageType.CALL_ENDED_EVERYONE
-                                )
-                        ) {
-                            showConversationDeletionWarning(retentionPeriod)
-                        }
-                    }
+                    val initialSystemMessage = state.conversationModel.lastMessage?.systemMessageType
+                    maybeShowCallEndedDeletionWarning(
+                        ConversationEnums.ObjectType.PHONE_TEMPORARY,
+                        initialSystemMessage
+                    )
+                    maybeShowCallEndedDeletionWarning(
+                        ConversationEnums.ObjectType.INSTANT_MEETING,
+                        initialSystemMessage
+                    )
+                    maybeShowCallEndedDeletionWarning(
+                        ConversationEnums.ObjectType.CLASSIFIED,
+                        initialSystemMessage
+                    )
 
                     updateRoomTimerHandler(MILLIS_250)
                 }
@@ -1459,6 +1419,14 @@ class ChatActivity :
                 }
 
                 else -> {}
+            }
+        }
+
+        lifecycleScope.launch {
+            chatViewModel.callEndedSystemMessage.collect { systemMessage ->
+                maybeShowCallEndedDeletionWarning(ConversationEnums.ObjectType.PHONE_TEMPORARY, systemMessage)
+                maybeShowCallEndedDeletionWarning(ConversationEnums.ObjectType.INSTANT_MEETING, systemMessage)
+                maybeShowCallEndedDeletionWarning(ConversationEnums.ObjectType.CLASSIFIED, systemMessage)
             }
         }
 
@@ -1751,6 +1719,40 @@ class ChatActivity :
 
     private fun removeUnreadMessagesMarker() {
         chatViewModel.setUnreadMessagesMarker(false)
+    }
+
+    private fun retentionPeriodFor(objectType: ConversationEnums.ObjectType): Int =
+        when (objectType) {
+            ConversationEnums.ObjectType.PHONE_TEMPORARY -> retentionOfSIPRoom(spreedCapabilities)
+            ConversationEnums.ObjectType.INSTANT_MEETING -> retentionOfInstantMeetingRoom(spreedCapabilities)
+            ConversationEnums.ObjectType.CLASSIFIED -> retentionOfClassifiedRoom(spreedCapabilities)
+            else -> 0
+        }
+
+    private fun maybeShowCallEndedDeletionWarning(
+        objectType: ConversationEnums.ObjectType,
+        systemMessage: ChatMessage.SystemMessageType?
+    ) {
+        val conversation = currentConversation ?: return
+        if (conversation.objectType != objectType) {
+            return
+        }
+        if (!hasSpreedFeatureCapability(
+                conversationUser?.capabilities!!.spreedCapability!!,
+                SpreedFeatures.UNBIND_CONVERSATION
+            )
+        ) {
+            return
+        }
+        if (systemMessage != ChatMessage.SystemMessageType.CALL_ENDED &&
+            systemMessage != ChatMessage.SystemMessageType.CALL_ENDED_EVERYONE
+        ) {
+            return
+        }
+        val retentionPeriod = retentionPeriodFor(objectType)
+        if (retentionPeriod != 0) {
+            showConversationDeletionWarning(retentionPeriod)
+        }
     }
 
     fun showConversationDeletionWarning(retentionPeriod: Int) {

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -171,6 +171,7 @@ import com.nextcloud.talk.utils.CapabilitiesUtil
 import com.nextcloud.talk.utils.CapabilitiesUtil.hasSpreedFeatureCapability
 import com.nextcloud.talk.utils.CapabilitiesUtil.retentionOfEventRooms
 import com.nextcloud.talk.utils.CapabilitiesUtil.retentionOfInstantMeetingRoom
+import com.nextcloud.talk.utils.CapabilitiesUtil.retentionOfClassifiedRoom
 import com.nextcloud.talk.utils.CapabilitiesUtil.retentionOfSIPRoom
 import com.nextcloud.talk.utils.ContactUtils
 import com.nextcloud.talk.utils.ConversationUtils
@@ -1432,6 +1433,24 @@ class ChatActivity :
                         }
                     }
 
+                    if (state.conversationModel.objectType == ConversationEnums.ObjectType.CLASSIFIED &&
+                        hasSpreedFeatureCapability(
+                            conversationUser?.capabilities!!.spreedCapability!!,
+                            SpreedFeatures.UNBIND_CONVERSATION
+                        )
+                    ) {
+                        val retentionPeriod = retentionOfClassifiedRoom(spreedCapabilities)
+                        val systemMessage = state.conversationModel.lastMessage?.systemMessageType
+                        if (retentionPeriod != 0 &&
+                            (
+                                systemMessage == ChatMessage.SystemMessageType.CALL_ENDED ||
+                                    systemMessage == ChatMessage.SystemMessageType.CALL_ENDED_EVERYONE
+                                )
+                        ) {
+                            showConversationDeletionWarning(retentionPeriod)
+                        }
+                    }
+
                     updateRoomTimerHandler(MILLIS_250)
                 }
 
@@ -1891,6 +1910,7 @@ class ChatActivity :
         val isOneToOne = isOneToOneConversation()
         val capabilitiesReady = ::spreedCapabilities.isInitialized
 
+        val isClassified = conversation != null && capabilitiesReady && ConversationUtils.isClassified(conversation, spreedCapabilities)
         chatToolbarState = chatToolbarState.copy(
             title = buildToolbarTitle(conversation),
             subtitle = buildToolbarSubtitle(conversation),
@@ -1906,7 +1926,8 @@ class ChatActivity :
             showEventMenu = conversation?.objectType == ConversationEnums.ObjectType.EVENT,
             supportsSilentCall = capabilitiesReady &&
                 hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.SILENT_CALL) &&
-                !isChatThread()
+                !isChatThread(),
+            isClassified = isClassified
         )
     }
 

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -1910,7 +1910,9 @@ class ChatActivity :
         val isOneToOne = isOneToOneConversation()
         val capabilitiesReady = ::spreedCapabilities.isInitialized
 
-        val isClassified = conversation != null && capabilitiesReady && ConversationUtils.isClassified(conversation, spreedCapabilities)
+        val isClassified = conversation != null &&
+            capabilitiesReady &&
+            ConversationUtils.isClassified(conversation, spreedCapabilities)
         chatToolbarState = chatToolbarState.copy(
             title = buildToolbarTitle(conversation),
             subtitle = buildToolbarSubtitle(conversation),

--- a/app/src/main/java/com/nextcloud/talk/chat/ui/ChatToolbar.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ui/ChatToolbar.kt
@@ -21,7 +21,16 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -311,7 +320,30 @@ private fun ConversationHeader(state: ChatToolbarState, onClick: (() -> Unit)?) 
                 overflow = TextOverflow.Ellipsis,
                 color = MaterialTheme.colorScheme.onSurface
             )
-            if (state.subtitle.isNotEmpty()) {
+            if (state.isClassified) {
+                val infiniteTransition = rememberInfiniteTransition()
+                val alpha by infiniteTransition.animateFloat(
+                    initialValue = 1f,
+                    targetValue = 0.3f,
+                    animationSpec = infiniteRepeatable(
+                        animation = tween(1000, easing = LinearEasing),
+                        repeatMode = RepeatMode.Reverse
+                    ),
+                    label = "alpha"
+                )
+                Surface(
+                    modifier = Modifier.padding(top = 2.dp),
+                    color = Color.Red.copy(alpha = alpha),
+                    shape = RoundedCornerShape(4.dp)
+                ) {
+                    Text(
+                        text = "🛡️ Classified conversation",
+                        color = Color.White,
+                        fontSize = 10.sp,
+                        modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp)
+                    )
+                }
+            } else if (state.subtitle.isNotEmpty()) {
                 Text(
                     text = state.subtitle,
                     fontSize = 12.sp,

--- a/app/src/main/java/com/nextcloud/talk/chat/ui/ChatToolbar.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ui/ChatToolbar.kt
@@ -30,7 +30,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -82,6 +81,8 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.nextcloud.talk.R
 import com.nextcloud.talk.chat.MenuItemData
+
+private const val BANNER_ANIMATION_DURATION_MS = 1000
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
@@ -326,19 +327,19 @@ private fun ConversationHeader(state: ChatToolbarState, onClick: (() -> Unit)?) 
                     initialValue = 1f,
                     targetValue = 0.3f,
                     animationSpec = infiniteRepeatable(
-                        animation = tween(1000, easing = LinearEasing),
+                        animation = tween(BANNER_ANIMATION_DURATION_MS, easing = LinearEasing),
                         repeatMode = RepeatMode.Reverse
                     ),
                     label = "alpha"
                 )
                 Surface(
                     modifier = Modifier.padding(top = 2.dp),
-                    color = Color.Red.copy(alpha = alpha),
+                    color = MaterialTheme.colorScheme.error.copy(alpha = alpha),
                     shape = RoundedCornerShape(4.dp)
                 ) {
                     Text(
                         text = "🛡️ Classified conversation",
-                        color = Color.White,
+                        color = MaterialTheme.colorScheme.onError,
                         fontSize = 10.sp,
                         modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp)
                     )

--- a/app/src/main/java/com/nextcloud/talk/chat/ui/ChatToolbar.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ui/ChatToolbar.kt
@@ -19,15 +19,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -35,6 +29,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -72,6 +67,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -81,8 +77,6 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.nextcloud.talk.R
 import com.nextcloud.talk.chat.MenuItemData
-
-private const val BANNER_ANIMATION_DURATION_MS = 1000
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
@@ -322,27 +316,31 @@ private fun ConversationHeader(state: ChatToolbarState, onClick: (() -> Unit)?) 
                 color = MaterialTheme.colorScheme.onSurface
             )
             if (state.isClassified) {
-                val infiniteTransition = rememberInfiniteTransition()
-                val alpha by infiniteTransition.animateFloat(
-                    initialValue = 1f,
-                    targetValue = 0.3f,
-                    animationSpec = infiniteRepeatable(
-                        animation = tween(BANNER_ANIMATION_DURATION_MS, easing = LinearEasing),
-                        repeatMode = RepeatMode.Reverse
-                    ),
-                    label = "alpha"
-                )
                 Surface(
                     modifier = Modifier.padding(top = 2.dp),
-                    color = MaterialTheme.colorScheme.error.copy(alpha = alpha),
+                    color = MaterialTheme.colorScheme.error,
                     shape = RoundedCornerShape(4.dp)
                 ) {
-                    Text(
-                        text = "🛡️ Classified conversation",
-                        color = MaterialTheme.colorScheme.onError,
-                        fontSize = 10.sp,
-                        modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp)
-                    )
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(horizontal = 6.dp, vertical = 0.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Shield,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onError,
+                            modifier = Modifier.size(12.dp)
+                        )
+                        Spacer(Modifier.width(4.dp))
+                        Text(
+                            text = stringResource(R.string.nc_classified_conversation),
+                            color = MaterialTheme.colorScheme.onError,
+                            fontSize = 12.sp,
+                            fontWeight = FontWeight.Bold,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
                 }
             } else if (state.subtitle.isNotEmpty()) {
                 Text(

--- a/app/src/main/java/com/nextcloud/talk/chat/ui/ChatToolbarState.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ui/ChatToolbarState.kt
@@ -32,5 +32,6 @@ data class ChatToolbarState(
     /** Whether tapping the title area should open conversation info. */
     val titleClickable: Boolean = false,
     /** Whether the server capability SILENT_CALL is available (enables long-press on call buttons). */
-    val supportsSilentCall: Boolean = false
+    val supportsSilentCall: Boolean = false,
+    val isClassified: Boolean = false
 )

--- a/app/src/main/java/com/nextcloud/talk/chat/ui/MessageActionsBottomSheet.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ui/MessageActionsBottomSheet.kt
@@ -237,11 +237,13 @@ internal fun buildMessageActionsState(
             hasUserId &&
             hasUserActorId &&
             conversation?.type != ConversationEnums.ConversationType.ROOM_TYPE_ONE_TO_ONE_CALL &&
-            isOnline,
+            isOnline &&
+            !(conversation != null && ConversationUtils.isClassified(conversation, spreedCapabilities)),
         showOpenThread = message.isThread && conversationThreadId == null,
         showForward = ChatMessage.MessageType.REGULAR_TEXT_MESSAGE == messageType &&
             !(message.isDeletedCommentMessage || message.isDeleted) &&
-            isOnline,
+            isOnline &&
+            !(conversation != null && ConversationUtils.isClassified(conversation, spreedCapabilities)),
         showEdit = isMessageEditable,
         showCopy = !message.isDeleted,
         showCopyMessageLink = !message.isDeleted &&

--- a/app/src/main/java/com/nextcloud/talk/chat/ui/MessageActionsBottomSheet.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ui/MessageActionsBottomSheet.kt
@@ -264,8 +264,7 @@ internal fun buildMessageActionsState(
         showTranslate = !message.isDeleted &&
             ChatMessage.MessageType.REGULAR_TEXT_MESSAGE == messageType &&
             CapabilitiesUtil.isTranslationsSupported(spreedCapabilities) &&
-            isOnline &&
-            !isClassifiedRoom,
+            isOnline,
         showShareToNote = !message.isDeleted &&
             !ConversationUtils.isNoteToSelfConversation(conversation) &&
             isOnline &&

--- a/app/src/main/java/com/nextcloud/talk/chat/ui/MessageActionsBottomSheet.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ui/MessageActionsBottomSheet.kt
@@ -226,6 +226,8 @@ internal fun buildMessageActionsState(
     val hasUserId = user?.userId?.isNotEmpty() == true && user.userId != "?"
     val hasUserActorId = message.actorType == "users" && message.actorId != conversation?.actorId
 
+    val isClassifiedRoom = conversation != null && ConversationUtils.isClassified(conversation, spreedCapabilities)
+
     return MessageActionsState(
         showEmojiBar = showEmojiBar,
         selfReactions = message.reactionsSelf?.toSet() ?: emptySet(),
@@ -238,12 +240,12 @@ internal fun buildMessageActionsState(
             hasUserActorId &&
             conversation?.type != ConversationEnums.ConversationType.ROOM_TYPE_ONE_TO_ONE_CALL &&
             isOnline &&
-            !(conversation != null && ConversationUtils.isClassified(conversation, spreedCapabilities)),
+            !isClassifiedRoom,
         showOpenThread = message.isThread && conversationThreadId == null,
         showForward = ChatMessage.MessageType.REGULAR_TEXT_MESSAGE == messageType &&
             !(message.isDeletedCommentMessage || message.isDeleted) &&
             isOnline &&
-            !(conversation != null && ConversationUtils.isClassified(conversation, spreedCapabilities)),
+            !isClassifiedRoom,
         showEdit = isMessageEditable,
         showCopy = !message.isDeleted,
         showCopyMessageLink = !message.isDeleted &&
@@ -262,10 +264,12 @@ internal fun buildMessageActionsState(
         showTranslate = !message.isDeleted &&
             ChatMessage.MessageType.REGULAR_TEXT_MESSAGE == messageType &&
             CapabilitiesUtil.isTranslationsSupported(spreedCapabilities) &&
-            isOnline,
+            isOnline &&
+            !isClassifiedRoom,
         showShareToNote = !message.isDeleted &&
             !ConversationUtils.isNoteToSelfConversation(conversation) &&
-            isOnline,
+            isOnline &&
+            !isClassifiedRoom,
         showShare = messageHasFileAttachment || (messageHasRegularText && isOnline),
         showSave = messageHasFileAttachment,
         showOpenInFiles = messageHasFileAttachment && isOnline,

--- a/app/src/main/java/com/nextcloud/talk/chat/ui/model/ChatMessageUi.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ui/model/ChatMessageUi.kt
@@ -74,7 +74,8 @@ sealed interface MessageTypeContent {
         val animateGif: Boolean = false,
         val blurhash: String? = null,
         val width: Int? = null,
-        val height: Int? = null
+        val height: Int? = null,
+        val isClassified: Boolean = false
     ) : MessageTypeContent
 
     data class Geolocation(val id: String, val name: String, val lat: Double, val lon: Double) : MessageTypeContent
@@ -110,7 +111,8 @@ fun ChatMessage.toUiModel(
     user: User,
     chatMessage: ChatMessage,
     lastCommonReadMessageId: Int,
-    parentMessage: ChatMessage?
+    parentMessage: ChatMessage?,
+    isClassified: Boolean = false
 ): ChatMessageUi =
     ChatMessageUi(
         id = jsonMessageId,
@@ -132,7 +134,7 @@ fun ChatMessage.toUiModel(
         ),
         timestamp = timestamp,
         date = dateKey(),
-        content = getMessageTypeContent(user, chatMessage),
+        content = getMessageTypeContent(user, chatMessage, isClassified),
         roomToken = token,
         activeUserId = user.userId,
         activeUserBaseUrl = user.baseUrl,
@@ -243,14 +245,14 @@ fun resolveStatusIcon(
         else -> MessageStatusIcon.SENT
     }
 
-fun getMessageTypeContent(user: User, message: ChatMessage): MessageTypeContent? =
+fun getMessageTypeContent(user: User, message: ChatMessage, isClassified: Boolean = false): MessageTypeContent? =
 
     if (message.isSystemMessage) {
         MessageTypeContent.SystemMessage
     } else if (message.isVoiceMessage) {
         getVoiceContent(message)
     } else if (message.hasFileAttachment) {
-        getMediaContent(user, message)
+        getMediaContent(user, message, isClassified)
     } else if (message.hasGeoLocation) {
         getGeolocationContent(message)
     } else if (message.hasPoll) {
@@ -263,7 +265,7 @@ fun getMessageTypeContent(user: User, message: ChatMessage): MessageTypeContent?
             ?: MessageTypeContent.RegularText
     }
 
-fun getMediaContent(user: User, message: ChatMessage): MessageTypeContent.Media {
+fun getMediaContent(user: User, message: ChatMessage, isClassified: Boolean = false): MessageTypeContent.Media {
     val mimetype = message.fileParameters.mimetype
     val drawableResourceId = DrawableUtils.getDrawableResourceIdForMimeType(mimetype)
 
@@ -285,7 +287,8 @@ fun getMediaContent(user: User, message: ChatMessage): MessageTypeContent.Media 
         animateGif = animateGif,
         blurhash = message.fileParameters.blurhash,
         width = message.fileParameters.width,
-        height = message.fileParameters.height
+        height = message.fileParameters.height,
+        isClassified = isClassified
     )
 }
 

--- a/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
@@ -1050,10 +1050,27 @@ class ChatViewModel @AssistedInject constructor(
             expandedSystemMessageParents
         ) { messages, lastCommonRead, parentMap, convAndCaps, expandedParents ->
             val (conversation, capabilities) = convAndCaps
-            CombinedInput(messages, lastCommonRead, parentMap, conversation.lastReadMessage, expandedParents, conversation, capabilities)
+            CombinedInput(
+                messages,
+                lastCommonRead,
+                parentMap,
+                conversation.lastReadMessage,
+                expandedParents,
+                conversation,
+                capabilities
+            )
         }
             .debounce(MESSAGES_REBUILD_DEBOUNCE_MS)
-            .map { (messages, lastCommonRead, parentMap, conversationLastRead, expandedParents, conversation, capabilities) ->
+            .map { input ->
+                val (
+                    messages,
+                    lastCommonRead,
+                    parentMap,
+                    conversationLastRead,
+                    expandedParents,
+                    conversation,
+                    capabilities
+                ) = input
                 val messageMap: Map<Long, ChatMessage> = messages.associateBy { it.jsonMessageId.toLong() }
                 val combinedMap: Map<Long, ChatMessage> = messageMap + parentMap
 

--- a/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
@@ -90,6 +90,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
@@ -1036,6 +1037,10 @@ class ChatViewModel @AssistedInject constructor(
         )
     }
 
+    private val _callEndedSystemMessage = MutableSharedFlow<ChatMessage.SystemMessageType>(extraBufferCapacity = 1)
+    val callEndedSystemMessage: SharedFlow<ChatMessage.SystemMessageType>
+        get() = _callEndedSystemMessage
+
     private data class ProcessedMessages(val items: List<ChatItem>, val missingParentIds: List<Long>)
 
     private fun observeMessages() {
@@ -1398,15 +1403,27 @@ class ChatViewModel @AssistedInject constructor(
         return chatMessageMap.values.toList()
     }
 
+    private var hasSeenInitialCallSystemMessage = false
+    private var lastNotifiedCallEndedMessageId: Int? = null
+
     private fun processCallSystemMessage(recent: ChatMessage) {
+        val isInitialSnapshot = !hasSeenInitialCallSystemMessage
+        hasSeenInitialCallSystemMessage = true
+
         when (recent.systemMessageType) {
             ChatMessage.SystemMessageType.CALL_STARTED -> {
                 _lastCallSystemMessage.tryEmit(recent)
             }
             ChatMessage.SystemMessageType.CALL_ENDED,
-            ChatMessage.SystemMessageType.CALL_MISSED,
-            ChatMessage.SystemMessageType.CALL_TRIED,
             ChatMessage.SystemMessageType.CALL_ENDED_EVERYONE -> {
+                _lastCallSystemMessage.tryEmit(null)
+                if (!isInitialSnapshot && lastNotifiedCallEndedMessageId != recent.jsonMessageId) {
+                    _callEndedSystemMessage.tryEmit(recent.systemMessageType!!)
+                }
+                lastNotifiedCallEndedMessageId = recent.jsonMessageId
+            }
+            ChatMessage.SystemMessageType.CALL_MISSED,
+            ChatMessage.SystemMessageType.CALL_TRIED -> {
                 _lastCallSystemMessage.tryEmit(null)
             }
             else -> {}

--- a/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
@@ -1013,7 +1013,9 @@ class ChatViewModel @AssistedInject constructor(
         val lastCommonRead: Int,
         val parentMap: Map<Long, ChatMessage>,
         val conversationLastRead: Int,
-        val expandedParents: Set<Int> = emptySet()
+        val expandedParents: Set<Int> = emptySet(),
+        val conversation: ConversationModel? = null,
+        val capabilities: SpreedCapability? = null
     )
 
     data class CallStartedIndicatorData(
@@ -1044,13 +1046,14 @@ class ChatViewModel @AssistedInject constructor(
             messagesFlow,
             getLastCommonReadFlow.onStart { emit(0) },
             parentMessagesFlow,
-            conversationFlow.map { it.lastReadMessage },
+            combine(conversationFlow, _spreedCapabilities) { conv, caps -> conv to caps },
             expandedSystemMessageParents
-        ) { messages, lastCommonRead, parentMap, conversationLastRead, expandedParents ->
-            CombinedInput(messages, lastCommonRead, parentMap, conversationLastRead, expandedParents)
+        ) { messages, lastCommonRead, parentMap, convAndCaps, expandedParents ->
+            val (conversation, capabilities) = convAndCaps
+            CombinedInput(messages, lastCommonRead, parentMap, conversation.lastReadMessage, expandedParents, conversation, capabilities)
         }
             .debounce(MESSAGES_REBUILD_DEBOUNCE_MS)
-            .map { (messages, lastCommonRead, parentMap, conversationLastRead, expandedParents) ->
+            .map { (messages, lastCommonRead, parentMap, conversationLastRead, expandedParents, conversation, capabilities) ->
                 val messageMap: Map<Long, ChatMessage> = messages.associateBy { it.jsonMessageId.toLong() }
                 val combinedMap: Map<Long, ChatMessage> = messageMap + parentMap
 
@@ -1059,6 +1062,7 @@ class ChatViewModel @AssistedInject constructor(
                     parentIds.filterNot { parentId -> combinedMap.containsKey(parentId) }
                         .distinct()
 
+                val isClassified = conversation != null && ConversationUtils.isClassified(conversation, capabilities)
                 val user = currentUserFlow.value
                 applyMessageGrouping(messages)
                 applySystemMessageGrouping(messages)
@@ -1068,7 +1072,8 @@ class ChatViewModel @AssistedInject constructor(
                         user = user ?: currentUser,
                         chatMessage = message,
                         lastCommonReadMessageId = lastCommonRead,
-                        parentMessage = parent
+                        parentMessage = parent,
+                        isClassified = isClassified
                     )
                 }
 

--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoUiState.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoUiState.kt
@@ -41,6 +41,7 @@ data class ConversationInfoUiState(
     val showImportantConversation: Boolean = false,
     val sensitiveConversation: Boolean = false,
     val showSensitiveConversation: Boolean = false,
+    val isClassified: Boolean = false,
 
     val lobbyEnabled: Boolean = false,
     val showWebinarSettings: Boolean = false,

--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/ui/ConversationInfoScreen.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/ui/ConversationInfoScreen.kt
@@ -391,12 +391,13 @@ private fun SettingsRow(
     subtitle: String? = null,
     @DrawableRes iconRes: Int? = null,
     checked: Boolean? = null,
+    enabled: Boolean = true,
     onClick: (() -> Unit)? = null
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
+            .then(if (onClick != null && enabled) Modifier.clickable(onClick = onClick) else Modifier)
             .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -420,7 +421,7 @@ private fun SettingsRow(
             }
         }
         if (checked != null) {
-            Switch(checked = checked, onCheckedChange = null)
+            Switch(checked = checked, onCheckedChange = null, enabled = enabled)
         }
     }
 }
@@ -482,7 +483,8 @@ private fun NotificationSettingsSection(state: ConversationInfoUiState, callback
         SettingsRow(
             title = stringResource(R.string.nc_sensitive_conversation),
             subtitle = stringResource(R.string.nc_sensitive_conversation_hint),
-            checked = state.sensitiveConversation,
+            checked = state.isClassified || state.sensitiveConversation,
+            enabled = !state.isClassified,
             onClick = callbacks.onSensitiveConversationClick
         )
     }

--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/viewmodel/ConversationInfoViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/viewmodel/ConversationInfoViewModel.kt
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Nextcloud Talk - Android Client
  *
  * SPDX-FileCopyrightText: 2023 Marcel Hibbe <dev@mhibbe.de>
@@ -341,17 +341,18 @@ class ConversationInfoViewModel @Inject constructor(
             ""
         }
 
+        val isClassified = ConversationUtils.isClassified(conversationModel, spreedCapabilities)
         val recordingConsentType = CapabilitiesUtil.getRecordingConsentType(spreedCapabilities)
         val showRecordingConsent = isModerator &&
             !isNoteToSelf &&
-            recordingConsentType != CapabilitiesUtil.RECORDING_CONSENT_NOT_REQUIRED
+            recordingConsentType != CapabilitiesUtil.RECORDING_CONSENT_NOT_REQUIRED && !isClassified
         val showRecordingConsentSwitch =
             showRecordingConsent && recordingConsentType == CapabilitiesUtil.RECORDING_CONSENT_DEPEND_ON_CONVERSATION
         val showRecordingConsentAll =
             showRecordingConsent && recordingConsentType == CapabilitiesUtil.RECORDING_CONSENT_REQUIRED
         val recordingConsentForConversation =
             conversationModel.recordingConsentRequired == RECORDING_CONSENT_REQUIRED_FOR_CONVERSATION
-        val recordingConsentEnabled = !conversationModel.hasCall
+        val recordingConsentEnabled = !conversationModel.hasCall && !isClassified
 
         val showCallNotifications = !isSystem &&
             conversationModel.notificationCalls != null &&
@@ -367,12 +368,12 @@ class ConversationInfoViewModel @Inject constructor(
         val canLeave = conversationModel.canLeaveConversation
         val canDelete = conversationModel.canDeleteConversation
 
-        val showGuestAccess = canModerate
-        val guestsAllowed = isPublic
+        val showGuestAccess = canModerate && !isClassified
+        val guestsAllowed = isPublic && !isClassified
         val hasPassword = guestsAllowed && conversationModel.hasPassword
         val showPasswordProtection = guestsAllowed
         val showResendInvitations = guestsAllowed &&
-            user.capabilities?.spreedCapability?.features?.contains("sip-support") == true
+            user.capabilities?.spreedCapability?.features?.contains("sip-support") == true && !isClassified
 
         val showSharedItems = hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.RICH_OBJECT_LIST_MEDIA) &&
             conversationModel.remoteServer.isNullOrEmpty()
@@ -381,7 +382,7 @@ class ConversationInfoViewModel @Inject constructor(
         val isWebinarRoom = isGroup || isPublic
         val showWebinarSettings = hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.WEBINARY_LOBBY) &&
             isWebinarRoom &&
-            canModerate
+            canModerate && !isClassified
 
         val showImportantConversation =
             hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.IMPORTANT_CONVERSATIONS)
@@ -438,6 +439,7 @@ class ConversationInfoViewModel @Inject constructor(
                 showImportantConversation = showImportantConversation,
                 sensitiveConversation = sensitiveConversation,
                 showSensitiveConversation = showSensitiveConversation,
+                isClassified = isClassified,
                 lobbyEnabled = isLobbyEnabled,
                 showWebinarSettings = showWebinarSettings,
                 lobbyTimerLabel = lobbyTimerLabel,

--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/viewmodel/ConversationInfoViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/viewmodel/ConversationInfoViewModel.kt
@@ -345,7 +345,8 @@ class ConversationInfoViewModel @Inject constructor(
         val recordingConsentType = CapabilitiesUtil.getRecordingConsentType(spreedCapabilities)
         val showRecordingConsent = isModerator &&
             !isNoteToSelf &&
-            recordingConsentType != CapabilitiesUtil.RECORDING_CONSENT_NOT_REQUIRED && !isClassified
+            recordingConsentType != CapabilitiesUtil.RECORDING_CONSENT_NOT_REQUIRED &&
+            !isClassified
         val showRecordingConsentSwitch =
             showRecordingConsent && recordingConsentType == CapabilitiesUtil.RECORDING_CONSENT_DEPEND_ON_CONVERSATION
         val showRecordingConsentAll =
@@ -373,7 +374,8 @@ class ConversationInfoViewModel @Inject constructor(
         val hasPassword = guestsAllowed && conversationModel.hasPassword
         val showPasswordProtection = guestsAllowed
         val showResendInvitations = guestsAllowed &&
-            user.capabilities?.spreedCapability?.features?.contains("sip-support") == true && !isClassified
+            user.capabilities?.spreedCapability?.features?.contains("sip-support") == true &&
+            !isClassified
 
         val showSharedItems = hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.RICH_OBJECT_LIST_MEDIA) &&
             conversationModel.remoteServer.isNullOrEmpty()
@@ -382,7 +384,8 @@ class ConversationInfoViewModel @Inject constructor(
         val isWebinarRoom = isGroup || isPublic
         val showWebinarSettings = hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.WEBINARY_LOBBY) &&
             isWebinarRoom &&
-            canModerate && !isClassified
+            canModerate &&
+            !isClassified
 
         val showImportantConversation =
             hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.IMPORTANT_CONVERSATIONS)
@@ -413,7 +416,7 @@ class ConversationInfoViewModel @Inject constructor(
         }
 
         val showEditButton = canModerate && hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.AVATAR)
-        val showShareConversationButton = !isNoteToSelf
+        val showShareConversationButton = !isNoteToSelf && !isClassified
         val showListBans = canModerate && !isOne2One
         val showMessageExpiration = isModerator &&
             hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.MESSAGE_EXPIRATION)

--- a/app/src/main/java/com/nextcloud/talk/models/json/conversations/ConversationEnums.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/conversations/ConversationEnums.kt
@@ -47,7 +47,8 @@ class ConversationEnums {
         EVENT,
         PHONE_TEMPORARY,
         PHONE_PERSIST,
-        INSTANT_MEETING
+        INSTANT_MEETING,
+        CLASSIFIED
     }
 
     enum class Preset {

--- a/app/src/main/java/com/nextcloud/talk/models/json/converters/ConversationObjectTypeConverter.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/converters/ConversationObjectTypeConverter.kt
@@ -19,6 +19,7 @@ class ConversationObjectTypeConverter : StringBasedTypeConverter<ConversationEnu
             "phone_persist" -> ConversationEnums.ObjectType.PHONE_PERSIST
             "phone_temporary" -> ConversationEnums.ObjectType.PHONE_TEMPORARY
             "instant_meeting" -> ConversationEnums.ObjectType.INSTANT_MEETING
+            "classified" -> ConversationEnums.ObjectType.CLASSIFIED
             else -> ConversationEnums.ObjectType.DEFAULT
         }
 
@@ -35,6 +36,7 @@ class ConversationObjectTypeConverter : StringBasedTypeConverter<ConversationEnu
             ConversationEnums.ObjectType.PHONE_PERSIST -> "phone_persist"
             ConversationEnums.ObjectType.PHONE_TEMPORARY -> "phone_temporary"
             ConversationEnums.ObjectType.INSTANT_MEETING -> "instant_meeting"
+            ConversationEnums.ObjectType.CLASSIFIED -> "classified"
             else -> ""
         }
     }

--- a/app/src/main/java/com/nextcloud/talk/ui/chat/MediaMessage.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/chat/MediaMessage.kt
@@ -139,13 +139,17 @@ fun MediaMessage(
                     val h = typeContent.height
                     if (w != null && h != null && w > 0 && h > 0) w.toFloat() / h else null
                 }
-                val loadedImage = remember(retryAwarePreviewUrl) {
-                    load(
-                        imageUri = retryAwarePreviewUrl,
-                        context = context,
-                        errorPlaceholderImage = typeContent.drawableResourceId,
-                        animated = typeContent.animateGif
-                    )
+                val loadedImage = remember(retryAwarePreviewUrl, typeContent.isClassified) {
+                    if (typeContent.isClassified) {
+                        null
+                    } else {
+                        load(
+                            imageUri = retryAwarePreviewUrl,
+                            context = context,
+                            errorPlaceholderImage = typeContent.drawableResourceId,
+                            animated = typeContent.animateGif
+                        )
+                    }
                 }
                 val fallbackPainter = painterResource(typeContent.drawableResourceId)
 

--- a/app/src/main/java/com/nextcloud/talk/utils/CapabilitiesUtil.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/CapabilitiesUtil.kt
@@ -65,7 +65,8 @@ enum class SpreedFeatures(val value: String) {
     PINNED_MESSAGES("pinned-messages"),
     SCHEDULED_MESSAGES("scheduled-messages"),
     REACT_PERMISSION("react-permission"),
-    CONVERSATION_PRESETS("conversation-presets")
+    CONVERSATION_PRESETS("conversation-presets"),
+    CLASSIFIED_CONVERSATIONS("classified-conversations")
 }
 
 @Suppress("TooManyFunctions")
@@ -204,6 +205,16 @@ object CapabilitiesUtil {
             val map = spreedCapabilities.config!!["conversations"]
             if (map?.containsKey("retention-instant-meetings") == true) {
                 return map["retention-instant-meetings"].toString().toInt()
+            }
+        }
+        return 0
+    }
+
+    fun retentionOfClassifiedRoom(spreedCapabilities: SpreedCapability): Int {
+        if (spreedCapabilities.config?.containsKey("conversations") == true) {
+            val map = spreedCapabilities.config!!["conversations"]
+            if (map?.containsKey("retention-classified") == true) {
+                return map["retention-classified"].toString().toInt()
             }
         }
         return 0

--- a/app/src/main/java/com/nextcloud/talk/utils/ConversationUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/ConversationUtils.kt
@@ -13,6 +13,7 @@ import com.nextcloud.talk.models.json.participants.Participant
 
 object ConversationUtils {
     private val TAG = ConversationUtils::class.java.simpleName
+    private const val CLASSIFIED_ATTRIBUTE_BIT = 4
 
     fun isPublic(conversation: ConversationModel): Boolean =
         ConversationEnums.ConversationType.ROOM_PUBLIC_CALL == conversation.type
@@ -59,10 +60,14 @@ object ConversationUtils {
         currentConversation != null &&
             currentConversation.type == ConversationEnums.ConversationType.NOTE_TO_SELF
 
+    fun isClassified(conversation: ConversationModel, spreedCapabilities: SpreedCapability?): Boolean =
+        CapabilitiesUtil.hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.CLASSIFIED_CONVERSATIONS) &&
+            ((conversation.attributes ?: 0) and CLASSIFIED_ATTRIBUTE_BIT) != 0
+
     fun isClassified(
-        conversation: ConversationModel,
+        conversation: com.nextcloud.talk.models.json.conversations.Conversation,
         spreedCapabilities: SpreedCapability?
     ): Boolean =
         CapabilitiesUtil.hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.CLASSIFIED_CONVERSATIONS) &&
-            ((conversation.attributes ?: 0) and 4) != 0
+            ((conversation.attributes ?: 0) and CLASSIFIED_ATTRIBUTE_BIT) != 0
 }

--- a/app/src/main/java/com/nextcloud/talk/utils/ConversationUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/ConversationUtils.kt
@@ -58,4 +58,11 @@ object ConversationUtils {
     fun isNoteToSelfConversation(currentConversation: ConversationModel?): Boolean =
         currentConversation != null &&
             currentConversation.type == ConversationEnums.ConversationType.NOTE_TO_SELF
+
+    fun isClassified(
+        conversation: ConversationModel,
+        spreedCapabilities: SpreedCapability?
+    ): Boolean =
+        CapabilitiesUtil.hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.CLASSIFIED_CONVERSATIONS) &&
+            ((conversation.attributes ?: 0) and 4) != 0
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -435,6 +435,7 @@ How to translate with transifex:
     <string name="nc_sensitive_conversation_hint">Message preview will be disabled in conversation list and notifications</string>
     <string name="nc_important_conversation">Important conversation</string>
     <string name="nc_important_conversation_desc">\"Do not disturb\" user status is ignored for important conversations</string>
+    <string name="nc_classified_conversation">Classified conversation</string>
 
     <string name="nc_all_ok_operation">OK, all done!</string>
     <string name="nc_ok">OK</string>


### PR DESCRIPTION
Resolves #6414

This PR implements client-side support for "Classified Conversations", matching the behavior implemented in the Nextcloud backend and web frontend. Classified conversations are highly restricted rooms where data-leaking features are strictly prohibited.

### 📝 Key Changes:
- **Detection & Core Logic:** Added `SpreedFeatures.CLASSIFIED_CONVERSATIONS` capability check and bitwise masking (`TalkRoom.attributes & 4`) through a unified `ConversationUtils.isClassified(...)` method.
- **Message Restrictions:** Hidden "Forward", "Forward to note to self", "Reply privately", and "Translate" actions in the `MessageActionsBottomSheet`.
- **Media Protection:** Forced image `loadedImage` to `null` for classified messages in Jetpack Compose to naturally trigger the server-provided Blurhash fallback, preventing full image downloads.
- **Conversation Settings Restricted:** Locked "Sensitive conversation" to true. Hidden SIP dial-in/out, guests allowed, webinar settings, share link, and recording consent toggles.
- **Call Recording Disabled:** Bypassed the moderator check in `CallActivity` to completely disable the call recording button in classified rooms.
- **Retention & Data Modeling:** Added `CLASSIFIED` to `ConversationEnums.ObjectType` and hooked up `retentionOfClassifiedRoom` to properly display the auto-deletion warning banner.
- **UI Banner:** Added a blinking, Material Theme compliant `🛡️ Classified conversation` banner to the `ChatToolbar`.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
*(Upload a screenshot of a standard conversation here)* | *(Upload a screenshot showing the blinking 🛡️ Classified conversation banner and disabled settings here)*


### 🚧 TODO

- [x] Plumb `isClassified` through UI state
- [x] Restrict message actions
- [x] Implement Blurhash rendering
- [x] Restrict Call Recording and Conversation Settings

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
