### PR TITLE
fix: avoid IllegalStateException crash when playing calling sound

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/CallActivity.kt
@@ -2848,6 +2848,7 @@ class CallActivity : CallBaseActivity() {
         }
     }
 
+    @Suppress("Detekt.TooGenericExceptionCaught")
     private fun playCallingSound() {
         stopCallingSound()
         val ringtoneUri: Uri? = if (isIncomingCallFromNotification) {
@@ -2859,17 +2860,21 @@ class CallActivity : CallBaseActivity() {
             mediaPlayer = MediaPlayer()
             try {
                 mediaPlayer!!.setDataSource(this, ringtoneUri)
-                mediaPlayer!!.isLooping = true
                 val audioAttributes = AudioAttributes.Builder().setContentType(
                     AudioAttributes.CONTENT_TYPE_SONIFICATION
                 )
                     .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
                     .build()
                 mediaPlayer!!.setAudioAttributes(audioAttributes)
-                mediaPlayer!!.setOnPreparedListener { mp: MediaPlayer? -> mediaPlayer!!.start() }
+                mediaPlayer!!.setOnPreparedListener { mp: MediaPlayer? ->
+                    mp?.isLooping = true
+                    mp?.start()
+                }
                 mediaPlayer!!.prepareAsync()
-            } catch (e: IOException) {
-                Log.e(TAG, "Failed to play sound")
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to play calling sound", e)
+                mediaPlayer?.release()
+                mediaPlayer = null
             }
         }
     }


### PR DESCRIPTION
MediaPlayer.setLooping() was called right after setDataSource(), before the player reached the Prepared state. On some OEM devices this throws IllegalStateException, which was not caught since only IOException was handled. Move setLooping() into the OnPreparedListener callback and broaden the catch so a failure to set up the ringtone no longer crashes the call.

Assisted-by: Claude Code:claude-sonnet-5


### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
