### PR TITLE
avoid FK constraint exceptions

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/data/network/ChatMessageSyncer.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/network/ChatMessageSyncer.kt
@@ -776,7 +776,12 @@ class ChatMessageSyncer @Inject constructor(
             newestMessageId = newestMessageIdForNewChatBlock,
             hasHistory = hasHistory
         )
-        chatBlocksDao.upsertAndMergeConnectedChatBlocks(newChatBlock)
+        try {
+            chatBlocksDao.upsertAndMergeConnectedChatBlocks(newChatBlock)
+        } catch (e: SQLiteConstraintException) {
+            Log.w(TAG, "Skip chat block update: conversation ${target.internalConversationId} gone. Swallowed: $e")
+            return emptyList()
+        }
 
         return chatMessageEntities
     }

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/data/network/OfflineFirstConversationsRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/data/network/OfflineFirstConversationsRepository.kt
@@ -9,6 +9,7 @@
 package com.nextcloud.talk.conversationlist.data.network
 
 import android.content.Context
+import android.database.sqlite.SQLiteConstraintException
 import android.net.ConnectivityManager
 import android.os.PowerManager
 import android.util.Log
@@ -148,7 +149,11 @@ class OfflineFirstConversationsRepository @Inject constructor(
                                 previous,
                                 listOf(model.asEntity())
                             )
-                            dao.upsertConversations(user.id!!, entityList)
+                            try {
+                                dao.upsertConversations(user.id!!, entityList)
+                            } catch (e: SQLiteConstraintException) {
+                                Log.w(TAG, "Skipping conversation upsert for removed account ${user.id}", e)
+                            }
                         }
                     }
                 })


### PR DESCRIPTION
fixes the crash

```
Exception android.database.sqlite.SQLiteConstraintException: FOREIGN KEY constraint failed (code 787)
  at net.zetetic.database.sqlcipher.SQLiteConnection.nativeExecute
  at net.zetetic.database.sqlcipher.SQLiteConnection.execute (SQLiteConnection.java:592)
  at net.zetetic.database.sqlcipher.SQLiteSession.execute (SQLiteSession.java:624)
  at net.zetetic.database.sqlcipher.SQLiteStatement.execute (SQLiteStatement.java:70)
  at androidx.sqlite.driver.SupportSQLiteStatement$OtherSQLiteStatement.step (SupportSQLiteStatement.android.kt:540)
  at androidx.room.EntityInsertAdapter.insert (EntityInsertAdapter.kt:59)
  at com.nextcloud.talk.data.database.dao.ConversationsDao_Impl.insertConversation$lambda$0 (ConversationsDao_Impl.kt:336)
  at com.nextcloud.talk.data.database.dao.ConversationsDao_Impl$$ExternalSyntheticLambda5.invoke (D8$$SyntheticClass)
  at androidx.room.util.DBUtil__DBUtil_androidKt$performBlocking$1$1$invokeSuspend$$inlined$internalPerform$1.invokeSuspend (DBUtil.kt:173)
  at androidx.room.util.DBUtil__DBUtil_androidKt$performBlocking$1$1$invokeSuspend$$inlined$internalPerform$1.invoke (DBUtil.kt:8)
  at androidx.room.util.DBUtil__DBUtil_androidKt$performBlocking$1$1$invokeSuspend$$inlined$internalPerform$1.invoke (DBUtil.kt:4)
  at androidx.room.coroutines.PassthroughConnectionPool$useConnection$2.invokeSuspend (PassthroughConnectionPool.kt:59)
  at androidx.room.coroutines.PassthroughConnectionPool$useConnection$2.invoke (PassthroughConnectionPool.kt:8)
  at androidx.room.coroutines.PassthroughConnectionPool$useConnection$2.invoke (PassthroughConnectionPool.kt:4)
```

This could happen when a account was deleted and chat sync is in progress at the same time.

This might be a side effect of duplicated accounts. See https://github.com/nextcloud/talk-android/pull/6559 which might even trigger the FK constraint exception more often by deleting duplicated accounts.

The conversation (and cascaded via its account removal) may have been deleted between persisting chatMessageEntities above and this chat block write, tripping the ChatBlocks.internalConversationId foreign key. The block is now moot.



### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
