### PR TITLE
refactor(conversations): drop the null checks the share dialog makes for itself

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationcreation/ConversationCreationActivity.kt
@@ -798,21 +798,17 @@ fun CreateConversation(conversationCreationViewModel: ConversationCreationViewMo
     )
 
     val currentUser by conversationCreationViewModel.currentUser.collectAsState()
-    val roomToken = createdPublicConversation
-    val user = currentUser
-    if (roomToken != null && user != null) {
-        ShareCreatedConversation(
-            roomToken = roomToken,
-            password = conversationCreationViewModel.password.value.takeIf { createdWithPassword },
-            currentUser = user,
-            context = context,
-            onDismiss = {
-                createdPublicConversation = null
-                conversationCreationViewModel.clearCreationState()
-                openConversation(context, roomToken)
-            }
-        )
-    }
+    ShareCreatedConversation(
+        roomToken = createdPublicConversation,
+        password = password.takeIf { createdWithPassword },
+        currentUser = currentUser,
+        context = context,
+        onDismiss = { roomToken ->
+            createdPublicConversation = null
+            conversationCreationViewModel.clearCreationState()
+            openConversation(context, roomToken)
+        }
+    )
 
     Box(
         modifier = Modifier


### PR DESCRIPTION
`ShareCreatedConversation` takes nullable arguments and returns early when there is nothing to show, so the guards around its call site were dead code, and they carried `CreateConversation` past detekt's 60-line limit. The two halves disagreed because the commit that introduced them was split on its way into master (`303b286b9` and `8f29a0744`). No behaviour change: detekt drops from 106 findings to 105.

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
B | A

### 🚧 TODO

- [ ] nothing

### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

