### PR TITLE
fix(camera): declare photos/ as FileProvider cache path

### DIFF
--- a/app/src/main/res/xml/file_provider_paths.xml
+++ b/app/src/main/res/xml/file_provider_paths.xml
@@ -8,6 +8,9 @@
     <cache-path
         name="shared_attachments"
         path="shared_attachments/" />
+    <cache-path
+        name="photos"
+        path="photos/" />
     <files-path
         name="logs"
         path="logs/" />


### PR DESCRIPTION
Camera capture files are written to cache/photos/camera_capture.jpg, but file_provider_paths.xml only declared shared_attachments/, causing FileProvider.getUriForFile to throw IllegalArgumentException when taking a picture from the conversation info edit screen.


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
