### PR TITLE
ci: Bootstrap the test server on PHP 8.3

### DIFF
--- a/.github/workflows/garm.yml
+++ b/.github/workflows/garm.yml
@@ -22,7 +22,7 @@ jobs:
         runs-on: ubuntu-24.04
         services:
             server:
-                image: ${{ matrix.server == 'stable22' && 'ghcr.io/nextcloud/continuous-integration-shallow-server-php8.0:1' || 'ghcr.io/nextcloud/continuous-integration-shallow-server-php8.2:1' }}
+                image: ${{ matrix.server == 'stable22' && 'ghcr.io/nextcloud/continuous-integration-shallow-server-php8.0:1' || 'ghcr.io/nextcloud/continuous-integration-shallow-server-php8.3:latest' }}
                 options: --name server
                 ports:
                     - 80:80


### PR DESCRIPTION
### The problem

Every Garm run against server `master` fails in `configure server`, before the emulator is ever
started:

```
This version of Nextcloud requires at least PHP 8.3
You are currently running 8.2.31. Please update your PHP version.
```

Nextcloud master raised its minimum to PHP 8.3, so the shallow-server image pinned at `php8.2` can no
longer install it.

Example failure: https://github.com/nextcloud/talk-android/actions/runs/32749478902/job/97502761100

### The fix

Point the non-`stable22` matrix entry at the `php8.3` image.

**Note the tag differs.** This is not a straight substitution of the version inside the tag — the two
images do not publish the same tags:

| Image | Tags published |
|---|---|
| `continuous-integration-shallow-server-php8.2` | `1` |
| `continuous-integration-shallow-server-php8.3` | `latest` |
| `continuous-integration-shallow-server-php8.4` | does not exist |

So `php8.3:1` would have 404'd. The pin is therefore looser than it was and should be tightened once
a numbered tag is published upstream.

The `stable22` branch of the expression keeps `php8.0`. It is unreachable today, since the matrix
only lists `master`, but it belongs with that server version if the entry is ever restored.

### Still open

The same job log shows a second error immediately above the PHP one:

```
fatal: Remote branch master not found in upstream origin
```

That originates in `initnc.sh` inside the container rather than in this repo, and the job failed on
the PHP check regardless, so it is untouched here. This PR's own CI run should show whether it is
benign or a second problem that only surfaces once bootstrapping gets further.

### AI tool use

The change was prepared with Claude Code, which read the failing job log, queried the GHCR registry
to establish which image tags actually exist, and made the one-line edit. Reviewed and signed off by
me. Commit carries an `Assisted-by:` trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
