### PR TITLE
fix(call): end push to talk on ACTION_CANCEL

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -3028,14 +3028,23 @@ class CallActivity : CallBaseActivity() {
         @SuppressLint("ClickableViewAccessibility")
         override fun onTouch(v: View, event: MotionEvent): Boolean {
             v.onTouchEvent(event)
-            if (event.action == MotionEvent.ACTION_UP && isPushToTalkActive) {
-                isPushToTalkActive = false
-                binding!!.microphoneButton.setImageResource(R.drawable.ic_mic_off_white_24px)
-                pulseAnimation!!.stop()
-                toggleMedia(false, false)
+            if (isPushToTalkRelease(event.action)) {
+                stopPushToTalk()
             }
             return true
         }
+    }
+
+    // ACTION_CANCEL must end push to talk just like ACTION_UP, otherwise the microphone stays enabled although
+    // the gesture was aborted (e.g. by a system gesture or the notification shade) and the button shows "muted".
+    private fun stopPushToTalk() {
+        if (!isPushToTalkActive) {
+            return
+        }
+        isPushToTalkActive = false
+        binding!!.microphoneButton.setImageResource(R.drawable.ic_mic_off_white_24px)
+        pulseAnimation!!.stop()
+        toggleMedia(false, false)
     }
 
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
@@ -3224,6 +3233,9 @@ class CallActivity : CallBaseActivity() {
 
         private const val CALLING_TIMEOUT: Long = 45000
         private const val PULSE_ANIMATION_DURATION: Int = 310
+
+        internal fun isPushToTalkRelease(action: Int): Boolean =
+            action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL
 
         private const val DELAY_ON_ERROR_STOP_THRESHOLD: Int = 16
 

--- a/app/src/test/java/com/nextcloud/talk/activities/CallActivityPushToTalkTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/activities/CallActivityPushToTalkTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.activities
+
+import android.view.MotionEvent
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Push-to-talk release detection ([CallActivity.isPushToTalkRelease]).
+ *
+ * A long-press that ends with ACTION_CANCEL (system gesture, notification shade) must mute the microphone again
+ * just like ACTION_UP, otherwise the mic stays hot while the button shows "muted".
+ */
+class CallActivityPushToTalkTest {
+
+    @Test
+    fun `ACTION_UP ends push to talk`() {
+        assertTrue(CallActivity.isPushToTalkRelease(MotionEvent.ACTION_UP))
+    }
+
+    @Test
+    fun `ACTION_CANCEL ends push to talk`() {
+        assertTrue(CallActivity.isPushToTalkRelease(MotionEvent.ACTION_CANCEL))
+    }
+
+    @Test
+    fun `other actions do not end push to talk`() {
+        assertFalse(CallActivity.isPushToTalkRelease(MotionEvent.ACTION_DOWN))
+        assertFalse(CallActivity.isPushToTalkRelease(MotionEvent.ACTION_MOVE))
+        assertFalse(CallActivity.isPushToTalkRelease(MotionEvent.ACTION_OUTSIDE))
+    }
+}


### PR DESCRIPTION
fix(call): end push to talk on ACTION_CANCEL

## Description

The microphone button's touch listener only released push to talk on `ACTION_UP`. When the long-press ended with `MotionEvent.ACTION_CANCEL` instead — finger dragged into the system back-gesture edge or navigation bar, notification shade pulled while holding, or any other touch interception — the release branch never ran:

- `isPushToTalkActive` stayed `true`
- the WebRTC audio track stayed enabled
- the device kept transmitting room audio indefinitely while the button showed "muted"

A hot-mic privacy bug, and a source of "they hear me although I'm muted" reports.

The release logic is extracted into `stopPushToTalk()` and now runs for both `ACTION_UP` and `ACTION_CANCEL`, pinned by unit tests.

## Steps to reproduce / How to test

1. Join a call, microphone muted
2. Long-press the mic button (push to talk activates)
3. End the gesture so it produces `ACTION_CANCEL` — e.g. drag the finger into the back-gesture edge or pull down the notification shade while holding
4. Ask a remote participant whether they can still hear you

**Without this PR:** remote keeps hearing you; the button shows "muted".
**With this PR:** the mic is muted as soon as the gesture ends, regardless of how it ends.

Also verify regular PTT behavior is unchanged: long-press to talk, release to mute; tap toggles mute as before.

- [x] ⛑️ Tests are included (`CallActivityPushToTalkTest`)
- [x] 🔖 Capability is checked or not needed
- [ ] 🔙 Backport requests or not needed
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful

---

*Note: This PR was developed with AI assistance (opencode / Kimi-K3).*
