### PR TITLE
Bugfix/noid/wrong images shown

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/jobs/DownloadFileToCacheWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/DownloadFileToCacheWorker.kt
@@ -59,6 +59,7 @@ class DownloadFileToCacheWorker(val context: Context, workerParameters: WorkerPa
             val baseUrl = inputData.getString(KEY_BASE_URL)
             val userId = inputData.getString(KEY_USER_ID)
             val attachmentFolder = inputData.getString(KEY_ATTACHMENT_FOLDER)
+            val fileId = inputData.getString(KEY_FILE_ID)
             val fileName = inputData.getString(KEY_FILE_NAME)
             val remotePath = inputData.getString(KEY_FILE_PATH)
             totalFileSize = (inputData.getLong(KEY_FILE_SIZE, -1))
@@ -72,24 +73,28 @@ class DownloadFileToCacheWorker(val context: Context, workerParameters: WorkerPa
 
             val url = ApiUtils.getUrlForFileDownload(baseUrl, userId, remotePath)
 
-            return downloadFile(currentUser, url, fileName)
+            return downloadFile(currentUser, url, fileId, fileName)
         } catch (e: IllegalStateException) {
             Log.e(javaClass.simpleName, "Something went wrong when trying to download file", e)
             return Result.failure()
         }
     }
 
-    private fun downloadFile(currentUser: User, url: String, fileName: String): Result {
+    private fun downloadFile(currentUser: User, url: String, fileId: String?, fileName: String): Result {
         val downloadCall = ncApi.downloadFile(
             ApiUtils.getCredentials(currentUser.username, currentUser.token),
             url
         )
 
-        return executeDownload(downloadCall.execute().body(), fileName)
+        return executeDownload(downloadCall.execute().body(), fileId, fileName)
     }
 
-    private fun executeDownload(body: ResponseBody?, fileName: String): Result {
-        val targetFile = FileUtils.resolveSharedAttachmentFile(context.cacheDir, fileName)
+    private fun executeDownload(body: ResponseBody?, fileId: String?, fileName: String): Result {
+        val targetFile = if (fileId.isNullOrEmpty()) {
+            FileUtils.resolveSharedAttachmentFile(context.cacheDir, fileName)
+        } else {
+            FileUtils.resolveSharedAttachmentFile(context.cacheDir, fileId, fileName)
+        }
         if (body == null || targetFile == null) {
             if (body == null) {
                 Log.e(TAG, "Response body when downloading $fileName is null!")
@@ -145,6 +150,7 @@ class DownloadFileToCacheWorker(val context: Context, workerParameters: WorkerPa
         const val KEY_BASE_URL = "KEY_BASE_URL"
         const val KEY_USER_ID = "KEY_USER_ID"
         const val KEY_ATTACHMENT_FOLDER = "KEY_ATTACHMENT_FOLDER"
+        const val KEY_FILE_ID = "KEY_FILE_ID"
         const val KEY_FILE_NAME = "KEY_FILE_NAME"
         const val KEY_FILE_PATH = "KEY_FILE_PATH"
         const val KEY_FILE_SIZE = "KEY_FILE_SIZE"

--- a/app/src/main/java/com/nextcloud/talk/mediaviewer/activities/MediaViewerScreen.kt
+++ b/app/src/main/java/com/nextcloud/talk/mediaviewer/activities/MediaViewerScreen.kt
@@ -120,13 +120,13 @@ fun MediaViewerScreen(
     }
     val coroutineScope = rememberCoroutineScope()
 
-    // See MediaViewerViewModel.indexShiftEvents: prepending older groups shifts every existing
-    // index, so the pager must silently jump to keep the same item on screen.
-    LaunchedEffect(viewModel) {
-        viewModel.indexShiftEvents.collect { shift ->
-            if (shift != 0) {
-                pagerState.scrollToPage((pagerState.currentPage + shift).coerceIn(0, items.size - 1))
+    LaunchedEffect(uiState.pendingShift?.id) {
+        val shift = uiState.pendingShift
+        if (shift != null) {
+            if (shift.amount != 0) {
+                pagerState.scrollToPage((pagerState.currentPage + shift.amount).coerceIn(0, items.size - 1))
             }
+            viewModel.consumePendingShift(shift.id)
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/mediaviewer/viewmodels/MediaViewerViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/mediaviewer/viewmodels/MediaViewerViewModel.kt
@@ -127,7 +127,7 @@ class MediaViewerViewModel @Inject constructor(private val sharedItemsRepository
         }
 
         val context = NextcloudTalkApplication.sharedApplication!!
-        val existing = FileUtils.resolveSharedAttachmentFile(context.cacheDir, item.fileName)
+        val existing = FileUtils.resolveSharedAttachmentFile(context.cacheDir, item.fileId, item.fileName)
         if (existing != null && existing.exists()) {
             _uiState.update {
                 it.copy(cachedFilePaths = it.cachedFilePaths + (item.messageId to existing.absolutePath))
@@ -144,6 +144,7 @@ class MediaViewerViewModel @Inject constructor(private val sharedItemsRepository
                 DownloadFileToCacheWorker.KEY_ATTACHMENT_FOLDER,
                 CapabilitiesUtil.getAttachmentFolder(user.capabilities!!.spreedCapability!!)
             )
+            .putString(DownloadFileToCacheWorker.KEY_FILE_ID, item.fileId)
             .putString(DownloadFileToCacheWorker.KEY_FILE_NAME, item.fileName)
             .putString(DownloadFileToCacheWorker.KEY_FILE_PATH, item.path)
             .putLong(DownloadFileToCacheWorker.KEY_FILE_SIZE, item.fileSize)
@@ -161,7 +162,11 @@ class MediaViewerViewModel @Inject constructor(private val sharedItemsRepository
                 if (workInfo == null) return@collect
                 when (workInfo.state) {
                     WorkInfo.State.SUCCEEDED -> {
-                        val downloaded = FileUtils.resolveSharedAttachmentFile(context.cacheDir, item.fileName)
+                        val downloaded = FileUtils.resolveSharedAttachmentFile(
+                            context.cacheDir,
+                            item.fileId,
+                            item.fileName
+                        )
                         _uiState.update {
                             it.copy(
                                 downloadingMessageIds = it.downloadingMessageIds - item.messageId,

--- a/app/src/main/java/com/nextcloud/talk/mediaviewer/viewmodels/MediaViewerViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/mediaviewer/viewmodels/MediaViewerViewModel.kt
@@ -30,7 +30,6 @@ import com.nextcloud.talk.shareditems.repositories.SharedItemsRepository
 import com.nextcloud.talk.utils.CapabilitiesUtil
 import com.nextcloud.talk.utils.FileUtils
 import io.reactivex.Observable
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect
@@ -52,13 +51,16 @@ import kotlin.coroutines.resumeWithException
 class MediaViewerViewModel @Inject constructor(private val sharedItemsRepository: SharedItemsRepository) :
     ViewModel() {
 
+    data class PendingShift(val id: Long, val amount: Int)
+
     data class UiState(
         val groups: List<MediaViewerGroup> = emptyList(),
         val currentGlobalIndex: Int = 0,
         val loadingOlder: Boolean = false,
         val canLoadOlder: Boolean = true,
         val cachedFilePaths: Map<Long, String> = emptyMap(),
-        val downloadingMessageIds: Set<Long> = emptySet()
+        val downloadingMessageIds: Set<Long> = emptySet(),
+        val pendingShift: PendingShift? = null
     ) {
         val flattenedItems: List<MediaViewerItem> get() = groups.flatMap { it.items }
         val currentItem: MediaViewerItem? get() = flattenedItems.getOrNull(currentGlobalIndex)
@@ -71,14 +73,7 @@ class MediaViewerViewModel @Inject constructor(private val sharedItemsRepository
 
     private val _uiState = MutableStateFlow(UiState())
     val uiState: StateFlow<UiState> = _uiState
-
-    // HorizontalPager indexes into the flattened item list; prepending older groups shifts every
-    // existing index by the number of items prepended. This is a one-shot event (not part of
-    // UiState) so the pager can silently jump to the shifted position - via
-    // pagerState.scrollToPage(pagerState.currentPage + shift) - the moment it fires, keeping the
-    // same item on screen instead of visually jumping to whatever is now at the old index.
-    private val _indexShiftEvents = MutableSharedFlow<Int>(extraBufferCapacity = 1)
-    val indexShiftEvents = _indexShiftEvents
+    private var nextShiftId = 0L
 
     private lateinit var user: User
     private lateinit var repositoryParameters: SharedItemsRepository.Parameters
@@ -110,6 +105,10 @@ class MediaViewerViewModel @Inject constructor(private val sharedItemsRepository
 
     fun jumpTo(globalIndex: Int) {
         onPageSettled(globalIndex)
+    }
+
+    fun consumePendingShift(id: Long) {
+        _uiState.update { if (it.pendingShift?.id == id) it.copy(pendingShift = null) else it }
     }
 
     private fun ensureCachedAround(globalIndex: Int) {
@@ -215,17 +214,16 @@ class MediaViewerViewModel @Inject constructor(private val sharedItemsRepository
             }
 
             oldestKnownMessageId = olderItems.first().messageId
-            val previousCount = _uiState.value.flattenedItems.size
             _uiState.update { current ->
                 val combined = (olderItems + current.flattenedItems).toMediaViewerGroups()
                 current.copy(
                     groups = combined,
                     currentGlobalIndex = current.currentGlobalIndex + olderItems.size,
                     loadingOlder = false,
-                    canLoadOlder = sharedItems?.moreItemsExisting == true
+                    canLoadOlder = sharedItems?.moreItemsExisting == true,
+                    pendingShift = PendingShift(id = nextShiftId++, amount = olderItems.size)
                 )
             }
-            _indexShiftEvents.tryEmit(_uiState.value.flattenedItems.size - previousCount)
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/utils/FileUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/FileUtils.kt
@@ -49,6 +49,21 @@ object FileUtils {
     }
 
     /**
+     * Resolves a shared attachment file inside a per-[fileId] subdirectory of the dedicated cache
+     * directory. [untrustedFileName] alone is sender-controlled and not unique - two different
+     * attachments (e.g. two pasted screenshots both named "image.png") can share it, which would
+     * otherwise let concurrent downloads (see MediaViewerViewModel's prefetch) resolve to, and
+     * overwrite, the very same cache file. Nesting under the server-assigned [fileId] keeps every
+     * attachment's cache slot unique regardless of what its sender named it.
+     */
+    fun resolveSharedAttachmentFile(cacheDir: File, fileId: String, untrustedFileName: String?): File? {
+        val sharedDirectory = getSharedAttachmentsDirectory(cacheDir) ?: return null
+        val fileIdDirectory = resolveFileInDirectory(sharedDirectory, fileId) ?: return null
+        if (!fileIdDirectory.exists() && !fileIdDirectory.mkdirs()) return null
+        return resolveFileInDirectory(fileIdDirectory, untrustedFileName)
+    }
+
+    /**
      * Resolves an untrusted file name inside [baseDirectory] and rejects traversal attempts.
      */
     fun resolveFileInDirectory(baseDirectory: File, untrustedFileName: String?): File? {

--- a/app/src/test/java/com/nextcloud/talk/utils/FileUtilsTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/utils/FileUtilsTest.kt
@@ -118,6 +118,47 @@ class FileUtilsTest {
     }
 
     @Test
+    fun resolveSharedAttachmentFile_withFileId_resolvesInsidePerFileIdSubDirectory() {
+        val baseDir = createTempDir()
+        try {
+            val result = FileUtils.resolveSharedAttachmentFile(baseDir, "42", "example.pdf")
+
+            assertNotNull(result)
+            val expected = File(baseDir, "shared_attachments/42/example.pdf").canonicalPath
+            assertEquals(expected, result?.canonicalPath)
+        } finally {
+            baseDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun resolveSharedAttachmentFile_withFileId_keepsDifferentFileIdsFromColliding() {
+        val baseDir = createTempDir()
+        try {
+            val first = FileUtils.resolveSharedAttachmentFile(baseDir, "1", "image.jpg")
+            val second = FileUtils.resolveSharedAttachmentFile(baseDir, "2", "image.jpg")
+
+            assertNotNull(first)
+            assertNotNull(second)
+            assertTrue(first?.canonicalPath != second?.canonicalPath)
+        } finally {
+            baseDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun resolveSharedAttachmentFile_withFileId_rejectsTraversalInFileId() {
+        val baseDir = createTempDir()
+        try {
+            val result = FileUtils.resolveSharedAttachmentFile(baseDir, "../evil", "example.pdf")
+
+            assertNull(result)
+        } finally {
+            baseDir.deleteRecursively()
+        }
+    }
+
+    @Test
     fun getSharedAttachmentsDirectory_returnsNullWhenPathIsFile() {
         val baseDir = createTempDir()
         try {


### PR DESCRIPTION
Fix wrong image shown in media viewer                                                                                                                                                             
                                                                                                                                                                                                    
  Fixes a bug where tapping an image in a chat's grouped image gallery opens the correct image briefly, then a second later flips to a completely different (often much older) image — reproducible 
  reliably by opening the first image of a group.                                                                                                                                                   
                                                                                                                                                                                                    
Root cause                                                                                                                                                                                        
                                                                                                                                                                                                    
  The media viewer prefetches older conversation history whenever the tapped image sits within the first two positions of the currently-loaded media list (MediaViewerViewModel.loadOlderGroups()). 
  Once older items are fetched, they're prepended to the pager's item list, which shifts every existing index — the pager then needs to silently jump forward by that shift amount to keep the same 
  tapped image on screen.                                                                                                                                                                           
                                                                                                                                                                                                    
  That shift correction was emitted as a one-shot SharedFlow event, collected by a LaunchedEffect that launches once and lives for the screen's lifetime. Its body captured the item count          
  (items.size) from whatever composition was active when it first launched. By the time the shift event actually fired (after the older-items network fetch completed), the item list had already   
  grown, but the effect's clamp still used the stale, smaller count — so the pager settled on the wrong, small index instead of the correctly-shifted one, landing on an unrelated older image.     
                                                                                                                                                                                                    
Fix                                                                                                                                                                                               
                                                                                                                                                                                                    
  Moved the shift into MediaViewerViewModel.UiState itself as a PendingShift(id, amount) field, set atomically together with the prepended item list in the same state update. The Compose side now 
  reads it via LaunchedEffect(uiState.pendingShift?.id), so the item count and the shift always come from the same state snapshot, eliminating the stale-count race.                                
                                                                                                                                                                                                    
  Also included: a related but separate hardening fix — the on-disk cache used for downloaded chat attachments (shared_attachments/<fileName>) was keyed only by the sender-controlled, non-unique  
  file name. Two different attachments sharing a name (e.g. a generically-named pasted screenshot) could resolve to, and overwrite, the same cache file when downloaded concurrently. Cache files   
  used by the media viewer are now nested under a per-fileId subdirectory (shared_attachments/<fileId>/<fileName>) so same-named attachments can no longer collide. 

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
