### PR TITLE
fix(call): detect dead signaling WebSocket connections via ping interval

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketInstance.kt
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketInstance.kt
@@ -43,6 +43,7 @@ import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import java.io.IOException
 import java.lang.Thread.sleep
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 @AutoInjector(NextcloudTalkApplication::class)
@@ -80,6 +81,7 @@ class WebSocketInstance internal constructor(conversationUser: User, connectionU
     private var messagesQueue: MutableList<String> = ArrayList()
     private val signalingMessageReceiver = ExternalSignalingMessageReceiver()
     val signalingMessageSender = ExternalSignalingMessageSender()
+    private val signalingHttpClient: OkHttpClient by lazy { createSignalingHttpClient(okHttpClient!!) }
 
     init {
         sharedApplication!!.componentApplication.inject(this)
@@ -140,7 +142,7 @@ class WebSocketInstance internal constructor(conversationUser: User, connectionU
         reconnecting = true
         Log.d(TAG, "restartWebSocket: $connectionUrl")
         val request = Request.Builder().url(connectionUrl).build()
-        okHttpClient!!.newWebSocket(request, this)
+        signalingHttpClient.newWebSocket(request, this)
     }
 
     override fun onMessage(webSocket: WebSocket, text: String) {
@@ -524,5 +526,13 @@ class WebSocketInstance internal constructor(conversationUser: User, connectionU
         private const val TAG = "WebSocketInstance"
         private const val NORMAL_CLOSURE = 1000
         private const val ONE_SECOND: Long = 1000
+        private const val PING_INTERVAL_SECONDS: Long = 10
+
+        // Dedicated client with pings, so half-open WebSocket connections
+        // (e.g. after a WiFi to cellular switch without TCP reset) fail and trigger the reconnect path.
+        internal fun createSignalingHttpClient(baseClient: OkHttpClient): OkHttpClient =
+            baseClient.newBuilder()
+                .pingInterval(PING_INTERVAL_SECONDS, TimeUnit.SECONDS)
+                .build()
     }
 }

--- a/app/src/test/java/com/nextcloud/talk/webrtc/WebSocketInstanceSignalingClientTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/webrtc/WebSocketInstanceSignalingClientTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.webrtc
+
+import okhttp3.OkHttpClient
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+/**
+ * Tests for the signaling WebSocket client configuration ([WebSocketInstance.createSignalingHttpClient]).
+ *
+ * Without a ping interval OkHttp sends no protocol-level pings on WebSockets and uses an infinite read timeout,
+ * so a half-open connection (e.g. after a WiFi to cellular switch without a TCP reset) is never detected: the
+ * reconnect path via "onFailure" never runs and the call goes silently mute/deaf. These tests pin the ping
+ * configuration that makes dead connections fail fast.
+ */
+class WebSocketInstanceSignalingClientTest {
+
+    @Test
+    fun signalingClientHasPingIntervalConfigured() {
+        val signalingClient = WebSocketInstance.createSignalingHttpClient(OkHttpClient())
+
+        // hardcoded on purpose: fails if the ping interval in WebSocketInstance changes or is removed
+        assertEquals(
+            "signaling WebSocket client must send pings to detect half-open connections",
+            10_000,
+            signalingClient.pingIntervalMillis
+        )
+    }
+
+    @Test
+    fun signalingClientIsDerivedFromBaseClientWithoutMutatingIt() {
+        val baseClient = OkHttpClient.Builder()
+            .connectTimeout(45, TimeUnit.SECONDS)
+            .readTimeout(45, TimeUnit.SECONDS)
+            .build()
+
+        val signalingClient = WebSocketInstance.createSignalingHttpClient(baseClient)
+
+        assertNotSame("a dedicated client instance must be used", baseClient, signalingClient)
+        assertEquals(
+            "base client (shared with regular HTTP calls) must stay unchanged",
+            0,
+            baseClient.pingIntervalMillis
+        )
+        assertEquals(baseClient.connectTimeoutMillis, signalingClient.connectTimeoutMillis)
+        assertEquals(baseClient.readTimeoutMillis, signalingClient.readTimeoutMillis)
+    }
+}


### PR DESCRIPTION
fix(call): detect dead signaling WebSocket connections via ping interval

## Description

The signaling WebSocket is currently created from the shared `OkHttpClient`, which never sets a ping interval. In OkHttp 4.x this means no protocol-level pings are sent and the WebSocket read timeout is effectively infinite. When the underlying network dies without a TCP reset — the normal case when switching from WiFi to cellular, or when a router/NAT drops an idle mapping — the connection becomes half-open:

- `onFailure` never fires (TCP retransmission timeouts can take 15+ minutes)
- `isConnected` stays `true`, so the existing reconnect logic never runs
- outgoing offers/answers/ICE candidates/mute state are silently lost, incoming signaling stops

The result is a "zombie" call: participants still see each other, but the call is mute/deaf. This is the root cause of the failure mode reported in #2368 and #1760 (analysis also posted on #2368).

This PR derives a dedicated client for signaling WebSocket connections with a 10 second ping interval. OkHttp now fails the socket when a pong is not received in time, which triggers the existing `onFailure` → `restartWebSocket()` path. The shared client used for regular HTTP calls is unchanged (ping intervals have no effect on non-WebSocket calls, but the dedicated instance keeps the change scoped).

## Steps to reproduce / How to test

1. Join a call using external signaling (HPB) or internal signaling
2. Drop WiFi in a way that does not produce a TCP reset (walk out of range, reboot the router) so cellular takes over
3. Speak / observe the call

**Without this PR:** the call silently stops working — no reconnect, participants appear present but nothing is transmitted, for 15+ minutes.

**With this PR:** within ~10–20 seconds the dead socket fails, `onFailure` triggers, and the existing reconnect flow runs (reconnect + hello/resume).

Also test that normal call behavior is unaffected: join/leave calls, chat while connected, both WiFi and cellular, with and without HPB.

- [x] ⛑️ Tests are included (unit tests pin the client configuration)
- [x] 🔖 Capability is checked or not needed (no capability change)
- [x] 🔙 Backport requests or not needed: `/backport to stable-24.0` may be worthwhile given #2368 affects older versions
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful

Fixes part of #2368

---

Note: This change was developed with AI assistance (opencode / Kimi K3 and GLM-5.3).
