### PR TITLE
fix NPE in updateMessagesData

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
@@ -596,6 +596,11 @@ class OfflineFirstChatRepository @Inject constructor(
         val chatMessageEntities =
             persistChatMessagesAndHandleSystemMessages(chatMessagesJson, emitOnIncoming = lookIntoFuture)
 
+        if (chatMessageEntities.isEmpty()) {
+            Log.w(TAG, "No messages were persisted, skipping chat block update")
+            return
+        }
+
         val oldestIdFromSync = chatMessageEntities.minByOrNull { it.id }!!.id
         val newestIdFromSync = chatMessageEntities.maxByOrNull { it.id }!!.id
         Log.d(TAG, "oldestIdFromSync: $oldestIdFromSync")


### PR DESCRIPTION
```
Exception java.lang.NullPointerException:
  at com.nextcloud.talk.chat.data.network.OfflineFirstChatRepository.updateMessagesData (OfflineFirstChatRepository.kt:1341)
  at com.nextcloud.talk.chat.data.network.OfflineFirstChatRepository.access$updateMessagesData (OfflineFirstChatRepository.kt:55)
  at com.nextcloud.talk.chat.data.network.OfflineFirstChatRepository$updateMessagesData$1.invokeSuspend (OfflineFirstChatRepository.kt:19)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:34)
  at kotlinx.coroutines.DispatchedTask.run (DispatchedTask.kt:98)
  at android.os.Handler.handleCallback (Handler.java:958)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:224)
  at android.os.Looper.loop (Looper.java:318)
  at android.app.ActivityThread.main (ActivityThread.java:8763)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:561)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1013)
```



### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
