### PR TITLE
fix IllegalArgumentException for images in notifications

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/NotificationUtils.kt
@@ -352,7 +352,8 @@ object NotificationUtils {
     }
 
     fun saveBitmapToCache(context: Context, bitmap: Bitmap, fileName: String): Uri? {
-        val cacheFile = File(context.cacheDir, fileName)
+        val sharedAttachmentsDir = FileUtils.getSharedAttachmentsDirectory(context.cacheDir) ?: return null
+        val cacheFile = File(sharedAttachmentsDir, fileName)
         return try {
             FileOutputStream(cacheFile).use { out ->
                 bitmap.compress(Bitmap.CompressFormat.PNG, BITMAP_COMPRESSION_QUALITY, out)


### PR DESCRIPTION
fix IllegalArgumentException for images in notifications

followup to https://github.com/nextcloud/talk-android/pull/6012

```
2026-09-01 19:21:31.681 21169-21204 WM-WorkerWrappercom.nextcloud.talk2EWork [ id=2eeff2df-b907-4d3f-81e3-d9eeb3e32821,
tags={ com.nextcloud.talk.jobs.NotificationWorker } ] failed because it threw an exception/error (Fix with AI)
java.lang.IllegalArgumentException: Failed to
find configured root that contains /data/data/com.nextcloud.talk2/cache/notification_preview_3853979093.png
at
androidx.core.content.FileProvider$SimplePathStrategy.getUriForFile(FileProvider.java:911)
at
androidx.core.content.FileProvider.getUriForFile(FileProvider.java:415)
at
com.nextcloud.talk.utils.NotificationUtils.saveBitmapToCache(NotificationUtils.kt:360)
at
com.nextcloud.talk.jobs.NotificationWorker.showNotification(NotificationWorker.kt:731)
at
```

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
