### PR TITLE
fix(settings): avoid NPE in setupPhoneBookIntegration

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/settings/SettingsActivity.kt
@@ -341,7 +341,7 @@ class SettingsActivity :
 
     private fun setupPhoneBookIntegration(isOnline: Boolean) {
         if (CapabilitiesUtil.hasSpreedFeatureCapability(
-                currentUser?.capabilities?.spreedCapability!!,
+                currentUser?.capabilities?.spreedCapability,
                 SpreedFeatures.PHONEBOOK_SEARCH
             ) &&
             isOnline


### PR DESCRIPTION
currentUser?.capabilities?.spreedCapability!! crashed with NPE when capabilities were not yet loaded. hasSpreedFeatureCapability already accepts a nullable SpreedCapability?, so drop the non-null assertion.

The root cause of not yet loaded capabilities must be solved in other PRs.


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
