### PR TITLE
fix(scheduled-messages): use unique message id as LazyColumn item key

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/ScheduledMessagesActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ScheduledMessagesActivity.kt
@@ -545,7 +545,7 @@ class ScheduledMessagesActivity : BaseActivity() {
 
                                         items(
                                             items = grouped[date].orEmpty(),
-                                            key = { it.token ?: "" }
+                                            key = { it.jsonMessageId }
                                         ) { message ->
 
                                             val parentId = message.parentMessageId


### PR DESCRIPTION
fix the crash:

```
Exception java.lang.IllegalArgumentException:
  at androidx.compose.ui.internal.InlineClassHelperKt.throwIllegalArgumentException (InlineClassHelper.kt:36)
  at androidx.compose.ui.layout.LayoutNodeSubcompositionsState.subcompose (SubcomposeLayout.kt:1592)
  at androidx.compose.ui.layout.LayoutNodeSubcompositionsState$Scope.subcompose (SubcomposeLayout.kt:1353)
  at androidx.compose.foundation.lazy.layout.LazyLayoutMeasureScopeImpl.compose (LazyLayoutMeasureScope.kt:94)
  at androidx.compose.foundation.lazy.layout.LazyLayoutMeasuredItemProvider.getPlaceables-3p2s80s (LazyLayoutMeasuredItem.kt:118)
  at androidx.compose.foundation.lazy.LazyListMeasuredItemProvider.getAndMeasure-0kLqBqw (LazyListMeasuredItemProvider.kt:54)
  at androidx.compose.foundation.lazy.LazyListMeasuredItemProvider.getAndMeasure-0kLqBqw$default (LazyListMeasuredItemProvider.kt:48)
```

however i assume there is still some other bug in the app which produces the same issue (given the amount of reports its maybe chatview itself. to be fixed in a separate PR).


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
