### PR TITLE
Fix outdated warning because of e2ee calls

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -455,6 +455,10 @@ class CallActivity : CallBaseActivity() {
         processExtras(intent.extras!!)
         conversationUser = currentUserProviderOld.currentUser.blockingGet()
 
+        if (warnAndFinishIfCallEndToEndEncryptionUnsupported()) {
+            return
+        }
+
         credentials = ApiUtils.getCredentials(conversationUser!!.username, conversationUser!!.token)
         if (TextUtils.isEmpty(baseUrl)) {
             baseUrl = conversationUser!!.baseUrl
@@ -475,6 +479,15 @@ class CallActivity : CallBaseActivity() {
         reactionAnimator = ReactionAnimator(context, binding!!.reactionAnimationWrapper, viewThemeUtils)
 
         checkInitialDevicePermissions()
+    }
+
+    private fun warnAndFinishIfCallEndToEndEncryptionUnsupported(): Boolean {
+        if (!CapabilitiesUtil.isCallEndToEndEncryptionEnabled(conversationUser?.capabilities?.spreedCapability)) {
+            return false
+        }
+        Toast.makeText(context, R.string.nc_call_e2ee_not_supported, Toast.LENGTH_LONG).show()
+        finish()
+        return true
     }
 
     private fun initCallRecordingViewModel(recordingState: Int) {

--- a/app/src/main/java/com/nextcloud/talk/callnotification/CallNotificationActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/callnotification/CallNotificationActivity.kt
@@ -15,6 +15,7 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import android.view.View
+import android.widget.Toast
 import androidx.core.app.NotificationManagerCompat
 import autodagger.AutoInjector
 import com.nextcloud.talk.R
@@ -29,6 +30,7 @@ import com.nextcloud.talk.extensions.loadUserAvatar
 import com.nextcloud.talk.models.json.participants.Participant
 import com.nextcloud.talk.users.UserManager
 import com.nextcloud.talk.utils.ApiUtils
+import com.nextcloud.talk.utils.CapabilitiesUtil
 import com.nextcloud.talk.utils.CapabilitiesUtil.hasSpreedFeatureCapability
 import com.nextcloud.talk.utils.NotificationUtils
 import com.nextcloud.talk.utils.SpreedFeatures
@@ -190,6 +192,11 @@ class CallNotificationActivity : CallBaseActivity() {
     }
 
     private fun proceedToCall() {
+        if (CapabilitiesUtil.isCallEndToEndEncryptionEnabled(userBeingCalled?.capabilities?.spreedCapability)) {
+            Toast.makeText(context, R.string.nc_call_e2ee_not_supported, Toast.LENGTH_LONG).show()
+            hangup()
+            return
+        }
         val callIntent = Intent(this, CallActivity::class.java)
         intent.putExtra(KEY_ROOM_ONE_TO_ONE, isOneToOneCall)
         callIntent.putExtras(intent.extras!!)

--- a/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/ChatActivity.kt
@@ -3437,6 +3437,10 @@ class ChatActivity :
     private fun startACall(isVoiceOnlyCall: Boolean, callWithoutNotification: Boolean) {
         currentConversation?.let {
             if (::conversationUser.isInitialized) {
+                if (CapabilitiesUtil.isCallEndToEndEncryptionEnabled(spreedCapabilities)) {
+                    Snackbar.make(binding.root, R.string.nc_call_e2ee_not_supported, Snackbar.LENGTH_LONG).show()
+                    return
+                }
                 val pp = ParticipantPermissions(spreedCapabilities, it)
                 if (!pp.canStartCall() && currentConversation?.hasCall == false) {
                     Snackbar.make(binding.root, R.string.startCallForbidden, Snackbar.LENGTH_LONG).show()

--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -1100,6 +1100,10 @@ class ConversationsListActivity : BaseActivity() {
             chatIntent.putExtras(bundle)
 
             if (currentUser != null) {
+                if (CapabilitiesUtil.isCallEndToEndEncryptionEnabled(currentUser?.capabilities?.spreedCapability)) {
+                    showSnackbar(context.getString(R.string.nc_call_e2ee_not_supported))
+                    return@let
+                }
                 val pp = ParticipantPermissions(currentUser?.capabilities?.spreedCapability, it)
                 if (!pp.canStartCall() && selectedConversation?.hasCall == false) {
                     Log.e(TAG, "Error starting call from conversations list: call is forbidden")

--- a/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.kt
@@ -1317,7 +1317,12 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
         val intent = createMainActivityIntent()
 
         val notification: Notification = notificationBuilder
-            .setContentTitle(context!!.resources.getString(R.string.nc_call_e2ee_not_supported_title))
+            .setContentTitle(
+                String.format(
+                    context!!.resources.getString(R.string.nc_call_e2ee_not_supported_title),
+                    conversation.displayName
+                )
+            )
             .setContentText(context!!.resources.getString(R.string.nc_call_e2ee_not_supported))
             .setSmallIcon(R.drawable.ic_call_black_24dp)
             .setOngoing(false)

--- a/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.kt
+++ b/app/src/main/java/com/nextcloud/talk/jobs/NotificationWorker.kt
@@ -76,6 +76,7 @@ import com.nextcloud.talk.receivers.ShareRecordingToChatReceiver
 import com.nextcloud.talk.users.UserManager
 import com.nextcloud.talk.utils.ActorAvatar
 import com.nextcloud.talk.utils.ApiUtils
+import com.nextcloud.talk.utils.CapabilitiesUtil
 import com.nextcloud.talk.utils.CharacterAvatarUtils
 import com.nextcloud.talk.utils.ConversationUtils
 import com.nextcloud.talk.utils.DisplayUtils
@@ -404,7 +405,14 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
 
                 override fun onNext(conversation: ConversationModel) {
                     if (userManager.setUserAsActive(userBeingCalled!!).blockingGet()) {
-                        prepareCallNotificationScreen(conversation)
+                        if (CapabilitiesUtil.isCallEndToEndEncryptionEnabled(
+                                userBeingCalled?.capabilities?.spreedCapability
+                            )
+                        ) {
+                            showEndToEndEncryptionUnsupportedNotification(conversation)
+                        } else {
+                            prepareCallNotificationScreen(conversation)
+                        }
                     }
                 }
 
@@ -1297,6 +1305,29 @@ class NotificationWorker(context: Context, workerParams: WorkerParameters) : Wor
             notificationManager.notify(notificationId, notification)
             Log.d(TAG, "'you missed a call' notification was created")
         }
+    }
+
+    private fun showEndToEndEncryptionUnsupportedNotification(conversation: ConversationModel) {
+        val notificationBuilder = NotificationCompat.Builder(
+            context!!,
+            NotificationUtils.NotificationChannels
+                .NOTIFICATION_CHANNEL_MESSAGES_V4.name
+        )
+
+        val intent = createMainActivityIntent()
+
+        val notification: Notification = notificationBuilder
+            .setContentTitle(context!!.resources.getString(R.string.nc_call_e2ee_not_supported_title))
+            .setContentText(context!!.resources.getString(R.string.nc_call_e2ee_not_supported))
+            .setSmallIcon(R.drawable.ic_call_black_24dp)
+            .setOngoing(false)
+            .setAutoCancel(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setContentIntent(createUniquePendingIntent(intent))
+            .build()
+
+        sendNotification(pushMessage.timestamp.toInt(), notification)
+        Log.d(TAG, "'end-to-end-encryption not supported' notification was created for ${conversation.token}")
     }
 
     private fun createMainActivityIntent(): Intent {

--- a/app/src/main/java/com/nextcloud/talk/utils/CapabilitiesUtil.kt
+++ b/app/src/main/java/com/nextcloud/talk/utils/CapabilitiesUtil.kt
@@ -321,6 +321,17 @@ object CapabilitiesUtil {
     fun isBanningAvailable(spreedCapabilities: SpreedCapability): Boolean =
         hasSpreedFeatureCapability(spreedCapabilities, SpreedFeatures.BAN_V1)
 
+    fun isCallEndToEndEncryptionEnabled(spreedCapabilities: SpreedCapability?): Boolean {
+        if (
+            spreedCapabilities?.config?.containsKey("call") == true &&
+            spreedCapabilities.config!!["call"] != null &&
+            spreedCapabilities.config!!["call"]!!.containsKey("end-to-end-encryption")
+        ) {
+            return spreedCapabilities.config!!["call"]!!["end-to-end-encryption"].toString().toBoolean()
+        }
+        return false
+    }
+
     // endregion
 
     //region SpreedCapabilities that can't be used with federation as the settings for them are global

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -641,7 +641,7 @@ How to translate with transifex:
     <string name="nc_keep">Keep</string>
     <string name="nc_delete_message_leaked_to_matterbridge">Message deleted successfully, but it might have been leaked to other services</string>
     <string name="startCallForbidden">You are not allowed to start a call</string>
-    <string name="nc_call_e2ee_not_supported_title">Calling unavailable</string>
+    <string name="nc_call_e2ee_not_supported_title">Call from %s unavailable</string>
     <string name="nc_call_e2ee_not_supported">Calling is currently not supported because end-to-end encryption is enabled on the server</string>
     <string name="nc_last_moderator_leaving_room_warning">You need to promote a new moderator before you can leave the conversation</string>
     <string name="nc_room_retention">Room is retained successfully</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -641,6 +641,8 @@ How to translate with transifex:
     <string name="nc_keep">Keep</string>
     <string name="nc_delete_message_leaked_to_matterbridge">Message deleted successfully, but it might have been leaked to other services</string>
     <string name="startCallForbidden">You are not allowed to start a call</string>
+    <string name="nc_call_e2ee_not_supported_title">Calling unavailable</string>
+    <string name="nc_call_e2ee_not_supported">Calling is currently not supported because end-to-end encryption is enabled on the server</string>
     <string name="nc_last_moderator_leaving_room_warning">You need to promote a new moderator before you can leave the conversation</string>
     <string name="nc_room_retention">Room is retained successfully</string>
 


### PR DESCRIPTION
fix #5892 until e2ee calls are possible


Show warnings when e2ee calls are enabled on server. They are not yet supported by the android talk app. But until now, the app show that it is outdated which is not true and confusing.

With this PR the app can be used for chatting but will show warnings when trying to call.

For this, a flag must be set on server to tell which android talk version "support" e2ee --> https://github.com/nextcloud/spreed/pull/19352

How to test until the server change was made: 
just set

```
    fun isCallEndToEndEncryptionEnabled(spreedCapabilities: SpreedCapability?): Boolean {
        return true
    }
```

Same solution as applied as for talk iOS:
https://github.com/nextcloud/talk-ios/pull/2369
https://github.com/nextcloud/spreed/pull/16955



### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
