### PR TITLE
fix UninitializedPropertyAccessException

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -859,16 +859,18 @@ class ChatActivity :
                     value = reactionsSheetMessageId?.let { id -> chatViewModel.getMessageById(id).first() }
                 }
                 reactionsSheetMessage?.let { msg ->
-                    conversationUser?.let { user ->
-                        ShowReactionsModalBottomSheet(
-                            chatMessage = msg,
-                            user = user,
-                            roomToken = roomToken,
-                            hasReactPermission = participantPermissions?.hasReactPermission() == true,
-                            ncApiCoroutines = ncApiCoroutines,
-                            onDeleteReaction = { emoji -> chatViewModel.deleteReaction(roomToken, msg, emoji) },
-                            onDismiss = { chatViewModel.dismissReactionsSheet() }
-                        )
+                    if (::conversationUser.isInitialized) {
+                        conversationUser.let { user ->
+                            ShowReactionsModalBottomSheet(
+                                chatMessage = msg,
+                                user = user,
+                                roomToken = roomToken,
+                                hasReactPermission = participantPermissions?.hasReactPermission() == true,
+                                ncApiCoroutines = ncApiCoroutines,
+                                onDeleteReaction = { emoji -> chatViewModel.deleteReaction(roomToken, msg, emoji) },
+                                onDismiss = { chatViewModel.dismissReactionsSheet() }
+                            )
+                        }
                     }
                 }
 
@@ -880,14 +882,16 @@ class ChatActivity :
                     ?.takeIf { it.actorType.equals("users") }
                     ?.let { msg ->
                         val actorId = msg.actorId ?: return@let
-                        conversationUser?.let { user ->
-                            ProfileModalBottomSheet(
-                                actorId = actorId,
-                                user = user,
-                                ncApiCoroutines = ncApiCoroutines,
-                                onTalkTo = { actorId -> startDirectChat(actorId) },
-                                onDismiss = { chatViewModel.dismissProfileSheet() }
-                            )
+                        if (::conversationUser.isInitialized) {
+                            conversationUser.let { user ->
+                                ProfileModalBottomSheet(
+                                    actorId = actorId,
+                                    user = user,
+                                    ncApiCoroutines = ncApiCoroutines,
+                                    onTalkTo = { actorId -> startDirectChat(actorId) },
+                                    onDismiss = { chatViewModel.dismissProfileSheet() }
+                                )
+                            }
                         }
                     }
 
@@ -916,59 +920,61 @@ class ChatActivity :
                             onDismiss = { chatViewModel.dismissMessageActions() }
                         )
                     } else {
-                        conversationUser?.let { user ->
-                            MessageActionsBottomSheet(
-                                actionsState = buildMessageActionsState(
-                                    message = msg,
-                                    user = user,
-                                    conversation = currentConversation,
-                                    hasChatPermission = participantPermissions?.hasChatPermission() == true,
-                                    hasReactPermission = participantPermissions?.hasReactPermission() == true,
-                                    spreedCapabilities = spreedCapabilities,
-                                    isOnline = isOnline,
-                                    dateUtils = dateUtils,
-                                    conversationThreadId = conversationThreadId
-                                ),
-                                onEmojiClick = { emoji ->
-                                    if (msg.reactionsSelf?.contains(emoji) == true) {
-                                        chatViewModel.deleteReaction(roomToken, msg, emoji)
-                                    } else {
-                                        chatViewModel.addReaction(roomToken, msg, emoji)
-                                    }
-                                },
-                                onReply = {
-                                    if (msg.isThread && conversationThreadId == null) {
-                                        openThread(msg)
-                                    } else {
-                                        messageInputViewModel.reply(msg)
-                                    }
-                                },
-                                onReplyPrivately = { replyPrivately(msg) },
-                                onOpenThread = { msg.threadId?.let { openThread(it) } },
-                                onForward = { forwardMessage(msg) },
-                                onEdit = { messageInputViewModel.edit(msg) },
-                                onCopy = { copyMessage(msg) },
-                                onCopyMessageLink = { copyMessageLink(msg) },
-                                onMarkAsUnread = { markAsUnread(msg) },
-                                onRemind = { remindMeLater(msg) },
-                                onPin = { pinMessage(msg) },
-                                onUnpin = { unPinMessage(msg) },
-                                onTranslate = { translateMessage(msg) },
-                                onShareToNote = { shareToNotes(msg) },
-                                onShare = {
-                                    if (msg.getCalculateMessageType() ==
-                                        ChatMessage.MessageType.SINGLE_NC_ATTACHMENT_MESSAGE
-                                    ) {
-                                        checkIfSharable(msg)
-                                    } else {
-                                        msg.message?.let { shareMessageText(it) }
-                                    }
-                                },
-                                onSave = { checkIfSaveable(msg) },
-                                onOpenInFiles = { openInFilesApp(msg) },
-                                onDelete = { deleteMessage(msg) },
-                                onDismiss = { chatViewModel.dismissMessageActions() }
-                            )
+                        if (::conversationUser.isInitialized) {
+                            conversationUser.let { user ->
+                                MessageActionsBottomSheet(
+                                    actionsState = buildMessageActionsState(
+                                        message = msg,
+                                        user = user,
+                                        conversation = currentConversation,
+                                        hasChatPermission = participantPermissions?.hasChatPermission() == true,
+                                        hasReactPermission = participantPermissions?.hasReactPermission() == true,
+                                        spreedCapabilities = spreedCapabilities,
+                                        isOnline = isOnline,
+                                        dateUtils = dateUtils,
+                                        conversationThreadId = conversationThreadId
+                                    ),
+                                    onEmojiClick = { emoji ->
+                                        if (msg.reactionsSelf?.contains(emoji) == true) {
+                                            chatViewModel.deleteReaction(roomToken, msg, emoji)
+                                        } else {
+                                            chatViewModel.addReaction(roomToken, msg, emoji)
+                                        }
+                                    },
+                                    onReply = {
+                                        if (msg.isThread && conversationThreadId == null) {
+                                            openThread(msg)
+                                        } else {
+                                            messageInputViewModel.reply(msg)
+                                        }
+                                    },
+                                    onReplyPrivately = { replyPrivately(msg) },
+                                    onOpenThread = { msg.threadId?.let { openThread(it) } },
+                                    onForward = { forwardMessage(msg) },
+                                    onEdit = { messageInputViewModel.edit(msg) },
+                                    onCopy = { copyMessage(msg) },
+                                    onCopyMessageLink = { copyMessageLink(msg) },
+                                    onMarkAsUnread = { markAsUnread(msg) },
+                                    onRemind = { remindMeLater(msg) },
+                                    onPin = { pinMessage(msg) },
+                                    onUnpin = { unPinMessage(msg) },
+                                    onTranslate = { translateMessage(msg) },
+                                    onShareToNote = { shareToNotes(msg) },
+                                    onShare = {
+                                        if (msg.getCalculateMessageType() ==
+                                            ChatMessage.MessageType.SINGLE_NC_ATTACHMENT_MESSAGE
+                                        ) {
+                                            checkIfSharable(msg)
+                                        } else {
+                                            msg.message?.let { shareMessageText(it) }
+                                        }
+                                    },
+                                    onSave = { checkIfSaveable(msg) },
+                                    onOpenInFiles = { openInFilesApp(msg) },
+                                    onDelete = { deleteMessage(msg) },
+                                    onDismiss = { chatViewModel.dismissMessageActions() }
+                                )
+                            }
                         }
                     }
                 }
@@ -1068,7 +1074,8 @@ class ChatActivity :
     private fun startDirectChat(actorId: String) {
         lifecycleScope.launch {
             try {
-                val user = conversationUser ?: return@launch
+                if (!::conversationUser.isInitialized) return@launch
+                val user = conversationUser
                 val apiVersion = ApiUtils.getConversationApiVersion(user, intArrayOf(ApiUtils.API_V4, 1))
                 val retrofitBucket = ApiUtils.getRetrofitBucketForCreateRoom(
                     version = apiVersion,
@@ -1368,13 +1375,15 @@ class ChatActivity :
                         }
                     }
 
-                    conversationUser?.let { user ->
-                        val credentials = ApiUtils.getCredentials(user.username, user.token)
-                        chatViewModel.fetchUpcomingEvent(
-                            credentials!!,
-                            user.baseUrl!!,
-                            roomToken
-                        )
+                    if (::conversationUser.isInitialized) {
+                        conversationUser.let { user ->
+                            val credentials = ApiUtils.getCredentials(user.username, user.token)
+                            chatViewModel.fetchUpcomingEvent(
+                                credentials!!,
+                                user.baseUrl!!,
+                                roomToken
+                            )
+                        }
                     }
 
                     if (state.conversationModel.objectType == ConversationEnums.ObjectType.EVENT &&
@@ -1887,7 +1896,7 @@ class ChatActivity :
 
     fun updateToolbarState() {
         val conversation = currentConversation
-        val user = conversationUser
+        val user = if (::conversationUser.isInitialized) conversationUser else null
         val isOneToOne = isOneToOneConversation()
         val capabilitiesReady = ::spreedCapabilities.isInitialized
 
@@ -2039,7 +2048,7 @@ class ChatActivity :
     }
 
     private fun switchToRoom(token: String, startCallAfterRoomSwitch: Boolean, isVoiceOnlyCall: Boolean) {
-        if (conversationUser != null) {
+        if (::conversationUser.isInitialized) {
             runOnUiThread {
                 val toastInfo = if (currentConversation?.objectType == ConversationEnums.ObjectType.ROOM) {
                     context.resources.getString(R.string.switch_to_main_room)
@@ -2695,7 +2704,7 @@ class ChatActivity :
 
     @Suppress("Detekt.TooGenericExceptionCaught")
     private fun cancelNotificationsForCurrentConversation() {
-        if (conversationUser != null) {
+        if (::conversationUser.isInitialized) {
             if (!TextUtils.isEmpty(roomToken)) {
                 try {
                     NotificationUtils.cancelExistingNotificationsForRoom(
@@ -2726,7 +2735,7 @@ class ChatActivity :
             getRoomInfoTimerHandler?.removeCallbacksAndMessages(null)
         }
 
-        if (conversationUser != null && isActivityNotChangingConfigurations() && isNotInCall()) {
+        if (::conversationUser.isInitialized && isActivityNotChangingConfigurations() && isNotInCall()) {
             ApplicationWideCurrentRoomHolder.getInstance().clear()
             if (validSessionId()) {
                 leaveRoom(null)
@@ -2832,8 +2841,8 @@ class ChatActivity :
 
         var apiVersion = 1
         // FIXME Fix API checking with guests?
-        if (conversationUser != null) {
-            apiVersion = ApiUtils.getConversationApiVersion(conversationUser!!, intArrayOf(ApiUtils.API_V4, 1))
+        if (::conversationUser.isInitialized) {
+            apiVersion = ApiUtils.getConversationApiVersion(conversationUser, intArrayOf(ApiUtils.API_V4, 1))
         }
 
         val startNanoTime = System.nanoTime()
@@ -2850,7 +2859,7 @@ class ChatActivity :
     }
 
     private fun setupWebsocket() {
-        if (currentConversation == null || conversationUser == null) {
+        if (currentConversation == null || !::conversationUser.isInitialized) {
             Log.e(TAG, "setupWebsocket: currentConversation or conversationUser is null")
             return
         }
@@ -3214,7 +3223,7 @@ class ChatActivity :
 
     private fun startACall(isVoiceOnlyCall: Boolean, callWithoutNotification: Boolean) {
         currentConversation?.let {
-            if (conversationUser != null) {
+            if (::conversationUser.isInitialized) {
                 val pp = ParticipantPermissions(spreedCapabilities, it)
                 if (!pp.canStartCall() && currentConversation?.hasCall == false) {
                     Snackbar.make(binding.root, R.string.startCallForbidden, Snackbar.LENGTH_LONG).show()
@@ -3341,7 +3350,7 @@ class ChatActivity :
         } else {
             var apiVersion = 1
             // FIXME Fix API checking with guests?
-            if (conversationUser != null) {
+            if (::conversationUser.isInitialized) {
                 apiVersion = ApiUtils.getChatApiVersion(spreedCapabilities, intArrayOf(1))
             }
 
@@ -3787,7 +3796,7 @@ class ChatActivity :
     }
 
     fun userAllowedByPrivilages(message: ChatMessage): Boolean {
-        if (conversationUser == null) return false
+        if (!::conversationUser.isInitialized) return false
 
         val isUserAllowedByPrivileges = if (message.actorId == conversationUser!!.userId) {
             true


### PR DESCRIPTION
fix https://github.com/nextcloud/talk-android/issues/6449

```
Exception java.lang.RuntimeException:
  at android.app.ActivityThread.performResumeActivity (ActivityThread.java:5938)   at android.app.ActivityThread.handleResumeActivity (ActivityThread.java:6011)   at android.app.servertransaction.ResumeActivityItem.execute (ResumeActivityItem.java:57)   at android.app.servertransaction.ActivityTransactionItem.execute (ActivityTransactionItem.java:60)   at android.app.servertransaction.TransactionExecutor.executeLifecycleItem (TransactionExecutor.java:225)   at android.app.servertransaction.TransactionExecutor.executeTransactionItems (TransactionExecutor.java:107)   at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:81)   at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2899)   at android.os.Handler.dispatchMessage (Handler.java:107)   at android.os.Looper.loopOnce (Looper.java:257)
  at android.os.Looper.loop (Looper.java:342)
  at android.app.ActivityThread.main (ActivityThread.java:9638)   at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:619)   at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:929) Caused by kotlin.UninitializedPropertyAccessException: lateinit property conversationUser has not been initialized   at com.nextcloud.talk.chat.ChatActivity.getConversationUser (ChatActivity.kt:352)   at com.nextcloud.talk.chat.ChatActivity.cancelNotificationsForCurrentConversation (ChatActivity.kt:2727)   at com.nextcloud.talk.chat.ChatActivity.onResume (ChatActivity.kt:1830)   at android.app.Instrumentation.callActivityOnResume (Instrumentation.java:1722)   at android.app.Activity.performResume (Activity.java:9533)   at android.app.ActivityThread.performResumeActivity (ActivityThread.java:5908)
```


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
