### PR TITLE
fix(chat): avoid NPE when local spreed capabilities are not yet loaded

### DIFF
--- a/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
+++ b/app/src/main/java/com/nextcloud/talk/chat/viewmodels/ChatViewModel.kt
@@ -1758,19 +1758,24 @@ class ChatViewModel @AssistedInject constructor(
     fun getCapabilities(user: User, token: String, conversationModel: ConversationModel) {
         Log.d(TAG, "Remote server ${conversationModel.remoteServer}")
         if (conversationModel.remoteServer.isNullOrEmpty()) {
+            val spreedCapability = user.capabilities?.spreedCapability
+            if (spreedCapability == null) {
+                Log.w(TAG, "No local spreed capabilities available yet for user ${user.id}, skipping update")
+                return
+            }
             participantPermissions = ParticipantPermissions(
-                user.capabilities!!.spreedCapability!!,
+                spreedCapability,
                 conversationModel
             )
             if (_getCapabilitiesViewState.value == GetCapabilitiesStartState) {
                 _getCapabilitiesViewState.value = GetCapabilitiesInitialLoadState(
-                    user.capabilities!!.spreedCapability!!,
+                    spreedCapability,
                     conversationModel
                 )
             } else {
-                _getCapabilitiesViewState.value = GetCapabilitiesUpdateState(user.capabilities!!.spreedCapability!!)
+                _getCapabilitiesViewState.value = GetCapabilitiesUpdateState(spreedCapability)
             }
-            _spreedCapabilities.value = user.capabilities!!.spreedCapability!!
+            _spreedCapabilities.value = spreedCapability
         } else {
             chatNetworkDataSource.getCapabilities(user, token)
                 .subscribeOn(Schedulers.io())


### PR DESCRIPTION
user.capabilities and its spreedCapability are nullable and were force-unwrapped in getCapabilities(), crashing whenever observeConversationAndUserEveryTime fired before the local user's capabilities had been cached. Now falls back to skipping the update and logging a warning instead of crashing.

Assisted-by: Claude Code:claude-sonnet-5



### 🏁 Checklist

- [x] ⛑️ Tests (unit and/or integration) are included or not needed
- [x] 🔖 Capability is checked or not needed 
- [x] 🔙 Backport requests are created or not needed: `/backport to stable-xx.x`
- [x] 📅 Milestone is set
- [x] 🌸 PR title is meaningful (if it should be in the changelog: is it meaningful to users?)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
