### PR TITLE
fix(crash): forward original exception instead of secondary handler f…

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/errorhandling/ExceptionHandler.kt
+++ b/app/src/main/java/com/nextcloud/talk/errorhandling/ExceptionHandler.kt
@@ -73,8 +73,11 @@ class ExceptionHandler(
                 }
             }
         } catch (fatal: Exception) {
+            // Forward the original crash, not this secondary failure, so crash
+            // reporting reflects why the app actually died rather than why we
+            // failed to show the crash screen for it.
             Log.e(TAG, "Fatal error in ExceptionHandler itself", fatal)
-            defaultExceptionHandler.uncaughtException(thread, fatal)
+            defaultExceptionHandler.uncaughtException(thread, exception)
             return
         }
         // Forward to the default handler so AMS records the crash as REASON_CRASH and


### PR DESCRIPTION
…ailure

When starting ShowErrorActivity fails (e.g. a system_server-side NPE in Task.getTaskWithAdjacent()), the outer catch block was forwarding that secondary failure to the default handler, masking the actual crash the app died from.

crash was:

❯ fix this crash
  Exception java.lang.NullPointerException: Attempt to invoke virtual method 'com.android.server.wm.Task com.android.server.wm.Task.getTaskWithAdjacent()' on a null object reference
    at android.os.Parcel.createExceptionOrNull (Parcel.java:3394)
    at android.os.Parcel.createException (Parcel.java:3372)
    at android.os.Parcel.readException (Parcel.java:3355)
    at android.os.Parcel.readException (Parcel.java:3297)
    at android.app.IActivityTaskManager$Stub$Proxy.startActivity (IActivityTaskManager.java:4645)
    at android.app.Instrumentation.execStartActivity (Instrumentation.java:2030)
    at android.app.ContextImpl.startActivity (ContextImpl.java:1246)
    at android.app.ContextImpl.startActivity (ContextImpl.java:1217)
    at android.content.ContextWrapper.startActivity (ContextWrapper.java:458)
    at com.nextcloud.talk.errorhandling.ExceptionHandler.uncaughtException (ExceptionHandler.kt:55)
    at java.lang.ThreadGroup.uncaughtException (ThreadGroup.java:1098)
    at java.lang.ThreadGroup.uncaughtException (ThreadGroup.java:1093)
    at java.lang.Thread.dispatchUncaughtException (Thread.java:3387)

Assisted-by: Claude Code:claude-sonnet-5

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
