### PR TITLE
Keep reply reference when restoring a message draft

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -2398,13 +2398,12 @@ class ChatActivity :
         cursor?.close()
     }
 
-    fun getReplyToMessageId(): Int {
-        var replyMessageId = messageInputViewModel.getReplyChatMessage.value?.jsonMessageId
-        if (replyMessageId == null || replyMessageId == 0) {
-            replyMessageId = conversationThreadInfo?.thread?.id ?: 0
-        }
-        return replyMessageId
-    }
+    fun getReplyToMessageId(): Int =
+        resolveReplyToMessageId(
+            messageInputViewModel.getReplyChatMessage.value?.jsonMessageId,
+            chatViewModel.messageDraft.quotedJsonId,
+            conversationThreadInfo?.thread?.id
+        )
 
     @Throws(IllegalStateException::class)
     private fun onPickCameraResult(intent: Intent?) {
@@ -4034,4 +4033,13 @@ class ChatActivity :
         private const val SEARCH_CENTER_STABILIZE_ATTEMPTS = 8
         private const val SEARCH_CENTER_STABILIZE_DELAY_MS = 200L
     }
+}
+
+/**
+ * The reply is only kept in the view model, so it is gone when the activity was recreated.
+ * The saved draft still holds it, so use it as fallback before falling back to the thread.
+ */
+internal fun resolveReplyToMessageId(replyMessageId: Int?, draftQuotedJsonId: Int?, threadId: Int?): Int {
+    val replyId = replyMessageId?.takeIf { it != 0 } ?: draftQuotedJsonId?.takeIf { it != 0 }
+    return replyId ?: threadId ?: 0
 }

--- a/app/src/test/java/com/nextcloud/talk/chat/ResolveReplyToMessageIdTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/chat/ResolveReplyToMessageIdTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.chat
+
+import org.junit.Assert
+import org.junit.Test
+
+class ResolveReplyToMessageIdTest {
+
+    @Test
+    fun replyFromViewModelIsUsed() {
+        Assert.assertEquals(7, resolveReplyToMessageId(7, null, 42))
+    }
+
+    @Test
+    fun replyFromDraftIsUsedWhenViewModelIsEmpty() {
+        Assert.assertEquals(7, resolveReplyToMessageId(null, 7, 42))
+    }
+
+    @Test
+    fun replyFromDraftIsUsedWhenViewModelIsZero() {
+        Assert.assertEquals(7, resolveReplyToMessageId(0, 7, 42))
+    }
+
+    @Test
+    fun threadIsUsedWithoutReply() {
+        Assert.assertEquals(42, resolveReplyToMessageId(null, null, 42))
+    }
+
+    @Test
+    fun zeroWithoutReplyAndThread() {
+        Assert.assertEquals(0, resolveReplyToMessageId(null, 0, null))
+    }
+}


### PR DESCRIPTION
When drafting a reply to a message via the reply function, then switching to a different conversation or app and then back to Talk, the reply reference is lost.

It is especially strange since the reply reference (the original message) is shown above the saved draft. But on sending, it seems to get lost as it is not shown on the sent message.

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
