### PR TITLE
Fix collapsed call card text overlapping controls

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
@@ -572,6 +572,7 @@ class MessageInputFragment : Fragment() {
         }
 
         binding.fragmentCallStarted.callStartedCloseBtn.setImageDrawable(drawable)
+        viewThemeUtils.platform.colorImageView(binding.fragmentCallStarted.callStartedCloseBtn, ColorRole.PRIMARY)
     }
 
     @Suppress("ClickableViewAccessibility", "CyclomaticComplexMethod", "LongMethod")

--- a/app/src/main/res/layout/call_started_message.xml
+++ b/app/src/main/res/layout/call_started_message.xml
@@ -39,8 +39,11 @@
             />
 
         <TextView
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:maxLines="1"
+            android:ellipsize="end"
             android:text="@string/started_a_call" />
 
         <ImageView


### PR DESCRIPTION
## Summary
- Collapsed call card: give the "started a call" label `layout_weight` with single-line ellipsis so it no longer crowds the controls.
- Theme the close button with the primary color for clearer visibility in the collapsed state.

Fixes #5066

## Test plan
- [ ] Start/join a call so the call-started banner appears, then collapse it.
- [ ] Confirm the label truncates cleanly and the expand/close controls remain visible and tappable.
- [ ] Rotate / switch theme and confirm the card still lays out correctly.
