### PR TITLE
fix(threads): show new thread immediately instead of only after reopening chat

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/data/ChatMessageRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/ChatMessageRepository.kt
@@ -142,12 +142,14 @@ interface ChatMessageRepository : LifecycleAwareManager {
         referenceId: String
     ): Flow<Result<ChatMessage?>>
 
+    @Suppress("LongParameterList")
     suspend fun addTemporaryMessage(
         message: CharSequence,
         displayName: String,
         replyTo: Int,
         sendWithoutNotification: Boolean,
-        referenceId: String
+        referenceId: String,
+        threadTitle: String?
     ): Flow<Result<ChatMessage?>>
 
     @Suppress("LongParameterList")

--- a/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/data/network/OfflineFirstChatRepository.kt
@@ -608,22 +608,17 @@ class OfflineFirstChatRepository @Inject constructor(
                 threadTitle
             )
 
-            val chatMessageModel = response.ocs?.data?.toDomainModel()
+            val messageJson = response.ocs?.data
+            val chatMessageModel = messageJson?.toDomainModel()
 
-            val sentMessage = if (this@OfflineFirstChatRepository::internalConversationId.isInitialized) {
-                chatDao
-                    .getTempMessageForConversation(
-                        internalConversationId,
-                        referenceId,
-                        threadId
-                    ).firstOrNull()
-            } else {
-                null
-            }
-
-            sentMessage?.let {
-                it.sendStatus = SendStatus.SENT_PENDING_ACK
-                chatDao.updateChatMessage(it)
+            if (messageJson != null && this@OfflineFirstChatRepository::internalConversationId.isInitialized) {
+                // Persist the authoritative response immediately (correct isThread/threadId/threadTitle
+                // included) instead of leaving the client-side guess in the temp row until the next sync -
+                // otherwise a thread indicator only appears after reopening the chat.
+                chatDao.upsertChatMessagesAndDeleteTemp(
+                    internalConversationId,
+                    listOf(messageJson.asEntity(currentUser.id!!))
+                )
             }
 
             Log.d(TAG, "sending chat message succeeded: " + message)
@@ -691,13 +686,14 @@ class OfflineFirstChatRepository @Inject constructor(
         }
     }
 
-    @Suppress("Detekt.TooGenericExceptionCaught")
+    @Suppress("Detekt.TooGenericExceptionCaught", "LongParameterList")
     override suspend fun addTemporaryMessage(
         message: CharSequence,
         displayName: String,
         replyTo: Int,
         sendWithoutNotification: Boolean,
-        referenceId: String
+        referenceId: String,
+        threadTitle: String?
     ): Flow<Result<ChatMessage?>> =
         flow {
             try {
@@ -706,7 +702,8 @@ class OfflineFirstChatRepository @Inject constructor(
                     message.toString(),
                     replyTo,
                     sendWithoutNotification,
-                    referenceId
+                    referenceId,
+                    threadTitle
                 )
                 chatDao.upsertChatMessage(tempChatMessageEntity)
             } catch (e: Exception) {
@@ -1037,12 +1034,14 @@ class OfflineFirstChatRepository @Inject constructor(
             emit(Result.failure(e))
         }
 
+    @Suppress("LongParameterList")
     private fun createChatMessageEntity(
         internalConversationId: String,
         message: String,
         replyTo: Int,
         sendWithoutNotification: Boolean,
-        referenceId: String
+        referenceId: String,
+        threadTitle: String?
     ): ChatMessageEntity {
         val currentTimeMillis = System.currentTimeMillis()
 
@@ -1063,6 +1062,8 @@ class OfflineFirstChatRepository @Inject constructor(
             internalConversationId = internalConversationId,
             id = negativeTimeOfDayMillis,
             threadId = threadId,
+            isThread = threadTitle != null,
+            threadTitle = threadTitle,
             message = message,
             deleted = false,
             token = conversationModel.token,

--- a/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
@@ -1676,6 +1676,7 @@ class ChatViewModel @AssistedInject constructor(
     private fun handleThreadMessages(chatMessageList: List<ChatMessage>): List<ChatMessage> {
         fun isThreadChildMessage(currentMessage: MutableMap.MutableEntry<Int, ChatMessage>): Boolean =
             currentMessage.value.isThread &&
+                currentMessage.value.threadId != null &&
                 currentMessage.value.threadId?.toInt() != currentMessage.value.jsonMessageId
 
         val chatMessageMap = chatMessageList.associateBy { it.jsonMessageId }.toMutableMap()

--- a/app/src/main/java/com/nextcloud/talk/chat/viewmodels/MessageInputViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/viewmodels/MessageInputViewModel.kt
@@ -166,7 +166,8 @@ class MessageInputViewModel :
                 displayName,
                 replyTo,
                 sendWithoutNotification,
-                referenceId
+                referenceId,
+                threadTitle
             ).collect { result ->
                 if (result.isSuccess) {
                     Log.d(TAG, "temp message ref id: " + (result.getOrNull()?.referenceId ?: "none"))


### PR DESCRIPTION
WIP

---

Starting a new thread showed the message as a normal chat message until the chat was reopened. Two gaps caused this:

- OfflineFirstChatRepository.sendChatMessage() discarded the server's response after a successful send and only updated the temp message's sendStatus, so the correct isThread/threadId/threadTitle from the server was never persisted until a later resync (e.g. on reopening the chat). Now the authoritative response is persisted right away, replacing the temp row.
- The optimistic temp message itself did not carry isThread/ threadTitle at all, and ChatViewModel.handleThreadMessages() misclassified that temp message (isThread=true, threadId=null, not yet confirmed by the server) as a thread reply and filtered it out of the normal chat view.

Assisted-by: Claude Code:claude-sonnet-5

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A


### 🚧 TODO

- [ ] ...

### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
