### PR TITLE
bump conscrypt to 2.6.2 (stable 24.0.x)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -213,7 +213,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-rx2:$coroutinesVersion")
 
-    implementation("androidx.appcompat:appcompat:1.7.1")
+    implementation("androidx.appcompat:appcompat:1.8.0")
     implementation("com.google.android.material:material:1.13.0")
     implementation("androidx.constraintlayout:constraintlayout:2.2.1")
     implementation("com.vanniktech:emoji-google:0.23.0")
@@ -229,7 +229,7 @@ dependencies {
     implementation("com.github.bitfireAT:dav4jvm:2.1.3") {
         exclude(group = "org.ogce", module = "xpp3") // Android comes with its own XmlPullParser
     }
-    implementation("org.conscrypt:conscrypt-android:2.5.3")
+    implementation("org.conscrypt:conscrypt-android:2.6.2")
     implementation("com.github.nextcloud-deps:qrcodescanner:0.1.2.4") // "com.github.blikoon:QRCodeScanner:0.1.2"
 
     implementation("androidx.camera:camera-core:$androidxCameraVersion")
@@ -386,7 +386,7 @@ dependencies {
     testImplementation("org.robolectric:robolectric:4.16.1")
     // conscrypt-android provides Android JNI libs only; the openjdk-uber variant bundles
     // JVM host natives so Robolectric can initialise the security provider without crashing.
-    testImplementation("org.conscrypt:conscrypt-openjdk-uber:2.5.2")
+    testImplementation("org.conscrypt:conscrypt-openjdk-uber:2.6.2")
 }
 
 tasks.register<Copy>("installGitHooks") {

--- a/gradle/verification-keyring.keys
+++ b/gradle/verification-keyring.keys
@@ -6789,6 +6789,22 @@ Tky9VthoZQdJTLH/QYXHZRI0HRXfo3AVtf8=
 =PL93
 -----END PGP PUBLIC KEY BLOCK-----
 
+pub    655CCC51B9BD2C38
+uid    Juerg Wullschleger (Key for signing maven artifacts) <juerg@google.com>
+
+sub    1D8420104D50DEB6
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+xjMEaha/UBYJKwYBBAHaRw8BAQdAbsQnyQZeUSn3HeAYjG4LfUmBiGA8AbVgdh4o
+r94PKTG0R0p1ZXJnIFd1bGxzY2hsZWdlciAoS2V5IGZvciBzaWduaW5nIG1hdmVu
+IGFydGlmYWN0cykgPGp1ZXJnQGdvb2dsZS5jb20+zjgEaha/UBIKKwYBBAGXVQEF
+AQEHQBZaO7bwfVR88kyicIFPVrz3GhdM7MBYoQk54gSx2hw+AwEIB8J+BBgWCgAm
+FiEESc9OOymWvmWKV905ZVzMUbm9LDgFAmoWv1ACGwwFCQHhM4AACgkQZVzMUbm9
+LDhPFQD/fJsIXrtRDbCR7PkozwpPY8z6dOGZ3qRTFxuyWjuWoycA/RMUHBSGOJeP
++QiG9g497f/rjbC8s02quHS1CHna0lIC
+=Eb5c
+-----END PGP PUBLIC KEY BLOCK-----
+
 pub    6601E5C08DCCBB96
 uid    Popma Remko <remkop@yahoo.com>
 

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -37,6 +37,7 @@
          <trusted-key id="0D5D634755737A19ABBE2930D4DA5EAB3CD7E958" group="com.google.devtools.ksp" name="symbol-processing-api" version="1.7.0-1.0.6"/>
          <trusted-key id="0E225917414670F4442C250DFD533C07C264648F">
             <trusting group="androidx.activity"/>
+            <trusting group="androidx.appcompat"/>
             <trusting group="androidx.core"/>
             <trusting group="androidx.databinding"/>
             <trusting group="androidx.datastore"/>
@@ -202,6 +203,7 @@
             <trusting group="org.springframework" name="spring-framework-bom" version="5.3.32"/>
             <trusting group="org.springframework" name="spring-framework-bom" version="5.3.39"/>
          </trusted-key>
+         <trusted-key group="org.conscrypt" id="49CF4E3B2996BE658A57DD39655CCC51B9BD2C38"/>
          <trusted-key id="4A2E4BE286EDAE3ADB3A3C26C21CE653B639E41A" group="com.bluelinelabs"/>
          <trusted-key id="4BF79B8259007B566D2FCE82296CD27F60EED12C" group="com.google.crypto.tink" name="tink" version="1.7.0"/>
          <trusted-key id="4C5F68D09D42BA7FAC888DF9A929EA2321FDBF8F">


### PR DESCRIPTION
to remove "Your app could crash on 16 KB devices" warning on gplay.

https://github.com/google/conscrypt/releases -> 2.6.0 -> "conscrypt-android is 16 KB-aligned."

manual "backport" of https://github.com/nextcloud/talk-android/pull/6487



### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
