### PR TITLE
fix(chat): stack emoji button below attachment button on multi-line messages

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/MessageInputFragment.kt
@@ -15,6 +15,7 @@ import android.os.CountDownTimer
 import android.os.SystemClock
 import android.text.Editable
 import android.text.InputFilter
+import android.text.StaticLayout
 import android.text.TextUtils
 import android.text.TextWatcher
 import android.util.Log
@@ -41,6 +42,7 @@ import androidx.appcompat.view.ContextThemeWrapper
 import androidx.compose.material3.MaterialTheme
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.toDrawable
+import androidx.core.view.doOnLayout
 import androidx.core.view.isVisible
 import androidx.core.widget.doAfterTextChanged
 import androidx.emoji2.emojipicker.RecentEmojiProvider
@@ -467,8 +469,11 @@ class MessageInputFragment : Fragment() {
                 chatActivity.chatViewModel.messageDraft.messageCursor = cursor
                 chatActivity.chatViewModel.messageDraft.messageText = text
                 handleButtonsVisibility()
+                updateEmojiButtonPlacement()
             }
         })
+
+        binding.fragmentMessageInputView.inputEditText.doOnLayout { updateEmojiButtonPlacement() }
 
         // Image keyboard support
         // See: https://developer.android.com/guide/topics/text/image-keyboard
@@ -718,6 +723,30 @@ class MessageInputFragment : Fragment() {
                 }
             }
         }
+    }
+
+    private fun updateEmojiButtonPlacement() {
+        if (!this::binding.isInitialized) {
+            return
+        }
+
+        val editText = binding.fragmentMessageInputView.inputEditText
+        val smileyButton = binding.fragmentMessageInputView.smileyButton
+        val text = editText.text
+        val currentWidth = editText.width
+        val isCurrentlyStacked = binding.fragmentMessageInputView.isEmojiButtonStacked
+        val widestPossibleWidth = if (isCurrentlyStacked) currentWidth else currentWidth + smileyButton.width
+
+        if (text == null || currentWidth <= 0 || widestPossibleWidth <= 0) {
+            return
+        }
+
+        val lineCountAtWidestWidth = StaticLayout.Builder
+            .obtain(text, 0, text.length, editText.paint, widestPossibleWidth)
+            .build()
+            .lineCount
+
+        binding.fragmentMessageInputView.setEmojiButtonStacked(lineCountAtWidestWidth >= LONG_MESSAGE_LINE_THRESHOLD)
     }
 
     fun updateScheduledMessagesAvailability(hasMessages: Boolean) {
@@ -1280,5 +1309,6 @@ class MessageInputFragment : Fragment() {
         private const val FULLY_OPAQUE: Float = 1.0f
         private const val FULLY_TRANSPARENT: Float = 0.0f
         private const val OPACITY_DISABLED = 0.7f
+        private const val LONG_MESSAGE_LINE_THRESHOLD = 2
     }
 }

--- a/app/src/main/java/com/nextcloud/talk/ui/MessageInput.kt
+++ b/app/src/main/java/com/nextcloud/talk/ui/MessageInput.kt
@@ -13,6 +13,8 @@ import android.widget.Chronometer
 import android.widget.FrameLayout
 import android.widget.ImageButton
 import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.RelativeLayout
 import android.widget.SeekBar
 import android.widget.TextView
 import androidx.emoji2.widget.EmojiEditText
@@ -38,10 +40,14 @@ class MessageInput : FrameLayout {
     lateinit var inputEditText: EmojiEditText
     lateinit var attachmentButton: ImageButton
     lateinit var messageSendButton: ImageButton
+    private lateinit var attachmentEmojiContainer: LinearLayout
     val messageInput: EmojiEditText
         get() = inputEditText
     val button: ImageButton
         get() = messageSendButton
+
+    var isEmojiButtonStacked = false
+        private set
 
     constructor(context: Context) : super(context) {
         init()
@@ -64,6 +70,7 @@ class MessageInput : FrameLayout {
         inputEditText.maxHeight = screenHeight / 3
 
         attachmentButton = findViewById(R.id.attachmentButton)
+        attachmentEmojiContainer = findViewById(R.id.attachmentEmojiContainer)
         messageSendButton = findViewById(R.id.messageSendButton)
         audioRecordDuration = findViewById(R.id.audioRecordDuration)
         recordAudioButton = findViewById(R.id.recordAudioButton)
@@ -85,5 +92,24 @@ class MessageInput : FrameLayout {
         attachmentButton.setOnClickListener {
             listener?.invoke()
         }
+    }
+
+    fun setEmojiButtonStacked(stacked: Boolean) {
+        if (isEmojiButtonStacked == stacked) {
+            return
+        }
+        isEmojiButtonStacked = stacked
+
+        attachmentEmojiContainer.orientation = if (stacked) LinearLayout.VERTICAL else LinearLayout.HORIZONTAL
+
+        val containerParams = attachmentEmojiContainer.layoutParams as RelativeLayout.LayoutParams
+        if (stacked) {
+            containerParams.removeRule(RelativeLayout.ALIGN_BOTTOM)
+            containerParams.addRule(RelativeLayout.CENTER_VERTICAL)
+        } else {
+            containerParams.removeRule(RelativeLayout.CENTER_VERTICAL)
+            containerParams.addRule(RelativeLayout.ALIGN_BOTTOM, inputEditText.id)
+        }
+        attachmentEmojiContainer.layoutParams = containerParams
     }
 }

--- a/app/src/main/res/layout/view_message_input.xml
+++ b/app/src/main/res/layout/view_message_input.xml
@@ -33,28 +33,33 @@
             android:layout_height="wrap_content"
             android:layoutDirection="ltr">
 
-            <ImageButton
-                android:id="@+id/attachmentButton"
-                android:layout_width="@dimen/min_size_clickable_area"
-                android:layout_height="@dimen/min_size_clickable_area"
+            <LinearLayout
+                android:id="@+id/attachmentEmojiContainer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 android:layout_alignBottom="@id/messageInput"
-                android:background="@color/transparent"
-                android:contentDescription="@string/nc_add_attachment"
-                android:gravity="bottom"
-                android:src="@drawable/ic_baseline_attach_file_24"
-                app:tint="?attr/colorControlNormal" />
+                android:orientation="horizontal">
 
-            <ImageButton
-                android:id="@+id/smileyButton"
-                android:layout_width="@dimen/min_size_clickable_area"
-                android:layout_height="@dimen/min_size_clickable_area"
-                android:layout_alignBottom="@id/messageInput"
-                android:layout_toEndOf="@id/attachmentButton"
-                android:background="@color/transparent"
-                android:contentDescription="@string/nc_add_emojis"
-                android:gravity="bottom"
-                android:src="@drawable/ic_insert_emoticon_black_24dp"
-                app:tint="?attr/colorControlNormal" />
+                <ImageButton
+                    android:id="@+id/attachmentButton"
+                    android:layout_width="@dimen/min_size_clickable_area"
+                    android:layout_height="@dimen/min_size_clickable_area"
+                    android:background="@color/transparent"
+                    android:contentDescription="@string/nc_add_attachment"
+                    android:gravity="bottom"
+                    android:src="@drawable/ic_baseline_attach_file_24"
+                    app:tint="?attr/colorControlNormal" />
+
+                <ImageButton
+                    android:id="@+id/smileyButton"
+                    android:layout_width="@dimen/min_size_clickable_area"
+                    android:layout_height="@dimen/min_size_clickable_area"
+                    android:background="@color/transparent"
+                    android:contentDescription="@string/nc_add_emojis"
+                    android:gravity="bottom"
+                    android:src="@drawable/ic_insert_emoticon_black_24dp"
+                    app:tint="?attr/colorControlNormal" />
+            </LinearLayout>
 
             <com.nextcloud.talk.utils.ImageEmojiEditText
                 android:id="@+id/messageInput"
@@ -62,7 +67,7 @@
                 android:layout_height="wrap_content"
                 android:layout_centerHorizontal="true"
                 android:layout_marginEnd="48dp"
-                android:layout_toEndOf="@id/smileyButton"
+                android:layout_toEndOf="@id/attachmentEmojiContainer"
                 android:background="@null"
                 android:imeOptions="actionDone"
                 android:inputType="textAutoCorrect|textMultiLine|textCapSentences"
@@ -267,7 +272,7 @@
                 android:id="@+id/attachmentButtonSpace"
                 android:layout_width="0dp"
                 android:layout_height="0dp"
-                android:layout_toEndOf="@id/attachmentButton"
+                android:layout_toEndOf="@id/attachmentEmojiContainer"
                 android:visibility="gone" />
 
             <Space


### PR DESCRIPTION
- fixes #6652 

The emoji button sitting next to the attachment button wasted about a third of the input's width once a message wrapped to multiple lines. Move it below the attachment button in that case, freeing that width for the text, while keeping the original layout for short messages.

### 🖼️ Screenshots

Shorter messages | Long messages
---|---
<img width="358" height="728" alt="Screenshot 2026-09-09 at 10 08 44 AM" src="https://github.com/user-attachments/assets/6e389078-7810-4c9d-9ac1-c82ec6ae6e6c" /> | <img width="358" height="728" alt="Screenshot 2026-09-09 at 10 56 24 AM" src="https://github.com/user-attachments/assets/f8c81ee5-910d-4528-a864-0bb10466c36c" />



### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [ ] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
