### PR TITLE
fix(crash): guard startActivity calls against finishing/destroyed activity

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/activities/MainActivity.kt
@@ -262,6 +262,8 @@ class MainActivity :
                 }
 
                 override fun onSuccess(users: List<User>) {
+                    if (isFinishing || isDestroyed) return
+
                     if (users.isNotEmpty()) {
                         if (appPreferences.useUnifiedPush) {
                             UnifiedPushUtils.setPeriodicPushRegistrationWorker(this@MainActivity)
@@ -269,10 +271,12 @@ class MainActivity :
                             ClosedInterfaceImpl().setUpPushTokenRegistration()
                         }
                         runOnUiThread {
+                            if (isFinishing || isDestroyed) return@runOnUiThread
                             openConversationList()
                         }
                     } else {
                         runOnUiThread {
+                            if (isFinishing || isDestroyed) return@runOnUiThread
                             launchServerSelection()
                         }
                     }


### PR DESCRIPTION
Async user lookups in handleIntent() could resolve after the user already left MainActivity, so the resulting startActivity call ran on an invalid activity state. That rare timing triggers a framework NPE in ActivityTaskManagerService.getTaskWithAdjacent. Skip the call when the activity is finishing or destroyed, matching the existing guard already used in handleDeepLink() and startConversation().

Assisted-by: Claude Code:claude-sonnet-5



### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
