### PR TITLE
avoid SocketTimeoutException by higher interval

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketInstance.kt
+++ b/app/src/main/java/com/nextcloud/talk/webrtc/WebSocketInstance.kt
@@ -533,7 +533,7 @@ class WebSocketInstance internal constructor(conversationUser: User, connectionU
         private const val TAG = "WebSocketInstance"
         private const val NORMAL_CLOSURE = 1000
         private const val ONE_SECOND: Long = 1000
-        private const val PING_INTERVAL_SECONDS: Long = 10
+        private const val PING_INTERVAL_SECONDS: Long = 30
 
         // Dedicated client with pings, so half-open WebSocket connections
         // (e.g. after a WiFi to cellular switch without TCP reset) fail and trigger the reconnect path.

--- a/app/src/test/java/com/nextcloud/talk/webrtc/WebSocketInstanceSignalingClientTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/webrtc/WebSocketInstanceSignalingClientTest.kt
@@ -29,7 +29,7 @@ class WebSocketInstanceSignalingClientTest {
         // hardcoded on purpose: fails if the ping interval in WebSocketInstance changes or is removed
         assertEquals(
             "signaling WebSocket client must send pings to detect half-open connections",
-            10_000,
+            30_000,
             signalingClient.pingIntervalMillis
         )
     }


### PR DESCRIPTION
set websocket ping interval from 10s to 30s to avoid too many of these errors:

```
2026-09-04 09:46:30.920 17696-26274 WebSocketInstance com.nextcloud.talk2EError : WebSocket 261462868 (Fix with AI) java.net.SocketTimeoutException: sent ping but didn't receive pong within 10000ms (after 2 successful ping/pongs)
	at okhttp3.internal.ws.RealWebSocket.writePingFrame$okhttp(RealWebSocket.kt:563)
	at okhttp3.internal.ws.RealWebSocket$initReaderAndWriter$lambda$3$$inlined$schedule$1.runOnce(TaskQueue.kt:219)
	at okhttp3.internal.concurrent.TaskRunner.runTask(TaskRunner.kt:116)
	at okhttp3.internal.concurrent.TaskRunner.access$runTask(TaskRunner.kt:42)
	at okhttp3.internal.concurrent.TaskRunner$runnable$1.run(TaskRunner.kt:65)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1100)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:1572)
```

followup of #6543

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
