### PR TITLE
refactor(conversations): stop blocking on the current user when opening the creation screen

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationActivity.kt
@@ -106,7 +106,6 @@ import com.nextcloud.talk.models.json.autocomplete.AutocompleteUser
 import com.nextcloud.talk.passwordpolicy.PasswordPolicyField
 import com.nextcloud.talk.passwordpolicy.isPasswordAccepted
 import com.nextcloud.talk.utils.ApiUtils
-import com.nextcloud.talk.utils.CapabilitiesUtil
 import com.nextcloud.talk.utils.copyPasswordToClipboard
 import com.nextcloud.talk.utils.DisplayUtils
 import com.nextcloud.talk.utils.PickImage
@@ -118,7 +117,7 @@ import javax.inject.Inject
 class ConversationCreationActivity : BaseActivity() {
     @Inject
     lateinit var viewModelFactory: ViewModelProvider.Factory
-    private lateinit var pickImage: PickImage
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -127,18 +126,29 @@ class ConversationCreationActivity : BaseActivity() {
             this,
             viewModelFactory
         )[ConversationCreationViewModel::class.java]
-        val conversationUser = conversationCreationViewModel.currentUser
-        pickImage = PickImage(this, conversationUser)
-
         setContent {
             val colorScheme = viewThemeUtils.getColorScheme(this)
             val context = LocalContext.current
+            val currentUser by conversationCreationViewModel.currentUser.collectAsState()
             MaterialTheme(
                 colorScheme = colorScheme
             ) {
-                ConversationCreationScreen(conversationCreationViewModel, context, pickImage)
+                val user = currentUser
+                if (user == null) {
+                    LoadingScreen()
+                } else {
+                    val pickImage = remember(user) { PickImage(this@ConversationCreationActivity, user) }
+                    ConversationCreationScreen(conversationCreationViewModel, context, pickImage)
+                }
             }
         }
+    }
+}
+
+@Composable
+private fun LoadingScreen() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
     }
 }
 
@@ -357,18 +367,9 @@ fun ConversationNameAndDescription(conversationCreationViewModel: ConversationCr
     OutlinedTextField(
         value = conversationDescription.value,
         onValueChange = {
-            if (it.length > CapabilitiesUtil.conversationDescriptionLength(
-                    conversationCreationViewModel.currentUser
-                        .capabilities?.spreedCapability
-                )
-            ) {
+            if (it.length > conversationCreationViewModel.conversationDescriptionLength) {
                 conversationCreationViewModel.updateConversationDescription(
-                    it.take(
-                        CapabilitiesUtil.conversationDescriptionLength(
-                            conversationCreationViewModel.currentUser
-                                .capabilities?.spreedCapability
-                        )
-                    )
+                    it.take(conversationCreationViewModel.conversationDescriptionLength)
                 )
             } else {
                 conversationCreationViewModel.updateConversationDescription(it)
@@ -430,8 +431,11 @@ fun AddParticipants(
         }
         participants.toSet().forEach { participant ->
             Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                val imageUri = participant.id?.let {
-                    avatarUri(conversationCreationViewModel.currentUser, it, DisplayUtils.isDarkModeOn(context))
+                val avatarUser = conversationCreationViewModel.currentUser.value
+                val imageUri = if (avatarUser == null) {
+                    null
+                } else {
+                    participant.id?.let { avatarUri(avatarUser, it, DisplayUtils.isDarkModeOn(context)) }
                 }
                 val errorPlaceholderImage: Int = R.drawable.account_circle_96dp
                 val loadedImage = loadImage(imageUri, context, errorPlaceholderImage)
@@ -777,11 +781,14 @@ fun CreateConversation(conversationCreationViewModel: ConversationCreationViewMo
         onHandled = { conversationCreationViewModel.clearCreationState() }
     )
 
-    createdPublicConversation?.let { roomToken ->
+    val currentUser by conversationCreationViewModel.currentUser.collectAsState()
+    val roomToken = createdPublicConversation
+    val user = currentUser
+    if (roomToken != null && user != null) {
         ShareCreatedConversation(
             roomToken = roomToken,
             password = conversationCreationViewModel.password.value.takeIf { createdWithPassword },
-            currentUser = conversationCreationViewModel.currentUser,
+            currentUser = user,
             context = context,
             onDismiss = {
                 createdPublicConversation = null

--- a/app/src/main/java/com/nextcloud/talk/conversationcreation/viewmodel/ConversationCreationViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationcreation/viewmodel/ConversationCreationViewModel.kt
@@ -31,11 +31,15 @@ import com.nextcloud.talk.repositories.passwordpolicy.PasswordPolicyRepository
 import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.CapabilitiesUtil
 import com.nextcloud.talk.utils.SpreedFeatures
-import com.nextcloud.talk.utils.database.user.CurrentUserProviderOld
+import com.nextcloud.talk.utils.database.user.CurrentUserProvider
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -43,14 +47,14 @@ class ConversationCreationViewModel @Inject constructor(
     private val repository: ConversationCreationRepository,
     private val conversationCreator: ConversationCreator,
     private val passwordPolicyRepository: PasswordPolicyRepository,
-    private val currentUserProvider: CurrentUserProviderOld
+    currentUserProvider: CurrentUserProvider
 ) : ViewModel() {
     private val _selectedParticipants = MutableStateFlow<List<AutocompleteUser>>(emptyList())
     val selectedParticipants: StateFlow<List<AutocompleteUser>> = _selectedParticipants
     private val roomViewState = MutableStateFlow<RoomUIState>(RoomUIState.None)
     val creationState: StateFlow<RoomUIState> = roomViewState
 
-    val passwordValidation = PasswordPolicyValidator(passwordPolicyRepository, viewModelScope) { _currentUser }
+    val passwordValidation = PasswordPolicyValidator(passwordPolicyRepository, viewModelScope) { currentUser.value }
 
     private val _selectedImageUri = MutableStateFlow<Uri?>(null)
     val selectedImageUri: StateFlow<Uri?> = _selectedImageUri
@@ -64,15 +68,20 @@ class ConversationCreationViewModel @Inject constructor(
     private val _isCreatingRoom = MutableStateFlow(false)
     val isCreatingRoom: StateFlow<Boolean> = _isCreatingRoom
 
-    private val _currentUser = currentUserProvider.currentUser.blockingGet()
-    val currentUser: User = _currentUser
+    val currentUser: StateFlow<User?> = currentUserProvider.currentUserFlow
+        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
-    private val spreedCapabilities = _currentUser.capabilities?.spreedCapability
+    private val spreedCapabilities
+        get() = currentUser.value?.capabilities?.spreedCapability
 
-    val showPresetSelection = CapabilitiesUtil.hasSpreedFeatureCapability(
-        spreedCapabilities,
-        SpreedFeatures.CONVERSATION_PRESETS
-    )
+    val showPresetSelection: Boolean
+        get() = CapabilitiesUtil.hasSpreedFeatureCapability(
+            spreedCapabilities,
+            SpreedFeatures.CONVERSATION_PRESETS
+        )
+
+    val conversationDescriptionLength: Int
+        get() = CapabilitiesUtil.conversationDescriptionLength(spreedCapabilities)
 
     fun updateSelectedParticipants(participants: List<AutocompleteUser>) {
         _selectedParticipants.value = participants
@@ -112,7 +121,7 @@ class ConversationCreationViewModel @Inject constructor(
     private var presetsJob: Job? = null
 
     val isLoadingPresets: Boolean
-        get() = showPresetSelection && _presets.value is PresetsUiState.Loading
+        get() = currentUser.value == null || (showPresetSelection && _presets.value is PresetsUiState.Loading)
 
     val pinnedParameters: Set<String>
         get() = (_presets.value as? PresetsUiState.Success)
@@ -122,8 +131,11 @@ class ConversationCreationViewModel @Inject constructor(
             .orEmpty()
 
     init {
-        if (showPresetSelection) {
-            loadPresets()
+        viewModelScope.launch {
+            currentUser.filterNotNull().first()
+            if (showPresetSelection) {
+                loadPresets()
+            }
         }
     }
 
@@ -133,9 +145,10 @@ class ConversationCreationViewModel @Inject constructor(
         _presets.value = PresetsUiState.Loading
         presetsJob = viewModelScope.launch {
             try {
+                val user = currentUser.filterNotNull().first()
                 val presets = repository.getConversationPresets(
-                    ApiUtils.getCredentials(_currentUser.username, _currentUser.token),
-                    ApiUtils.getUrlForConversationPresets(_currentUser.baseUrl)
+                    ApiUtils.getCredentials(user.username, user.token),
+                    ApiUtils.getUrlForConversationPresets(user.baseUrl)
                 ).mapNotNull { ConversationPresetModel.mapToConversationPresetModel(it) }
                 _presets.value = PresetsUiState.Success(presets)
                 recomputeParams()
@@ -173,7 +186,8 @@ class ConversationCreationViewModel @Inject constructor(
         recomputeParams()
     }
 
-    val isPasswordEnforced = CapabilitiesUtil.isPasswordEnforced(spreedCapabilities)
+    val isPasswordEnforced: Boolean
+        get() = CapabilitiesUtil.isPasswordEnforced(spreedCapabilities)
 
     val isLockedDown: Boolean
         get() = conversationPreset.value in ConversationPresetId.lockedDown
@@ -225,7 +239,8 @@ class ConversationCreationViewModel @Inject constructor(
 
     @Suppress("Detekt.TooGenericExceptionCaught")
     fun createRoomAndAddParticipants() {
-        if (_isCreatingRoom.value) {
+        val user = currentUser.value
+        if (_isCreatingRoom.value || user == null) {
             return
         }
         _isCreatingRoom.value = true
@@ -234,7 +249,7 @@ class ConversationCreationViewModel @Inject constructor(
             roomViewState.value = RoomUIState.None
             try {
                 val conversation = conversationCreator.create(
-                    _currentUser,
+                    user,
                     NewConversation(
                         name = _roomName.value,
                         description = _conversationDescription.value,

--- a/app/src/main/java/com/nextcloud/talk/utils/preview/ComposePreviewUtils.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/preview/ComposePreviewUtils.kt
@@ -250,7 +250,7 @@ class ComposePreviewUtils private constructor(context: Context) {
                 repository,
                 ConversationCreator(repository),
                 PasswordPolicyRepositoryImpl(ncApiCoroutines),
-                userProvider
+                currentUserProvider
             )
         }
 }

--- a/app/src/test/java/com/nextcloud/talk/conversationcreation/ConversationCreationViewModelTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/conversationcreation/ConversationCreationViewModelTest.kt
@@ -1,0 +1,128 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.conversationcreation
+
+import com.nextcloud.talk.conversationcreation.viewmodel.ConversationCreationViewModel
+import com.nextcloud.talk.conversationcreation.viewmodel.PresetsUiState
+import com.nextcloud.talk.data.user.model.User
+import com.nextcloud.talk.models.json.capabilities.Capabilities
+import com.nextcloud.talk.models.json.capabilities.SpreedCapability
+import com.nextcloud.talk.models.json.passwordResult.PasswordResult
+import com.nextcloud.talk.repositories.passwordpolicy.PasswordPolicyRepository
+import com.nextcloud.talk.utils.SpreedFeatures
+import com.nextcloud.talk.utils.database.user.CurrentUserProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * What the creation screen's ViewModel does before and after the current user is known.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ConversationCreationViewModelTest {
+
+    private val users = MutableSharedFlow<User>(replay = 1)
+    private val repository = FakeConversationCreationRepository()
+
+    private val userProvider = object : CurrentUserProvider {
+        override val currentUserFlow: Flow<User> = users
+        override suspend fun getCurrentUser(timeout: Long): Result<User> =
+            Result.failure(UnsupportedOperationException())
+    }
+
+    private val passwordPolicyRepository = object : PasswordPolicyRepository {
+        override suspend fun validatePassword(credentials: String, url: String, password: String): PasswordResult =
+            PasswordResult(passed = true, reason = null)
+    }
+
+    private fun viewModel() =
+        ConversationCreationViewModel(
+            repository,
+            ConversationCreator(repository),
+            passwordPolicyRepository,
+            userProvider
+        )
+
+    private fun user(vararg spreedFeatures: SpreedFeatures) =
+        User(
+            username = "alice",
+            token = "token",
+            baseUrl = "https://cloud.example.com",
+            capabilities = Capabilities().apply {
+                spreedCapability = SpreedCapability().apply {
+                    features = spreedFeatures.map { it.value }
+                }
+            }
+        )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `nothing is asked of the server while the current user is unknown`() =
+        runTest {
+            val model = viewModel()
+
+            assertNull(model.currentUser.value)
+            assertEquals(0, repository.presetCalls)
+            assertTrue(model.isLoadingPresets)
+        }
+
+    @Test
+    fun `creating is refused while the current user is unknown`() =
+        runTest {
+            val model = viewModel()
+
+            model.createRoomAndAddParticipants()
+
+            assertNull(repository.bodyRequest)
+            assertNull(repository.formRequest)
+        }
+
+    @Test
+    fun `the presets are requested once the user arrives`() =
+        runTest {
+            val model = viewModel()
+
+            users.emit(user(SpreedFeatures.CONVERSATION_PRESETS))
+
+            assertEquals(1, repository.presetCalls)
+            assertTrue(model.presets.value is PresetsUiState.Success)
+            assertFalse(model.isLoadingPresets)
+        }
+
+    @Test
+    fun `a server without the capability is never asked for presets`() =
+        runTest {
+            val model = viewModel()
+
+            users.emit(user())
+
+            assertEquals(0, repository.presetCalls)
+            assertFalse(model.showPresetSelection)
+            assertFalse(model.isLoadingPresets)
+        }
+}

--- a/app/src/test/java/com/nextcloud/talk/conversationcreation/FakeConversationCreationRepository.kt
+++ b/app/src/test/java/com/nextcloud/talk/conversationcreation/FakeConversationCreationRepository.kt
@@ -26,6 +26,7 @@ class FakeConversationCreationRepository(private val token: String = "abc123") :
 
     var bodyRequest: CreateRoomRequest? = null
     var formRequest: RetrofitBucket? = null
+    var presetCalls = 0
     var passwordCalls = 0
     var descriptionCalls = 0
     var listableCalls = 0
@@ -34,8 +35,10 @@ class FakeConversationCreationRepository(private val token: String = "abc123") :
     var failPassword = false
     var failingParticipants = emptySet<String>()
 
-    override suspend fun getConversationPresets(credentials: String?, url: String): List<ConversationPreset> =
-        emptyList()
+    override suspend fun getConversationPresets(credentials: String?, url: String): List<ConversationPreset> {
+        presetCalls++
+        return emptyList()
+    }
 
     override suspend fun createRoomWithBody(credentials: String?, url: String, body: CreateRoomRequest): RoomOverall {
         bodyRequest = body


### PR DESCRIPTION
Stacked on top of #6660 and targeting its branch, so only the top commit belongs to this PR. The creation screen's ViewModel read the current user through a blocking database call in its constructor, on the main thread, which also left it untestable. It collects the deprecated provider's replacement now and waits for the user before asking the server for anything.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🚧 TODO

- [ ] nothing

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)


