### PR TITLE
fix(account): fix stuck login and stale active-user state when adding a second account

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/account/AccountVerificationActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/account/AccountVerificationActivity.kt
@@ -240,7 +240,7 @@ class AccountVerificationActivity : BaseActivity() {
             UserManager.UserAttributes(
                 id = null,
                 serverUrl = baseUrl,
-                currentUser = true,
+                currentUser = false,
                 userId = userId,
                 token = token,
                 displayName = displayName,

--- a/app/src/main/java/com/nextcloud/talk/account/AccountVerificationActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/account/AccountVerificationActivity.kt
@@ -529,6 +529,7 @@ class AccountVerificationActivity : BaseActivity() {
                         ApplicationWideMessageHolder.MessageType.ACCOUNT_WAS_IMPORTED
                 }
                 val intent = Intent(context, ConversationsListActivity::class.java)
+                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
                 startActivity(intent)
             }
         } else {

--- a/app/src/main/java/com/nextcloud/talk/account/AccountVerificationActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/account/AccountVerificationActivity.kt
@@ -519,32 +519,21 @@ class AccountVerificationActivity : BaseActivity() {
     private fun proceedWithLogin() {
         cookieManager.cookieStore.removeAll()
 
-        if (userManager.users.blockingGet().size == 1 ||
-            currentUserProviderOld.currentUser.blockingGet().id != internalAccountId
-        ) {
-            val userToSetAsActive = userManager.getUserWithId(internalAccountId).blockingGet()
-            Log.d(TAG, "userToSetAsActive: " + userToSetAsActive.username)
+        val userToSetAsActive = userManager.getUserWithId(internalAccountId).blockingGet()
+        Log.d(TAG, "userToSetAsActive: " + userToSetAsActive.username)
 
-            if (userManager.setUserAsActive(userToSetAsActive).blockingGet()) {
-                runOnUiThread {
-                    if (userManager.users.blockingGet().size == 1) {
-                        val intent = Intent(context, ConversationsListActivity::class.java)
-                        startActivity(intent)
-                    } else {
-                        if (isAccountImport) {
-                            ApplicationWideMessageHolder.getInstance().messageType =
-                                ApplicationWideMessageHolder.MessageType.ACCOUNT_WAS_IMPORTED
-                        }
-                        val intent = Intent(context, ConversationsListActivity::class.java)
-                        startActivity(intent)
-                    }
+        if (userManager.setUserAsActive(userToSetAsActive).blockingGet()) {
+            runOnUiThread {
+                if (userManager.users.blockingGet().size > 1 && isAccountImport) {
+                    ApplicationWideMessageHolder.getInstance().messageType =
+                        ApplicationWideMessageHolder.MessageType.ACCOUNT_WAS_IMPORTED
                 }
-            } else {
-                Log.e(TAG, "failed to set active user")
-                Snackbar.make(binding.root, R.string.nc_common_error_sorry, Snackbar.LENGTH_LONG).show()
+                val intent = Intent(context, ConversationsListActivity::class.java)
+                startActivity(intent)
             }
         } else {
-            Log.d(TAG, "continuing proceedWithLogin was skipped for this user")
+            Log.e(TAG, "failed to set active user")
+            Snackbar.make(binding.root, R.string.nc_common_error_sorry, Snackbar.LENGTH_LONG).show()
         }
     }
 

--- a/app/src/main/java/com/nextcloud/talk/users/UserManager.kt
+++ b/app/src/main/java/com/nextcloud/talk/users/UserManager.kt
@@ -19,6 +19,8 @@ import com.nextcloud.talk.models.json.push.PushConfigurationState
 import io.reactivex.Maybe
 import io.reactivex.Observable
 import io.reactivex.Single
+import io.reactivex.subjects.BehaviorSubject
+import io.reactivex.subjects.Subject
 
 @Suppress("TooManyFunctions")
 class UserManager internal constructor(private val userRepository: UsersRepository) {
@@ -34,10 +36,24 @@ class UserManager internal constructor(private val userRepository: UsersReposito
                 .switchIfEmpty(Maybe.defer { getAnyUserAndSetAsActive() })
         }
 
+    /**
+     * Backed by [activeUserSubject] rather than [UsersRepository.getActiveUserObservable] directly, so that
+     * [setUserAsActive] can push the newly-active user out synchronously the moment it succeeds, instead of
+     * consumers having to wait for Room's invalidation-tracker round trip to notice the DB write and re-query.
+     * That round trip is asynchronous and was racing against code (e.g. AccountVerificationActivity.
+     * proceedWithLogin()) that both changes the active user and immediately acts as if every observer already
+     * knows about it - e.g. launching a screen for the new user before its avatar/data had actually updated.
+     * Room's own observable is still relied on underneath to seed this and to catch any change to the `current`
+     * flag that doesn't go through [setUserAsActive].
+     */
     val currentUserObservable: Observable<User>
-        get() {
-            return userRepository.getActiveUserObservable()
-        }
+        get() = activeUserSubject
+
+    private val activeUserSubject: Subject<User> by lazy {
+        val subject = BehaviorSubject.create<User>().toSerialized()
+        userRepository.getActiveUserObservable().subscribe(subject::onNext) { }
+        subject
+    }
 
     fun deleteUser(internalId: Long): Int =
         userRepository.deleteUser(userRepository.getUserWithId(internalId).blockingGet())
@@ -156,6 +172,11 @@ class UserManager internal constructor(private val userRepository: UsersReposito
     fun setUserAsActive(user: User): Single<Boolean> {
         Log.d(TAG, "setUserAsActive:" + user.id!!)
         return userRepository.setUserAsActiveWithId(user.id!!)
+            .doOnSuccess { success ->
+                if (success) {
+                    activeUserSubject.onNext(user)
+                }
+            }
     }
 
     fun storeProfile(username: String?, userAttributes: UserAttributes): Maybe<User> =

--- a/app/src/main/java/com/nextcloud/talk/users/UserManager.kt
+++ b/app/src/main/java/com/nextcloud/talk/users/UserManager.kt
@@ -21,6 +21,8 @@ import io.reactivex.Observable
 import io.reactivex.Single
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.Subject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 @Suppress("TooManyFunctions")
 class UserManager internal constructor(private val userRepository: UsersRepository) {
@@ -45,14 +47,31 @@ class UserManager internal constructor(private val userRepository: UsersReposito
      * knows about it - e.g. launching a screen for the new user before its avatar/data had actually updated.
      * Room's own observable is still relied on underneath to seed this and to catch any change to the `current`
      * flag that doesn't go through [setUserAsActive].
+     *
+     * RxJava-based for CurrentUserProviderOld, the still-used but deprecated consumer. Coroutine-based code
+     * should prefer [currentUserFlow] instead, which is updated at the exact same point and needs no RxJava
+     * bridging on the consuming side.
      */
     val currentUserObservable: Observable<User>
         get() = activeUserSubject
+
+    /**
+     * Coroutine-native counterpart to [currentUserObservable] - see its doc for why this exists. Both are
+     * updated synchronously, at the same point in [setUserAsActive], from Room's same underlying query.
+     */
+    val currentUserFlow: StateFlow<User?>
+        get() = activeUserStateFlow
 
     private val activeUserSubject: Subject<User> by lazy {
         val subject = BehaviorSubject.create<User>().toSerialized()
         userRepository.getActiveUserObservable().subscribe(subject::onNext) { }
         subject
+    }
+
+    private val activeUserStateFlow: MutableStateFlow<User?> by lazy {
+        val flow = MutableStateFlow<User?>(null)
+        userRepository.getActiveUserObservable().subscribe({ flow.value = it }) { }
+        flow
     }
 
     fun deleteUser(internalId: Long): Int =
@@ -175,6 +194,7 @@ class UserManager internal constructor(private val userRepository: UsersReposito
             .doOnSuccess { success ->
                 if (success) {
                     activeUserSubject.onNext(user)
+                    activeUserStateFlow.value = user
                 }
             }
     }

--- a/app/src/main/java/com/nextcloud/talk/utils/database/user/CurrentUserProviderImpl.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/database/user/CurrentUserProviderImpl.kt
@@ -9,16 +9,9 @@ package com.nextcloud.talk.utils.database.user
 
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.users.UserManager
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.rx2.asFlow
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -26,18 +19,8 @@ import javax.inject.Singleton
 @Singleton
 class CurrentUserProviderImpl @Inject constructor(private val userManager: UserManager) : CurrentUserProvider {
 
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-
-    private val currentUser: StateFlow<User?> = userManager.currentUserObservable
-        .asFlow()
-        .stateIn(
-            scope = scope,
-            started = SharingStarted.Eagerly,
-            initialValue = null
-        )
-
     // only emit non-null users
-    override val currentUserFlow: Flow<User> = currentUser.filterNotNull()
+    override val currentUserFlow: Flow<User> = userManager.currentUserFlow.filterNotNull()
 
     // function for safe one-shot access
     override suspend fun getCurrentUser(timeout: Long): Result<User> {

--- a/app/src/main/java/com/nextcloud/talk/utils/database/user/UserModule.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/database/user/UserModule.kt
@@ -14,6 +14,7 @@ import com.nextcloud.talk.users.UserManager
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
+import javax.inject.Singleton
 
 @Module(includes = [DatabaseModule::class])
 abstract class UserModule {
@@ -28,6 +29,7 @@ abstract class UserModule {
 
     companion object {
         @Provides
+        @Singleton
         fun provideUserManager(userRepository: UsersRepository): UserManager = UserManager(userRepository)
     }
 }


### PR DESCRIPTION
Adding a second (or later) account got permanently stuck on the verification screen. Along the way to fixing that, a related but distinct bug surfaced: once login could actually complete, the           
  conversation list and the account-chooser dialog could briefly disagree about which account was active.                                                                                                   
                                                                                                                                                                                                            
Root causes                                                                                                                                                                                               
                                                                                                                                                                                                            
  1. Stuck login. AccountVerificationActivity.proceedWithLogin() had a guard meant to avoid redundant navigation on a duplicate completion event. The guard compared the DB's "current user" against the    
     account just verified — but storeProfile() already inserted new accounts with current = true immediately on creation, and a recent, unrelated fix (f4157de71, made the "active user" query             
     deterministic for duplicate-account cleanup) changed how ties between two current = 1 rows resolve. Combined, the guard's condition was false on the very first, legitimate completion for any 2nd+    
     account — not just on a hypothetical duplicate — so it silently skipped the step that sets the account active and opens the conversation list.                                                         
  2. Stale active-user cache. CurrentUserProviderOld, an app-wide singleton several screens read "who's logged in" from, only refreshed asynchronously via Room noticing the DB changed. proceedWithLogin() 
     flips the active-account flag and, almost immediately after, opens the conversation list — fast enough to usually win that race, so the freshly-shown screen (and which account's rooms/credentials it 
     loaded) could still reflect the previous account.                                                                                                                                                      
  3. Also found along the way: UserManager wasn't actually a Dagger singleton despite the app having one @Singleton component, and a stale ConversationsListActivity instance could be left behind in the   
     back stack if one was already open when a second account was added.                                                                                                                                    
                                                                                                                                                                                                            
  Fix                                                                                                                                                                                                       
                                                                                                                                                                                                            
  - AccountVerificationActivity.proceedWithLogin(): removed the broken guard so it always sets the verified account active and navigates once verification succeeds.                                        
  - AccountVerificationActivity: new accounts are no longer marked current = true until they're actually verified — setUserAsActive() remains the single place that flips this.                             
  - UserManager: now a proper @Singleton; setUserAsActive() pushes the newly-active user out synchronously (via a serialized RxJava subject and a coroutine StateFlow) instead of consumers waiting on      
    Room's async invalidation.                                                                                                                                                                              
  - CurrentUserProviderImpl (the coroutine-based provider) now reads that StateFlow directly, dropping its own RxJava-to-Flow bridging.                                                                     
  - AccountVerificationActivity now launches ConversationsListActivity with FLAG_ACTIVITY_CLEAR_TOP, matching the account-chooser's own manual-switch behavior, so a stale instance already in the back     
    stack is replaced instead of left behind.                                           


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
