### PR TITLE
fix(call): recover from stale room session instead of ringing forever

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -41,6 +41,7 @@ import android.view.MotionEvent
 import android.view.OrientationEventListener
 import android.view.View
 import android.view.View.OnTouchListener
+import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.DrawableRes
 import androidx.appcompat.app.AlertDialog
@@ -311,6 +312,7 @@ class CallActivity : CallBaseActivity() {
     private var webSocketClient: WebSocketInstance? = null
     private var webSocketConnectionHelper: WebSocketConnectionHelper? = null
     private var joinRoomInitiated = false
+    private var roomJoinRefreshes = 0
     private var hasMCU = false
     private var hasExternalSignalingServer = false
     private var conversationPassword: String? = null
@@ -1590,6 +1592,31 @@ class CallActivity : CallBaseActivity() {
         }
     }
 
+    /**
+     * Joining the room for a call was rejected because the cached room session is stale (reaped by the server).
+     * Drops the cached session so [joinRoomAndCall] fetches a fresh one via the joinRoom API, and retries a few
+     * times; otherwise the call UI would show "Ringing" forever, as the calling timeout is only armed after a
+     * successful join.
+     */
+    private fun handleRoomJoinFailed() {
+        Log.d(TAG, "onMessageEvent 'roomJoinFailed'")
+        if (!shouldRefreshRoomSession(currentCallStatus, roomJoinRefreshes)) {
+            if (currentCallStatus !== CallStatus.IN_CONVERSATION) {
+                Log.e(TAG, "Joining the room for the call failed repeatedly, leaving")
+                runOnUiThread {
+                    Toast.makeText(context, R.string.nc_call_join_failed, Toast.LENGTH_LONG).show()
+                    finish()
+                }
+            }
+            return
+        }
+        roomJoinRefreshes++
+        Log.d(TAG, "Refreshing the room session and retrying the join ($roomJoinRefreshes/$MAX_ROOM_JOIN_REFRESHES)")
+        ApplicationWideCurrentRoomHolder.getInstance().session = ""
+        callSession = null
+        joinRoomAndCall()
+    }
+
     private fun callOrJoinRoomViaWebSocket() {
         if (hasExternalSignalingServer) {
             webSocketClient!!.joinRoomWithRoomTokenAndSession(
@@ -1900,9 +1927,12 @@ class CallActivity : CallBaseActivity() {
                     }
                     startSendingNick()
                     if (webSocketCommunicationEvent.getHashMap()!!["roomToken"] == roomToken) {
+                        roomJoinRefreshes = 0
                         performCall()
                     }
                 }
+
+                "roomJoinFailed" -> handleRoomJoinFailed()
 
                 "recordingStatus" -> {
                     Log.d(TAG, "onMessageEvent 'recordingStatus'")
@@ -3236,6 +3266,11 @@ class CallActivity : CallBaseActivity() {
 
         internal fun isPushToTalkRelease(action: Int): Boolean =
             action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL
+
+        private const val MAX_ROOM_JOIN_REFRESHES: Int = 2
+
+        internal fun shouldRefreshRoomSession(callStatus: CallStatus?, refreshesDone: Int): Boolean =
+            callStatus !== CallStatus.IN_CONVERSATION && refreshesDone < MAX_ROOM_JOIN_REFRESHES
 
         private const val DELAY_ON_ERROR_STOP_THRESHOLD: Int = 16
 

--- a/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketInstance.kt
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketInstance.kt
@@ -313,6 +313,13 @@ class WebSocketInstance internal constructor(conversationUser: User, connectionU
                 restartWebSocket()
             } else if ("hello_expected" == message.code) {
                 restartWebSocket()
+            } else if ("no_such_room" == message.code) {
+                // The room session is stale (e.g. reaped by the server). Clear the cached join state so a retry
+                // actually sends, and let the call UI fetch a fresh room session via the joinRoom API.
+                Log.d(TAG, "Joining the room was rejected, the room session needs to be refreshed")
+                currentRoomToken = ""
+                currentNormalBackendSession = ""
+                eventBus!!.post(WebSocketCommunicationEvent("roomJoinFailed", null))
             }
         }
     }

--- a/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketInstance.kt
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketInstance.kt
@@ -319,7 +319,7 @@ class WebSocketInstance internal constructor(conversationUser: User, connectionU
                 Log.d(TAG, "Joining the room was rejected, the room session needs to be refreshed")
                 currentRoomToken = ""
                 currentNormalBackendSession = ""
-                eventBus!!.post(WebSocketCommunicationEvent("roomJoinFailed", null))
+                eventBus!!.post(WebSocketCommunicationEvent("roomJoinFailed", HashMap()))
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -398,6 +398,7 @@ How to translate with transifex:
     <string name="nc_nick_guest">Guest</string>
     <string name="nc_public_call_status">Public conversation</string>
     <string name="nc_call_timeout">No response in 45 seconds, tap to try again</string>
+    <string name="nc_call_join_failed">Could not join the call. Please try again.</string>
     <string name="nc_call_reconnecting">Reconnecting …</string>
     <string name="nc_offline">Currently offline, please check your connectivity</string>
     <string name="nc_leaving_call">Leaving call …</string>

--- a/app/src/test/java/com/nextcloud/talk/activities/CallActivityRoomJoinRefreshTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/activities/CallActivityRoomJoinRefreshTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.activities
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Room session refresh decisions ([CallActivity.shouldRefreshRoomSession]).
+ *
+ * Joining a call with a stale room session (reaped by the server) is rejected with "no_such_room". The cached
+ * session must be dropped and a fresh one fetched via the joinRoom API — but only while the call is still being
+ * set up (a stray error must never disturb an established call) and only a bounded number of times (otherwise the
+ * UI would retry forever instead of failing visibly).
+ */
+class CallActivityRoomJoinRefreshTest {
+
+    @Test
+    fun `stale session is refreshed while the call is being set up`() {
+        assertTrue(CallActivity.shouldRefreshRoomSession(CallStatus.CONNECTING, 0))
+        assertTrue(CallActivity.shouldRefreshRoomSession(CallStatus.JOINED, 0))
+        assertTrue(CallActivity.shouldRefreshRoomSession(CallStatus.RECONNECTING, 0))
+    }
+
+    @Test
+    fun `session is never refreshed once in conversation`() {
+        assertFalse(CallActivity.shouldRefreshRoomSession(CallStatus.IN_CONVERSATION, 0))
+    }
+
+    @Test
+    fun `gives up after the maximum number of refreshes`() {
+        assertTrue(CallActivity.shouldRefreshRoomSession(CallStatus.CONNECTING, 1))
+        assertFalse(CallActivity.shouldRefreshRoomSession(CallStatus.CONNECTING, 2))
+        assertFalse(CallActivity.shouldRefreshRoomSession(CallStatus.CONNECTING, 3))
+    }
+}


### PR DESCRIPTION
fix(call): recover from stale room session instead of ringing forever

## Description

Rejoining a call reuses the cached room session from `ApplicationWideCurrentRoomHolder` whenever it is non-empty — it is never validated. If the server reaped that session in the meantime (spreed invalidates sessions that stop pinging, `session-ping-limit`), the signaling server rejects the join with `no_such_room` ("The user is not invited to this room"). That error was only logged (`processErrorMessage` handled just `no_such_session`/`hello_expected`), and the calling timeout is armed only after a successful join — so the call UI showed "Ringing" forever with no way out. Reproduced live after a WiFi drop: reconnecting to the call was impossible until the app was restarted.

Changes:

- `WebSocketInstance`: `no_such_room` now clears the cached room join state (so a retry actually sends a new join message) and posts a `roomJoinFailed` event
- `CallActivity`: on `roomJoinFailed` the cached session is dropped and the joinRoom API is re-run to fetch a fresh session, then the join is retried. After two failed refreshes the user gets an error and the call screen closes instead of ringing forever. An already established call is never disturbed by a stray error.

## How to test

1. Join a call with external signaling (HPB), then put the app in the background long enough for the room session to be reaped server-side (or revoke/reap the session)
2. Return and rejoin the call

**Without this PR:** infinite "Ringing".
**With this PR:** the app fetches a fresh session and joins; if joining genuinely fails (e.g. removed from the conversation), an error toast is shown and the call screen closes.

Also regression-test: normal call joins, joining from a notification, and rejoining after a network switch.

- [x] ⛑️ Tests are included (`CallActivityRoomJoinRefreshTest`)
- [x] 🔖 Capability is checked or not needed
- [ ] 🔙 Backport requests or not needed
- [ ] 📅 Milestone is set
- [x] 🌸 PR title is meaningful

---

*Note: This PR was developed with AI assistance (opencode / Kimi-K3); see the `Assisted-by` commit trailer. Verified on a physical device (Samsung SM-S938B) against a live HPB+Janus setup.*
