### PR TITLE
revert vanniktech emoji-google version for now

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -216,7 +216,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.7.1")
     implementation("com.google.android.material:material:1.14.0")
     implementation("androidx.constraintlayout:constraintlayout:2.2.1")
-    implementation("com.vanniktech:emoji-google:0.24.1")
+    implementation("com.vanniktech:emoji-google:0.23.0")
     implementation("androidx.emoji2:emoji2:$emojiVersion")
     implementation("androidx.emoji2:emoji2-bundled:$emojiVersion")
     implementation("androidx.emoji2:emoji2-views:$emojiVersion")


### PR DESCRIPTION
to avoid CI error:

```
> Task :app:processGplayDebugManifestForPackage FROM-CACHE
> Task :app:processGplayDebugResources FROM-CACHE
> Task :app:preGplayDebugUnitTestBuild UP-TO-DATE
> Task :app:javaPreCompileGplayDebugUnitTest FROM-CACHE
> Task :app:kaptGenerateStubsGplayDebugKotlin FROM-CACHE
/home/runner/actions-runner/_work/talk-android/talk-android/app/build/intermediates/built_in_kapt_stubs/gplayDebug/kaptGenerateStubsGplayDebugKotlin/com/nextcloud/talk/ui/theme/TalkSpecificViewThemeUtils.java:47: error: cannot access EmojiTextView

> Task :app:kaptGplayDebugKotlin
import com.vanniktech.emoji.EmojiTextView;
                           ^
  bad class file: /home/runner/.gradle/caches/9.6.1/transforms/54ae6d2b10d9e28012116e24c80f143e/transformed/jetified-emoji-release-api.jar(/com/vanniktech/emoji/EmojiTextView.class)
    class file has wrong version 65.0, should be 61.0
    Please remove or make sure it appears in the correct subdirectory of the classpath.
/home/runner/actions-runner/_work/talk-android/talk-android/app/build/intermediates/built_in_kapt_stubs/gplayDebug/kaptGenerateStubsGplayDebugKotlin/com/nextcloud/talk/ui/theme/TalkSpecificViewThemeUtils.java:48: error: cannot access EmojiTheming import com.vanniktech.emoji.EmojiTheming;
                           ^
  bad class file: /home/runner/.gradle/caches/9.6.1/transforms/54ae6d2b10d9e28012116e24c80f143e/transformed/jetified-emoji-release-api.jar(/com/vanniktech/emoji/EmojiTheming.class)
    class file has wrong version 65.0, should be 61.0
    Please remove or make sure it appears in the correct subdirectory of the classpath.
/home/runner/actions-runner/_work/talk-android/talk-android/app/src/main/java/com/nextcloud/talk/callbacks/MentionAutocompleteCallback.java:23: error: cannot access EmojiRange import com.vanniktech.emoji.EmojiRange;
                           ^
  bad class file: /home/runner/.gradle/caches/9.6.1/transforms/54ae6d2b10d9e28012116e24c80f143e/transformed/jetified-emoji-release-api.jar(/com/vanniktech/emoji/EmojiRange.class)
    class file has wrong version 65.0, should be 61.0
    Please remove or make sure it appears in the correct subdirectory of the classpath.
/home/runner/actions-runner/_work/talk-android/talk-android/app/src/main/java/com/nextcloud/talk/callbacks/MentionAutocompleteCallback.java:24: error: cannot access Emojis import com.vanniktech.emoji.Emojis;
                           ^
  bad class file: /home/runner/.gradle/caches/9.6.1/transforms/54ae6d2b10d9e28012116e24c80f143e/transformed/jetified-emoji-release-api.jar(/com/vanniktech/emoji/Emojis.class)
    class file has wrong version 65.0, should be 61.0
    Please remove or make sure it appears in the correct subdirectory of the classpath.
/home/runner/actions-runner/_work/talk-android/talk-android/app/build/generated/data_binding_base_class_source_out/gplayDebug/out/com/nextcloud/talk/databinding/RvItemConversationInfoParticipantBinding.java:15: error: cannot access EmojiEditText import com.vanniktech.emoji.EmojiEditText;
                           ^
  bad class file: /home/runner/.gradle/caches/9.6.1/transforms/54ae6d2b10d9e28012116e24c80f143e/transformed/jetified-emoji-release-api.jar(/com/vanniktech/emoji/EmojiEditText.class)
    class file has wrong version 65.0, should be 61.0
    Please remove or make sure it appears in the correct subdirectory of the classpath.
/home/runner/actions-runner/_work/talk-android/talk-android/app/src/main/java/com/nextcloud/talk/utils/TextMatchers.java:12: error: cannot access EmojiInformation import com.vanniktech.emoji.EmojiInformation;
                           ^
  bad class file: /home/runner/.gradle/caches/9.6.1/transforms/54ae6d2b10d9e28012116e24c80f143e/transformed/jetified-emoji-release-api.jar(/com/vanniktech/emoji/EmojiInformation.class)
    class file has wrong version 65.0, should be 61.0
    Please remove or make sure it appears in the correct subdirectory of the classpath.
/home/runner/actions-runner/_work/talk-android/talk-android/app/build/intermediates/built_in_kapt_stubs/gplayDebug/kaptGenerateStubsGplayDebugKotlin/com/nextcloud/talk/application/NextcloudTalkApplication.java:52: error: cannot access EmojiManager import com.vanniktech.emoji.EmojiManager;
                           ^
  bad class file: /home/runner/.gradle/caches/9.6.1/transforms/54ae6d2b10d9e28012116e24c80f143e/transformed/jetified-emoji-release-api.jar(/com/vanniktech/emoji/EmojiManager.class)
    class file has wrong version 65.0, should be 61.0
    Please remove or make sure it appears in the correct subdirectory of the classpath.
/home/runner/actions-runner/_work/talk-android/talk-android/app/build/intermediates/built_in_kapt_stubs/gplayDebug/kaptGenerateStubsGplayDebugKotlin/com/nextcloud/talk/application/NextcloudTalkApplication.java:53: error: cannot access GoogleEmojiProvider import com.vanniktech.emoji.google.GoogleEmojiProvider;
                                  ^
  bad class file: /home/runner/.gradle/caches/9.6.1/transforms/a371e6009b52eb9d093144f994990509/transformed/jetified-emoji-google-release-api.jar(/com/vanniktech/emoji/google/GoogleEmojiProvider.class)
    class file has wrong version 65.0, should be 61.0
    Please remove or make sure it appears in the correct subdirectory of the classpath.
/home/runner/actions-runner/_work/talk-android/talk-android/app/build/intermediates/built_in_kapt_stubs/gplayDebug/kaptGenerateStubsGplayDebugKotlin/com/nextcloud/talk/chooseaccount/ui/StatusMessageInputComponentsKt.java:17: error: cannot access EmojiPopup import com.vanniktech.emoji.EmojiPopup;
                           ^
  bad class file: /home/runner/.gradle/caches/9.6.1/transforms/54ae6d2b10d9e28012116e24c80f143e/transformed/jetified-emoji-release-api.jar(/com/vanniktech/emoji/EmojiPopup.class)
    class file has wrong version 65.0, should be 61.0
    Please remove or make sure it appears in the correct subdirectory of the classpath.
/home/runner/actions-runner/_work/talk-android/talk-android/app/build/intermediates/built_in_kapt_stubs/gplayDebug/kaptGenerateStubsGplayDebugKotlin/com/nextcloud/talk/chat/ui/MessageActionsBottomSheetKt.java:30: error: cannot access Emoji import com.vanniktech.emoji.Emoji;
                           ^
  bad class file: /home/runner/.gradle/caches/9.6.1/transforms/54ae6d2b10d9e28012116e24c80f143e/transformed/jetified-emoji-release-api.jar(/com/vanniktech/emoji/Emoji.class)
    class file has wrong version 65.0, should be 61.0
    Please remove or make sure it appears in the correct subdirectory of the classpath.
/home/runner/actions-runner/_work/talk-android/talk-android/app/build/intermediates/built_in_kapt_stubs/gplayDebug/kaptGenerateStubsGplayDebugKotlin/com/nextcloud/talk/chat/ui/MessageActionsBottomSheetKt.java:33: error: cannot access RecentEmojiManager import com.vanniktech.emoji.recent.RecentEmojiManager;
                                  ^
  bad class file: /home/runner/.gradle/caches/9.6.1/transforms/54ae6d2b10d9e28012116e24c80f143e/transformed/jetified-emoji-release-api.jar(/com/vanniktech/emoji/recent/RecentEmojiManager.class)
    class file has wrong version 65.0, should be 61.0
    Please remove or make sure it appears in the correct subdirectory of the classpath.
/home/runner/actions-runner/_work/talk-android/talk-android/app/build/intermediates/built_in_kapt_stubs/gplayDebug/kaptGenerateStubsGplayDebugKotlin/com/nextcloud/talk/chat/ui/MessageActionsBottomSheetKt.java:34: error: cannot access SearchEmojiManager import com.vanniktech.emoji.search.SearchEmojiManager;
                                  ^
  bad class file: /home/runner/.gradle/caches/9.6.1/transforms/54ae6d2b10d9e28012116e24c80f143e/transformed/jetified-emoji-release-api.jar(/com/vanniktech/emoji/search/SearchEmojiManager.class)
    class file has wrong version 65.0, should be 61.0
    Please remove or make sure it appears in the correct subdirectory of the classpath.

> Task :app:kaptGplayDebugKotlin FAILED
gradle/actions: Writing build results to /home/runner/actions-runner/_work/_temp/.gradle-actions/build-results/__run-1785420852882.json

[Incubating] Problems report is available at: file:///home/runner/actions-runner/_work/talk-android/talk-android/build/reports/problems/problems-report.html

FAILURE: Build failed with an exception.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.

* What went wrong: You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins. Execution failed for task ':app:kaptGplayDebugKotlin' (registered by plugin 'com.android.internal.application').

For more on this, please refer to https://docs.gradle.org/9.6.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
> A failure occurred while executing org.jetbrains.kotlin.gradle.internal.KaptWithoutKotlincTask$KaptExecutionWorkAction

23 actionable tasks: 5 executed, 18 from cache
Configuration cache entry stored.
* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights from a Build Scan (powered by Develocity).
> Get more help at https://help.gradle.org.

BUILD FAILED in 1m 59s
Error: Process completed with exit code 1.
```

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
