### PR TITLE
fix to set User-Agent for OTP logins

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/account/data/network/NetworkLoginDataSource.kt
+++ b/app/src/main/java/com/nextcloud/talk/account/data/network/NetworkLoginDataSource.kt
@@ -61,6 +61,7 @@ class NetworkLoginDataSource(val okHttpClient: OkHttpClient) {
             .header("Authorization", oneTimeCredentials)
             .header("OCS-APIRequest", "true")
             .header("Accept", "application/json")
+            .header("User-Agent", ApiUtils.loginUserAgent)
             .build()
 
         val newOkHttpClient = OkHttpClient()


### PR DESCRIPTION
In https://github.com/nextcloud/talk-android/pull/6401/files it was forgotten to set the user agent for OTP logins. This commit fixes it.

That's the reason why in WebUI security settings, the app was identified as "okhttp/4.12.0" if the login ws done via QR code.


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
