### PR TITLE
fix(chat): Avoid NPE when opening a file attachment in the Files app

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -3920,8 +3920,12 @@ class ChatActivity :
     fun openInFilesApp(message: ChatMessage) {
         val keyID = message.fileParameters.id
         val link = message.fileParameters.link
-        val fileViewerUtils = FileViewerUtils(this, message.activeUser!!)
-        fileViewerUtils.openFileInFilesApp(link!!, keyID!!)
+        if (keyID.isEmpty() || link.isEmpty()) {
+            Snackbar.make(binding.root, R.string.nc_common_error_sorry, Snackbar.LENGTH_LONG).show()
+            return
+        }
+        val fileViewerUtils = FileViewerUtils(this, conversationUser)
+        fileViewerUtils.openFileInFilesApp(link, keyID)
     }
 
     private fun hasVisibleItems(message: ChatMessage): Boolean =


### PR DESCRIPTION
message.activeUser is a deprecated field that is no longer populated for messages loaded via chatViewModel.getMessageById(), causing openInFilesApp to crash on the !! assertion. Use the activity's own conversationUser instead, and guard against empty file id/link.

solves the crash

```
Exception java.lang.NullPointerException:
  at com.nextcloud.talk.chat.ChatActivity.openInFilesApp (ChatActivity.kt:3924)
  at com.nextcloud.talk.chat.ChatActivity.setChatListContent$lambda$0$0$25$5$16$0 (ChatActivity.kt:1073)
  at com.nextcloud.talk.chat.ChatActivity.$r8$lambda$gNw-gM-0_WBUE332dY-UQ59gx9A (ChatActivity.kt)
  at com.nextcloud.talk.chat.ChatActivity$$ExternalSyntheticLambda82.invoke (D8$$SyntheticClass)
  at com.nextcloud.talk.chat.ui.MessageActionsBottomSheetKt.MessageActionsSheetContent$lambda$3$1$15$0 (MessageActionsBottomSheet.kt:573)
  at com.nextcloud.talk.chat.ui.MessageActionsBottomSheetKt.$r8$lambda$U1EpqISFzC9zioliU6v53FiRDwI (MessageActionsBottomSheet.kt)
```


Assisted-by: Claude:claude-sonnet-5


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
