### PR TITLE
 fix(chat): stop loading indicator from shifting chat content

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ui/ChatToolbar.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ui/ChatToolbar.kt
@@ -86,7 +86,7 @@ import com.nextcloud.talk.extensions.loadSystemAvatar
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun ChatToolbar(state: ChatToolbarState, callbacks: ChatToolbarCallbacks, modifier: Modifier = Modifier) {
-    Column(modifier = modifier) {
+    Box(modifier = modifier) {
         TopAppBar(
             navigationIcon = {
                 IconButton(onClick = callbacks.onNavigateUp) {
@@ -112,7 +112,9 @@ fun ChatToolbar(state: ChatToolbarState, callbacks: ChatToolbarCallbacks, modifi
 
         if (state.isLoading) {
             LinearProgressIndicator(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.BottomStart),
                 color = MaterialTheme.colorScheme.primary,
                 trackColor = MaterialTheme.colorScheme.surface
             )


### PR DESCRIPTION
  The loading indicator was rendered as an in-flow sibling of the
  toolbar. Toggling it changed the toolbar's measured height, which
  shifted the message list below it (sized via layout_weight) —
  most noticeable when there weren't enough messages to scroll.

  Render it as an overlay on top of the toolbar instead, so it no
  longer occupies layout space or affects the toolbar's height.

Assisted-by: Claude Code 2.1.199:claude-sonnet-5

🏚️ Before | 🏡 After
---|---
<img width="300" alt="1" src="https://github.com/user-attachments/assets/178c0030-2913-492c-aed0-4047bc6f75ef" /> |<img width="300" alt="3" src="https://github.com/user-attachments/assets/9840ae50-a82c-40c4-a0e1-101969aee6f6" />



### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
