### PR TITLE
feat(conversations): meet the enforced conversation password instead of demanding it

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/api/NcApiCoroutines.kt
+++ b/app/src/main/java/com/nextcloud/talk/api/NcApiCoroutines.kt
@@ -593,4 +593,10 @@ interface NcApiCoroutines {
         @Url url: String,
         @Field("password") password: String
     ): PasswordResultOverall
+
+    @GET
+    suspend fun generatePassword(
+        @Header("Authorization") authorization: String,
+        @Url url: String
+    ): PasswordResultOverall
 }

--- a/app/src/main/java/com/nextcloud/talk/api/NcApiCoroutines.kt
+++ b/app/src/main/java/com/nextcloud/talk/api/NcApiCoroutines.kt
@@ -147,6 +147,14 @@ interface NcApiCoroutines {
     @POST
     suspend fun makeRoomPublic(@Header("Authorization") authorization: String, @Url url: String): GenericOverall
 
+    @FormUrlEncoded
+    @POST
+    suspend fun makeRoomPublicWithPassword(
+        @Header("Authorization") authorization: String,
+        @Url url: String,
+        @Field("password") password: String
+    ): GenericOverall
+
     @DELETE
     suspend fun makeRoomPrivate(@Header("Authorization") authorization: String, @Url url: String): GenericOverall
 

--- a/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationActivity.kt
@@ -60,6 +60,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -595,6 +596,19 @@ fun RoomCreationOptions(conversationCreationViewModel: ConversationCreationViewM
     }
 }
 
+/**
+ * Puts a password the screen already holds through validation, so a dialog that opens on one is as
+ * ready to be saved as a typed password would be.
+ */
+@Composable
+private fun ValidateOnOpen(password: String, conversationCreationViewModel: ConversationCreationViewModel) {
+    LaunchedEffect(Unit) {
+        if (password.isNotEmpty()) {
+            conversationCreationViewModel.passwordValidation.validate(password)
+        }
+    }
+}
+
 @Composable
 fun ConversationOption(
     icon: Int? = null,
@@ -633,7 +647,8 @@ fun ConversationOption(
 @Suppress("LongMethod")
 @Composable
 fun ShowChangePassword(onDismiss: () -> Unit, conversationCreationViewModel: ConversationCreationViewModel) {
-    var changedPassword by remember { mutableStateOf("") }
+    var changedPassword by remember { mutableStateOf(conversationCreationViewModel.password.value) }
+    ValidateOnOpen(changedPassword, conversationCreationViewModel)
     val passwordValidationState by conversationCreationViewModel.passwordValidation.state
         .collectAsStateWithLifecycle()
     Dialog(onDismissRequest = {
@@ -719,7 +734,8 @@ fun ShowChangePassword(onDismiss: () -> Unit, conversationCreationViewModel: Con
 
 @Composable
 fun ShowPasswordDialog(onDismiss: () -> Unit, conversationCreationViewModel: ConversationCreationViewModel) {
-    var password by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf(conversationCreationViewModel.password.value) }
+    ValidateOnOpen(password, conversationCreationViewModel)
     val passwordValidationState by conversationCreationViewModel.passwordValidation.state
         .collectAsStateWithLifecycle()
     AlertDialog(

--- a/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreator.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreator.kt
@@ -9,17 +9,20 @@ package com.nextcloud.talk.conversationcreation
 
 import android.net.Uri
 import android.util.Log
+import org.json.JSONObject
 import androidx.core.net.toFile
 import com.nextcloud.talk.conversationcreation.data.ConversationCreationRepository
 import com.nextcloud.talk.conversationinfo.CreateRoomRequest
 import com.nextcloud.talk.conversationinfo.Participants
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.models.json.autocomplete.AutocompleteUser
+import com.nextcloud.talk.models.json.capabilities.SpreedCapability
 import com.nextcloud.talk.models.json.conversations.Conversation
 import com.nextcloud.talk.utils.ApiUtils
 import com.nextcloud.talk.utils.CapabilitiesUtil
 import com.nextcloud.talk.utils.SpreedFeatures
 import kotlinx.coroutines.CancellationException
+import retrofit2.HttpException
 import javax.inject.Inject
 
 /**
@@ -41,6 +44,11 @@ data class NewConversation(
 }
 
 /**
+ * What the server answered when it refused to create a conversation.
+ */
+class ConversationRefusedException(override val message: String, cause: Throwable) : Exception(message, cause)
+
+/**
  * Creates conversations on the server, in a single request where the server supports all creation
  * parameters and with follow up requests otherwise.
  */
@@ -53,20 +61,7 @@ class ConversationCreator @Inject constructor(private val repository: Conversati
         val apiVersion = ApiUtils.getConversationApiVersion(user, intArrayOf(ApiUtils.API_V4, ApiUtils.API_V1))
         val context = RequestContext(user, credentials, apiVersion)
 
-        val conversation = if (
-            CapabilitiesUtil.hasSpreedFeatureCapability(capabilities, SpreedFeatures.CONVERSATION_CREATION_ALL)
-        ) {
-            createWithAllParameters(
-                context,
-                newConversation,
-                CapabilitiesUtil.hasSpreedFeatureCapability(
-                    capabilities,
-                    SpreedFeatures.CONVERSATION_CREATION_PASSWORD
-                )
-            )
-        } else {
-            createWithFollowUpRequests(context, newConversation)
-        }
+        val conversation = createConversation(context, newConversation, capabilities)
 
         conversation?.token?.let { token ->
             try {
@@ -79,6 +74,47 @@ class ConversationCreator @Inject constructor(private val repository: Conversati
         }
         return conversation
     }
+
+    private suspend fun createConversation(
+        context: RequestContext,
+        newConversation: NewConversation,
+        capabilities: SpreedCapability?
+    ): Conversation? =
+        try {
+            if (CapabilitiesUtil.hasSpreedFeatureCapability(capabilities, SpreedFeatures.CONVERSATION_CREATION_ALL)) {
+                createWithAllParameters(
+                    context,
+                    newConversation,
+                    CapabilitiesUtil.hasSpreedFeatureCapability(
+                        capabilities,
+                        SpreedFeatures.CONVERSATION_CREATION_PASSWORD
+                    )
+                )
+            } else {
+                createWithFollowUpRequests(context, newConversation)
+            }
+        } catch (e: HttpException) {
+            refusalMessage(e)?.let { throw ConversationRefusedException(it, e) }
+            throw e
+        }
+
+    /**
+     * The room endpoint reports why it refused in the OCS data as
+     * `{"ocs":{"data":{"error":"<reason>","message":"<hint>"}}}`.
+     */
+    @Suppress("Detekt.TooGenericExceptionCaught")
+    private fun refusalMessage(e: HttpException): String? =
+        try {
+            e.response()?.errorBody()?.string()
+                ?.let { JSONObject(it) }
+                ?.optJSONObject("ocs")
+                ?.optJSONObject("data")
+                ?.optString("message")
+                ?.takeIf { it.isNotEmpty() }
+        } catch (exception: Exception) {
+            Log.w(TAG, "Could not read why the server refused to create the conversation", exception)
+            null
+        }
 
     private suspend fun createWithAllParameters(
         context: RequestContext,

--- a/app/src/main/java/com/nextcloud/talk/conversationcreation/ui/CreatedConversation.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationcreation/ui/CreatedConversation.kt
@@ -72,14 +72,17 @@ fun CreationResultEffect(
 @Suppress("LongParameterList")
 @Composable
 fun ShareCreatedConversation(
-    roomToken: String,
+    roomToken: String?,
     password: String?,
-    currentUser: User,
+    currentUser: User?,
     context: Context,
-    onDismiss: () -> Unit
+    onDismiss: (roomToken: String) -> Unit
 ) {
+    if (roomToken == null || currentUser == null) {
+        return
+    }
     AlertDialog(
-        onDismissRequest = onDismiss,
+        onDismissRequest = { onDismiss(roomToken) },
         title = { Text(text = stringResource(R.string.nc_conversation_created_title)) },
         text = {
             Column {
@@ -108,7 +111,7 @@ fun ShareCreatedConversation(
             }
         },
         confirmButton = {
-            TextButton(onClick = onDismiss) {
+            TextButton(onClick = { onDismiss(roomToken) }) {
                 Text(text = stringResource(R.string.nc_open_conversation))
             }
         }

--- a/app/src/main/java/com/nextcloud/talk/conversationcreation/ui/CreatedConversation.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationcreation/ui/CreatedConversation.kt
@@ -43,7 +43,12 @@ fun CreationResultEffect(
     LaunchedEffect(creationState) {
         when (val state = creationState) {
             is RoomUIState.Error -> {
-                Toast.makeText(context, R.string.nc_common_error_sorry, Toast.LENGTH_LONG).show()
+                val reason = state.serverMessage?.takeIf { it.isNotBlank() }
+                if (reason == null) {
+                    Toast.makeText(context, R.string.nc_common_error_sorry, Toast.LENGTH_LONG).show()
+                } else {
+                    Toast.makeText(context, reason, Toast.LENGTH_LONG).show()
+                }
                 onHandled()
             }
 

--- a/app/src/main/java/com/nextcloud/talk/conversationcreation/viewmodel/ConversationCreationViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationcreation/viewmodel/ConversationCreationViewModel.kt
@@ -16,6 +16,7 @@ import androidx.lifecycle.viewModelScope
 import com.nextcloud.talk.conversationcreation.ConversationCreator
 import com.nextcloud.talk.conversationcreation.ConversationParameter
 import com.nextcloud.talk.conversationcreation.ConversationPresetId
+import com.nextcloud.talk.conversationcreation.ConversationRefusedException
 import com.nextcloud.talk.conversationcreation.ConversationPresetModel
 import com.nextcloud.talk.conversationcreation.CreateConversationParams
 import com.nextcloud.talk.conversationcreation.NewConversation
@@ -266,10 +267,14 @@ class ConversationCreationViewModel @Inject constructor(
                 if (!token.isNullOrEmpty()) {
                     roomViewState.value = RoomUIState.Success(conversation)
                 } else {
-                    roomViewState.value = RoomUIState.Error("Conversation is null")
+                    roomViewState.value = RoomUIState.Error()
+                    Log.e(TAG, "The created conversation came back without a token")
                 }
+            } catch (e: ConversationRefusedException) {
+                roomViewState.value = RoomUIState.Error(e.message)
+                Log.e(TAG, "The server refused to create the conversation", e)
             } catch (e: Exception) {
-                roomViewState.value = RoomUIState.Error(e.message ?: "Unknown error")
+                roomViewState.value = RoomUIState.Error()
                 Log.e(TAG, "Error - ${e.message}")
             } finally {
                 _isCreatingRoom.value = false
@@ -295,7 +300,7 @@ sealed interface PresetsUiState {
 sealed class RoomUIState {
     data object None : RoomUIState()
     data class Success(val conversation: Conversation?) : RoomUIState()
-    data class Error(val message: String) : RoomUIState()
+    data class Error(val serverMessage: String? = null) : RoomUIState()
 }
 
 sealed class AddParticipantsUiState {

--- a/app/src/main/java/com/nextcloud/talk/conversationcreation/viewmodel/ConversationCreationViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationcreation/viewmodel/ConversationCreationViewModel.kt
@@ -27,6 +27,7 @@ import com.nextcloud.talk.conversationcreation.parametersOf
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.models.json.autocomplete.AutocompleteUser
 import com.nextcloud.talk.models.json.conversations.Conversation
+import com.nextcloud.talk.passwordpolicy.PasswordGenerator
 import com.nextcloud.talk.passwordpolicy.PasswordPolicyValidator
 import com.nextcloud.talk.repositories.passwordpolicy.PasswordPolicyRepository
 import com.nextcloud.talk.utils.ApiUtils
@@ -56,6 +57,8 @@ class ConversationCreationViewModel @Inject constructor(
     val creationState: StateFlow<RoomUIState> = roomViewState
 
     val passwordValidation = PasswordPolicyValidator(passwordPolicyRepository, viewModelScope) { currentUser.value }
+
+    private val passwordGenerator = PasswordGenerator(passwordPolicyRepository)
 
     private val _selectedImageUri = MutableStateFlow<Uri?>(null)
     val selectedImageUri: StateFlow<Uri?> = _selectedImageUri
@@ -202,6 +205,10 @@ class ConversationCreationViewModel @Inject constructor(
     val isOpenForGuestAppUsers: Boolean
         get() = conversationParams.value.listable == CreateConversationParams.LISTABLE_ALL
 
+    /**
+     * Where the server enforces a password, one is generated as guests are let in, instead of
+     * leaving the user with a requirement to satisfy themselves.
+     */
     fun allowGuests(allow: Boolean) {
         val roomType = if (allow) {
             CreateConversationParams.ROOM_TYPE_PUBLIC
@@ -210,6 +217,11 @@ class ConversationCreationViewModel @Inject constructor(
         }
         parametersChosenByUser.value += ConversationParameter.ROOM_TYPE to roomType
         recomputeParams()
+
+        val user = currentUser.value
+        if (allow && user != null && isPasswordEnforced && _password.value.isEmpty()) {
+            viewModelScope.launch { _password.value = passwordGenerator.generate(user) }
+        }
     }
 
     fun openConversationToRegisteredUsers(open: Boolean) {

--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
@@ -350,18 +350,16 @@ class ConversationInfoActivity : BaseActivity() {
             },
             onPasswordProtectionClick = {
                 val user = conversationUser ?: return@ConversationInfoScreenCallbacks
-                when {
-                    !viewModel.uiState.value.hasPassword -> onPasswordRequest(PasswordRequest.SET)
-                    isPasswordEnforced() -> showSnackbar(R.string.nc_password_required)
-                    else -> {
-                        val apiVersion =
-                            ApiUtils.getConversationApiVersion(user, intArrayOf(ApiUtils.API_V4, ApiUtils.API_V1))
-                        viewModel.setPassword(
-                            user = user,
-                            url = ApiUtils.getUrlForRoomPassword(apiVersion, user.baseUrl!!, conversationToken),
-                            password = ""
-                        )
-                    }
+                if (!viewModel.uiState.value.hasPassword) {
+                    onPasswordRequest(PasswordRequest.SET)
+                } else {
+                    val apiVersion =
+                        ApiUtils.getConversationApiVersion(user, intArrayOf(ApiUtils.API_V4, ApiUtils.API_V1))
+                    viewModel.setPassword(
+                        user = user,
+                        url = ApiUtils.getUrlForRoomPassword(apiVersion, user.baseUrl!!, conversationToken),
+                        password = ""
+                    )
                 }
             },
             onResendInvitationsClick = {

--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/ConversationInfoActivity.kt
@@ -13,6 +13,7 @@ import android.util.Log
 import androidx.activity.compose.setContent
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -253,26 +254,26 @@ class ConversationInfoActivity : BaseActivity() {
                 }
             }
 
-            var showPasswordDialog by remember { mutableStateOf(false) }
+            var passwordRequest by remember { mutableStateOf<PasswordRequest?>(null) }
 
             MaterialTheme(colorScheme = colorScheme) {
                 ColoredStatusBar()
                 ConversationInfoScreen(
                     state = uiState,
-                    callbacks = buildCallbacks(onShowPasswordDialog = { showPasswordDialog = true })
+                    callbacks = buildCallbacks(onPasswordRequest = { passwordRequest = it })
                 )
-                if (showPasswordDialog) {
+                passwordRequest?.let { request ->
                     val validationState by viewModel.passwordValidation.state.collectAsStateWithLifecycle()
                     GuestAccessPasswordDialog(
                         validationState = validationState,
                         onPasswordChanged = viewModel.passwordValidation::validate,
                         onDismiss = {
-                            showPasswordDialog = false
+                            passwordRequest = null
                             viewModel.passwordValidation.reset()
                         },
                         onSave = { password, copyAfterSave ->
-                            onGuestPasswordSave(password, copyAfterSave)
-                            showPasswordDialog = false
+                            onGuestPasswordSave(request, password, copyAfterSave)
+                            passwordRequest = null
                             viewModel.passwordValidation.reset()
                         }
                     )
@@ -281,17 +282,29 @@ class ConversationInfoActivity : BaseActivity() {
         }
     }
 
-    private fun onGuestPasswordSave(password: String, copyAfterSave: Boolean) {
+    private fun onGuestPasswordSave(request: PasswordRequest, password: String, copyAfterSave: Boolean) {
         val user = conversationUser ?: return
         if (copyAfterSave) {
             copyPassword(password)
         }
-        val apiVersion = ApiUtils.getConversationApiVersion(user, intArrayOf(ApiUtils.API_V4, ApiUtils.API_V1))
-        viewModel.setPassword(
-            user = user,
-            url = ApiUtils.getUrlForRoomPassword(apiVersion, user.baseUrl!!, conversationToken),
-            password = password
-        )
+        when (request) {
+            PasswordRequest.SET -> {
+                val apiVersion = ApiUtils.getConversationApiVersion(user, intArrayOf(ApiUtils.API_V4, ApiUtils.API_V1))
+                viewModel.setPassword(
+                    user = user,
+                    url = ApiUtils.getUrlForRoomPassword(apiVersion, user.baseUrl!!, conversationToken),
+                    password = password
+                )
+            }
+            PasswordRequest.ALLOW_GUESTS -> viewModel.allowGuests(user, conversationToken, true, password)
+        }
+    }
+
+    private fun isPasswordEnforced(): Boolean =
+        CapabilitiesUtil.isPasswordEnforced(viewModel.uiState.value.spreedCapabilities)
+
+    private fun showSnackbar(@StringRes messageRes: Int) {
+        lifecycleScope.launch { viewModel.emitSnackbar(messageRes) }
     }
 
     private fun copyPassword(password: String) {
@@ -303,7 +316,7 @@ class ConversationInfoActivity : BaseActivity() {
     }
 
     @Suppress("LongMethod", "CyclomaticComplexMethod")
-    private fun buildCallbacks(onShowPasswordDialog: () -> Unit) =
+    private fun buildCallbacks(onPasswordRequest: (PasswordRequest) -> Unit) =
         ConversationInfoScreenCallbacks(
             onNavigateBack = { onBackPressedDispatcher.onBackPressed() },
             onEditConversation = {
@@ -327,20 +340,28 @@ class ConversationInfoActivity : BaseActivity() {
             onLobbyTimerClick = { showLobbyTimerDialog() },
             onAllowGuestsClick = {
                 val user = conversationUser ?: return@ConversationInfoScreenCallbacks
-                viewModel.allowGuests(user, conversationToken, !viewModel.uiState.value.guestsAllowed)
+                val state = viewModel.uiState.value
+                val allow = !state.guestsAllowed
+                if (allow && isPasswordEnforced() && !state.hasPassword) {
+                    onPasswordRequest(PasswordRequest.ALLOW_GUESTS)
+                } else {
+                    viewModel.allowGuests(user, conversationToken, allow)
+                }
             },
             onPasswordProtectionClick = {
                 val user = conversationUser ?: return@ConversationInfoScreenCallbacks
-                if (viewModel.uiState.value.hasPassword) {
-                    val apiVersion =
-                        ApiUtils.getConversationApiVersion(user, intArrayOf(ApiUtils.API_V4, ApiUtils.API_V1))
-                    viewModel.setPassword(
-                        user = user,
-                        url = ApiUtils.getUrlForRoomPassword(apiVersion, user.baseUrl!!, conversationToken),
-                        password = ""
-                    )
-                } else {
-                    onShowPasswordDialog()
+                when {
+                    !viewModel.uiState.value.hasPassword -> onPasswordRequest(PasswordRequest.SET)
+                    isPasswordEnforced() -> showSnackbar(R.string.nc_password_required)
+                    else -> {
+                        val apiVersion =
+                            ApiUtils.getConversationApiVersion(user, intArrayOf(ApiUtils.API_V4, ApiUtils.API_V1))
+                        viewModel.setPassword(
+                            user = user,
+                            url = ApiUtils.getUrlForRoomPassword(apiVersion, user.baseUrl!!, conversationToken),
+                            password = ""
+                        )
+                    }
                 }
             },
             onResendInvitationsClick = {
@@ -819,7 +840,7 @@ class ConversationInfoActivity : BaseActivity() {
         } else {
             R.string.nc_participant_type_change_failed
         }
-        lifecycleScope.launch { viewModel.emitSnackbar(messageRes) }
+        showSnackbar(messageRes)
     }
 
     /**
@@ -896,6 +917,14 @@ class ConversationInfoActivity : BaseActivity() {
         private const val PARTICIPANT_TYPE_MODERATOR: Int = 2
         private const val PARTICIPANT_TYPE_USER: Int = 3
     }
+}
+
+/**
+ * What a password the user is asked for is meant to do, since the same dialog serves both.
+ */
+private enum class PasswordRequest {
+    SET,
+    ALLOW_GUESTS
 }
 
 @Composable

--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/ui/ConversationInfoScreen.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/ui/ConversationInfoScreen.kt
@@ -91,6 +91,7 @@ import com.nextcloud.talk.models.json.participants.Participant
 import com.nextcloud.talk.models.json.status.StatusType
 import com.nextcloud.talk.ui.StatusDrawable
 import com.nextcloud.talk.utils.ApiUtils
+import com.nextcloud.talk.utils.CapabilitiesUtil
 import com.nextcloud.talk.utils.DisplayUtils
 import com.nextcloud.talk.utils.ParticipantRole
 import com.nextcloud.talk.utils.ParticipantRoleUtils
@@ -558,10 +559,17 @@ private fun GuestAccessSection(state: ConversationInfoUiState, callbacks: Conver
         onClick = callbacks.onAllowGuestsClick
     )
     if (state.showPasswordProtection) {
+        val isPasswordEnforced = CapabilitiesUtil.isPasswordEnforced(state.spreedCapabilities)
+        val isLocked = state.hasPassword && isPasswordEnforced
         SettingsRow(
             title = stringResource(R.string.nc_guest_access_password_title),
-            subtitle = stringResource(R.string.nc_guest_access_password_summary),
+            subtitle = if (isLocked) {
+                stringResource(R.string.nc_password_required)
+            } else {
+                stringResource(R.string.nc_guest_access_password_summary)
+            },
             checked = state.hasPassword,
+            enabled = !isLocked,
             onClick = callbacks.onPasswordProtectionClick
         )
     }

--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/viewmodel/ConversationInfoViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/viewmodel/ConversationInfoViewModel.kt
@@ -564,16 +564,23 @@ class ConversationInfoViewModel @Inject constructor(
     }
 
     @Suppress("Detekt.TooGenericExceptionCaught")
-    fun allowGuests(user: User, token: String, allow: Boolean) {
+    fun allowGuests(user: User, token: String, allow: Boolean, password: String = "") {
         val previous = _uiState.value.guestsAllowed
-        _uiState.update { it.copy(guestsAllowed = allow) }
+        val previousHasPassword = _uiState.value.hasPassword
+        _uiState.update { it.copy(guestsAllowed = allow, hasPassword = it.hasPassword || password.isNotEmpty()) }
         viewModelScope.launch {
             try {
                 val apiVersion = ApiUtils.getConversationApiVersion(user, intArrayOf(ApiUtils.API_V4, ApiUtils.API_V1))
                 val url = ApiUtils.getUrlForRoomPublic(apiVersion, user.baseUrl!!, token)
-                conversationsRepository.allowGuests(user = user, url = url, token = token, allow = allow)
+                conversationsRepository.allowGuests(
+                    user = user,
+                    url = url,
+                    token = token,
+                    allow = allow,
+                    password = password
+                )
             } catch (exception: Exception) {
-                _uiState.update { it.copy(guestsAllowed = previous) }
+                _uiState.update { it.copy(guestsAllowed = previous, hasPassword = previousHasPassword) }
                 _uiEvent.emit(ConversationInfoUiEvent.ShowSnackbar(R.string.nc_guest_access_allow_failed))
                 Log.e(TAG, "Error allowing guests", exception)
             }

--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/viewmodel/ConversationInfoViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/viewmodel/ConversationInfoViewModel.kt
@@ -567,8 +567,9 @@ class ConversationInfoViewModel @Inject constructor(
     fun allowGuests(user: User, token: String, allow: Boolean, password: String = "") {
         val previous = _uiState.value.guestsAllowed
         val previousHasPassword = _uiState.value.hasPassword
+        val previousShowPasswordProtection = _uiState.value.showPasswordProtection
         val hasPassword = allow && (_uiState.value.hasPassword || password.isNotEmpty())
-        _uiState.update { it.copy(guestsAllowed = allow, hasPassword = hasPassword) }
+        _uiState.update { it.copy(guestsAllowed = allow, hasPassword = hasPassword, showPasswordProtection = allow) }
         viewModelScope.launch {
             try {
                 val apiVersion = ApiUtils.getConversationApiVersion(user, intArrayOf(ApiUtils.API_V4, ApiUtils.API_V1))
@@ -581,7 +582,13 @@ class ConversationInfoViewModel @Inject constructor(
                     password = password
                 )
             } catch (exception: Exception) {
-                _uiState.update { it.copy(guestsAllowed = previous, hasPassword = previousHasPassword) }
+                _uiState.update {
+                    it.copy(
+                        guestsAllowed = previous,
+                        hasPassword = previousHasPassword,
+                        showPasswordProtection = previousShowPasswordProtection
+                    )
+                }
                 _uiEvent.emit(ConversationInfoUiEvent.ShowSnackbar(R.string.nc_guest_access_allow_failed))
                 Log.e(TAG, "Error allowing guests", exception)
             }

--- a/app/src/main/java/com/nextcloud/talk/conversationinfo/viewmodel/ConversationInfoViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationinfo/viewmodel/ConversationInfoViewModel.kt
@@ -567,7 +567,8 @@ class ConversationInfoViewModel @Inject constructor(
     fun allowGuests(user: User, token: String, allow: Boolean, password: String = "") {
         val previous = _uiState.value.guestsAllowed
         val previousHasPassword = _uiState.value.hasPassword
-        _uiState.update { it.copy(guestsAllowed = allow, hasPassword = it.hasPassword || password.isNotEmpty()) }
+        val hasPassword = allow && (_uiState.value.hasPassword || password.isNotEmpty())
+        _uiState.update { it.copy(guestsAllowed = allow, hasPassword = hasPassword) }
         viewModelScope.launch {
             try {
                 val apiVersion = ApiUtils.getConversationApiVersion(user, intArrayOf(ApiUtils.API_V4, ApiUtils.API_V1))

--- a/app/src/main/java/com/nextcloud/talk/models/json/capabilities/PasswordApi.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/capabilities/PasswordApi.kt
@@ -16,8 +16,10 @@ import kotlinx.parcelize.Parcelize
 @JsonObject
 data class PasswordApi(
     @JsonField(name = ["validate"])
-    var validatePasswordApi: String?
+    var validatePasswordApi: String?,
+    @JsonField(name = ["generate"])
+    var generatePasswordApi: String? = null
 ) : Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
-    constructor() : this(null)
+    constructor() : this(null, null)
 }

--- a/app/src/main/java/com/nextcloud/talk/models/json/passwordResult/PasswordResult.kt
+++ b/app/src/main/java/com/nextcloud/talk/models/json/passwordResult/PasswordResult.kt
@@ -18,8 +18,10 @@ data class PasswordResult(
     @JsonField(name = ["passed"])
     var passed: Boolean?,
     @JsonField(name = ["reason"])
-    var reason: String?
+    var reason: String?,
+    @JsonField(name = ["password"])
+    var password: String? = null
 ) : Parcelable {
     // This constructor is added to work with the 'com.bluelinelabs.logansquare.annotation.JsonObject'
-    constructor() : this(null, null)
+    constructor() : this(null, null, null)
 }

--- a/app/src/main/java/com/nextcloud/talk/passwordpolicy/PasswordGenerator.kt
+++ b/app/src/main/java/com/nextcloud/talk/passwordpolicy/PasswordGenerator.kt
@@ -1,0 +1,64 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.nextcloud.talk.passwordpolicy
+
+import android.util.Log
+import com.nextcloud.talk.data.user.model.User
+import com.nextcloud.talk.repositories.passwordpolicy.PasswordPolicyRepository
+import com.nextcloud.talk.utils.ApiUtils
+import com.nextcloud.talk.utils.CapabilitiesUtil
+import kotlinx.coroutines.CancellationException
+import java.security.SecureRandom
+
+/**
+ * Provides a password for a screen that needs one, from the server's own generator where the
+ * account advertises it and locally otherwise. What it returns is still subject to
+ * [PasswordPolicyValidator], which is what decides whether the server accepts it.
+ */
+class PasswordGenerator(private val repository: PasswordPolicyRepository) {
+
+    private val random = SecureRandom()
+
+    suspend fun generate(user: User): String = fromServer(user) ?: locally()
+
+    @Suppress("Detekt.TooGenericExceptionCaught")
+    private suspend fun fromServer(user: User): String? {
+        val url = CapabilitiesUtil.getPasswordGenerationUrl(user) ?: return null
+        val credentials = ApiUtils.getCredentials(user.username, user.token) ?: ""
+        return try {
+            repository.generatePassword(credentials, url).takeIf { it.isNotEmpty() }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (exception: Exception) {
+            Log.e(TAG, "Failed to have the server generate a password", exception)
+            null
+        }
+    }
+
+    /**
+     * The password policy capability is persisted with the account, so it stays absent until the
+     * capabilities are refreshed, which makes this a fallback rather than an error path.
+     */
+    private fun locally(): String {
+        val alphabet = LOWERCASE + UPPERCASE + DIGITS + SPECIAL
+        val mandatory = listOf(LOWERCASE, UPPERCASE, DIGITS, SPECIAL).map { it.random() }
+        val rest = List(LENGTH - mandatory.size) { alphabet.random() }
+        return (mandatory + rest).shuffled(random).joinToString("")
+    }
+
+    private fun String.random(): Char = this[random.nextInt(length)]
+
+    companion object {
+        private val TAG = PasswordGenerator::class.java.simpleName
+        private const val LENGTH = 16
+        private const val LOWERCASE = "abcdefghijkmnopqrstuvwxyz"
+        private const val UPPERCASE = "ABCDEFGHJKLMNPQRSTUVWXYZ"
+        private const val DIGITS = "23456789"
+        private const val SPECIAL = "!@#$%&*+-=?"
+    }
+}

--- a/app/src/main/java/com/nextcloud/talk/repositories/conversations/ConversationsRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/repositories/conversations/ConversationsRepository.kt
@@ -17,7 +17,13 @@ import io.reactivex.Observable
 
 interface ConversationsRepository {
 
-    suspend fun allowGuests(user: User, url: String, token: String, allow: Boolean): GenericOverall
+    suspend fun allowGuests(
+        user: User,
+        url: String,
+        token: String,
+        allow: Boolean,
+        password: String = ""
+    ): GenericOverall
 
     data class ResendInvitationsResult(val successful: Boolean)
     fun resendInvitations(user: User, url: String): Observable<ResendInvitationsResult>

--- a/app/src/main/java/com/nextcloud/talk/repositories/conversations/ConversationsRepositoryImpl.kt
+++ b/app/src/main/java/com/nextcloud/talk/repositories/conversations/ConversationsRepositoryImpl.kt
@@ -17,19 +17,36 @@ import com.nextcloud.talk.models.json.participants.TalkBan
 import com.nextcloud.talk.models.json.profile.Profile
 import com.nextcloud.talk.repositories.conversations.ConversationsRepository.ResendInvitationsResult
 import com.nextcloud.talk.utils.ApiUtils
+import com.nextcloud.talk.utils.CapabilitiesUtil
+import com.nextcloud.talk.utils.SpreedFeatures
 import io.reactivex.Observable
 
 class ConversationsRepositoryImpl(private val api: NcApi, private val coroutineApi: NcApiCoroutines) :
     ConversationsRepository {
-    override suspend fun allowGuests(user: User, url: String, token: String, allow: Boolean): GenericOverall {
+    override suspend fun allowGuests(
+        user: User,
+        url: String,
+        token: String,
+        allow: Boolean,
+        password: String
+    ): GenericOverall {
         val credentials = ApiUtils.getCredentials(user.username, user.token)!!
-        val result: GenericOverall = if (allow) {
-            coroutineApi.makeRoomPublic(
+        val sendsPassword = password.isNotEmpty() &&
+            CapabilitiesUtil.hasSpreedFeatureCapability(
+                user.capabilities?.spreedCapability,
+                SpreedFeatures.CONVERSATION_CREATION_PASSWORD
+            )
+        val result: GenericOverall = when {
+            allow && sendsPassword -> coroutineApi.makeRoomPublicWithPassword(
+                credentials,
+                url,
+                password
+            )
+            allow -> coroutineApi.makeRoomPublic(
                 credentials,
                 url
             )
-        } else {
-            coroutineApi.makeRoomPrivate(
+            else -> coroutineApi.makeRoomPrivate(
                 credentials,
                 url
             )

--- a/app/src/main/java/com/nextcloud/talk/repositories/passwordpolicy/PasswordPolicyRepository.kt
+++ b/app/src/main/java/com/nextcloud/talk/repositories/passwordpolicy/PasswordPolicyRepository.kt
@@ -17,4 +17,12 @@ interface PasswordPolicyRepository {
      * @throws IllegalStateException if the server answers without a result
      */
     suspend fun validatePassword(credentials: String, url: String, password: String): PasswordResult
+
+    /**
+     * Asks the server for a password that satisfies the policy it advertises.
+     *
+     * @param url the generation endpoint taken from the password_policy capability
+     * @throws IllegalStateException if the server answers without a password
+     */
+    suspend fun generatePassword(credentials: String, url: String): String
 }

--- a/app/src/main/java/com/nextcloud/talk/repositories/passwordpolicy/PasswordPolicyRepositoryImpl.kt
+++ b/app/src/main/java/com/nextcloud/talk/repositories/passwordpolicy/PasswordPolicyRepositoryImpl.kt
@@ -17,4 +17,8 @@ class PasswordPolicyRepositoryImpl @Inject constructor(private val ncApiCoroutin
     override suspend fun validatePassword(credentials: String, url: String, password: String): PasswordResult =
         ncApiCoroutines.validatePassword(credentials, url, password).ocs?.data
             ?: throw IllegalStateException("The password validation response carried no result")
+
+    override suspend fun generatePassword(credentials: String, url: String): String =
+        ncApiCoroutines.generatePassword(credentials, url).ocs?.data?.password
+            ?: throw IllegalStateException("The password generation response carried no password")
 }

--- a/app/src/main/java/com/nextcloud/talk/utils/CapabilitiesUtil.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/CapabilitiesUtil.kt
@@ -115,6 +115,12 @@ object CapabilitiesUtil {
      */
     fun getPasswordValidationUrl(user: User?): String? = user?.capabilities?.passwordPolicy?.api?.validatePasswordApi
 
+    /**
+     * The endpoint that generates a password satisfying the server's policy, or null when the
+     * server does not advertise the password_policy capability.
+     */
+    fun getPasswordGenerationUrl(user: User?): String? = user?.capabilities?.passwordPolicy?.api?.generatePasswordApi
+
     // endregion
 
     //region SpreedCapabilities

--- a/app/src/test/java/com/nextcloud/talk/conversationcreation/ConversationCreationViewModelTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/conversationcreation/ConversationCreationViewModelTest.kt
@@ -11,8 +11,9 @@ import com.nextcloud.talk.conversationcreation.viewmodel.PresetsUiState
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.models.json.capabilities.Capabilities
 import com.nextcloud.talk.models.json.capabilities.SpreedCapability
-import com.nextcloud.talk.models.json.passwordResult.PasswordResult
-import com.nextcloud.talk.repositories.passwordpolicy.PasswordPolicyRepository
+import com.nextcloud.talk.models.json.capabilities.PasswordApi
+import com.nextcloud.talk.models.json.capabilities.PasswordPolicy
+import com.nextcloud.talk.passwordpolicy.FakePasswordPolicyRepository
 import com.nextcloud.talk.utils.SpreedFeatures
 import com.nextcloud.talk.utils.database.user.CurrentUserProvider
 import kotlinx.coroutines.Dispatchers
@@ -46,10 +47,7 @@ class ConversationCreationViewModelTest {
             Result.failure(UnsupportedOperationException())
     }
 
-    private val passwordPolicyRepository = object : PasswordPolicyRepository {
-        override suspend fun validatePassword(credentials: String, url: String, password: String): PasswordResult =
-            PasswordResult(passed = true, reason = null)
-    }
+    private val passwordPolicyRepository = FakePasswordPolicyRepository()
 
     private fun viewModel() =
         ConversationCreationViewModel(
@@ -59,7 +57,7 @@ class ConversationCreationViewModelTest {
             userProvider
         )
 
-    private fun user(vararg spreedFeatures: SpreedFeatures) =
+    private fun user(vararg spreedFeatures: SpreedFeatures, passwordEnforced: Boolean = false) =
         User(
             username = "alice",
             token = "token",
@@ -67,7 +65,14 @@ class ConversationCreationViewModelTest {
             capabilities = Capabilities().apply {
                 spreedCapability = SpreedCapability().apply {
                     features = spreedFeatures.map { it.value }
+                    config = hashMapOf("conversations" to hashMapOf("force-passwords" to passwordEnforced))
                 }
+                passwordPolicy = PasswordPolicy(
+                    PasswordApi(
+                        validatePasswordApi = "https://cloud.example.com/validate",
+                        generatePasswordApi = "https://cloud.example.com/generate"
+                    )
+                )
             }
         )
 
@@ -112,6 +117,44 @@ class ConversationCreationViewModelTest {
             assertEquals(1, repository.presetCalls)
             assertTrue(model.presets.value is PresetsUiState.Success)
             assertFalse(model.isLoadingPresets)
+        }
+
+    @Test
+    fun `opening a conversation to guests generates the password the server enforces`() =
+        runTest {
+            passwordPolicyRepository.generatedPassword = "generated"
+            val model = viewModel()
+            users.emit(user(passwordEnforced = true))
+
+            model.allowGuests(true)
+
+            assertEquals("generated", model.password.value)
+        }
+
+    @Test
+    fun `a password the user typed is left alone`() =
+        runTest {
+            passwordPolicyRepository.generatedPassword = "generated"
+            val model = viewModel()
+            users.emit(user(passwordEnforced = true))
+            model.updatePassword("hunter2")
+
+            model.allowGuests(true)
+
+            assertEquals("hunter2", model.password.value)
+        }
+
+    @Test
+    fun `no password is generated where the server does not enforce one`() =
+        runTest {
+            passwordPolicyRepository.generatedPassword = "generated"
+            val model = viewModel()
+            users.emit(user())
+
+            model.allowGuests(true)
+
+            assertEquals("", model.password.value)
+            assertNull(passwordPolicyRepository.generationUrl)
         }
 
     @Test

--- a/app/src/test/java/com/nextcloud/talk/conversationinfo/viewmodel/ConversationInfoViewModelTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/conversationinfo/viewmodel/ConversationInfoViewModelTest.kt
@@ -7,12 +7,93 @@
 
 package com.nextcloud.talk.conversationinfo.viewmodel
 
+import com.nextcloud.talk.api.NcApi
+import com.nextcloud.talk.chat.data.network.ChatNetworkDataSource
 import com.nextcloud.talk.conversationinfo.model.ParticipantModel
+import com.nextcloud.talk.data.user.model.User
+import com.nextcloud.talk.models.json.capabilities.Capabilities
+import com.nextcloud.talk.models.json.capabilities.SpreedCapability
 import com.nextcloud.talk.models.json.participants.Participant
+import com.nextcloud.talk.repositories.passwordpolicy.PasswordPolicyRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.mock
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ConversationInfoViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private val user = User(
+        username = "alice",
+        token = "token",
+        baseUrl = "https://cloud.example.com",
+        capabilities = Capabilities().apply {
+            spreedCapability = SpreedCapability().apply {
+                features = listOf("conversation-v4")
+            }
+        }
+    )
+
+    private fun viewModel(repository: FakeConversationsRepository) =
+        ConversationInfoViewModel(
+            chatNetworkDataSource = mock<ChatNetworkDataSource>(),
+            conversationsRepository = repository,
+            ncApi = mock<NcApi>(),
+            passwordPolicyRepository = mock<PasswordPolicyRepository>()
+        )
+
+    @Test
+    fun `turning guests off clears hasPassword so a later enable asks for one again`() =
+        runTest(dispatcher) {
+            val repository = FakeConversationsRepository()
+            val model = viewModel(repository)
+
+            model.allowGuests(user, "token", true, "hunter2")
+            dispatcher.scheduler.advanceUntilIdle()
+            assertEquals(true, model.uiState.value.hasPassword)
+
+            model.allowGuests(user, "token", false)
+            dispatcher.scheduler.advanceUntilIdle()
+
+            assertFalse(model.uiState.value.hasPassword)
+        }
+
+    @Test
+    fun `re-enabling guests without a password fails against an enforcing server and reverts the switch`() =
+        runTest(dispatcher) {
+            val repository = FakeConversationsRepository().apply { failAllowGuests = true }
+            val model = viewModel(repository)
+
+            model.allowGuests(user, "token", true, "hunter2")
+            dispatcher.scheduler.advanceUntilIdle()
+            model.allowGuests(user, "token", false)
+            dispatcher.scheduler.advanceUntilIdle()
+
+            model.allowGuests(user, "token", true)
+            dispatcher.scheduler.advanceUntilIdle()
+
+            assertFalse(model.uiState.value.guestsAllowed)
+        }
 
     @Test
     fun `createConversationNameByParticipants should combine names correctly`() {

--- a/app/src/test/java/com/nextcloud/talk/conversationinfo/viewmodel/ConversationInfoViewModelTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/conversationinfo/viewmodel/ConversationInfoViewModelTest.kt
@@ -9,11 +9,9 @@ package com.nextcloud.talk.conversationinfo.viewmodel
 
 import com.nextcloud.talk.api.NcApi
 import com.nextcloud.talk.chat.data.network.ChatNetworkDataSource
-import com.nextcloud.talk.conversationinfo.model.ParticipantModel
 import com.nextcloud.talk.data.user.model.User
 import com.nextcloud.talk.models.json.capabilities.Capabilities
 import com.nextcloud.talk.models.json.capabilities.SpreedCapability
-import com.nextcloud.talk.models.json.participants.Participant
 import com.nextcloud.talk.repositories.passwordpolicy.PasswordPolicyRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Dispatchers
@@ -79,6 +77,21 @@ class ConversationInfoViewModelTest {
         }
 
     @Test
+    fun `turning guests off hides the password protection entry immediately`() =
+        runTest(dispatcher) {
+            val repository = FakeConversationsRepository()
+            val model = viewModel(repository)
+
+            model.allowGuests(user, "token", true, "hunter2")
+            dispatcher.scheduler.advanceUntilIdle()
+            assertEquals(true, model.uiState.value.showPasswordProtection)
+
+            model.allowGuests(user, "token", false)
+
+            assertFalse(model.uiState.value.showPasswordProtection)
+        }
+
+    @Test
     fun `re-enabling guests without a password fails against an enforcing server and reverts the switch`() =
         runTest(dispatcher) {
             val repository = FakeConversationsRepository().apply { failAllowGuests = true }
@@ -104,71 +117,5 @@ class ConversationInfoViewModelTest {
         val result = ConversationInfoViewModel.createConversationNameByParticipants(original, all)
 
         assertEquals(expectedName, result)
-    }
-
-    private fun model(
-        displayName: String,
-        type: Participant.ParticipantType,
-        isOnline: Boolean = true,
-        actorType: Participant.ActorType = Participant.ActorType.USERS
-    ) = ParticipantModel(
-        participant = Participant(
-            actorType = actorType,
-            actorId = displayName.lowercase(),
-            displayName = displayName,
-            type = type
-        ),
-        isOnline = isOnline
-    )
-
-    private fun sortedNames(vararg items: ParticipantModel) =
-        items.sortedWith(ConversationInfoViewModel.PARTICIPANT_COMPARATOR).map { it.participant.displayName }
-
-    @Test
-    fun `owners sort above moderators despite the display name`() {
-        val owner = model("Zoe", Participant.ParticipantType.OWNER)
-        val moderator = model("Alice", Participant.ParticipantType.MODERATOR)
-
-        assertEquals(listOf("Zoe", "Alice"), sortedNames(moderator, owner))
-    }
-
-    @Test
-    fun `owners sort above guest moderators`() {
-        val owner = model("Zoe", Participant.ParticipantType.OWNER)
-        val guestModerator = model("Alice", Participant.ParticipantType.GUEST_MODERATOR)
-
-        assertEquals(listOf("Zoe", "Alice"), sortedNames(guestModerator, owner))
-    }
-
-    @Test
-    fun `moderators sort above plain users`() {
-        val moderator = model("Zoe", Participant.ParticipantType.MODERATOR)
-        val user = model("Alice", Participant.ParticipantType.USER)
-
-        assertEquals(listOf("Zoe", "Alice"), sortedNames(user, moderator))
-    }
-
-    @Test
-    fun `offline participants sort below online ones regardless of rank`() {
-        val offlineOwner = model("Zoe", Participant.ParticipantType.OWNER, isOnline = false)
-        val onlineUser = model("Alice", Participant.ParticipantType.USER)
-
-        assertEquals(listOf("Alice", "Zoe"), sortedNames(offlineOwner, onlineUser))
-    }
-
-    @Test
-    fun `groups and teams sort last`() {
-        val group = model("Aaa Team", Participant.ParticipantType.USER, actorType = Participant.ActorType.GROUPS)
-        val user = model("Zoe", Participant.ParticipantType.USER)
-
-        assertEquals(listOf("Zoe", "Aaa Team"), sortedNames(group, user))
-    }
-
-    @Test
-    fun `same rank falls back to the display name`() {
-        val bob = model("Bob", Participant.ParticipantType.USER)
-        val alice = model("alice", Participant.ParticipantType.USER)
-
-        assertEquals(listOf("alice", "Bob"), sortedNames(bob, alice))
     }
 }

--- a/app/src/test/java/com/nextcloud/talk/conversationinfo/viewmodel/FakeConversationsRepository.kt
+++ b/app/src/test/java/com/nextcloud/talk/conversationinfo/viewmodel/FakeConversationsRepository.kt
@@ -1,0 +1,114 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.conversationinfo.viewmodel
+
+import com.nextcloud.talk.conversationinfo.CreateRoomRequest
+import com.nextcloud.talk.data.user.model.User
+import com.nextcloud.talk.models.json.conversations.RoomOverall
+import com.nextcloud.talk.models.json.generic.GenericOverall
+import com.nextcloud.talk.models.json.participants.TalkBan
+import com.nextcloud.talk.models.json.profile.Profile
+import com.nextcloud.talk.repositories.conversations.ConversationsRepository
+import io.reactivex.Observable
+
+/**
+ * Answers with what a test needs of [ConversationsRepository.allowGuests], and fails everything
+ * else this test does not exercise.
+ */
+class FakeConversationsRepository : ConversationsRepository {
+
+    var failAllowGuests = false
+    var lastAllowGuestsPassword: String? = null
+
+    override suspend fun allowGuests(
+        user: User,
+        url: String,
+        token: String,
+        allow: Boolean,
+        password: String
+    ): GenericOverall {
+        lastAllowGuestsPassword = password
+        if (allow && failAllowGuests) {
+            error("the server refused to make the room public without a password")
+        }
+        return GenericOverall()
+    }
+
+    override fun resendInvitations(
+        user: User,
+        url: String
+    ): Observable<ConversationsRepository.ResendInvitationsResult> = throw UnsupportedOperationException()
+
+    override suspend fun archiveConversation(credentials: String, url: String): GenericOverall =
+        throw UnsupportedOperationException()
+
+    override suspend fun unarchiveConversation(credentials: String, url: String): GenericOverall =
+        throw UnsupportedOperationException()
+
+    override suspend fun banActor(
+        credentials: String,
+        url: String,
+        actorType: String,
+        actorId: String,
+        internalNote: String
+    ): TalkBan = throw UnsupportedOperationException()
+
+    override suspend fun listBans(credentials: String, url: String): List<TalkBan> =
+        throw UnsupportedOperationException()
+
+    override suspend fun unbanActor(credentials: String, url: String): GenericOverall =
+        throw UnsupportedOperationException()
+
+    override suspend fun setPassword(user: User, url: String, password: String): GenericOverall = GenericOverall()
+
+    override suspend fun setConversationReadOnly(user: User, url: String, state: Int): GenericOverall =
+        throw UnsupportedOperationException()
+
+    override suspend fun clearChatHistory(user: User, url: String): GenericOverall =
+        throw UnsupportedOperationException()
+
+    override suspend fun createRoom(credentials: String, url: String, body: CreateRoomRequest): RoomOverall =
+        throw UnsupportedOperationException()
+
+    override suspend fun getProfile(credentials: String, url: String): Profile? = throw UnsupportedOperationException()
+
+    override suspend fun markConversationAsSensitive(
+        credentials: String,
+        baseUrl: String,
+        roomToken: String
+    ): GenericOverall = throw UnsupportedOperationException()
+
+    override suspend fun markConversationAsInsensitive(
+        credentials: String,
+        baseUrl: String,
+        roomToken: String
+    ): GenericOverall = throw UnsupportedOperationException()
+
+    override suspend fun markConversationAsImportant(
+        credentials: String,
+        baseUrl: String,
+        roomToken: String
+    ): GenericOverall = throw UnsupportedOperationException()
+
+    override suspend fun markConversationAsUnImportant(
+        credentials: String,
+        baseUrl: String,
+        roomToken: String
+    ): GenericOverall = throw UnsupportedOperationException()
+
+    override suspend fun markConversationAsRead(credentials: String, url: String, messageId: Int?): GenericOverall =
+        throw UnsupportedOperationException()
+
+    override suspend fun markConversationAsUnread(credentials: String, url: String): GenericOverall =
+        throw UnsupportedOperationException()
+
+    override suspend fun addConversationToFavorites(credentials: String, url: String): GenericOverall =
+        throw UnsupportedOperationException()
+
+    override suspend fun removeConversationFromFavorites(credentials: String, url: String): GenericOverall =
+        throw UnsupportedOperationException()
+}

--- a/app/src/test/java/com/nextcloud/talk/conversationinfo/viewmodel/ParticipantComparatorTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/conversationinfo/viewmodel/ParticipantComparatorTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2025 Marcel Hibbe <dev@mhibbe.de>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package com.nextcloud.talk.conversationinfo.viewmodel
+
+import com.nextcloud.talk.conversationinfo.model.ParticipantModel
+import com.nextcloud.talk.models.json.participants.Participant
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ParticipantComparatorTest {
+
+    private fun model(
+        displayName: String,
+        type: Participant.ParticipantType,
+        isOnline: Boolean = true,
+        actorType: Participant.ActorType = Participant.ActorType.USERS
+    ) = ParticipantModel(
+        participant = Participant(
+            actorType = actorType,
+            actorId = displayName.lowercase(),
+            displayName = displayName,
+            type = type
+        ),
+        isOnline = isOnline
+    )
+
+    private fun sortedNames(vararg items: ParticipantModel) =
+        items.sortedWith(ConversationInfoViewModel.PARTICIPANT_COMPARATOR).map { it.participant.displayName }
+
+    @Test
+    fun `owners sort above moderators despite the display name`() {
+        val owner = model("Zoe", Participant.ParticipantType.OWNER)
+        val moderator = model("Alice", Participant.ParticipantType.MODERATOR)
+
+        assertEquals(listOf("Zoe", "Alice"), sortedNames(moderator, owner))
+    }
+
+    @Test
+    fun `owners sort above guest moderators`() {
+        val owner = model("Zoe", Participant.ParticipantType.OWNER)
+        val guestModerator = model("Alice", Participant.ParticipantType.GUEST_MODERATOR)
+
+        assertEquals(listOf("Zoe", "Alice"), sortedNames(guestModerator, owner))
+    }
+
+    @Test
+    fun `moderators sort above plain users`() {
+        val moderator = model("Zoe", Participant.ParticipantType.MODERATOR)
+        val user = model("Alice", Participant.ParticipantType.USER)
+
+        assertEquals(listOf("Zoe", "Alice"), sortedNames(user, moderator))
+    }
+
+    @Test
+    fun `offline participants sort below online ones regardless of rank`() {
+        val offlineOwner = model("Zoe", Participant.ParticipantType.OWNER, isOnline = false)
+        val onlineUser = model("Alice", Participant.ParticipantType.USER)
+
+        assertEquals(listOf("Alice", "Zoe"), sortedNames(offlineOwner, onlineUser))
+    }
+
+    @Test
+    fun `groups and teams sort last`() {
+        val group = model("Aaa Team", Participant.ParticipantType.USER, actorType = Participant.ActorType.GROUPS)
+        val user = model("Zoe", Participant.ParticipantType.USER)
+
+        assertEquals(listOf("Zoe", "Aaa Team"), sortedNames(group, user))
+    }
+
+    @Test
+    fun `same rank falls back to the display name`() {
+        val bob = model("Bob", Participant.ParticipantType.USER)
+        val alice = model("alice", Participant.ParticipantType.USER)
+
+        assertEquals(listOf("alice", "Bob"), sortedNames(bob, alice))
+    }
+}

--- a/app/src/test/java/com/nextcloud/talk/passwordpolicy/FakePasswordPolicyRepository.kt
+++ b/app/src/test/java/com/nextcloud/talk/passwordpolicy/FakePasswordPolicyRepository.kt
@@ -1,0 +1,33 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.passwordpolicy
+
+import com.nextcloud.talk.models.json.passwordResult.PasswordResult
+import com.nextcloud.talk.repositories.passwordpolicy.PasswordPolicyRepository
+
+/**
+ * Answers with what a test needs of the password policy endpoints, and records what was asked.
+ */
+class FakePasswordPolicyRepository : PasswordPolicyRepository {
+
+    var validationResult = PasswordResult(passed = true, reason = null)
+    var generatedPassword: String? = null
+    var generationUrl: String? = null
+    var failGeneration = false
+
+    override suspend fun validatePassword(credentials: String, url: String, password: String): PasswordResult =
+        validationResult
+
+    override suspend fun generatePassword(credentials: String, url: String): String {
+        generationUrl = url
+        if (failGeneration) {
+            error("the server has no password policy")
+        }
+        return generatedPassword
+            ?: throw IllegalStateException("The password generation response carried no password")
+    }
+}

--- a/app/src/test/java/com/nextcloud/talk/passwordpolicy/PasswordGeneratorTest.kt
+++ b/app/src/test/java/com/nextcloud/talk/passwordpolicy/PasswordGeneratorTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Nextcloud Talk - Android Client
+ *
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package com.nextcloud.talk.passwordpolicy
+
+import com.nextcloud.talk.data.user.model.User
+import com.nextcloud.talk.models.json.capabilities.Capabilities
+import com.nextcloud.talk.models.json.capabilities.PasswordApi
+import com.nextcloud.talk.models.json.capabilities.PasswordPolicy
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Where a generated password comes from, and what the local fallback produces.
+ */
+class PasswordGeneratorTest {
+
+    private val repository = FakePasswordPolicyRepository()
+    private val generator = PasswordGenerator(repository)
+
+    private fun user(generateUrl: String? = GENERATE_URL) =
+        User(
+            username = "alice",
+            token = "token",
+            baseUrl = "https://cloud.example.com",
+            capabilities = Capabilities().apply {
+                passwordPolicy = PasswordPolicy(
+                    PasswordApi(validatePasswordApi = VALIDATE_URL, generatePasswordApi = generateUrl)
+                )
+            }
+        )
+
+    @Test
+    fun `the server generates the password where the account advertises the endpoint`() =
+        runTest {
+            repository.generatedPassword = "correct-horse-battery-staple"
+
+            val password = generator.generate(user())
+
+            assertEquals("correct-horse-battery-staple", password)
+            assertEquals(GENERATE_URL, repository.generationUrl)
+        }
+
+    @Test
+    fun `an account without the generation endpoint is served locally`() =
+        runTest {
+            val password = generator.generate(user(generateUrl = null))
+
+            assertNull(repository.generationUrl)
+            assertEquals(LENGTH, password.length)
+        }
+
+    @Test
+    fun `a failing request is served locally`() =
+        runTest {
+            repository.failGeneration = true
+
+            val password = generator.generate(user())
+
+            assertEquals(LENGTH, password.length)
+        }
+
+    @Test
+    fun `an answer without a password is served locally`() =
+        runTest {
+            repository.generatedPassword = null
+
+            val password = generator.generate(user())
+
+            assertEquals(LENGTH, password.length)
+        }
+
+    @Test
+    fun `an empty answer is served locally`() =
+        runTest {
+            repository.generatedPassword = ""
+
+            val password = generator.generate(user())
+
+            assertEquals(LENGTH, password.length)
+        }
+
+    @Test
+    fun `the local password mixes every character class`() =
+        runTest {
+            val password = generator.generate(user(generateUrl = null))
+
+            assertTrue(password.any { it.isLowerCase() })
+            assertTrue(password.any { it.isUpperCase() })
+            assertTrue(password.any { it.isDigit() })
+            assertTrue(password.any { !it.isLetterOrDigit() })
+        }
+
+    private companion object {
+        const val VALIDATE_URL = "https://cloud.example.com/ocs/v2.php/apps/password_policy/api/v1/validate"
+        const val GENERATE_URL = "https://cloud.example.com/ocs/v2.php/apps/password_policy/api/v1/generate"
+        const val LENGTH = 16
+    }
+}


### PR DESCRIPTION
Stacked on top of #6661 and targeting its branch, so only the three top commits belong to this PR. Where the server enforces a conversation password, one is now generated from its password policy as guests are let in, and conversation info asks for it before opening a conversation to guests instead of sending a request the server refuses. A refusal the server explains is shown with its own message rather than "Sorry, something went wrong".

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🚧 TODO

- [ ] screenshots of the generated password and the conversation info prompt

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

Capabilities checked: `conversations => force-passwords`, `conversation-creation-password` and the
top-level `password_policy`, with a local generator for accounts whose capabilities predate it.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)


