### PR TITLE
🔄️ Improve unread marker display

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/data/network/ChatMessageSyncer.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/network/ChatMessageSyncer.kt
@@ -201,9 +201,10 @@ class ChatMessageSyncer @Inject constructor(
      * Catches up a room with the server without requiring an open chat.
      *
      * If a chat block exists, only the delta since the newest locally known message is fetched and
-     * the block is extended. For rooms without any chat block (never-opened rooms) the newest
-     * messages are fetched and the initial chat block is created, so cached messages become
-     * visible to [ChatMessagesDao] block queries right away.
+     * the block is extended. For rooms without any chat block (never-opened rooms) the initial
+     * chat block is created via [initialCatchUp] — anchored at [lastReadMessage] when the unread
+     * backlog calls for it — so cached messages become visible to [ChatMessagesDao] block queries
+     * right away.
      *
      * Requires the chat-keep-notifications capability: without it, a background fetch would
      * dismiss the user's push notifications for the fetched messages, so the catch-up is skipped
@@ -213,7 +214,12 @@ class ChatMessageSyncer @Inject constructor(
      * active group chat) are coalesced: while a catch-up runs, further requests only mark a rerun
      * and return, and consecutive fetches are paced by [CATCH_UP_COOLDOWN_MILLIS].
      */
-    suspend fun catchUpRoom(target: SyncTarget, limit: Int = DEFAULT_MESSAGES_LIMIT): SyncOutcome =
+    suspend fun catchUpRoom(
+        target: SyncTarget,
+        limit: Int = DEFAULT_MESSAGES_LIMIT,
+        lastReadMessage: Int? = null,
+        unreadMessages: Int = 0
+    ): SyncOutcome =
         when {
             !networkMonitor.isOnline.value -> {
                 Log.d(TAG, "Device is offline, skipping catch-up for ${target.internalConversationId}")
@@ -229,7 +235,7 @@ class ChatMessageSyncer @Inject constructor(
                 NOTHING_SYNCED
             }
 
-            else -> coalescedRoomCatchUp(target, limit)
+            else -> coalescedRoomCatchUp(target, limit, lastReadMessage, unreadMessages)
         }
 
     /**
@@ -240,7 +246,12 @@ class ChatMessageSyncer @Inject constructor(
      * [MAX_CATCH_UP_RUNS_PER_BURST] fetches — later messages are covered by their own push or the
      * next room list sync.
      */
-    private suspend fun coalescedRoomCatchUp(target: SyncTarget, limit: Int): SyncOutcome {
+    private suspend fun coalescedRoomCatchUp(
+        target: SyncTarget,
+        limit: Int,
+        lastReadMessage: Int?,
+        unreadMessages: Int
+    ): SyncOutcome {
         val stateKey = syncStateKey(target.internalConversationId, target.threadId)
         val state = catchUpStates.getOrPut(stateKey) { RoomCatchUpState() }
 
@@ -256,7 +267,7 @@ class ChatMessageSyncer @Inject constructor(
             do {
                 awaitCatchUpCooldown(state, stateKey)
                 state.rerunRequested.set(false)
-                outcome = fetchRoomCatchUp(target, limit)
+                outcome = fetchRoomCatchUp(target, limit, lastReadMessage, unreadMessages)
                 state.lastCompletedAtMillis = SystemClock.elapsedRealtime()
                 runs++
             } while (state.rerunRequested.get() && runs < MAX_CATCH_UP_RUNS_PER_BURST)
@@ -309,7 +320,12 @@ class ChatMessageSyncer @Inject constructor(
     private fun syncStateKey(internalConversationId: String, threadId: Long?): String =
         "$internalConversationId#$threadId"
 
-    private suspend fun fetchRoomCatchUp(target: SyncTarget, limit: Int): SyncOutcome {
+    private suspend fun fetchRoomCatchUp(
+        target: SyncTarget,
+        limit: Int,
+        lastReadMessage: Int?,
+        unreadMessages: Int
+    ): SyncOutcome {
         val newestMessageIdFromDb =
             chatBlocksDao.getNewestMessageIdFromChatBlocks(target.internalConversationId, target.threadId)
 
@@ -321,17 +337,12 @@ class ChatMessageSyncer @Inject constructor(
                 markNotificationsAsRead = false
             )
         } else {
-            pullAndPersistMessages(
-                target,
-                buildFieldMap(
-                    lookIntoFuture = false,
-                    timeout = 0,
-                    includeLastKnown = true,
-                    lastKnown = null,
-                    limit = limit,
-                    threadId = target.threadId,
-                    markNotificationsAsRead = false
-                )
+            initialCatchUp(
+                target = target,
+                limit = limit,
+                lastReadMessage = lastReadMessage,
+                unreadMessages = unreadMessages,
+                markNotificationsAsRead = false
             )
         }
 
@@ -347,6 +358,117 @@ class ChatMessageSyncer @Inject constructor(
         }
 
         return outcome
+    }
+
+    /**
+     * First fetch for a conversation whose cached messages do not reach the unread boundary yet
+     * (typically a conversation without any chat block).
+     *
+     * The unread marker can only be placed correctly when the chat's visible window — the latest
+     * chat block — contains the last read message. A plain newest-messages fetch creates a block
+     * floating entirely above the boundary as soon as the unread backlog is larger than one page,
+     * so for such backlogs the fetch is anchored at [lastReadMessage] instead (including the last
+     * read message itself) and the rest of the backlog is closed via [tryCloseBacklog]. Backlogs
+     * smaller than one page fit into a newest-messages fetch anyway, and backlogs too large to be
+     * closed within [MAX_BACKLOG_ROUNDS] would end up in a floating newest-messages block either
+     * way, so both keep the plain newest-messages fetch.
+     */
+    @Suppress("LongParameterList")
+    suspend fun initialCatchUp(
+        target: SyncTarget,
+        limit: Int = DEFAULT_MESSAGES_LIMIT,
+        lastReadMessage: Int? = null,
+        unreadMessages: Int = 0,
+        lastCommonRead: Int? = null,
+        markNotificationsAsRead: Boolean = true,
+        events: Events = NO_EVENTS
+    ): SyncOutcome {
+        val closableBacklogAnchor = lastReadMessage?.takeIf {
+            it > 0 && unreadMessages >= limit && unreadMessages <= MAX_BACKLOG_ROUNDS * limit
+        }
+
+        return if (closableBacklogAnchor != null) {
+            anchoredInitialCatchUp(
+                target = target,
+                limit = limit,
+                lastReadMessage = closableBacklogAnchor,
+                unreadMessages = unreadMessages,
+                lastCommonRead = lastCommonRead,
+                markNotificationsAsRead = markNotificationsAsRead,
+                events = events
+            )
+        } else {
+            pullAndPersistMessages(
+                target,
+                buildFieldMap(
+                    lookIntoFuture = false,
+                    timeout = 0,
+                    includeLastKnown = true,
+                    lastKnown = null,
+                    limit = limit,
+                    threadId = target.threadId,
+                    lastCommonRead = lastCommonRead,
+                    markNotificationsAsRead = markNotificationsAsRead
+                ),
+                events
+            )
+        }
+    }
+
+    /**
+     * The anchored branch of [initialCatchUp]: fetches one page starting at [lastReadMessage]
+     * (inclusive) and closes the remaining backlog from there via [tryCloseBacklog].
+     */
+    @Suppress("LongParameterList")
+    private suspend fun anchoredInitialCatchUp(
+        target: SyncTarget,
+        limit: Int,
+        lastReadMessage: Int,
+        unreadMessages: Int,
+        lastCommonRead: Int?,
+        markNotificationsAsRead: Boolean,
+        events: Events
+    ): SyncOutcome {
+        Log.d(
+            TAG,
+            "Anchoring the initial fetch for ${target.internalConversationId} at lastReadMessage " +
+                "$lastReadMessage ($unreadMessages unread)"
+        )
+        val anchorOutcome = pullAndPersistMessages(
+            target,
+            buildFieldMap(
+                lookIntoFuture = true,
+                timeout = 0,
+                includeLastKnown = true,
+                lastKnown = lastReadMessage,
+                limit = limit,
+                threadId = target.threadId,
+                lastCommonRead = lastCommonRead,
+                markNotificationsAsRead = markNotificationsAsRead
+            ),
+            events
+        )
+
+        val nextAnchor = anchorOutcome.newestPersistedMessageId
+        if (nextAnchor == null || anchorOutcome.persistedMessageCount < limit) {
+            return anchorOutcome
+        }
+
+        val backlogOutcome = tryCloseBacklog(
+            target = target,
+            fromMessageId = nextAnchor,
+            limit = limit,
+            lastCommonRead = lastCommonRead,
+            markNotificationsAsRead = markNotificationsAsRead,
+            events = events
+        )
+        return SyncOutcome(
+            persistedNewMessages = true,
+            newestPersistedMessageId = backlogOutcome.newestPersistedMessageId ?: nextAnchor,
+            oldestPersistedMessageId = anchorOutcome.oldestPersistedMessageId,
+            persistedMessageCount = anchorOutcome.persistedMessageCount + backlogOutcome.persistedMessageCount,
+            syncFailed = backlogOutcome.syncFailed
+        )
     }
 
     /**

--- a/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
@@ -196,13 +196,13 @@ class OfflineFirstChatRepository @Inject constructor(
         // repaired by an anchored fetch — only closing the backlog above it would keep the marker
         // pinned to the block's oldest message, in the middle of the unread messages.
         val lastReadMessage = conversationModel.lastReadMessage.toLong()
-        val blockReachesUnreadBoundary = lastReadMessage <= 0 ||
+        val blockNotFloatingAboveLastReadMessage = lastReadMessage <= 0 ||
             latestBlock.oldestMessageId <= lastReadMessage ||
             !latestBlock.hasHistory
 
-        Log.d(TAG, "blockReachesUnreadBoundary:$blockReachesUnreadBoundary")
+        Log.d(TAG, "blockNotFloatingAboveLastReadMessage:$blockNotFloatingAboveLastReadMessage")
 
-        if (blockReachesUnreadBoundary) {
+        if (blockNotFloatingAboveLastReadMessage) {
             tryCloseBacklogFromNewestOfflineMessage(latestBlock.newestMessageId)
         } else {
             fetchInitialMessages(weAlreadyHaveSomeOfflineMessages = true)

--- a/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
@@ -182,25 +182,30 @@ class OfflineFirstChatRepository @Inject constructor(
         Log.d(TAG, "conversationModel.internalId: " + conversationModel.internalId)
         Log.d(TAG, "conversationModel.lastReadMessage:" + conversationModel.lastReadMessage)
 
-        val newestMessageIdFromDb = chatBlocksDao.getNewestMessageIdFromChatBlocks(internalConversationId, threadId)
-        Log.d(TAG, "newestMessageIdFromDb: $newestMessageIdFromDb")
+        val latestBlock = chatBlocksDao.getLatestChatBlock(internalConversationId, threadId).first()
+        Log.d(TAG, "latestBlock: ${latestBlock?.oldestMessageId}..${latestBlock?.newestMessageId}")
 
-        val weAlreadyHaveSomeOfflineMessages = newestMessageIdFromDb > 0
-        val weHaveAtLeastTheLastReadMessage = newestMessageIdFromDb >= conversationModel.lastReadMessage.toLong()
-        val weLikelyOnlyHaveASmallBacklog = weAlreadyHaveSomeOfflineMessages && weHaveAtLeastTheLastReadMessage
+        if (latestBlock == null) {
+            fetchInitialMessages(weAlreadyHaveSomeOfflineMessages = false)
+            return
+        }
 
-        Log.d(TAG, "weAlreadyHaveSomeOfflineMessages:$weAlreadyHaveSomeOfflineMessages")
-        Log.d(TAG, "weHaveAtLeastTheLastReadMessage:$weHaveAtLeastTheLastReadMessage")
-        Log.d(TAG, "weLikelyOnlyHaveASmallBacklog:$weLikelyOnlyHaveASmallBacklog")
+        // The chat shows the messages of the latest chat block, and the unread marker can only be
+        // placed correctly when that block reaches back to the last read message. A block floating
+        // entirely above the boundary (e.g. created by a capped newest-messages fetch) must be
+        // repaired by an anchored fetch — only closing the backlog above it would keep the marker
+        // pinned to the block's oldest message, in the middle of the unread messages.
+        val lastReadMessage = conversationModel.lastReadMessage.toLong()
+        val blockReachesUnreadBoundary = lastReadMessage <= 0 ||
+            latestBlock.oldestMessageId <= lastReadMessage ||
+            !latestBlock.hasHistory
 
-        if (weLikelyOnlyHaveASmallBacklog) {
-            tryCloseBacklogFromNewestOfflineMessage(newestMessageIdFromDb)
+        Log.d(TAG, "blockReachesUnreadBoundary:$blockReachesUnreadBoundary")
+
+        if (blockReachesUnreadBoundary) {
+            tryCloseBacklogFromNewestOfflineMessage(latestBlock.newestMessageId)
         } else {
-            fetchNewestMessagesForInitialLoad(
-                withNetworkParams,
-                weAlreadyHaveSomeOfflineMessages,
-                weHaveAtLeastTheLastReadMessage
-            )
+            fetchInitialMessages(weAlreadyHaveSomeOfflineMessages = true)
         }
     }
 
@@ -218,36 +223,32 @@ class OfflineFirstChatRepository @Inject constructor(
         )
     }
 
-    private suspend fun fetchNewestMessagesForInitialLoad(
-        withNetworkParams: Bundle,
-        weAlreadyHaveSomeOfflineMessages: Boolean,
-        weHaveAtLeastTheLastReadMessage: Boolean
-    ) {
+    /**
+     * Fetches the initial message window via [ChatMessageSyncer.initialCatchUp]: anchored at the
+     * last read message when a large unread backlog exists, the newest messages otherwise.
+     */
+    private suspend fun fetchInitialMessages(weAlreadyHaveSomeOfflineMessages: Boolean) {
         if (!weAlreadyHaveSomeOfflineMessages) {
-            Log.d(TAG, "An online request for newest 100 messages is made because offline chat is empty")
+            Log.d(TAG, "An initial online request is made because offline chat is empty")
             if (networkMonitor.isOnline.value.not()) {
                 // _generalUIFlow.emit(ChatActivity.NO_OFFLINE_MESSAGES_FOUND)
             }
-        } else if (!weHaveAtLeastTheLastReadMessage) {
+        } else {
             Log.d(
                 TAG,
-                "An online request for newest 100 messages is made because we don't have the " +
+                "An initial online request is made because the cached messages don't reach the " +
                     "lastReadMessage (gaps could be closed by scrolling up to merge the chatblocks)"
             )
         }
 
-        // set up field map to load the newest messages
-        val fieldMap = getFieldMap(
-            lookIntoFuture = false,
-            timeout = 0,
-            includeLastKnown = true,
-            lastKnown = null
-        )
-        withNetworkParams.putSerializable(BundleKeys.KEY_FIELD_MAP, fieldMap)
-        withNetworkParams.putString(BundleKeys.KEY_ROOM_TOKEN, conversationModel.token)
-
         Log.d(TAG, "Starting online request for initial loading")
-        getAndPersistMessages(withNetworkParams)
+        syncer.initialCatchUp(
+            target = syncTarget,
+            lastReadMessage = conversationModel.lastReadMessage,
+            unreadMessages = conversationModel.unreadMessages,
+            lastCommonRead = newXChatLastCommonRead,
+            events = syncEvents
+        )
     }
 
     override suspend fun startMessagePolling(hasHighPerformanceBackend: Boolean) {

--- a/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
@@ -333,12 +333,22 @@ class OfflineFirstChatRepository @Inject constructor(
      * newest message would skip exactly the range it has to check. The anchor lives in the
      * singleton [ChatMessageSyncer], so it survives reopening the chat.
      *
+     * No-ops when no HTTP sync has happened yet for this conversation: that means the initial
+     * load hasn't completed (or hasn't even started), which is already fetching this room from
+     * scratch — anchoring at 0 instead would try to close the backlog from the very beginning of
+     * the conversation's history, which for a busy room can't close within
+     * [ChatMessageSyncer.tryCloseBacklog]'s round budget and just burns requests before falling
+     * back anyway.
+     *
      * @return `true` if at least one new message was received and persisted.
      */
     override suspend fun fetchNewMessages(): Boolean {
         cleanupExpiredMessages()
 
-        val lastHttpSyncedMessageId = syncer.lastHttpSyncedMessageId(internalConversationId, threadId) ?: 0L
+        val lastHttpSyncedMessageId = syncer.lastHttpSyncedMessageId(internalConversationId, threadId) ?: run {
+            Log.d(TAG, "No HTTP-synced anchor yet for $internalConversationId, skipping insurance fetch")
+            return false
+        }
 
         // tryCloseBacklog loops until the backlog is fully closed, so a backlog larger than the
         // request limit is caught up within one insurance cycle instead of narrowing it by one

--- a/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
@@ -1131,22 +1131,10 @@ class ChatViewModel @AssistedInject constructor(
 
         return buildList {
             if (firstUnreadMessageId == null && lastReadMessage > 0) {
-                // Latch the marker position only when the visible window provably reaches back to
-                // the unread boundary, i.e. a message at or below lastReadMessage is visible.
-                // Without that proof the oldest visible message may still be far above the true
-                // first unread message (e.g. after a capped fetch of only the newest messages) and
-                // the marker would be latched in the middle of the unread messages. Temporary
-                // messages carry negative ids and don't count as proof.
-                val unreadBoundaryIsVisible = uiMessages.any { it.id in 1..lastReadMessage }
-                if (unreadBoundaryIsVisible) {
-                    firstUnreadMessageId =
-                        uiMessages.firstOrNull {
-                            it.id > lastReadMessage
-                        }?.id
-                    Log.d(TAG, "reversedMessages.size = ${uiMessages.size}")
-                    Log.d(TAG, "firstUnreadMessageId = $firstUnreadMessageId")
-                    Log.d(TAG, "conversation.lastReadMessage = $lastReadMessage")
-                }
+                firstUnreadMessageId = findFirstUnreadMessageId(uiMessages, lastReadMessage)
+                Log.d(TAG, "reversedMessages.size = ${uiMessages.size}")
+                Log.d(TAG, "firstUnreadMessageId = $firstUnreadMessageId")
+                Log.d(TAG, "conversation.lastReadMessage = $lastReadMessage")
             }
 
             for (uiMessage in uiMessages) {
@@ -2392,6 +2380,25 @@ class ChatViewModel @AssistedInject constructor(
 
     companion object {
         private val TAG = ChatViewModel::class.java.simpleName
+
+        /**
+         * Returns the id of the first unread message, or null when it cannot be determined (yet).
+         *
+         * The position is only trustworthy when the visible window provably reaches back to the
+         * unread boundary, i.e. a message at or below [lastReadMessage] is visible. Without that
+         * proof the oldest visible message may still be far above the true first unread message
+         * (e.g. after a capped fetch of only the newest messages) and a marker latched onto it
+         * would sit in the middle of the unread messages. Temporary messages carry negative ids
+         * and don't count as proof.
+         */
+        internal fun findFirstUnreadMessageId(uiMessages: List<ChatMessageUi>, lastReadMessage: Int): Int? {
+            val unreadBoundaryIsVisible = uiMessages.any { it.id in 1..lastReadMessage }
+            if (!unreadBoundaryIsVisible) {
+                return null
+            }
+            return uiMessages.firstOrNull { it.id > lastReadMessage }?.id
+        }
+
         const val JOIN_ROOM_RETRY_COUNT: Long = 3
         const val HTTP_CODE_OK: Int = 200
         private const val CONVERSATION_AND_USER_FLOW_SHARING_TIMEOUT_MS = 5_000L

--- a/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
@@ -221,11 +221,16 @@ class ChatViewModel @AssistedInject constructor(
 
     override fun onResume(owner: LifecycleOwner) {
         super.onResume(owner)
+        val isReturningFromBackground = ::currentLifeCycleFlag.isInitialized
         currentLifeCycleFlag = LifeCycleFlag.RESUMED
         mediaRecorderManager.handleOnResume()
         chatRepository.handleOnResume()
         mediaPlayerManager.handleOnResume()
-        viewModelScope.launch { fetchNewMessagesWithRetry() }
+        if (isReturningFromBackground) {
+            viewModelScope.launch {
+                chatRepository.fetchNewMessages()
+            }
+        }
     }
 
     override fun onPause(owner: LifecycleOwner) {

--- a/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
@@ -1131,13 +1131,22 @@ class ChatViewModel @AssistedInject constructor(
 
         return buildList {
             if (firstUnreadMessageId == null && lastReadMessage > 0) {
-                firstUnreadMessageId =
-                    uiMessages.firstOrNull {
-                        it.id > lastReadMessage
-                    }?.id
-                Log.d(TAG, "reversedMessages.size = ${uiMessages.size}")
-                Log.d(TAG, "firstUnreadMessageId = $firstUnreadMessageId")
-                Log.d(TAG, "conversation.lastReadMessage = $lastReadMessage")
+                // Latch the marker position only when the visible window provably reaches back to
+                // the unread boundary, i.e. a message at or below lastReadMessage is visible.
+                // Without that proof the oldest visible message may still be far above the true
+                // first unread message (e.g. after a capped fetch of only the newest messages) and
+                // the marker would be latched in the middle of the unread messages. Temporary
+                // messages carry negative ids and don't count as proof.
+                val unreadBoundaryIsVisible = uiMessages.any { it.id in 1..lastReadMessage }
+                if (unreadBoundaryIsVisible) {
+                    firstUnreadMessageId =
+                        uiMessages.firstOrNull {
+                            it.id > lastReadMessage
+                        }?.id
+                    Log.d(TAG, "reversedMessages.size = ${uiMessages.size}")
+                    Log.d(TAG, "firstUnreadMessageId = $firstUnreadMessageId")
+                    Log.d(TAG, "conversation.lastReadMessage = $lastReadMessage")
+                }
             }
 
             for (uiMessage in uiMessages) {

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/data/network/OfflineFirstConversationsRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/data/network/OfflineFirstConversationsRepository.kt
@@ -240,7 +240,13 @@ class OfflineFirstConversationsRepository @Inject constructor(
                             credentials = credentials,
                             urlForChatting = ApiUtils.getUrlForChat(CHAT_API_VERSION, user.baseUrl!!, room.token)
                         )
-                        runCatching { chatMessageSyncer.catchUpRoom(target) }
+                        runCatching {
+                            chatMessageSyncer.catchUpRoom(
+                                target = target,
+                                lastReadMessage = room.lastReadMessage,
+                                unreadMessages = room.unreadMessages
+                            )
+                        }
                             .onFailure { Log.e(TAG, "Message catch-up failed for room ${room.token}", it) }
                     }
                 }

--- a/app/src/main/java/com/nextcloud/talk/jobs/ChatMessageCatchUpWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/ChatMessageCatchUpWorker.kt
@@ -22,11 +22,13 @@ import autodagger.AutoInjector
 import com.nextcloud.talk.application.NextcloudTalkApplication
 import com.nextcloud.talk.application.NextcloudTalkApplication.Companion.sharedApplication
 import com.nextcloud.talk.chat.data.network.ChatMessageSyncer
+import com.nextcloud.talk.data.database.dao.ConversationsDao
 import com.nextcloud.talk.users.UserManager
 import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_INTERNAL_USER_ID
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_ROOM_TOKEN
 import com.nextcloud.talk.utils.bundle.BundleKeys.KEY_THREAD_ID
+import kotlinx.coroutines.flow.first
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
@@ -50,6 +52,9 @@ class ChatMessageCatchUpWorker(context: Context, workerParams: WorkerParameters)
 
     @Inject
     lateinit var chatMessageSyncer: ChatMessageSyncer
+
+    @Inject
+    lateinit var conversationsDao: ConversationsDao
 
     override suspend fun doWork(): Result {
         sharedApplication!!.componentApplication.inject(this)
@@ -89,7 +94,23 @@ class ChatMessageCatchUpWorker(context: Context, workerParams: WorkerParameters)
             urlForChatting = ApiUtils.getUrlForChat(CHAT_API_VERSION, user.baseUrl!!, roomToken)
         )
 
-        val outcome = runCatching { chatMessageSyncer.catchUpRoom(target) }.getOrElse { throwable ->
+        // For a room without any cached chat block the unread boundary of the locally cached
+        // conversation is passed along, so a large backlog is fetched anchored at the last read
+        // message and the unread marker can be placed when the chat is opened. The boundary is
+        // room-level state and therefore not passed for thread catch-ups.
+        val conversation = if (threadId == null) {
+            conversationsDao.getConversationForUser(user.id!!, roomToken).first()
+        } else {
+            null
+        }
+
+        val outcome = runCatching {
+            chatMessageSyncer.catchUpRoom(
+                target = target,
+                lastReadMessage = conversation?.lastReadMessage,
+                unreadMessages = conversation?.unreadMessages ?: 0
+            )
+        }.getOrElse { throwable ->
             Log.e(TAG, "Message catch-up failed for room $roomToken", throwable)
             null
         }

--- a/app/src/test/java/com/nextcloud/talk/chat/data/network/ChatMessageSyncerTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/chat/data/network/ChatMessageSyncerTest.kt
@@ -190,6 +190,76 @@ class ChatMessageSyncerTest {
         }
 
     @Test
+    fun `catchUpRoom anchors the initial fetch at the last read message for a large unread backlog`() =
+        runTest {
+            whenever(chatBlocksDao.getNewestMessageIdFromChatBlocks(INTERNAL_CONVERSATION_ID, null))
+                .thenReturn(0L)
+            whenever(chatBlocksDao.getChatBlocksContainingMessageId(eq(INTERNAL_CONVERSATION_ID), eq(null), any()))
+                .thenReturn(flowOf(emptyList()))
+            wheneverBlocking { network.pullChatMessages(any(), any(), any()) }
+                .thenReturn(
+                    // anchored page including the last read message 10 itself
+                    Response.success(overall(message(10), message(11))),
+                    // backlog rounds until the server returns fewer messages than the limit
+                    Response.success(overall(message(12), message(13))),
+                    Response.success(overall(message(14)))
+                )
+
+            val outcome = syncer.catchUpRoom(target(), limit = 2, lastReadMessage = 10, unreadMessages = 4)
+
+            assertTrue(outcome.persistedNewMessages)
+            assertEquals(5, outcome.persistedMessageCount)
+            assertEquals(10L, outcome.oldestPersistedMessageId)
+            assertEquals(14L, outcome.newestPersistedMessageId)
+
+            val fieldMapCaptor = argumentCaptor<HashMap<String, Int>>()
+            verifyBlocking(network, times(3)) { pullChatMessages(any(), any(), fieldMapCaptor.capture()) }
+            val anchoredFieldMap = fieldMapCaptor.firstValue
+            assertEquals(1, anchoredFieldMap["lookIntoFuture"])
+            assertEquals(1, anchoredFieldMap["includeLastKnown"])
+            assertEquals(10, anchoredFieldMap["lastKnownMessageId"])
+            assertEquals(0, anchoredFieldMap["markNotificationsAsRead"])
+        }
+
+    @Test
+    fun `catchUpRoom keeps the newest-messages fetch for a backlog smaller than one page`() =
+        runTest {
+            whenever(chatBlocksDao.getNewestMessageIdFromChatBlocks(INTERNAL_CONVERSATION_ID, null))
+                .thenReturn(0L)
+            whenever(chatBlocksDao.getChatBlocksContainingMessageId(eq(INTERNAL_CONVERSATION_ID), eq(null), any()))
+                .thenReturn(flowOf(emptyList()))
+            wheneverBlocking { network.pullChatMessages(any(), any(), any()) }
+                .thenReturn(Response.success(overall(message(9), message(10), message(11))))
+
+            syncer.catchUpRoom(target(), limit = 3, lastReadMessage = 10, unreadMessages = 1)
+
+            val fieldMapCaptor = argumentCaptor<HashMap<String, Int>>()
+            verifyBlocking(network) { pullChatMessages(any(), any(), fieldMapCaptor.capture()) }
+            assertEquals(0, fieldMapCaptor.firstValue["lookIntoFuture"])
+            assertEquals(1, fieldMapCaptor.firstValue["includeLastKnown"])
+            assertFalse(fieldMapCaptor.firstValue.containsKey("lastKnownMessageId"))
+        }
+
+    @Test
+    fun `catchUpRoom keeps the newest-messages fetch for a backlog too large to close`() =
+        runTest {
+            whenever(chatBlocksDao.getNewestMessageIdFromChatBlocks(INTERNAL_CONVERSATION_ID, null))
+                .thenReturn(0L)
+            whenever(chatBlocksDao.getChatBlocksContainingMessageId(eq(INTERNAL_CONVERSATION_ID), eq(null), any()))
+                .thenReturn(flowOf(emptyList()))
+            wheneverBlocking { network.pullChatMessages(any(), any(), any()) }
+                .thenReturn(Response.success(overall(message(999), message(1000))))
+
+            // MAX_BACKLOG_ROUNDS (5) * limit (2) = 10 closable messages, backlog is 11
+            syncer.catchUpRoom(target(), limit = 2, lastReadMessage = 10, unreadMessages = 11)
+
+            val fieldMapCaptor = argumentCaptor<HashMap<String, Int>>()
+            verifyBlocking(network) { pullChatMessages(any(), any(), fieldMapCaptor.capture()) }
+            assertEquals(0, fieldMapCaptor.firstValue["lookIntoFuture"])
+            assertFalse(fieldMapCaptor.firstValue.containsKey("lastKnownMessageId"))
+        }
+
+    @Test
     fun `catchUpRoom coalesces a burst of calls for the same room into two fetches`() =
         runTest {
             val existingBlock = block(oldest = 10, newest = 42)

--- a/app/src/test/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepositoryTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepositoryTest.kt
@@ -33,6 +33,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verifyBlocking
 import org.mockito.kotlin.whenever
 import org.mockito.kotlin.wheneverBlocking
@@ -151,6 +152,18 @@ class OfflineFirstChatRepositoryTest {
             assertEquals(0, fieldMap["lookIntoFuture"])
             assertEquals(1, fieldMap["includeLastKnown"])
             assertFalse(fieldMap.containsKey("lastKnownMessageId"))
+        }
+
+    @Test
+    fun `fetchNewMessages skips the request when no HTTP-synced anchor exists yet`() =
+        runTest {
+            // a fresh ChatMessageSyncer has recorded no HTTP sync for any conversation yet, so
+            // this is the state of a room whose initial load hasn't fetched anything so far —
+            // anchoring at 0 would try to close the backlog from the start of its history instead
+            val result = repository.fetchNewMessages()
+
+            assertFalse(result)
+            verifyBlocking(network, never()) { pullChatMessages(any(), any(), any()) }
         }
 
     private fun givenLatestBlock(block: ChatBlockEntity?) {

--- a/app/src/test/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepositoryTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepositoryTest.kt
@@ -1,0 +1,222 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.nextcloud.talk.chat.data.network
+
+import android.os.Bundle
+import com.nextcloud.talk.chat.data.model.ChatMessage
+import com.nextcloud.talk.data.database.dao.ChatBlocksDao
+import com.nextcloud.talk.data.database.dao.ChatMessagesDao
+import com.nextcloud.talk.data.database.model.ChatBlockEntity
+import com.nextcloud.talk.data.network.NetworkMonitor
+import com.nextcloud.talk.data.user.model.User
+import com.nextcloud.talk.logger.Logger
+import com.nextcloud.talk.models.domain.ConversationModel
+import com.nextcloud.talk.models.json.capabilities.Capabilities
+import com.nextcloud.talk.models.json.capabilities.SpreedCapability
+import com.nextcloud.talk.models.json.chat.ChatMessageJson
+import com.nextcloud.talk.models.json.chat.ChatOCS
+import com.nextcloud.talk.models.json.chat.ChatOverall
+import com.nextcloud.talk.models.json.conversations.Conversation
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verifyBlocking
+import org.mockito.kotlin.whenever
+import org.mockito.kotlin.wheneverBlocking
+import retrofit2.Response
+
+/**
+ * Covers the unread-boundary decisions of [OfflineFirstChatRepository.loadInitialMessages]: the
+ * cached window (the latest chat block) is only trusted when it reaches back to the conversation's
+ * last read message, otherwise the initial window is re-fetched — anchored at the boundary when
+ * the unread backlog calls for it.
+ */
+class OfflineFirstChatRepositoryTest {
+
+    private val logger: Logger = mock()
+    private val chatDao: ChatMessagesDao = mock()
+    private val chatBlocksDao: ChatBlocksDao = mock()
+    private val network: ChatNetworkDataSource = mock()
+    private val networkMonitor: NetworkMonitor = mock()
+
+    private lateinit var repository: OfflineFirstChatRepository
+
+    @Before
+    fun setUp() {
+        whenever(networkMonitor.isOnline).thenReturn(MutableStateFlow(true))
+        wheneverBlocking { chatDao.deleteExpiredMessages(eq(INTERNAL_CONVERSATION_ID), any()) }.thenReturn(0)
+        whenever(chatBlocksDao.getChatBlocksContainingMessageId(eq(INTERNAL_CONVERSATION_ID), eq(null), any()))
+            .thenReturn(flowOf(emptyList()))
+
+        repository = OfflineFirstChatRepository(
+            logger,
+            chatDao,
+            chatBlocksDao,
+            network,
+            networkMonitor,
+            ChatMessageSyncer(chatDao, chatBlocksDao, network, networkMonitor)
+        )
+        repository.initData(user(), CREDENTIALS, CHAT_URL, ROOM_TOKEN, null)
+    }
+
+    @Test
+    fun `loadInitialMessages closes the backlog when the latest block reaches the last read message`() =
+        runTest {
+            givenLatestBlock(block(oldest = 10, newest = 50))
+            repository.updateConversation(conversation(lastReadMessage = 40, unreadMessages = 5))
+            wheneverBlocking { network.pullChatMessages(any(), any(), any()) }
+                .thenReturn(Response.success(overall(message(51))))
+
+            repository.loadInitialMessages(Bundle())
+
+            val fieldMap = singleRequestFieldMap()
+            assertEquals(1, fieldMap["lookIntoFuture"])
+            assertEquals(0, fieldMap["includeLastKnown"])
+            assertEquals(50, fieldMap["lastKnownMessageId"])
+        }
+
+    @Test
+    fun `loadInitialMessages treats a block without history below as reaching the boundary`() =
+        runTest {
+            givenLatestBlock(block(oldest = 45, newest = 50, hasHistory = false))
+            repository.updateConversation(conversation(lastReadMessage = 40, unreadMessages = 5))
+            wheneverBlocking { network.pullChatMessages(any(), any(), any()) }
+                .thenReturn(Response.success(overall(message(51))))
+
+            repository.loadInitialMessages(Bundle())
+
+            val fieldMap = singleRequestFieldMap()
+            assertEquals(1, fieldMap["lookIntoFuture"])
+            assertEquals(50, fieldMap["lastKnownMessageId"])
+        }
+
+    @Test
+    fun `loadInitialMessages anchors the repair fetch when the latest block floats above the boundary`() =
+        runTest {
+            givenLatestBlock(block(oldest = 100, newest = 199))
+            repository.updateConversation(conversation(lastReadMessage = 40, unreadMessages = 160))
+            wheneverBlocking { network.pullChatMessages(any(), any(), any()) }
+                .thenReturn(Response.success(overall(message(40), message(41))))
+
+            repository.loadInitialMessages(Bundle())
+
+            val fieldMap = singleRequestFieldMap()
+            assertEquals(1, fieldMap["lookIntoFuture"])
+            assertEquals(1, fieldMap["includeLastKnown"])
+            assertEquals(40, fieldMap["lastKnownMessageId"])
+            // opening the chat clears notifications, so the fetch must not keep them
+            assertFalse(fieldMap.containsKey("markNotificationsAsRead"))
+        }
+
+    @Test
+    fun `loadInitialMessages anchors the initial fetch for an empty cache with a large backlog`() =
+        runTest {
+            givenLatestBlock(null)
+            repository.updateConversation(conversation(lastReadMessage = 40, unreadMessages = 160))
+            wheneverBlocking { network.pullChatMessages(any(), any(), any()) }
+                .thenReturn(Response.success(overall(message(40), message(41))))
+
+            repository.loadInitialMessages(Bundle())
+
+            val fieldMap = singleRequestFieldMap()
+            assertEquals(1, fieldMap["lookIntoFuture"])
+            assertEquals(1, fieldMap["includeLastKnown"])
+            assertEquals(40, fieldMap["lastKnownMessageId"])
+        }
+
+    @Test
+    fun `loadInitialMessages fetches the newest messages for an empty cache with a small backlog`() =
+        runTest {
+            givenLatestBlock(null)
+            repository.updateConversation(conversation(lastReadMessage = 40, unreadMessages = 5))
+            wheneverBlocking { network.pullChatMessages(any(), any(), any()) }
+                .thenReturn(Response.success(overall(message(44), message(45))))
+
+            repository.loadInitialMessages(Bundle())
+
+            val fieldMap = singleRequestFieldMap()
+            assertEquals(0, fieldMap["lookIntoFuture"])
+            assertEquals(1, fieldMap["includeLastKnown"])
+            assertFalse(fieldMap.containsKey("lastKnownMessageId"))
+        }
+
+    private fun givenLatestBlock(block: ChatBlockEntity?) {
+        whenever(chatBlocksDao.getLatestChatBlock(INTERNAL_CONVERSATION_ID, null))
+            .thenReturn(flowOf(block))
+    }
+
+    private fun singleRequestFieldMap(): HashMap<String, Int> {
+        val fieldMapCaptor = argumentCaptor<HashMap<String, Int>>()
+        verifyBlocking(network) { pullChatMessages(eq(CREDENTIALS), eq(CHAT_URL), fieldMapCaptor.capture()) }
+        return fieldMapCaptor.firstValue
+    }
+
+    private fun user(): User =
+        User(
+            id = ACCOUNT_ID,
+            userId = "me",
+            username = "me",
+            baseUrl = "https://server.example.com",
+            capabilities = Capabilities().apply {
+                spreedCapability = SpreedCapability().apply { features = listOf("chat-keep-notifications") }
+            }
+        )
+
+    private fun conversation(lastReadMessage: Int, unreadMessages: Int): ConversationModel =
+        ConversationModel.mapToConversationModel(
+            Conversation(
+                token = ROOM_TOKEN,
+                lastReadMessage = lastReadMessage,
+                unreadMessages = unreadMessages
+            ),
+            user()
+        )
+
+    private fun block(oldest: Long, newest: Long, hasHistory: Boolean = true): ChatBlockEntity =
+        ChatBlockEntity(
+            internalConversationId = INTERNAL_CONVERSATION_ID,
+            accountId = ACCOUNT_ID,
+            token = ROOM_TOKEN,
+            threadId = null,
+            oldestMessageId = oldest,
+            newestMessageId = newest,
+            hasHistory = hasHistory
+        )
+
+    private fun message(id: Long): ChatMessageJson =
+        ChatMessageJson(
+            id = id,
+            token = ROOM_TOKEN,
+            actorType = "users",
+            actorId = "other",
+            actorDisplayName = "Other User",
+            timestamp = id,
+            message = "message $id",
+            messageType = "comment",
+            systemMessageType = ChatMessage.SystemMessageType.DUMMY
+        )
+
+    private fun overall(vararg messages: ChatMessageJson): ChatOverall =
+        ChatOverall(ocs = ChatOCS(meta = null, data = messages.toList()))
+
+    companion object {
+        private const val ACCOUNT_ID = 1L
+        private const val ROOM_TOKEN = "room1"
+        private const val INTERNAL_CONVERSATION_ID = "$ACCOUNT_ID@$ROOM_TOKEN"
+        private const val CREDENTIALS = "credentials"
+        private const val CHAT_URL = "https://server.example.com/ocs/v2.php/apps/spreed/api/v1/chat/$ROOM_TOKEN"
+    }
+}

--- a/app/src/test/java/com/nextcloud/talk/chat/viewmodels/ChatViewModelTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/chat/viewmodels/ChatViewModelTest.kt
@@ -7,9 +7,15 @@
 
 package com.nextcloud.talk.chat.viewmodels
 
+import com.nextcloud.talk.chat.ui.model.ChatMessageUi
+import com.nextcloud.talk.chat.ui.model.MessageStatusIcon
+import com.nextcloud.talk.chat.ui.model.MessageTypeContent
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.time.LocalDate
 
 class ChatViewModelTest {
 
@@ -54,4 +60,64 @@ class ChatViewModelTest {
             ChatViewModel.isPlausibleLastReadMessageId(messageId = 1_963_726_147, newestKnownRealMessageId = 158761L)
         )
     }
+
+    // The unread marker latch: the marker position must only be derived from the visible window
+    // when the window provably reaches back to the unread boundary — otherwise a window of
+    // only-unread messages (e.g. after a capped fetch of the newest messages) would place the
+    // marker in the middle of the unread messages.
+
+    @Test
+    fun `marker is placed at the first message above the boundary when the boundary is visible`() {
+        val messages = listOf(uiMessage(39), uiMessage(40), uiMessage(41), uiMessage(42))
+
+        assertEquals(41, ChatViewModel.findFirstUnreadMessageId(messages, lastReadMessage = 40))
+    }
+
+    @Test
+    fun `marker is placed correctly when the boundary message itself is missing`() {
+        // the last read message may have been deleted or expired — an older read message is
+        // equally valid proof that the window reaches the boundary
+        val messages = listOf(uiMessage(38), uiMessage(41), uiMessage(42))
+
+        assertEquals(41, ChatViewModel.findFirstUnreadMessageId(messages, lastReadMessage = 40))
+    }
+
+    @Test
+    fun `no marker is placed when the window floats entirely above the boundary`() {
+        val messages = listOf(uiMessage(141), uiMessage(142), uiMessage(143))
+
+        assertNull(ChatViewModel.findFirstUnreadMessageId(messages, lastReadMessage = 40))
+    }
+
+    @Test
+    fun `temporary messages with negative ids are no proof of the boundary`() {
+        val messages = listOf(uiMessage(-5), uiMessage(141), uiMessage(142))
+
+        assertNull(ChatViewModel.findFirstUnreadMessageId(messages, lastReadMessage = 40))
+    }
+
+    @Test
+    fun `no marker is placed when everything is read`() {
+        val messages = listOf(uiMessage(38), uiMessage(39), uiMessage(40))
+
+        assertNull(ChatViewModel.findFirstUnreadMessageId(messages, lastReadMessage = 40))
+    }
+
+    private fun uiMessage(id: Int): ChatMessageUi =
+        ChatMessageUi(
+            id = id,
+            message = "message $id",
+            renderMarkdown = false,
+            actorDisplayName = "Other User",
+            isThread = false,
+            threadTitle = "",
+            threadReplies = 0,
+            incoming = true,
+            isDeleted = false,
+            avatarUrl = null,
+            statusIcon = MessageStatusIcon.SENT,
+            timestamp = id.toLong(),
+            date = LocalDate.of(2026, 8, 12),
+            content = MessageTypeContent.RegularText
+        )
 }


### PR DESCRIPTION
When entering a conversation, especially when using #6454 the read-state is not always correct / read / propagated.

This PR addresses this, implementing read-status propagation

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
