### PR TITLE
Show "Team" instead of team ID in mention autocomplete

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/MentionAutocompleteAdapter.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/MentionAutocompleteAdapter.kt
@@ -93,7 +93,7 @@ class MentionAutocompleteAdapter(
             )
             viewThemeUtils.talk.themeAndHighlightText(
                 holder.binding.secondaryText,
-                "@${item.objectId}",
+                secondaryText(item),
                 filterQuery
             )
         } else {
@@ -103,6 +103,9 @@ class MentionAutocompleteAdapter(
         setAvatar(holder, item)
         drawStatus(holder, item)
     }
+
+    private fun secondaryText(item: MentionAutocompleteItem): String =
+        secondaryText(item.source, item.objectId, context.resources.getString(R.string.nc_team))
 
     private fun setAvatar(holder: ViewHolder, item: MentionAutocompleteItem) {
         val avatarView = holder.binding.avatarView
@@ -188,5 +191,13 @@ class MentionAutocompleteAdapter(
         private const val STATUS_SIZE_IN_DP = 9f
         private const val NO_ICON = ""
         private const val NO_USER_STATUS_DP_FROM_TOP: Float = 10f
+
+        // Teams use a "team/<id>" objectId that should not be exposed; show "Team" like the web client does.
+        fun secondaryText(source: String?, objectId: String?, teamLabel: String): String =
+            if (source == SOURCE_TEAMS) {
+                teamLabel
+            } else {
+                "@$objectId"
+            }
     }
 }

--- a/app/src/test/java/com/nextcloud/talk/chat/MentionAutocompleteAdapterTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/chat/MentionAutocompleteAdapterTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.chat
+
+import com.nextcloud.talk.adapters.items.MentionAutocompleteItem.Companion.SOURCE_TEAMS
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MentionAutocompleteAdapterTest {
+
+    @Test
+    fun teamSourceShowsTeamLabelInsteadOfObjectId() {
+        assertEquals(
+            "Team",
+            MentionAutocompleteAdapter.secondaryText(SOURCE_TEAMS, "team/RFu2UR8oOhEaI6OKUlQ", "Team")
+        )
+    }
+
+    @Test
+    fun nonTeamSourceShowsMentionHandle() {
+        assertEquals(
+            "@admin",
+            MentionAutocompleteAdapter.secondaryText("users", "admin", "Team")
+        )
+    }
+}


### PR DESCRIPTION
Team mentions have weird technical additions in the suggestion like `@team/[ID composed of mixed letters]`. That should not be exposed, instead showing the text "Team" as it does on the web.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="1077" height="549" alt="talk-team-mention-before tmp" src="https://github.com/user-attachments/assets/bc65aef9-8696-4563-b2ce-c458ad408267" />|<img width="1077" height="545" alt="talk-team-mention-after tmp" src="https://github.com/user-attachments/assets/f0514bce-3cc4-4449-9119-2d8ad9c17c55" />


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
