### PR TITLE
fix(download): avoid divide by zero when file size is 0

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/jobs/DownloadFileToCacheWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/DownloadFileToCacheWorker.kt
@@ -112,7 +112,7 @@ class DownloadFileToCacheWorker(val context: Context, workerParameters: WorkerPa
         count = bis.read(data)
 
         while (count != -1) {
-            if (totalFileSize > -1) {
+            if (totalFileSize > 0) {
                 total += count.toLong()
                 val progress = (total * COMPLETE_PERCENTAGE / totalFileSize).toInt()
                 val currentTime = System.currentTimeMillis() - startTime


### PR DESCRIPTION
otherwise download failed with error

```
2026-09-03 09:55:13.8612743-2796WM-WorkerWrappercom.nextcloud.talk2EWork [ id=6044ab54-1b6a-4024-9ed7-09435d65a87e, tags={ com.nextcloud.talk.jobs.DownloadFileToCacheWorker,14053871 } ] failed because it threw an exception/error (Fix with AI) java.lang.ArithmeticException: divide by zero
at
com.nextcloud.talk.jobs.DownloadFileToCacheWorker.executeDownload(DownloadFileToCacheWorker.kt:117) at
com.nextcloud.talk.jobs.DownloadFileToCacheWorker.downloadFile(DownloadFileToCacheWorker.kt:88) at
com.nextcloud.talk.jobs.DownloadFileToCacheWorker.doWork(DownloadFileToCacheWorker.kt:75) at androidx.work.Worker.startWork$lambda$0(Worker.kt:64) at androidx.work.Worker$$ExternalSyntheticLambda0.invoke(D8$$SyntheticClass:0) at androidx.work.WorkerKt.future$lambda$2$lambda$1(Worker.kt:100) at androidx.work.WorkerKt$$ExternalSyntheticLambda1.run(D8$$SyntheticClass:0) at
java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1100) at
java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) at java.lang.Thread.run(Thread.java:1572)
```



### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
