### PR TITLE
fix(conversationlist): avoid blocking main thread in onResume, causin…

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
+++ b/app/src/main/java/com/nextcloud/talk/conversationlist/ConversationsListActivity.kt
@@ -118,6 +118,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.rx2.await
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
 import retrofit2.HttpException
@@ -423,7 +424,9 @@ class ConversationsListActivity : BaseActivity() {
                 appPreferences.setConversationListPositionAndOffset(0, 0)
             }
 
-            hasMultipleAccountsState.value = userManager.users.blockingGet().size > 1
+            lifecycleScope.launch {
+                hasMultipleAccountsState.value = userManager.users.await().size > 1
+            }
             conversationsListViewModel.setHideRoomToken(intent.getStringExtra(KEY_FORWARD_HIDE_SOURCE_ROOM))
             fetchRooms()
             fetchPendingInvitations()


### PR DESCRIPTION
…g ANR

blockingGet() on userManager.users in onResume() forced the main thread to wait on the SQLCipher connection pool, which background WorkManager jobs (CapabilitiesWorker, AccountRemovalWorker) were contending for at the same time, leading to an ANR. Fetch the account count asynchronously via lifecycleScope + await() instead.

The same blockingGet() pattern exists in several other places in this class and elsewhere touching the DB/network synchronously from the main thread; those are lower risk since they're not in the onResume hot path, but are worth revisiting if similar ANRs show up.

Assisted-by: Claude Code:claude-sonnet-5


### 🏁 Checklist

- [ ] ⛑️ Tests (unit and/or integration) are included or not needed
- [ ] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [ ] 📅 Milestone is set
- [ ] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
