### PR TITLE
fix(chat): don't freeze the author-info flag at first composition

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -889,8 +889,7 @@ class ChatActivity :
                     LocalUploadProgressProvider provides { refId -> uploadProgressMap[refId] },
                     LocalUploadedLocalPreviewProvider provides { refId -> uploadedLocalPreviewMap[refId] }
                 ) {
-                    val isOneToOneConversation by remember { mutableStateOf(uiState.isOneToOneConversation) }
-                    Log.d(TAG, "isOneToOneConversation=" + isOneToOneConversation)
+                    val isOneToOneConversation = uiState.isOneToOneConversation
 
                     // list of the file ids of messages being downloaded
                     val downloadingFileState = remember { mutableStateOf(listOf<String>()) }

--- a/app/src/main/java/com/nextcloud/talk/ui/chat/MentionChip.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/chat/MentionChip.kt
@@ -160,7 +160,7 @@ fun resolveMentionFallbackIcon(mention: MentionChipModel): Int =
         mention.type == "user-group" -> R.drawable.ic_circular_group_mentions
         mention.type == "circle" -> R.drawable.icon_circular_team
         mention.isSelfMention -> R.drawable.mention_chip
-        else -> R.drawable.accent_circle
+        else -> R.drawable.ic_circular_user
     }
 
 fun estimateMentionChipWidthInEm(label: String, fontSizeSp: Float): Float {

--- a/app/src/main/java/com/nextcloud/talk/utils/DisplayUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/DisplayUtils.kt
@@ -182,7 +182,7 @@ object DisplayUtils {
             drawable = if (chipResource == R.xml.chip_you) {
                 R.drawable.mention_chip
             } else {
-                R.drawable.accent_circle
+                R.drawable.ic_circular_user
             }
             chip.setChipIconResource(drawable)
         } else {

--- a/app/src/main/res/drawable/ic_circular_user.xml
+++ b/app/src/main/res/drawable/ic_circular_user.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Nextcloud Talk - Android Client
+  ~
+  ~ SPDX-FileCopyrightText: 2018-2026 Google LLC
+  ~ SPDX-License-Identifier: Apache-2.0
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+
+    <path
+        android:fillColor="#6B6B6B"
+        android:pathData="M480,0A480,480 0 1,0 480,960A480,480 0 1,0 480,0Z"/>
+
+    <group
+        android:scaleX="0.7"
+        android:scaleY="0.7"
+        android:pivotX="480"
+        android:pivotY="480">
+
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M480,480Q414,480 367,433Q320,386 320,320Q320,254 367,207Q414,160 480,160Q546,160 593,207Q640,254 640,320Q640,386 593,433Q546,480 480,480ZM160,800L160,688Q160,654 177.5,625.5Q195,597 224,582Q286,551 350,535.5Q414,520 480,520Q546,520 610,535.5Q674,551 736,582Q765,597 782.5,625.5Q800,654 800,688L800,800L160,800ZM240,720L720,720L720,688Q720,677 714.5,668Q709,659 700,654Q646,627 591,613.5Q536,600 480,600Q424,600 369,613.5Q314,627 260,654Q251,659 245.5,668Q240,677 240,688L240,720ZM480,400Q513,400 536.5,376.5Q560,353 560,320Q560,287 536.5,263.5Q513,240 480,240Q447,240 423.5,263.5Q400,287 400,320Q400,353 423.5,376.5Q447,400 480,400Z"/>
+    </group>
+</vector>


### PR DESCRIPTION
Fixes group chats rendering incoming messages without the author's avatar and display name since the recent room-list/prefetching changes.

### Root cause

`ChatActivity.setChatListContent()` read `ChatUiState.isOneToOneConversation` — which, despite its name, carries "show author avatars and names", i.e. `!conversation.isOneToOneConversation()` as set in `ChatViewModel.observeConversation()` — through `remember { mutableStateOf(uiState.isOneToOneConversation) }` without a key. That snapshots the field at the very first composition and never updates it again.

Whether that snapshot was correct was a race: it only held the real value when the conversation emission from the database reached `uiState` before the ComposeView's initial composition. Since the conversation list, chat opening and message prefetching moved onto local database flows (#6454, #6498), a chat opens straight from the cache and the first composition reliably runs before the conversation state lands — the flag stays frozen at its default `false`, and `MessageScaffold` (`incoming && isOneToOneConversation && !isGrouped`) never shows the avatar or the author name in group chats. The conversation-avatar caching (#6499) is not directly involved; chat-message avatars use the default Coil loader.

### Fix

Read the flag directly from the collected `uiState`, so the message list recomposes with the real value once the conversation arrives. Also drops the debug log that would otherwise print on every recomposition.

Possible follow-up (deliberately out of scope for this fix): the field's inverted naming — `isOneToOneConversation` holding "is NOT one-to-one" across `ChatUiState`, `ChatViewState`, `ChatMessageContext` and the message composables — is what made this freeze hard to spot and is worth a rename.

### 🚧 TODO

- [x] Manual verification on a group chat

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed — UI composition timing fix; no testable unit seam in `ChatActivity`
- [x] 🔖 Capability is checked or not needed
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI