### PR TITLE
fix audio in call for Android 9 and lower

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -1180,6 +1180,11 @@ class CallActivity : CallBaseActivity() {
 
     @SuppressLint("MissingPermission")
     private fun startMicInputDetection() {
+        // concurrent audio capture isn't supported before Android 10
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            return
+        }
+
         if (permissionUtil!!.isMicrophonePermissionGranted() && micInputAudioRecordThread == null) {
             micInputAudioRecorder = AudioRecord(
                 MediaRecorder.AudioSource.MIC,


### PR DESCRIPTION
- fix https://github.com/nextcloud/talk-android/issues/4888

concurrent audio capture isn't supported before Android 10. For Android 9 and lower we do not support the isSpeaking feature.

---
if this is tested: https://github.com/nextcloud/talk-android/pull/6620 is necessary in order to setup a android 9 device


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
