### PR TITLE
fix CancellationException

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -251,6 +251,7 @@ import java.util.Date
 import java.util.Locale
 import java.util.concurrent.ExecutionException
 import javax.inject.Inject
+import java.util.concurrent.CancellationException
 import kotlin.math.abs
 
 @Suppress("TooManyFunctions", "LargeClass", "LongMethod")
@@ -1375,7 +1376,11 @@ class ChatActivity :
         mediaControllerFuture = MediaController.Builder(this, sessionToken).buildAsync()
 
         mediaControllerFuture?.addListener({
-            mediaController = mediaControllerFuture?.get()
+            mediaController = try {
+                mediaControllerFuture?.get()
+            } catch (_: CancellationException) {
+                null
+            }
 
             mediaController?.addListener(playerListener)
 


### PR DESCRIPTION
followup fix to #6396

app crashed with his error when i returned to chat:

Exception in thread "main"
java.util.concurrent.CancellationException: Task was cancelled. at com.google.common.util.concurrent.AbstractFuture.cancellationExceptionWithCause(AbstractFuture.java:1590) at com.google.common.util.concurrent.AbstractFuture.getDoneValue(AbstractFuture.java:594) at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:555) at com.nextcloud.talk.chat.ChatActivity.onStart$lambda$0(ChatActivity.kt:1386) at com.nextcloud.talk.chat.ChatActivity$$ExternalSyntheticLambda129.run(D8$$SyntheticClass:0) at android.os.Handler.handleCallback(Handler.java:1037) at android.os.Handler.dispatchMessage(Handler.java:108) at android.os.Looper.loopOnce(Looper.java:304)
at android.os.Looper.loop(Looper.java:430)
at android.app.ActivityThread.main(ActivityThread.java:9345) at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:593) at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:953)



@rapterjet2004 feel free to check if this needs some other handling than this quickfix

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
