### PR TITLE
perf(workers): expedite user-facing and latency-critical WorkManager …

### DIFF
--- a/app/src/gplay/java/com/nextcloud/talk/services/firebase/NCFirebaseMessagingService.kt
+++ b/app/src/gplay/java/com/nextcloud/talk/services/firebase/NCFirebaseMessagingService.kt
@@ -11,6 +11,7 @@ package com.nextcloud.talk.services.firebase
 import android.util.Log
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import autodagger.AutoInjector
 import com.google.firebase.messaging.FirebaseMessagingService
@@ -53,6 +54,7 @@ class NCFirebaseMessagingService : FirebaseMessagingService() {
                 .build()
             val notificationWork =
                 OneTimeWorkRequest.Builder(NotificationWorker::class.java).setInputData(messageData)
+                    .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                     .build()
             WorkManager.getInstance().enqueue(notificationWork)
         }

--- a/app/src/main/java/com/nextcloud/talk/account/AccountVerificationActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/account/AccountVerificationActivity.kt
@@ -18,6 +18,7 @@ import android.util.Log
 import android.widget.Toast
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import autodagger.AutoInjector
@@ -498,6 +499,7 @@ class AccountVerificationActivity : BaseActivity() {
         val capabilitiesWork =
             OneTimeWorkRequest.Builder(CapabilitiesWorker::class.java)
                 .setInputData(userData)
+                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                 .build()
         WorkManager.getInstance().enqueue(capabilitiesWork)
     }
@@ -592,7 +594,9 @@ class AccountVerificationActivity : BaseActivity() {
     @SuppressLint("CheckResult")
     private fun deleteUserAndStartServerSelection(userId: Long) {
         userManager.scheduleUserForDeletionWithId(userId).blockingGet()
-        val accountRemovalWork = OneTimeWorkRequest.Builder(AccountRemovalWorker::class.java).build()
+        val accountRemovalWork = OneTimeWorkRequest.Builder(AccountRemovalWorker::class.java)
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+            .build()
         WorkManager.getInstance(applicationContext).enqueue(accountRemovalWork)
 
         WorkManager.getInstance(context).getWorkInfoByIdLiveData(accountRemovalWork.id)

--- a/app/src/main/java/com/nextcloud/talk/account/data/io/LocalLoginDataSource.kt
+++ b/app/src/main/java/com/nextcloud/talk/account/data/io/LocalLoginDataSource.kt
@@ -10,6 +10,7 @@ package com.nextcloud.talk.account.data.io
 import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import com.nextcloud.talk.account.data.model.LoginCompletion
@@ -31,7 +32,9 @@ class LocalLoginDataSource(val userManager: UserManager, val appPreferences: App
     }
 
     fun startAccountRemovalWorker(): LiveData<WorkInfo?> {
-        val accountRemovalWork = OneTimeWorkRequest.Builder(AccountRemovalWorker::class.java).build()
+        val accountRemovalWork = OneTimeWorkRequest.Builder(AccountRemovalWorker::class.java)
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+            .build()
         WorkManager.getInstance(context).enqueue(accountRemovalWork)
 
         return WorkManager.getInstance(context).getWorkInfoByIdLiveData(accountRemovalWork.id)

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -84,6 +84,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import autodagger.AutoInjector
@@ -2198,6 +2199,7 @@ class ChatActivity :
         val downloadWorker: OneTimeWorkRequest = OneTimeWorkRequest.Builder(DownloadFileToCacheWorker::class.java)
             .setInputData(data)
             .addTag(fileId)
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
             .build()
 
         WorkManager.getInstance().enqueue(downloadWorker)
@@ -2355,6 +2357,7 @@ class ChatActivity :
                         .build()
                     val worker = OneTimeWorkRequest.Builder(ShareOperationWorker::class.java)
                         .setInputData(data)
+                        .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                         .build()
                     WorkManager.getInstance().enqueue(worker)
                 }
@@ -3160,7 +3163,10 @@ class ChatActivity :
         data.putString(KEY_ROOM_TOKEN, conversation.token)
 
         val deleteConversationWorker =
-            OneTimeWorkRequest.Builder(DeleteConversationWorker::class.java).setInputData(data.build()).build()
+            OneTimeWorkRequest.Builder(DeleteConversationWorker::class.java)
+                .setInputData(data.build())
+                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                .build()
         WorkManager.getInstance().enqueue(deleteConversationWorker)
 
         WorkManager.getInstance(context).getWorkInfoByIdLiveData(deleteConversationWorker.id)

--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
@@ -28,6 +28,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import autodagger.AutoInjector
@@ -499,7 +500,10 @@ class ConversationInfoActivity : BaseActivity() {
             .build()
 
         val addParticipantsWorker =
-            OneTimeWorkRequest.Builder(AddParticipantsToConversationWorker::class.java).setInputData(data).build()
+            OneTimeWorkRequest.Builder(AddParticipantsToConversationWorker::class.java)
+                .setInputData(data)
+                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                .build()
         WorkManager.getInstance().enqueue(addParticipantsWorker)
         WorkManager.getInstance(context).getWorkInfoByIdLiveData(addParticipantsWorker.id)
             .observeForever { workInfo: WorkInfo? ->
@@ -513,6 +517,7 @@ class ConversationInfoActivity : BaseActivity() {
         workerData?.let { data ->
             val workRequest = OneTimeWorkRequest.Builder(LeaveConversationWorker::class.java)
                 .setInputData(data)
+                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                 .build()
             WorkManager.getInstance(context).enqueueUniqueWork(
                 "leave_conversation_work",
@@ -585,7 +590,10 @@ class ConversationInfoActivity : BaseActivity() {
     private fun deleteConversation() {
         workerData?.let {
             WorkManager.getInstance(context).enqueue(
-                OneTimeWorkRequest.Builder(DeleteConversationWorker::class.java).setInputData(it).build()
+                OneTimeWorkRequest.Builder(DeleteConversationWorker::class.java)
+                    .setInputData(it)
+                    .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                    .build()
             )
 
             conversationUser?.id?.let { userId ->

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -30,6 +30,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import autodagger.AutoInjector
@@ -1227,7 +1228,10 @@ class ConversationsListActivity : BaseActivity() {
             .putString(KEY_ROOM_TOKEN, conversation.token)
             .putLong(KEY_INTERNAL_USER_ID, currentUser?.id!!)
             .build()
-        val worker = OneTimeWorkRequest.Builder(LeaveConversationWorker::class.java).setInputData(data).build()
+        val worker = OneTimeWorkRequest.Builder(LeaveConversationWorker::class.java)
+            .setInputData(data)
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+            .build()
         WorkManager.getInstance().enqueue(worker)
         WorkManager.getInstance(this).getWorkInfoByIdLiveData(worker.id).observeForever { workInfo ->
             when (workInfo?.state) {
@@ -1330,7 +1334,9 @@ class ConversationsListActivity : BaseActivity() {
     @SuppressLint("CheckResult")
     private fun deleteUserAndRestartApp() {
         userManager.scheduleUserForDeletionWithId(currentUser!!.id!!).blockingGet()
-        val accountRemovalWork = OneTimeWorkRequest.Builder(AccountRemovalWorker::class.java).build()
+        val accountRemovalWork = OneTimeWorkRequest.Builder(AccountRemovalWorker::class.java)
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+            .build()
         WorkManager.getInstance(applicationContext).enqueue(accountRemovalWork)
 
         WorkManager.getInstance(context).getWorkInfoByIdLiveData(accountRemovalWork.id)
@@ -1467,7 +1473,10 @@ class ConversationsListActivity : BaseActivity() {
         data.putString(KEY_ROOM_TOKEN, conversation.token)
 
         val deleteConversationWorker =
-            OneTimeWorkRequest.Builder(DeleteConversationWorker::class.java).setInputData(data.build()).build()
+            OneTimeWorkRequest.Builder(DeleteConversationWorker::class.java)
+                .setInputData(data.build())
+                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                .build()
         WorkManager.getInstance().enqueue(deleteConversationWorker)
 
         WorkManager.getInstance(context).getWorkInfoByIdLiveData(deleteConversationWorker.id)

--- a/app/src/main/java/com/nextcloud/talk/jobs/ChatMessageCatchUpWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/ChatMessageCatchUpWorker.kt
@@ -15,6 +15,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.Data
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import androidx.work.WorkRequest
 import androidx.work.WorkerParameters
@@ -126,6 +127,7 @@ class ChatMessageCatchUpWorker(context: Context, workerParams: WorkerParameters)
                 .setInputData(data)
                 .setConstraints(Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build())
                 .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, WorkRequest.MIN_BACKOFF_MILLIS, TimeUnit.MILLISECONDS)
+                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                 .build()
 
             WorkManager.getInstance(context).enqueue(catchUpWork)

--- a/app/src/main/java/com/nextcloud/talk/jobs/PushRegistrationWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/PushRegistrationWorker.kt
@@ -11,6 +11,7 @@ import android.content.Context
 import android.util.Log
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
@@ -286,6 +287,7 @@ class PushRegistrationWorker(context: Context, workerParams: WorkerParameters) :
             .build()
         val notificationWork =
             OneTimeWorkRequest.Builder(NotificationWorker::class.java).setInputData(messageData)
+                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                 .build()
         WorkManager.getInstance(applicationContext).enqueue(notificationWork)
     }

--- a/app/src/main/java/com/nextcloud/talk/jobs/ShareOperationWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/ShareOperationWorker.kt
@@ -11,6 +11,7 @@ import android.content.Context
 import android.util.Log
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
@@ -118,6 +119,7 @@ class ShareOperationWorker(context: Context, workerParams: WorkerParameters) : W
                 .build()
             val shareWorker = OneTimeWorkRequest.Builder(ShareOperationWorker::class.java)
                 .setInputData(data)
+                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                 .build()
             WorkManager.getInstance().enqueue(shareWorker)
         }

--- a/app/src/main/java/com/nextcloud/talk/services/UnifiedPushService.kt
+++ b/app/src/main/java/com/nextcloud/talk/services/UnifiedPushService.kt
@@ -10,6 +10,7 @@ package com.nextcloud.talk.services
 import android.util.Log
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkManager
 import com.nextcloud.talk.jobs.NotificationWorker
 import com.nextcloud.talk.jobs.PushRegistrationWorker
@@ -55,6 +56,7 @@ class UnifiedPushService : PushService() {
                 .build()
             val notificationWork =
                 OneTimeWorkRequest.Builder(NotificationWorker::class.java).setInputData(messageData)
+                    .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                     .build()
             WorkManager.getInstance(this).enqueue(notificationWork)
         }

--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -43,6 +43,7 @@ import androidx.core.net.toUri
 import androidx.core.view.ViewCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import autodagger.AutoInjector
@@ -309,7 +310,9 @@ class SettingsActivity :
     }
 
     private fun loadCapabilitiesAndUpdateSettings(isOnline: Boolean) {
-        val capabilitiesWork = OneTimeWorkRequest.Builder(CapabilitiesWorker::class.java).build()
+        val capabilitiesWork = OneTimeWorkRequest.Builder(CapabilitiesWorker::class.java)
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+            .build()
         WorkManager.getInstance(context).enqueue(capabilitiesWork)
 
         WorkManager.getInstance(context).getWorkInfoByIdLiveData(capabilitiesWork.id)
@@ -984,7 +987,9 @@ class SettingsActivity :
     @SuppressLint("CheckResult", "StringFormatInvalid")
     private fun removeCurrentAccount() {
         userManager.scheduleUserForDeletionWithId(currentUser!!.id!!).blockingGet()
-        val accountRemovalWork = OneTimeWorkRequest.Builder(AccountRemovalWorker::class.java).build()
+        val accountRemovalWork = OneTimeWorkRequest.Builder(AccountRemovalWorker::class.java)
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+            .build()
         WorkManager.getInstance(applicationContext).enqueue(accountRemovalWork)
 
         WorkManager.getInstance(context).getWorkInfoByIdLiveData(accountRemovalWork.id)

--- a/app/src/main/java/com/nextcloud/talk/ui/dialog/SaveToStorageDialogFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/dialog/SaveToStorageDialogFragment.kt
@@ -16,6 +16,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import autodagger.AutoInjector
@@ -98,6 +99,7 @@ class SaveToStorageDialogFragment : DialogFragment() {
         val saveWorker: OneTimeWorkRequest = OneTimeWorkRequest.Builder(SaveFileToStorageWorker::class.java)
             .setInputData(data)
             .addTag(workerTag)
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
             .build()
 
         WorkManager.getInstance().enqueue(saveWorker)

--- a/app/src/main/java/com/nextcloud/talk/utils/FileViewerUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/FileViewerUtils.kt
@@ -22,6 +22,7 @@ import androidx.emoji2.widget.EmojiTextView
 import androidx.lifecycle.Observer
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import com.google.android.material.snackbar.Snackbar
@@ -316,6 +317,7 @@ class FileViewerUtils(private val context: Context, private val user: User) {
         downloadWorker = OneTimeWorkRequest.Builder(DownloadFileToCacheWorker::class.java)
             .setInputData(data)
             .addTag(fileInfo.fileId)
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
             .build()
         WorkManager.getInstance().enqueue(downloadWorker)
         val liveData = WorkManager.getInstance(context).getWorkInfoByIdLiveData(downloadWorker.id)


### PR DESCRIPTION
…jobs

Mark standalone OneTimeWorkRequests as expedited where completion time is bounded and either the user is waiting on it (delete/leave conversation, add participants, save/share/download a file, remove account) or it's notification-latency-sensitive (push/call notifications, post-push chat catch-up).

Left non-expedited: chained/periodic requests (unsupported by WorkManager), long-running uploads not promoted to a foreground service, and pure background bookkeeping with no user-facing wait.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
