### PR TITLE
Bugfix/noid/fix npe for get message

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
@@ -448,7 +448,7 @@ class OfflineFirstChatRepository @Inject constructor(
                 return@flow
             }
 
-            getAndPersistMessages(bundle)
+            fetchAndPersistSingleMessage(messageId)
 
             emitAll(
                 observeMessageNonNull(internalConversationId, messageId)
@@ -456,6 +456,21 @@ class OfflineFirstChatRepository @Inject constructor(
                     .take(1)
             )
         }
+
+    // getMessage's callers never populate bundle's KEY_FIELD_MAP (unlike the loadMoreMessages /
+    // longpolling call sites), so this fetches the message directly by id instead of routing
+    // through getAndPersistMessages, which requires that field map.
+    private suspend fun fetchAndPersistSingleMessage(messageId: Long) {
+        val messages = network.getContextForChatMessage(
+            credentials = credentials,
+            baseUrl = currentUser.baseUrl!!,
+            token = roomToken,
+            messageId = messageId.toString(),
+            limit = 1,
+            threadId = threadId?.toInt()
+        )
+        persistChatMessagesAndHandleSystemMessages(messages)
+    }
 
     @Suppress("Detekt.TooGenericExceptionCaught")
     override suspend fun loadMessageContext(

--- a/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
@@ -457,9 +457,6 @@ class OfflineFirstChatRepository @Inject constructor(
             )
         }
 
-    // getMessage's callers never populate bundle's KEY_FIELD_MAP (unlike the loadMoreMessages /
-    // longpolling call sites), so this fetches the message directly by id instead of routing
-    // through getAndPersistMessages, which requires that field map.
     private suspend fun fetchAndPersistSingleMessage(messageId: Long) {
         val messages = network.getContextForChatMessage(
             credentials = credentials,
@@ -557,8 +554,12 @@ class OfflineFirstChatRepository @Inject constructor(
         }
     }
 
+    // Callers must put a KEY_FIELD_MAP (see getFieldMap/syncer.buildFieldMap) into bundle before
+    // calling this.
     private suspend fun getAndPersistMessages(bundle: Bundle): Boolean {
-        val fieldMap = bundle.getSerializable(BundleKeys.KEY_FIELD_MAP) as HashMap<String, Int>
+        val fieldMap = requireNotNull(bundle.getSerializable(BundleKeys.KEY_FIELD_MAP) as? HashMap<String, Int>) {
+            "getAndPersistMessages requires bundle to carry KEY_FIELD_MAP"
+        }
         val outcome = syncer.pullAndPersistMessages(syncTarget, fieldMap, syncEvents)
         return outcome.persistedNewMessages
     }


### PR DESCRIPTION
getMessage's network fallback called getAndPersistMessages(bundle), which does `bundle.getSerializable(KEY_FIELD_MAP) as HashMap<String, Int>` - a non-null cast that throws NullPointerException when the key is absent. None of getMessage's callers (pinned message lookup, both getMessageById overloads in ChatViewModel) ever put KEY_FIELD_MAP into the bundle, so this crashed whenever the requested message wasn't already cached locally.

java.lang.NullPointerException
  at OfflineFirstChatRepository.getAndPersistMessages (OfflineFirstChatRepository.kt:546)
  at OfflineFirstChatRepository$getMessage$1.invokeSuspend (OfflineFirstChatRepository.kt:451)

Fetch the message directly via network.getContextForChatMessage instead, the same by-id lookup loadMessageContext already uses for this situation, rather than routing through the windowed pull API that getAndPersistMessages is meant for.

Assisted-by: Claude Code:claude-sonnet-5


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
